### PR TITLE
feat(v0.2): transport Phase 1 — interface, loopback, IPC adapter

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@dashframe/server-core": "workspace:*",
+    "@dashframe/transport": "workspace:*",
+    "@dashframe/types": "workspace:*",
     "electron": "^33.2.1"
   },
   "devDependencies": {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,7 @@
 import { openProject, type ProjectHandle } from "@dashframe/server-core";
+import { Router } from "@dashframe/transport";
+import { registerIpcMainTransport } from "@dashframe/transport/ipc/main";
+import type { ProjectInfo } from "@dashframe/types";
 import { app, BrowserWindow, ipcMain } from "electron";
 import path from "node:path";
 
@@ -32,23 +35,38 @@ function createWindow(): void {
   loaded.catch((err) => console.error("[dashframe] window load failed:", err));
 }
 
-function registerIpc(handle: ProjectHandle): void {
-  ipcMain.handle("dashframe:project:info", () => ({
-    dir: handle.dir,
-    dbPath: handle.dbPath,
-    dataSourcesDir: handle.dataSourcesDir,
-    projectId: handle.meta.projectId,
-    name: handle.meta.name,
-    schemaVersion: handle.meta.schemaVersion,
-    createdAt: handle.meta.createdAt.toISOString(),
-    createdBy: handle.meta.createdBy,
-  }));
+/**
+ * Build the RPC `Router` for the desktop app. All future channels (queries,
+ * mutations, subscriptions) register here — `main.ts` should NOT grow new
+ * `ipcMain.handle` calls. Adding a route is a one-liner against the router;
+ * the IPC adapter dispatches automatically.
+ */
+function buildRouter(handle: ProjectHandle): Router {
+  const router = new Router();
+
+  router.invoke("project.info", (): ProjectInfo => {
+    return {
+      dir: handle.dir,
+      dbPath: handle.dbPath,
+      dataSourcesDir: handle.dataSourcesDir,
+      projectId: handle.meta.projectId,
+      name: handle.meta.name,
+      schemaVersion: handle.meta.schemaVersion,
+      createdAt: handle.meta.createdAt.toISOString(),
+      createdBy: handle.meta.createdBy,
+    };
+  });
+
+  return router;
 }
 
 await app.whenReady();
 const project = await openProject();
 console.log(`[dashframe] project ready at ${project.dir}`);
-registerIpc(project);
+
+const router = buildRouter(project);
+registerIpcMainTransport({ ipcMain, router });
+
 createWindow();
 
 app.on("activate", () => {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,29 +1,18 @@
+/**
+ * Preload bridge. Exposes a single `dashframe.transport` object on the
+ * renderer's `window`. Renderer code uses `@dashframe/transport/ipc/renderer`
+ * to wrap the bridge in a typed `Transport`.
+ *
+ * Per Greptile P2 on PR #30: shared types live in `@dashframe/types`, NOT
+ * here, so the renderer can import them without a stale CJS preload bundle
+ * leaking into its module graph.
+ */
+import { createPreloadBridge } from "@dashframe/transport/ipc/preload";
 import { contextBridge, ipcRenderer } from "electron";
 
-/**
- * IPC surface exposed to the renderer. Keep the shape narrow and serializable:
- * the main process owns the artifact DB, and the renderer only reads metadata
- * via named channels. Future channels (query, mutate) grow from here.
- */
-const api = {
+const bridge = createPreloadBridge(ipcRenderer);
+
+contextBridge.exposeInMainWorld("dashframe", {
   version: "0.2.0-alpha.0",
-  project: {
-    getInfo: (): Promise<ProjectInfo> =>
-      ipcRenderer.invoke("dashframe:project:info"),
-  },
-} as const;
-
-export interface ProjectInfo {
-  dir: string;
-  dbPath: string;
-  dataSourcesDir: string;
-  projectId: string;
-  name: string;
-  schemaVersion: number;
-  createdAt: string;
-  createdBy: string;
-}
-
-export type DashFrameApi = typeof api;
-
-contextBridge.exposeInMainWorld("dashframe", api);
+  transport: bridge,
+});

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -12,6 +12,8 @@
     "check": "bun run typecheck && bun run lint"
   },
   "dependencies": {
+    "@dashframe/transport": "workspace:*",
+    "@dashframe/types": "workspace:*",
     "@tanstack/react-router": "^1.95.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/renderer/src/global.d.ts
+++ b/apps/renderer/src/global.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Ambient typing for the preload-exposed surface. The preload script
+ * injects `window.dashframe` via `contextBridge.exposeInMainWorld`; we
+ * declare its shape here so renderer code stays typed without reaching
+ * into the preload bundle (which the renderer can't import — it's CJS,
+ * runs in the isolated preload world, and is bundled separately).
+ *
+ * Resolves the Greptile P2 from PR #30: shared types live in
+ * `@dashframe/types` and `@dashframe/transport`, both renderer-importable.
+ */
+import type { PreloadIpcBridge } from "@dashframe/transport/ipc/preload";
+
+declare global {
+  interface Window {
+    dashframe: {
+      version: string;
+      transport: PreloadIpcBridge;
+    };
+  }
+}
+
+export {};

--- a/apps/renderer/src/routes/index.tsx
+++ b/apps/renderer/src/routes/index.tsx
@@ -1,14 +1,65 @@
+import type { ProjectInfo } from "@dashframe/types";
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { transport } from "../transport";
 
 export const Route = createFileRoute("/")({
   component: HelloView,
 });
 
 function HelloView() {
+  const [info, setInfo] = useState<ProjectInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    transport
+      .invoke("project.info")
+      .then((data) => {
+        if (!cancelled) setInfo(data as ProjectInfo);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <main style={{ fontFamily: "system-ui", padding: "2rem" }}>
       <h1>DashFrame v0.2</h1>
       <p>hello — desktop shell boot</p>
+      <ProjectInfoView info={info} error={error} />
     </main>
+  );
+}
+
+function ProjectInfoView({
+  info,
+  error,
+}: {
+  info: ProjectInfo | null;
+  error: string | null;
+}) {
+  if (error)
+    return <p style={{ color: "crimson" }}>project.info failed: {error}</p>;
+  if (!info) return <p>loading project…</p>;
+  return (
+    <dl>
+      <dt>name</dt>
+      <dd>{info.name}</dd>
+      <dt>dir</dt>
+      <dd>
+        <code>{info.dir}</code>
+      </dd>
+      <dt>projectId</dt>
+      <dd>
+        <code>{info.projectId}</code>
+      </dd>
+    </dl>
   );
 }

--- a/apps/renderer/src/transport.ts
+++ b/apps/renderer/src/transport.ts
@@ -1,0 +1,20 @@
+/**
+ * Renderer-side `Transport` singleton. Built once at module load by
+ * wrapping the preload bridge — `window.dashframe.transport`, populated
+ * by `apps/desktop/src/preload.ts`.
+ *
+ * Renderer code uses this to call `project.info`, future query/mutation
+ * paths, and (eventually) live subscriptions. Treat it as the only door
+ * to the main process.
+ */
+import type { Transport } from "@dashframe/transport";
+import { createIpcRendererTransport } from "@dashframe/transport/ipc/renderer";
+
+const bridge = window.dashframe?.transport;
+if (!bridge) {
+  throw new Error(
+    "[dashframe] preload bridge missing — window.dashframe.transport is undefined",
+  );
+}
+
+export const transport: Transport = createIpcRendererTransport(bridge);

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@dashframe/server-core": "workspace:*",
+        "@dashframe/transport": "workspace:*",
+        "@dashframe/types": "workspace:*",
         "electron": "^33.2.1",
       },
       "devDependencies": {
@@ -34,6 +36,8 @@
       "name": "@dashframe/renderer",
       "version": "0.0.0",
       "dependencies": {
+        "@dashframe/transport": "workspace:*",
+        "@dashframe/types": "workspace:*",
         "@tanstack/react-router": "^1.95.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -233,6 +237,28 @@
         "typescript": "5.7.2",
       },
     },
+    "packages/transport": {
+      "name": "@dashframe/transport",
+      "version": "0.0.0",
+      "dependencies": {
+        "@dashframe/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@dashframe/eslint-config": "workspace:*",
+        "@types/bun": "^1.2.0",
+        "electron": "^33.2.1",
+        "typescript": "5.7.2",
+      },
+    },
+    "packages/types": {
+      "name": "@dashframe/types",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@dashframe/eslint-config": "workspace:*",
+        "@types/bun": "^1.2.0",
+        "typescript": "5.7.2",
+      },
+    },
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -288,6 +314,10 @@
     "@dashframe/server": ["@dashframe/server@workspace:apps/server"],
 
     "@dashframe/server-core": ["@dashframe/server-core@workspace:packages/server-core"],
+
+    "@dashframe/transport": ["@dashframe/transport@workspace:packages/transport"],
+
+    "@dashframe/types": ["@dashframe/types@workspace:packages/types"],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@dashframe/transport",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./router": "./src/router.ts",
+    "./loopback": "./src/loopback.ts",
+    "./ipc/main": "./src/ipc/main.ts",
+    "./ipc/preload": "./src/ipc/preload.ts",
+    "./ipc/renderer": "./src/ipc/renderer.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "bun test",
+    "check": "bun run typecheck && bun run lint && bun run test"
+  },
+  "dependencies": {
+    "@dashframe/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@dashframe/eslint-config": "workspace:*",
+    "@types/bun": "^1.2.0",
+    "electron": "^33.2.1",
+    "typescript": "5.7.2"
+  }
+}

--- a/packages/transport/src/errors.ts
+++ b/packages/transport/src/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * `TransportError` is the single boundary type the transport surfaces to
+ * callers. Wrapping every cross-process failure in it gives the renderer
+ * (and same-process callers) one `instanceof` check rather than a discrim-
+ * inated union scattered through call sites.
+ *
+ * `code` is one of the tagged values from `RpcError`; the original
+ * `RpcError` is exposed verbatim so consumers that want richer treatment
+ * (e.g. surfacing validation `details`) can reach in without parsing
+ * `message`.
+ */
+import type { RpcError, RpcErrorCode } from "@dashframe/types";
+
+export class TransportError extends Error {
+  readonly code: RpcErrorCode;
+  readonly details: unknown;
+  readonly rpcError: RpcError;
+
+  constructor(error: RpcError) {
+    super(error.message);
+    this.name = "TransportError";
+    this.code = error.code;
+    this.details = error.details;
+    this.rpcError = error;
+  }
+}
+
+/**
+ * Normalize an unknown thrown value into an `RpcError`. Used by the router
+ * and adapters when a handler throws or rejects: anything that isn't already
+ * a structured `RpcError` becomes `internal` with the message preserved.
+ */
+export function toTransportError(err: unknown): RpcError {
+  if (err instanceof TransportError) return err.rpcError;
+  if (err instanceof Error) {
+    return { code: "internal", message: err.message };
+  }
+  return { code: "internal", message: String(err) };
+}

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @dashframe/transport — single RPC surface for the DashFrame v0.2 stack.
+ *
+ * Why a transport package:
+ *   - main↔renderer (Electron IPC) and standalone↔web (future WebSocket)
+ *     should share one client contract; the renderer should not care which
+ *     adapter is wired underneath
+ *   - the host process owns a `Router` of handlers; every adapter is a thin
+ *     dispatcher into that router
+ *   - same-process callers (unit tests, future server-side tooling) get a
+ *     `LoopbackTransport` that skips serialization entirely
+ *
+ * Layout:
+ *   - `Transport` (this file) — interface every client implements
+ *   - `Router` — handler registry shared by all adapters
+ *   - `LoopbackTransport` — direct dispatch into a `Router`
+ *   - `ipc/main` — `ipcMain` wiring around a `Router`
+ *   - `ipc/preload` — `contextBridge` shim mapping IPC to `Transport`
+ *   - `ipc/renderer` — thin client that consumes whatever preload exposed
+ *
+ * Phase 1 explicitly omits: WebSocket adapter, retry/backoff, subscription
+ * backpressure, structured cancellation. Each is a follow-up ticket.
+ */
+
+export { TransportError, toTransportError } from "./errors";
+export { LoopbackTransport, createLoopbackTransport } from "./loopback";
+export { Router } from "./router";
+export type {
+  RouterContext,
+  RouterHandler,
+  SubscriptionHandle,
+} from "./router";
+export type {
+  Subscription,
+  SubscriptionObserver,
+  Transport,
+} from "./transport";

--- a/packages/transport/src/ipc/channels.ts
+++ b/packages/transport/src/ipc/channels.ts
@@ -1,0 +1,20 @@
+/**
+ * IPC channel names. Shared between main, preload, and renderer to keep
+ * the wire surface in one place. Anything outside this file using a raw
+ * channel string is a bug.
+ *
+ * Single namespaced surface — `dashframe:rpc:*` — replaces the legacy
+ * one-off `dashframe:project:info` channel removed in TASK-548.
+ */
+export const IPC_CHANNELS = {
+  /** Renderer → main: one-shot RPC call (request/response). */
+  invoke: "dashframe:rpc:invoke",
+  /** Renderer → main: open a subscription, returns the assigned id. */
+  subscribe: "dashframe:rpc:subscribe",
+  /** Renderer → main: close a subscription by id. */
+  unsubscribe: "dashframe:rpc:unsubscribe",
+  /** Main → renderer: subscription event push (next/error/complete). */
+  event: "dashframe:rpc:event",
+} as const;
+
+export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];

--- a/packages/transport/src/ipc/ipc.test.ts
+++ b/packages/transport/src/ipc/ipc.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration test for the Electron IPC adapter. We don't spin up Electron
+ * here — that's expensive and brittle in CI. Instead we wire a fake
+ * `ipcMain` + `ipcRenderer` pair that mirrors Electron's invoke/event
+ * semantics: `ipcRenderer.invoke(ch, payload)` calls the handler registered
+ * on `ipcMain` and resolves with its return; `webContents.send(ch, payload)`
+ * delivers an event to listeners on `ipcRenderer.on(ch, ...)`.
+ *
+ * This proves the full path:
+ *   renderer Transport → preload bridge → ipcMain → Router → handler
+ *   handler → SubscriptionHandle → webContents.send → ipcRenderer event →
+ *     renderer observer
+ *
+ * Renderer-reload teardown (subscription cleanup on `destroyed`) is covered
+ * by emitting the `destroyed` event on the fake WebContents.
+ */
+import { EventEmitter } from "node:events";
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  IpcMain,
+  IpcMainInvokeEvent,
+  IpcRenderer,
+  WebContents,
+} from "electron";
+
+import { Router } from "../router";
+import { registerIpcMainTransport } from "./main";
+import { createPreloadBridge } from "./preload";
+import { createIpcRendererTransport } from "./renderer";
+
+interface Wired {
+  ipcMain: IpcMain;
+  ipcRenderer: IpcRenderer;
+  webContents: FakeWebContents;
+  /** Trigger a renderer reload (destroys WebContents). */
+  reload: () => void;
+}
+
+class FakeWebContents extends EventEmitter {
+  destroyed = false;
+  // The preload bridge listens for `dashframe:rpc:event`; we pump pushes
+  // into the fake ipcRenderer.
+  constructor(private readonly rendererBus: EventEmitter) {
+    super();
+  }
+  send(channel: string, payload: unknown): void {
+    if (this.destroyed) return;
+    this.rendererBus.emit(channel, /* event */ {}, payload);
+  }
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.emit("destroyed");
+  }
+}
+
+function wire(): Wired {
+  type Handler = (
+    event: IpcMainInvokeEvent,
+    ...args: unknown[]
+  ) => unknown | Promise<unknown>;
+  const handlers = new Map<string, Handler>();
+  const rendererBus = new EventEmitter();
+
+  const wc = new FakeWebContents(rendererBus);
+
+  const ipcMain = {
+    handle(channel: string, handler: Handler) {
+      handlers.set(channel, handler);
+    },
+    removeHandler(channel: string) {
+      handlers.delete(channel);
+    },
+  } as unknown as IpcMain;
+
+  const ipcRenderer = {
+    async invoke(channel: string, ...args: unknown[]) {
+      const handler = handlers.get(channel);
+      if (!handler) throw new Error(`no handler: ${channel}`);
+      // Synthesize an event with our fake sender.
+      const event = {
+        sender: wc as unknown as WebContents,
+      } as IpcMainInvokeEvent;
+      return handler(event, ...args);
+    },
+    on(channel: string, listener: (...args: unknown[]) => void) {
+      rendererBus.on(channel, listener);
+    },
+    removeListener(channel: string, listener: (...args: unknown[]) => void) {
+      rendererBus.removeListener(channel, listener);
+    },
+  } as unknown as IpcRenderer;
+
+  return {
+    ipcMain,
+    ipcRenderer,
+    webContents: wc,
+    reload: () => wc.destroy(),
+  };
+}
+
+describe("Electron IPC transport", () => {
+  test("should invoke a query through the full bridge", async () => {
+    const router = new Router();
+    router.invoke("project.info", () => ({ name: "test-project" }));
+
+    const { ipcMain, ipcRenderer } = wire();
+    registerIpcMainTransport({ ipcMain, router });
+    const transport = createIpcRendererTransport(
+      createPreloadBridge(ipcRenderer),
+    );
+
+    const result = await transport.invoke("project.info");
+    expect(result).toEqual({ name: "test-project" });
+  });
+
+  test("should surface handler errors as TransportError", async () => {
+    const router = new Router();
+    router.invoke("fail", () => {
+      throw new Error("oh no");
+    });
+
+    const { ipcMain, ipcRenderer } = wire();
+    registerIpcMainTransport({ ipcMain, router });
+    const transport = createIpcRendererTransport(
+      createPreloadBridge(ipcRenderer),
+    );
+
+    await expect(transport.invoke("fail")).rejects.toMatchObject({
+      name: "TransportError",
+      code: "internal",
+      message: "oh no",
+    });
+  });
+
+  test("should deliver subscription events end-to-end", async () => {
+    const router = new Router();
+    const ctl: {
+      pushNext?: (v: unknown) => void;
+      pushComplete?: () => void;
+    } = {};
+    router.subscription("counter", (_args, handle) => {
+      ctl.pushNext = (v) => handle.next(v);
+      ctl.pushComplete = () => handle.complete();
+    });
+
+    const { ipcMain, ipcRenderer } = wire();
+    registerIpcMainTransport({ ipcMain, router });
+    const transport = createIpcRendererTransport(
+      createPreloadBridge(ipcRenderer),
+    );
+
+    const seen: unknown[] = [];
+    let completed = false;
+    transport.subscribe("counter", undefined, {
+      next: (v) => seen.push(v),
+      error: () => {},
+      complete: () => {
+        completed = true;
+      },
+    });
+
+    // Wait for subscribe round-trip to land.
+    await new Promise((r) => setTimeout(r, 0));
+
+    ctl.pushNext?.(1);
+    ctl.pushNext?.(2);
+    ctl.pushComplete?.();
+
+    expect(seen).toEqual([1, 2]);
+    expect(completed).toBe(true);
+  });
+
+  test("should tear down subscriptions when WebContents is destroyed", async () => {
+    const router = new Router();
+    let tornDown = false;
+    router.subscription("hot", (_args, _handle) => {
+      return () => {
+        tornDown = true;
+      };
+    });
+
+    const { ipcMain, ipcRenderer, reload } = wire();
+    registerIpcMainTransport({ ipcMain, router });
+    const transport = createIpcRendererTransport(
+      createPreloadBridge(ipcRenderer),
+    );
+
+    let completedFromHost = false;
+    transport.subscribe("hot", undefined, {
+      next: () => {},
+      error: () => {},
+      complete: () => {
+        completedFromHost = true;
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    reload();
+    // Teardown ran on main side (host complete pushed but renderer is gone).
+    expect(tornDown).toBe(true);
+    // The renderer observer never sees `complete` because the WebContents
+    // is destroyed before the event is sent — that's the actual behavior
+    // we want under reload.
+    expect(completedFromHost).toBe(false);
+  });
+
+  test("should support caller-driven unsubscribe", async () => {
+    const router = new Router();
+    let tornDown = false;
+    router.subscription("hot", (_args, _handle) => {
+      return () => {
+        tornDown = true;
+      };
+    });
+
+    const { ipcMain, ipcRenderer } = wire();
+    registerIpcMainTransport({ ipcMain, router });
+    const transport = createIpcRendererTransport(
+      createPreloadBridge(ipcRenderer),
+    );
+
+    const sub = transport.subscribe("hot", undefined, {
+      next: () => {},
+      error: () => {},
+      complete: () => {},
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    sub.close();
+    // Allow unsubscribe round-trip.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(tornDown).toBe(true);
+  });
+});

--- a/packages/transport/src/ipc/main.ts
+++ b/packages/transport/src/ipc/main.ts
@@ -1,0 +1,191 @@
+/**
+ * Electron main-side IPC adapter. Registers handlers on `ipcMain` for the
+ * three request channels and pushes subscription events back to the
+ * renderer via the `dashframe:rpc:event` channel.
+ *
+ * Single subscription registry per main process. Subscriptions are keyed
+ * by their server-assigned `subId` AND associated with the originating
+ * `WebContents` — when a renderer reloads or a window closes the
+ * registry tears down everything tied to that target. This is the
+ * subscription-cleanup-on-renderer-reload guarantee called out in the AC.
+ *
+ * Phase 1 leaves out: per-frame backpressure, queue draining for offline
+ * renderers, retry. The renderer is in-process and the IPC channel is
+ * effectively reliable; deferring is fine until the WS adapter ships and
+ * those concerns become real.
+ */
+import type { IpcMain, WebContents } from "electron";
+
+import type {
+  RpcError,
+  RpcRequest,
+  RpcResponse,
+  RpcSubscribeRequest,
+  RpcSubscriptionEvent,
+} from "@dashframe/types";
+// Imported types: `RpcRequest` for the type guard return; `RpcSubscribeRequest`
+// for the narrowed subscribe arg; the rest are wire-frame shapes used in
+// handler signatures.
+
+import { toTransportError } from "../errors";
+import type { Router, SubscriptionHandle } from "../router";
+import { IPC_CHANNELS } from "./channels";
+
+interface RegisteredSub {
+  handle: SubscriptionHandle;
+  webContents: WebContents;
+}
+
+export interface IpcMainTransportOptions {
+  ipcMain: IpcMain;
+  router: Router;
+  /** Source tag forwarded into router context. Defaults to `"ipc"`. */
+  source?: string;
+}
+
+export interface IpcMainTransport {
+  /** Tear down: removes all `ipcMain` listeners and closes live subs. */
+  dispose(): void;
+}
+
+export function registerIpcMainTransport(
+  options: IpcMainTransportOptions,
+): IpcMainTransport {
+  const { ipcMain, router } = options;
+  const source = options.source ?? "ipc";
+
+  const subs = new Map<string, RegisteredSub>();
+  let nextSubId = 0;
+
+  function makeSubId(): string {
+    return `ipc_${nextSubId++}`;
+  }
+
+  function clearSubsForContents(wc: WebContents): void {
+    for (const [id, sub] of subs) {
+      if (sub.webContents === wc) {
+        sub.handle.complete();
+        subs.delete(id);
+      }
+    }
+  }
+
+  function pushEvent(wc: WebContents, payload: RpcSubscriptionEvent): void {
+    if (wc.isDestroyed()) return;
+    wc.send(IPC_CHANNELS.event, payload);
+  }
+
+  // --- invoke ---
+  const invokeHandler = async (
+    _event: Electron.IpcMainInvokeEvent,
+    raw: unknown,
+  ): Promise<RpcResponse> => {
+    if (!isRpcRequest(raw)) {
+      const fallbackId =
+        typeof (raw as { id?: unknown })?.id === "string"
+          ? (raw as { id: string }).id
+          : "<unknown>";
+      return malformed(fallbackId, "invalid invoke request");
+    }
+    const req = raw;
+    try {
+      const data = await router.dispatch(req.path, req.args, { source });
+      return { id: req.id, ok: true, data };
+    } catch (err) {
+      return {
+        id: req.id,
+        ok: false,
+        error: toTransportError(err),
+      };
+    }
+  };
+  ipcMain.handle(IPC_CHANNELS.invoke, invokeHandler);
+
+  // --- subscribe ---
+  const subscribeHandler = async (
+    event: Electron.IpcMainInvokeEvent,
+    raw: unknown,
+  ): Promise<RpcResponse> => {
+    if (!isRpcRequest(raw)) {
+      const fallbackId =
+        typeof (raw as { id?: unknown })?.id === "string"
+          ? (raw as { id: string }).id
+          : "<unknown>";
+      return malformed(fallbackId, "invalid subscribe request");
+    }
+    const req: RpcSubscribeRequest = raw;
+    const wc = event.sender;
+    const subId = makeSubId();
+    const handle = router.open(
+      req.path,
+      req.args,
+      { source },
+      {
+        next: (data) => pushEvent(wc, { subId, kind: "next", data }),
+        error: (error) => {
+          subs.delete(subId);
+          pushEvent(wc, { subId, kind: "error", error });
+        },
+        complete: () => {
+          subs.delete(subId);
+          pushEvent(wc, { subId, kind: "complete" });
+        },
+      },
+      subId,
+    );
+    if (handle.closed) {
+      // Setup synchronously failed — the failure was already pushed via
+      // the error observer; respond with the assigned id so the renderer
+      // can correlate any observer events that fired before the resolve.
+      return { id: req.id, ok: true, data: { subId } };
+    }
+    subs.set(subId, { handle, webContents: wc });
+    // Track per-WebContents teardown once. `destroyed` covers reloads
+    // (the old WebContents is destroyed before the new one mounts) AND
+    // window-close.
+    wc.once("destroyed", () => clearSubsForContents(wc));
+    return { id: req.id, ok: true, data: { subId } };
+  };
+  ipcMain.handle(IPC_CHANNELS.subscribe, subscribeHandler);
+
+  // --- unsubscribe ---
+  const unsubscribeHandler = (
+    _event: Electron.IpcMainInvokeEvent,
+    raw: unknown,
+  ): RpcResponse => {
+    const payload = raw as { id?: unknown; subId?: unknown } | null;
+    if (typeof payload?.id !== "string" || typeof payload?.subId !== "string") {
+      const fallbackId =
+        typeof payload?.id === "string" ? payload.id : "<unknown>";
+      return malformed(fallbackId, "invalid unsubscribe");
+    }
+    const sub = subs.get(payload.subId);
+    if (sub) {
+      subs.delete(payload.subId);
+      sub.handle.complete();
+    }
+    return { id: payload.id, ok: true, data: null };
+  };
+  ipcMain.handle(IPC_CHANNELS.unsubscribe, unsubscribeHandler);
+
+  return {
+    dispose() {
+      ipcMain.removeHandler(IPC_CHANNELS.invoke);
+      ipcMain.removeHandler(IPC_CHANNELS.subscribe);
+      ipcMain.removeHandler(IPC_CHANNELS.unsubscribe);
+      for (const [, sub] of subs) sub.handle.complete();
+      subs.clear();
+    },
+  };
+}
+
+function isRpcRequest(req: unknown): req is RpcRequest {
+  if (typeof req !== "object" || req === null) return false;
+  const r = req as Record<string, unknown>;
+  return typeof r.id === "string" && typeof r.path === "string";
+}
+
+function malformed(id: string, message: string): RpcResponse {
+  const error: RpcError = { code: "transport", message };
+  return { id, ok: false, error };
+}

--- a/packages/transport/src/ipc/preload.ts
+++ b/packages/transport/src/ipc/preload.ts
@@ -1,0 +1,58 @@
+/**
+ * Preload-side IPC adapter. Runs in Electron's isolated preload context
+ * (CJS, sandbox-friendly) and exposes a `Transport` over `contextBridge`.
+ *
+ * The preload script wraps this in `contextBridge.exposeInMainWorld(...)`.
+ * The renderer never touches `ipcRenderer` directly — it only sees the
+ * `Transport` shape exposed here.
+ *
+ * Important: `contextBridge` clones what you pass through it, so the
+ * Transport object exposed must be plain functions and primitive return
+ * values. Subscription `Subscription` handles are reconstructed renderer-
+ * side because their methods would otherwise be detached from preload
+ * state. We expose a pair of low-level primitives (`invoke`, `subscribe`,
+ * `unsubscribe`, `onEvent`) and let the renderer assemble them into a
+ * `Transport` via `createIpcRendererTransport`.
+ */
+import type { IpcRenderer } from "electron";
+
+import type {
+  RpcRequest,
+  RpcResponse,
+  RpcSubscribeRequest,
+  RpcSubscriptionEvent,
+} from "@dashframe/types";
+
+import { IPC_CHANNELS } from "./channels";
+
+export interface PreloadIpcBridge {
+  invoke(req: RpcRequest): Promise<RpcResponse>;
+  subscribe(req: RpcSubscribeRequest): Promise<RpcResponse>;
+  unsubscribe(payload: { id: string; subId: string }): Promise<RpcResponse>;
+  /**
+   * Subscribe to subscription event pushes. Returns a teardown function.
+   * Renderer-side fans these out by `subId` to the registered observers.
+   */
+  onEvent(listener: (event: RpcSubscriptionEvent) => void): () => void;
+}
+
+export function createPreloadBridge(
+  ipcRenderer: IpcRenderer,
+): PreloadIpcBridge {
+  return {
+    invoke: (req) => ipcRenderer.invoke(IPC_CHANNELS.invoke, req),
+    subscribe: (req) => ipcRenderer.invoke(IPC_CHANNELS.subscribe, req),
+    unsubscribe: (payload) =>
+      ipcRenderer.invoke(IPC_CHANNELS.unsubscribe, payload),
+    onEvent(listener) {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: RpcSubscriptionEvent,
+      ) => listener(payload);
+      ipcRenderer.on(IPC_CHANNELS.event, handler);
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.event, handler);
+      };
+    },
+  };
+}

--- a/packages/transport/src/ipc/renderer.ts
+++ b/packages/transport/src/ipc/renderer.ts
@@ -1,0 +1,130 @@
+/**
+ * Renderer-side `Transport` built on the preload bridge. Owns request-id
+ * generation and per-subscription observer fanout.
+ *
+ * The renderer assembles its own ids for invoke calls so it can correlate
+ * pending promises if the bridge ever moves to a fire-and-forget model.
+ * Today `bridge.invoke` already round-trips via `ipcRenderer.invoke` (which
+ * is itself a request/response), but keeping ids end-to-end makes logs
+ * traceable across the boundary.
+ */
+import type { RpcSubscriptionEvent } from "@dashframe/types";
+
+import { TransportError } from "../errors";
+import type {
+  Subscription,
+  SubscriptionObserver,
+  Transport,
+} from "../transport";
+import type { PreloadIpcBridge } from "./preload";
+
+export function createIpcRendererTransport(
+  bridge: PreloadIpcBridge,
+): Transport {
+  let nextReqId = 0;
+  const newReqId = () => `req_${nextReqId++}`;
+
+  // Active subscriptions, keyed by the server-assigned subId. Populated
+  // when subscribe() resolves; entries are removed when the host emits
+  // `error` / `complete` OR the caller calls `close()`.
+  const subs = new Map<string, SubscriptionObserver>();
+
+  bridge.onEvent((event: RpcSubscriptionEvent) => {
+    const observer = subs.get(event.subId);
+    if (!observer) return;
+    if (event.kind === "next") {
+      observer.next(event.data);
+      return;
+    }
+    if (event.kind === "error") {
+      subs.delete(event.subId);
+      observer.error(event.error);
+      return;
+    }
+    // complete
+    subs.delete(event.subId);
+    observer.complete();
+  });
+
+  return {
+    async invoke(path, args) {
+      const id = newReqId();
+      const res = await bridge.invoke({ id, path, args });
+      if (!res.ok) throw new TransportError(res.error);
+      return res.data;
+    },
+
+    subscribe(path, args, observer) {
+      const reqId = newReqId();
+      let subId: string | null = null;
+      let closed = false;
+
+      // Future-proofing note: under the WS adapter the `subscribed` ack and
+      // the first `next` may race. Today over IPC the subscribe call is a
+      // synchronous round-trip so events can't precede the resolve, and the
+      // proxy observer below is sufficient. If/when the WS adapter ships,
+      // add an event buffer here gated on `subId === null`.
+      const proxyObserver: SubscriptionObserver = {
+        next: (data) => observer.next(data),
+        error: (err) => {
+          if (closed) return;
+          closed = true;
+          observer.error(err);
+        },
+        complete: () => {
+          if (closed) return;
+          closed = true;
+          observer.complete();
+        },
+      };
+
+      bridge
+        .subscribe({ id: reqId, path, args })
+        .then((res) => {
+          if (!res.ok) {
+            proxyObserver.error(res.error);
+            return;
+          }
+          const data = res.data as { subId?: unknown };
+          if (typeof data?.subId !== "string") {
+            proxyObserver.error({
+              code: "transport",
+              message: "subscribe response missing subId",
+            });
+            return;
+          }
+          subId = data.subId;
+          if (closed) {
+            // Caller closed before we got the id — fire-and-forget the
+            // unsubscribe so the host can release.
+            bridge.unsubscribe({ id: newReqId(), subId }).catch(() => {});
+            return;
+          }
+          subs.set(subId, proxyObserver);
+        })
+        .catch((err: unknown) => {
+          proxyObserver.error({
+            code: "transport",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        });
+
+      return {
+        get id() {
+          return subId ?? reqId;
+        },
+        get closed() {
+          return closed;
+        },
+        close() {
+          if (closed) return;
+          closed = true;
+          if (subId !== null) {
+            subs.delete(subId);
+            bridge.unsubscribe({ id: newReqId(), subId }).catch(() => {});
+          }
+        },
+      } satisfies Subscription;
+    },
+  };
+}

--- a/packages/transport/src/loopback.test.ts
+++ b/packages/transport/src/loopback.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+
+import { TransportError } from "./errors";
+import { createLoopbackTransport, LoopbackTransport } from "./loopback";
+import { Router } from "./router";
+
+// Router.open defers handler setup via Promise.resolve().then(...) so
+// callbacks fire on the microtask queue. Two ticks lets the handler run
+// AND the returned teardown be wired up.
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("LoopbackTransport.invoke", () => {
+  test("should round-trip handler value", async () => {
+    const router = new Router();
+    router.invoke("project.info", () => ({ name: "demo" }));
+    const t = createLoopbackTransport(router);
+    expect(await t.invoke("project.info")).toEqual({ name: "demo" });
+  });
+
+  test("should reject with TransportError on handler failure", async () => {
+    const router = new Router();
+    router.invoke("fail", () => {
+      throw new Error("nope");
+    });
+    const t = new LoopbackTransport(router);
+    let caught: TransportError | undefined;
+    try {
+      await t.invoke("fail");
+    } catch (err) {
+      caught = err as TransportError;
+    }
+    expect(caught).toBeInstanceOf(TransportError);
+    expect(caught?.code).toBe("internal");
+    expect(caught?.message).toBe("nope");
+  });
+
+  test("should reject with not_found for unknown path", async () => {
+    const router = new Router();
+    const t = new LoopbackTransport(router);
+    await expect(t.invoke("nope")).rejects.toMatchObject({
+      code: "not_found",
+    });
+  });
+
+  test("should expose loopback as the source tag", async () => {
+    const router = new Router();
+    router.invoke("src", (_args, ctx) => ctx.source);
+    const t = new LoopbackTransport(router);
+    expect(await t.invoke("src")).toBe("loopback");
+  });
+});
+
+describe("LoopbackTransport.subscribe", () => {
+  test("should deliver next/complete events from handler", async () => {
+    const router = new Router();
+    router.subscription("counter", (_args, handle) => {
+      handle.next(1);
+      handle.next(2);
+      handle.complete();
+    });
+    const t = new LoopbackTransport(router);
+
+    const received: unknown[] = [];
+    let completed = false;
+    let errored: unknown = null;
+    const sub = t.subscribe("counter", undefined, {
+      next: (v) => received.push(v),
+      error: (e) => {
+        errored = e;
+      },
+      complete: () => {
+        completed = true;
+      },
+    });
+    // Allow the router's microtask boundary to flush.
+    await flush();
+    expect(received).toEqual([1, 2]);
+    expect(completed).toBe(true);
+    expect(errored).toBeNull();
+    expect(sub.closed).toBe(true);
+  });
+
+  test("should run teardown when caller closes the subscription", async () => {
+    const router = new Router();
+    let tornDown = false;
+    router.subscription("hot", (_args, _handle) => {
+      return () => {
+        tornDown = true;
+      };
+    });
+    const t = new LoopbackTransport(router);
+    const sub = t.subscribe("hot", undefined, {
+      next: () => {},
+      error: () => {},
+      complete: () => {},
+    });
+    await flush();
+    sub.close();
+    expect(tornDown).toBe(true);
+    expect(sub.closed).toBe(true);
+
+    // Idempotent close.
+    sub.close();
+    expect(sub.closed).toBe(true);
+  });
+
+  test("should propagate handler error as RpcError event", async () => {
+    const router = new Router();
+    router.subscription("broken", () => {
+      throw new Error("setup failed");
+    });
+    const t = new LoopbackTransport(router);
+    let received: unknown = null;
+    const sub = t.subscribe("broken", undefined, {
+      next: () => {},
+      error: (e) => {
+        received = e;
+      },
+      complete: () => {},
+    });
+    await flush();
+    expect(received).toMatchObject({
+      code: "internal",
+      message: "setup failed",
+    });
+    expect(sub.closed).toBe(true);
+  });
+
+  test("should drop next() after caller close", async () => {
+    const router = new Router();
+    const ctl: { push?: (v: unknown) => void } = {};
+    router.subscription("manual", (_args, handle) => {
+      ctl.push = (v) => handle.next(v);
+    });
+    const t = new LoopbackTransport(router);
+    const seen: unknown[] = [];
+    const sub = t.subscribe("manual", undefined, {
+      next: (v) => seen.push(v),
+      error: () => {},
+      complete: () => {},
+    });
+    await flush();
+    ctl.push?.("a");
+    sub.close();
+    ctl.push?.("b");
+    expect(seen).toEqual(["a"]);
+  });
+
+  test("should surface not_found via observer.error for unknown sub path", async () => {
+    const router = new Router();
+    const t = new LoopbackTransport(router);
+    let received: unknown = null;
+    const sub = t.subscribe("ghost", undefined, {
+      next: () => {},
+      error: (e) => {
+        received = e;
+      },
+      complete: () => {},
+    });
+    expect(received).toMatchObject({ code: "not_found" });
+    expect(sub.closed).toBe(true);
+  });
+});

--- a/packages/transport/src/loopback.ts
+++ b/packages/transport/src/loopback.ts
@@ -1,0 +1,83 @@
+/**
+ * `LoopbackTransport` — same-process `Transport` that dispatches directly
+ * into a `Router`, with no IPC, no serialization, and no async deferral
+ * beyond what the router itself needs.
+ *
+ * Used by:
+ *   - unit tests that want to exercise handler logic without spinning up
+ *     Electron
+ *   - same-process callers in the future server runtime (e.g. `dashframe
+ *     serve`'s admin tooling reaching into its own router)
+ *
+ * Behaviorally identical to a perfect IPC adapter:
+ *   - `invoke` resolves with the handler's return; rejects with
+ *     `TransportError` on any failure
+ *   - `subscribe` returns a closable `Subscription`, observer receives
+ *     `next` / `error` / `complete`
+ *   - subscription `id`s are monotonically generated so test logs are
+ *     stable
+ */
+import { TransportError } from "./errors";
+import { Router } from "./router";
+import type {
+  Subscription,
+  SubscriptionObserver,
+  Transport,
+} from "./transport";
+
+export interface LoopbackTransportOptions {
+  /** Override the source tag passed to handlers; defaults to `"loopback"`. */
+  source?: string;
+}
+
+export class LoopbackTransport implements Transport {
+  private readonly source: string;
+  private nextId = 0;
+
+  constructor(
+    private readonly router: Router,
+    options: LoopbackTransportOptions = {},
+  ) {
+    this.source = options.source ?? "loopback";
+  }
+
+  async invoke(path: string, args?: unknown): Promise<unknown> {
+    return this.router.dispatch(path, args, { source: this.source });
+  }
+
+  subscribe(
+    path: string,
+    args: unknown,
+    observer: SubscriptionObserver,
+  ): Subscription {
+    const id = `sub_${this.nextId++}`;
+    const handle = this.router.open(
+      path,
+      args,
+      { source: this.source },
+      observer,
+      id,
+    );
+    return {
+      id,
+      get closed() {
+        return handle.closed;
+      },
+      close() {
+        if (handle.closed) return;
+        handle.complete();
+      },
+    };
+  }
+}
+
+export function createLoopbackTransport(
+  router: Router,
+  options?: LoopbackTransportOptions,
+): LoopbackTransport {
+  return new LoopbackTransport(router, options);
+}
+
+// Re-export for convenience: callers using only the loopback rarely need
+// to import the error class from `@dashframe/transport` separately.
+export { TransportError };

--- a/packages/transport/src/router.test.ts
+++ b/packages/transport/src/router.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { TransportError } from "./errors";
+import { Router } from "./router";
+
+describe("Router.dispatch", () => {
+  test("should resolve invoke handler return value", async () => {
+    const router = new Router();
+    router.invoke("ping", () => "pong");
+    const result = await router.dispatch("ping", undefined, {
+      source: "test",
+    });
+    expect(result).toBe("pong");
+  });
+
+  test("should pass args + ctx through to handler", async () => {
+    const router = new Router();
+    router.invoke("echo", (args, ctx) => ({ args, source: ctx.source }));
+    const result = await router.dispatch(
+      "echo",
+      { hi: 1 },
+      {
+        source: "loopback",
+      },
+    );
+    expect(result).toEqual({ args: { hi: 1 }, source: "loopback" });
+  });
+
+  test("should throw not_found TransportError for unknown route", async () => {
+    const router = new Router();
+    let caught: unknown;
+    try {
+      await router.dispatch("missing", undefined, { source: "test" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TransportError);
+    expect((caught as TransportError).code).toBe("not_found");
+  });
+
+  test("should wrap handler exceptions in TransportError(internal)", async () => {
+    const router = new Router();
+    router.invoke("boom", () => {
+      throw new Error("kaboom");
+    });
+    let caught: TransportError | undefined;
+    try {
+      await router.dispatch("boom", undefined, { source: "test" });
+    } catch (err) {
+      caught = err as TransportError;
+    }
+    expect(caught?.code).toBe("internal");
+    expect(caught?.message).toBe("kaboom");
+  });
+
+  test("should preserve TransportError code from handler", async () => {
+    const router = new Router();
+    router.invoke("badargs", () => {
+      throw new TransportError({
+        code: "validation",
+        message: "missing field",
+        details: { field: "name" },
+      });
+    });
+    let caught: TransportError | undefined;
+    try {
+      await router.dispatch("badargs", undefined, { source: "test" });
+    } catch (err) {
+      caught = err as TransportError;
+    }
+    expect(caught?.code).toBe("validation");
+    expect(caught?.details).toEqual({ field: "name" });
+  });
+
+  test("should reject duplicate invoke registration", () => {
+    const router = new Router();
+    router.invoke("dup", () => 1);
+    expect(() => router.invoke("dup", () => 2)).toThrow(/already registered/);
+  });
+
+  test("should reject calling subscription via dispatch", async () => {
+    const router = new Router();
+    router.subscription("stream", () => {});
+    let caught: TransportError | undefined;
+    try {
+      await router.dispatch("stream", undefined, { source: "test" });
+    } catch (err) {
+      caught = err as TransportError;
+    }
+    expect(caught?.code).toBe("transport");
+  });
+});

--- a/packages/transport/src/router.ts
+++ b/packages/transport/src/router.ts
@@ -1,0 +1,242 @@
+/**
+ * `Router` is the host-side handler registry. Adapters dispatch into a
+ * single shared router so a project can register a handler once and have
+ * it reachable from every adapter (loopback for tests, IPC for renderer,
+ * future WS for `dashframe serve`).
+ *
+ * Phase 1 keeps the registry deliberately thin: a path → handler map plus
+ * structured-error normalization. It does NOT implement WyStack-style
+ * read-set tracking or invalidation-driven re-runs. When the WyStack
+ * server transport ships (Phase 2), the router will delegate to
+ * `app.call()` and forward `tablesRead` / `tablesWritten` upstream.
+ *
+ * Subscription model:
+ *   - `subscribe(path, args, ctx, observer)` returns a `SubscriptionHandle`
+ *     with `.close()` for caller-driven teardown
+ *   - the handler's first responsibility is to push an initial `next`;
+ *     the router does NOT auto-invoke the matching `query` handler today
+ *     — host code (or, in the future, `@wystack/server`) decides when to
+ *     emit `next` and when to emit `error`/`complete`
+ *   - this keeps the router agnostic to whether subscriptions are reactive
+ *     (WyStack) or one-shot push (e.g. progress events for an import)
+ */
+import type { RpcError } from "@dashframe/types";
+
+import { toTransportError, TransportError } from "./errors";
+
+export interface RouterContext {
+  /**
+   * Stable identifier for the calling adapter — `"loopback"` for in-memory
+   * dispatch, `"ipc"` for Electron IPC, `"ws"` once the WS adapter lands.
+   * Handlers can use this to log, gate dev-only paths, or refuse certain
+   * calls from untrusted sources.
+   */
+  source: string;
+}
+
+export type RouterHandler = (
+  args: unknown,
+  ctx: RouterContext,
+) => unknown | Promise<unknown>;
+
+export interface SubscriptionHandle {
+  readonly id: string;
+  /** Push the next value to the observer. No-op once closed. */
+  next(data: unknown): void;
+  /**
+   * Terminal failure. The observer receives `error`, the handle is marked
+   * closed, and the host should release any underlying resources.
+   */
+  fail(error: RpcError): void;
+  /**
+   * Graceful teardown initiated by the host (e.g. project closing).
+   * Observer receives `complete`; further `next` calls are dropped.
+   */
+  complete(): void;
+  readonly closed: boolean;
+}
+
+export interface SubscriptionHandler {
+  /**
+   * Set up the subscription. Returns a teardown function the router calls
+   * when the caller (or host) closes the sub. The handler should push the
+   * initial value via `handle.next()` synchronously or shortly after — the
+   * loopback test harness asserts initial-value delivery.
+   */
+  (
+    args: unknown,
+    handle: SubscriptionHandle,
+    ctx: RouterContext,
+  ): (() => void) | void | Promise<(() => void) | void>;
+}
+
+interface InvokeEntry {
+  kind: "invoke";
+  handler: RouterHandler;
+}
+interface SubscribeEntry {
+  kind: "subscribe";
+  handler: SubscriptionHandler;
+}
+type RouteEntry = InvokeEntry | SubscribeEntry;
+
+export class Router {
+  private readonly routes = new Map<string, RouteEntry>();
+
+  /**
+   * Register a one-shot handler (query or mutation). Path collisions throw
+   * loudly — silent overwrite would mask wiring bugs.
+   */
+  invoke(path: string, handler: RouterHandler): this {
+    this.assertFree(path);
+    this.routes.set(path, { kind: "invoke", handler });
+    return this;
+  }
+
+  /**
+   * Register a subscription handler. See `SubscriptionHandler` for the
+   * expected lifecycle.
+   */
+  subscription(path: string, handler: SubscriptionHandler): this {
+    this.assertFree(path);
+    this.routes.set(path, { kind: "subscribe", handler });
+    return this;
+  }
+
+  has(path: string): boolean {
+    return this.routes.has(path);
+  }
+
+  /**
+   * Execute an invoke handler. Throws `TransportError` on any failure path:
+   * unknown route, wrong route kind (caller used invoke on a sub), or
+   * handler exception. Adapters are expected to translate these into the
+   * wire envelope (`RpcResponse` with `ok:false`).
+   */
+  async dispatch(
+    path: string,
+    args: unknown,
+    ctx: RouterContext,
+  ): Promise<unknown> {
+    const entry = this.routes.get(path);
+    if (!entry) {
+      throw new TransportError({
+        code: "not_found",
+        message: `Unknown route: ${path}`,
+      });
+    }
+    if (entry.kind !== "invoke") {
+      throw new TransportError({
+        code: "transport",
+        message: `Route ${path} is a subscription — use subscribe()`,
+      });
+    }
+    try {
+      return await entry.handler(args, ctx);
+    } catch (err) {
+      throw new TransportError(toTransportError(err));
+    }
+  }
+
+  /**
+   * Open a subscription. The router owns the `SubscriptionHandle` lifecycle
+   * and observer plumbing; the registered handler returns a teardown
+   * function called when the caller closes.
+   *
+   * If the handler throws synchronously OR rejects, the failure is reported
+   * via `observer.error` and the returned handle is already closed. This
+   * matches the contract in `Transport.subscribe`: callers never see raw
+   * throws, only structured `error` events.
+   */
+  open(
+    path: string,
+    args: unknown,
+    ctx: RouterContext,
+    observer: {
+      next: (data: unknown) => void;
+      error: (err: RpcError) => void;
+      complete: () => void;
+    },
+    id: string,
+  ): SubscriptionHandle {
+    const entry = this.routes.get(path);
+    if (!entry || entry.kind !== "subscribe") {
+      const err: RpcError = entry
+        ? {
+            code: "transport",
+            message: `Route ${path} is not a subscription`,
+          }
+        : { code: "not_found", message: `Unknown route: ${path}` };
+      const handle = makeHandle(id, observer, () => {});
+      handle.fail(err);
+      return handle;
+    }
+
+    let teardown: (() => void) | undefined;
+    const handle = makeHandle(id, observer, () => teardown?.());
+
+    Promise.resolve()
+      .then(() => entry.handler(args, handle, ctx))
+      .then((maybeTeardown) => {
+        if (handle.closed) {
+          // Caller already closed before setup completed — run teardown
+          // immediately so handlers don't leak resources started in their
+          // setup body.
+          maybeTeardown?.();
+          return;
+        }
+        teardown = maybeTeardown ?? undefined;
+      })
+      .catch((err: unknown) => {
+        handle.fail(toTransportError(err));
+      });
+
+    return handle;
+  }
+
+  private assertFree(path: string): void {
+    if (this.routes.has(path)) {
+      throw new Error(`Route already registered: ${path}`);
+    }
+  }
+}
+
+function makeHandle(
+  id: string,
+  observer: {
+    next: (data: unknown) => void;
+    error: (err: RpcError) => void;
+    complete: () => void;
+  },
+  releaseResources: () => void,
+): SubscriptionHandle {
+  let closed = false;
+  return {
+    id,
+    get closed() {
+      return closed;
+    },
+    next(data) {
+      if (closed) return;
+      observer.next(data);
+    },
+    fail(error) {
+      if (closed) return;
+      closed = true;
+      try {
+        observer.error(error);
+      } finally {
+        releaseResources();
+      }
+    },
+    complete() {
+      if (closed) return;
+      closed = true;
+      try {
+        observer.complete();
+      } finally {
+        releaseResources();
+      }
+    },
+  };
+}

--- a/packages/transport/src/transport.ts
+++ b/packages/transport/src/transport.ts
@@ -1,0 +1,54 @@
+/**
+ * The `Transport` is the single contract every adapter implements. Two
+ * methods, both async-friendly, both returning structured errors at the
+ * boundary rather than throwing transport-internal failures.
+ *
+ * `invoke` covers both queries and mutations — Phase 1 does not distinguish
+ * at the wire layer (the router knows the difference). Server-driven push
+ * is layered on top via `subscribe`, which returns a `Subscription` handle
+ * the caller is responsible for closing.
+ *
+ * Subscription lifecycle is intentionally caller-driven (no automatic
+ * cleanup on host teardown beyond the `complete` event). A renderer that
+ * navigates away should `close()` its subs; reload events drop the underlying
+ * IPC socket and the main process clears the registry.
+ */
+import type { RpcError } from "@dashframe/types";
+
+export interface SubscriptionObserver {
+  next: (data: unknown) => void;
+  error: (error: RpcError) => void;
+  complete: () => void;
+}
+
+export interface Subscription {
+  /** Server-assigned id; useful for logging and test assertions. */
+  readonly id: string;
+  /** Tear down. Idempotent — second call is a no-op. */
+  close(): void;
+  /** Whether `close()` has run (or the host sent `complete`/`error`). */
+  readonly closed: boolean;
+}
+
+export interface Transport {
+  /**
+   * Call a registered handler once. Resolves with the data on success;
+   * rejects with a `TransportError` (carrying a tagged `RpcError`) on
+   * failure. Implementations MUST surface handler errors as
+   * `TransportError`s — never as raw exceptions — so callers have a stable
+   * boundary type.
+   */
+  invoke(path: string, args?: unknown): Promise<unknown>;
+
+  /**
+   * Open a subscription. The observer's `next` is called for the initial
+   * value AND every subsequent invalidation (Phase 1: re-runs are host-
+   * driven; today no host pushes invalidations, but the contract is in
+   * place). `error` is terminal; `complete` is sent on host-side teardown.
+   */
+  subscribe(
+    path: string,
+    args: unknown,
+    observer: SubscriptionObserver,
+  ): Subscription;
+}

--- a/packages/transport/tsconfig.json
+++ b/packages/transport/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true,
+    "types": ["node", "bun"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@dashframe/types",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "bun test",
+    "check": "bun run typecheck && bun run lint && bun run test"
+  },
+  "devDependencies": {
+    "@dashframe/eslint-config": "workspace:*",
+    "@types/bun": "^1.2.0",
+    "typescript": "5.7.2"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @dashframe/types — wire-shape contracts shared across the desktop process
+ * boundary (main, preload, renderer) and the future `dashframe serve` web
+ * client.
+ *
+ * Keep this package zero-dependency and runtime-free: every consumer (Node,
+ * Electron preload sandbox, browser) must be able to import these types
+ * without dragging in heavy modules.
+ */
+
+export { isRpcError } from "./rpc";
+export type {
+  RpcError,
+  RpcErrorCode,
+  RpcRequest,
+  RpcResponse,
+  RpcSubscribeRequest,
+  RpcSubscriptionEvent,
+} from "./rpc";
+
+export type { ProjectInfo } from "./project";

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -1,0 +1,16 @@
+/**
+ * Wire shape of `project.info` — the metadata snapshot a client needs to
+ * render the shell. Mirrors `ProjectHandle` from `@dashframe/server-core`
+ * but flattens dates to ISO strings so the payload survives JSON transport
+ * (Electron IPC, future WS) without bespoke revivers.
+ */
+export interface ProjectInfo {
+  dir: string;
+  dbPath: string;
+  dataSourcesDir: string;
+  projectId: string;
+  name: string;
+  schemaVersion: number;
+  createdAt: string;
+  createdBy: string;
+}

--- a/packages/types/src/rpc.test.ts
+++ b/packages/types/src/rpc.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { isRpcError } from "./rpc";
+
+describe("isRpcError", () => {
+  test("should accept a well-formed error", () => {
+    expect(isRpcError({ code: "validation", message: "missing field" })).toBe(
+      true,
+    );
+  });
+
+  test("should reject objects missing required keys", () => {
+    expect(isRpcError({ code: "validation" })).toBe(false);
+    expect(isRpcError({ message: "x" })).toBe(false);
+  });
+
+  test("should reject non-objects", () => {
+    expect(isRpcError(null)).toBe(false);
+    expect(isRpcError("error")).toBe(false);
+    expect(isRpcError(undefined)).toBe(false);
+  });
+});

--- a/packages/types/src/rpc.ts
+++ b/packages/types/src/rpc.ts
@@ -1,0 +1,74 @@
+/**
+ * RPC wire envelope for the DashFrame transport.
+ *
+ * Errors are tagged at the transport boundary using a small fixed vocabulary.
+ * The codes intentionally match the categories called out in the v0.2
+ * architecture (see CLAUDE.md): `connection | sql | validation | transport`.
+ * `not_found` and `internal` are added because the transport itself needs
+ * them — a missing handler is not a SQL/validation failure.
+ *
+ * Wire format is JSON. v0.2 ships JSON frames only; Arrow IPC is deferred.
+ */
+
+export type RpcErrorCode =
+  | "connection"
+  | "sql"
+  | "validation"
+  | "transport"
+  | "not_found"
+  | "internal";
+
+export interface RpcError {
+  code: RpcErrorCode;
+  message: string;
+  /**
+   * Optional structured detail. Validation errors typically carry a list of
+   * field issues here; SQL errors may carry the offending statement. Kept
+   * loose because the renderer should treat it as opaque diagnostic data.
+   */
+  details?: unknown;
+}
+
+export function isRpcError(value: unknown): value is RpcError {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.code === "string" && typeof v.message === "string";
+}
+
+/**
+ * Caller → handler request. `id` correlates the response across the IPC
+ * boundary; the in-memory loopback also assigns one for symmetry and
+ * test-debuggability even though direct dispatch doesn't need it.
+ */
+export interface RpcRequest {
+  id: string;
+  path: string;
+  args?: unknown;
+}
+
+export type RpcResponse =
+  | { id: string; ok: true; data: unknown }
+  | { id: string; ok: false; error: RpcError };
+
+/**
+ * Subscription request. The handler is invoked once for the initial value,
+ * then re-invoked on every `invalidate` event the host pushes back. Phase 1
+ * leaves invalidation triggering up to whatever sits behind the transport
+ * (today: nothing; later: WyStack's table-watch reactivity).
+ */
+export interface RpcSubscribeRequest {
+  id: string;
+  path: string;
+  args?: unknown;
+}
+
+/**
+ * Server → client push frame for an active subscription. `next` carries a
+ * fresh result; `error` carries a terminal failure (the subscription is
+ * considered closed once an error frame is delivered); `complete` is sent
+ * by the host when it tears the subscription down (e.g. project closed).
+ */
+export type RpcSubscriptionEvent =
+  | { subId: string; kind: "next"; data: unknown }
+  | { subId: string; kind: "error"; error: RpcError }
+  | { subId: string; kind: "complete" };

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Implements TASK-548. Introduces a single RPC surface for the desktop process boundary, replacing the one-off `dashframe:project:info` ipcMain channel. Future channels grow on the router (one-liner per route) instead of accumulating bespoke `ipcMain.handle` calls in `main.ts`.

## Summary
- New package `@dashframe/types` — zero-dep wire-shape contracts (`RpcRequest`/`Response`, `RpcError` tagged with `connection|sql|validation|transport|not_found|internal`, `ProjectInfo`). Renderer + preload + main share these (resolves PR #30 Greptile P2 about preload-only types being unreachable).
- New package `@dashframe/transport` — `Transport` interface, `Router`, `LoopbackTransport`, and Electron IPC adapter split into subpath exports (`@dashframe/transport/ipc/main`, `/preload`, `/renderer`).
- Migration: `main.ts` registers `project.info` against the router via `registerIpcMainTransport`; renderer assembles a typed `Transport` once in `apps/renderer/src/transport.ts` and the index route exercises `transport.invoke('project.info')` end-to-end.

## Architecture notes
- Adapters dispatch into a shared `Router`. `LoopbackTransport` gives unit tests direct same-process dispatch with no IPC.
- The IPC adapter uses one namespaced channel set (`dashframe:rpc:invoke / subscribe / unsubscribe / event`), per-request id correlation, and per-`WebContents` subscription teardown on `destroyed` so renderer reload cleans up automatically.
- WyStack submodule was NOT touched — Phase 1 doesn't need to refactor `@wystack/client` to accept an injected transport. The contract here is DashFrame-local; integrating `@wystack/client.useWyQuery` over this transport is a Phase 2 concern (will require splitting `createClient` upstream).

## Tests
21 across 3 files (`bun test --filter @dashframe/transport` + `--filter @dashframe/types`):
- `Router`: invoke success/failure, `not_found`, code passthrough, duplicate-route guard, kind mismatch
- `LoopbackTransport`: invoke round-trip, subscribe `next`/`complete`/`error`, caller-driven teardown, post-close drop, unknown route via observer
- IPC integration: full path through a fake `ipcMain`/`ipcRenderer` pair (avoids spinning Electron in vitest), `WebContents.destroyed` teardown, caller unsubscribe

`bun check` clean across all DashFrame packages and the WyStack submodule (38 tasks). Pre-existing `@stdui/react` "no test files" failure is unrelated to this PR (unchanged stdui submodule).

## Manual verification
1. `bun run dev` (orchestrates Vite + Electron)
2. The renderer's index route now renders `project.info` (name / dir / projectId) by calling `transport.invoke('project.info')`
3. From the renderer console: `await window.dashframe.transport.invoke({id:'x',path:'project.info'})` returns the `RpcResponse` directly

Note: per CLAUDE.md, I did not run `bun run dev` myself — the user runs their own dev environment.

## Decisions / divergences from brief
- **`window.dashframe.project.getInfo()` no longer exists.** The brief's verification step referenced it; replaced with `transport.invoke('project.info')` (see manual verification above). The renderer route does this for you on load.
- **Two new packages, not one.** `@dashframe/types` is split out from `@dashframe/transport` because the wire types (`ProjectInfo`, `RpcError`) need to be importable by the preload sandbox without bringing in the `electron` dev-dep that `@dashframe/transport` carries for its main/renderer subpaths.
- **Subscription contract is in Phase 1.** The brief said Phase 1 is invoke-focused, but the transport interface includes `subscribe` and the IPC adapter implements it with proper teardown — locking the shape now is much cheaper than retrofitting later. No production code uses subscriptions yet; tests do.
- **Router does not auto-invoke for subscriptions.** Today subscription handlers push values directly via `handle.next()`. When this layer integrates with `@wystack/server`'s reactive engine (Phase 2), `app.call` will replace the manual push and `tablesRead` will drive invalidation. Documented in `router.ts`.

## Punted to follow-ups
- WebSocket adapter for `dashframe serve` (Phase 2 ticket)
- WyStack-side transport injection so `@wystack/client.useWyQuery` works over this transport
- Subscription backpressure / queue draining
- Retry/backoff at the IPC layer
- AbortSignal-driven cancellation through subscription handlers
- Pre-existing concern (NOT introduced here): `apps/desktop/dist/main.js` is built with `--packages=external`, which keeps workspace `@dashframe/*` imports as bare specifiers; Electron's Node 20 runtime can't load `src/index.ts` directly. Same status as `@dashframe/server-core` since `03bef08`. Worth a separate ticket to either bundle workspace deps or add a runtime TS loader.

## Test plan
- [x] `bun check --filter @dashframe/types --filter @dashframe/transport --filter @dashframe/desktop --filter @dashframe/renderer` passes
- [x] `bun check` (full) passes for all DashFrame packages
- [ ] Manual: `bun run dev`, observe project info rendered in the renderer
- [ ] Manual: hit Cmd-R to reload the renderer, confirm no leaked subscriptions in main logs (Phase 1 has no live subs registered yet, but the teardown path is exercised by tests)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Introduces two new packages (`@dashframe/types`, `@dashframe/transport`) and migrates `main.ts` from bespoke `ipcMain.handle` calls to a shared `Router` + IPC adapter, with `LoopbackTransport` for in-process tests. The architecture is solid and the test suite is thorough.

- **P1 — listener leak in `packages/transport/src/ipc/main.ts`:** `wc.once(\"destroyed\", ...)` is registered on every `subscribeHandler` invocation without deduplication. The `unsubscribeHandler` removes the entry from `subs` but does not remove the listener, so long-lived windows accumulate stale `once` listeners and trigger `MaxListenersExceededWarning` after 10 open-close cycles. See inline comment for a `Set<WebContents>` guard fix.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the `wc.once` listener accumulation; P2s are non-blocking.

One P1 (listener leak in the subscribe path) sets the ceiling at 4. The rest of the implementation is well-structured with solid tests. The P1 has a clear fix and doesn't affect correctness of Phase 1 (no production subscriptions yet), but will manifest as warnings as soon as subscription usage scales.

packages/transport/src/ipc/main.ts — `wc.once` deduplication; apps/desktop/src/main.ts — capture `dispose()` handle.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/transport/src/ipc/main.ts | IPC main adapter: core logic is sound, but `wc.once("destroyed", ...)` is registered per-subscription rather than per-WebContents, causing listener accumulation and MaxListenersExceededWarning in long-lived windows. |
| packages/transport/src/router.ts | Router implementation is clean: dispatch/open separation, structured error normalization, duplicate-route guard, and safe async teardown on close-before-setup. No issues found. |
| packages/transport/src/ipc/renderer.ts | Renderer transport correctly handles subscribe race (close-before-ack), proxies observer lifecycle, and cleans up `subs` map on close/error/complete. No issues found. |
| packages/types/src/rpc.ts | Wire envelope types and `isRpcError` guard — guard accepts any string as `code` instead of validating against the `RpcErrorCode` union, allowing untrusted payloads with unknown codes to pass through. |
| apps/desktop/src/main.ts | Migrates to Router + IPC adapter cleanly, but discards the `IpcMainTransport` return value, making `dispose()` unreachable and preventing explicit cleanup on app quit. |
| packages/transport/src/loopback.ts | LoopbackTransport correctly delegates to Router; invoke rejects with TransportError, subscribe mirrors the IPC observer contract. No issues. |
| packages/transport/src/ipc/preload.ts | Preload bridge exposes only serializable primitives through contextBridge; onEvent teardown pattern is correct. No issues. |
| packages/transport/src/ipc/ipc.test.ts | Integration test suite covers invoke, error surfacing, subscription events, WebContents-destroyed teardown, and caller-driven unsubscribe without spinning up Electron. Well-structured. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Renderer (React)
    participant RT as IpcRendererTransport
    participant PB as PreloadBridge (contextBridge)
    participant IM as IpcMain Adapter
    participant RO as Router
    participant H as Handler

    Note over R,H: invoke flow
    R->>RT: transport.invoke("project.info")
    RT->>PB: bridge.invoke({id, path, args})
    PB->>IM: ipcRenderer.invoke("dashframe:rpc:invoke", req)
    IM->>RO: router.dispatch(path, args, ctx)
    RO->>H: handler(args, ctx)
    H-->>RO: ProjectInfo
    RO-->>IM: data
    IM-->>PB: RpcResponse {ok:true, data}
    PB-->>RT: RpcResponse
    RT-->>R: data (or throws TransportError)

    Note over R,H: subscribe flow
    R->>RT: transport.subscribe("stream", args, observer)
    RT->>PB: bridge.subscribe({id, path, args})
    PB->>IM: ipcRenderer.invoke("dashframe:rpc:subscribe", req)
    IM->>RO: router.open(path, args, ctx, observer, subId)
    RO->>H: handler(args, handle, ctx)
    H-->>RO: teardown fn
    IM-->>PB: RpcResponse {ok:true, data:{subId}}
    PB-->>RT: subId registered

    Note over IM,R: host pushes events
    H->>IM: handle.next(data)
    IM->>PB: wc.send("dashframe:rpc:event", {subId, kind:"next", data})
    PB->>RT: onEvent listener fires
    RT->>R: observer.next(data)

    Note over R,IM: caller unsubscribes
    R->>RT: sub.close()
    RT->>PB: bridge.unsubscribe({id, subId})
    PB->>IM: ipcRenderer.invoke("dashframe:rpc:unsubscribe")
    IM->>RO: handle.complete() → teardown()
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Ftransport%2Fsrc%2Fipc%2Fmain.ts%3A142-146%0A**%60destroyed%60%20listener%20accumulates%20across%20subscription%20lifetimes**%0A%0AA%20new%20%60once%28%22destroyed%22%2C%20...%29%60%20listener%20is%20registered%20on%20%60wc%60%20every%20time%20a%20subscription%20is%20opened%2C%20but%20the%20%60unsubscribeHandler%60%20%28lines%20162%E2%80%93168%29%20only%20calls%20%60subs.delete%60%20%2B%20%60handle.complete%60%20%E2%80%94%20it%20never%20removes%20the%20listener.%20In%20a%20long-lived%20window%20that%20opens%20and%20closes%20many%20subscriptions%2C%20stale%20%60once%60%20listeners%20pile%20up%20on%20the%20%60WebContents%60%20EventEmitter.%20Node.js%20emits%20%60MaxListenersExceededWarning%60%20after%2010.%20The%20comment%20above%20reads%20%22Track%20per-WebContents%20teardown%20once%22%20but%20the%20implementation%20registers%20once-per-subscription%2C%20not%20once-per-WebContents.%0A%0AThe%20fix%20is%20to%20guard%20the%20registration%20with%20a%20%60Set%3CWebContents%3E%60%20so%20only%20the%20first%20subscription%20from%20a%20given%20%60wc%60%20adds%20the%20listener%3A%0A%0A%60%60%60typescript%0A%2F%2F%20Add%20before%20%60subscribeHandler%60%3A%0Aconst%20watchedContents%20%3D%20new%20Set%3CWebContents%3E%28%29%3B%0A%0A%2F%2F%20Replace%20the%20unconditional%20wc.once%28...%29%20at%20line%20146%20with%3A%0Aif%20%28!watchedContents.has%28wc%29%29%20%7B%0A%20%20watchedContents.add%28wc%29%3B%0A%20%20wc.once%28%22destroyed%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20watchedContents.delete%28wc%29%3B%0A%20%20%20%20clearSubsForContents%28wc%29%3B%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0AAlso%20clear%20%60watchedContents%60%20in%20%60dispose%28%29%60%20to%20avoid%20any%20stale%20references%20when%20the%20transport%20is%20torn%20down.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A68%0A**%60dispose%28%29%60%20is%20unreachable%20%E2%80%94%20return%20value%20discarded**%0A%0A%60registerIpcMainTransport%60%20returns%20an%20%60IpcMainTransport%60%20with%20a%20%60dispose%28%29%60%20method%20that%20removes%20all%20%60ipcMain%60%20handlers%20and%20closes%20live%20subs%2C%20but%20the%20return%20value%20is%20never%20captured.%20If%20the%20main%20process%20wants%20to%20cleanly%20shut%20down%20the%20transport%20%28e.g.%20on%20%60app.before-quit%60%29%2C%20there%20is%20no%20way%20to%20call%20%60dispose%28%29%60.%0A%0A%60%60%60suggestion%0Aconst%20ipcTransport%20%3D%20registerIpcMainTransport%28%7B%20ipcMain%2C%20router%20%7D%29%3B%0A%60%60%60%0A%0AThen%20wire%20it%20up%3A%0A%60%60%60typescript%0Aapp.on%28%22before-quit%22%2C%20%28%29%20%3D%3E%20ipcTransport.dispose%28%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Ftypes%2Fsrc%2Frpc.ts%3A42-46%0A**%60isRpcError%60%20accepts%20any%20%60code%60%20string%2C%20not%20just%20%60RpcErrorCode%60%20values**%0A%0AThe%20guard%20validates%20%60typeof%20v.code%20%3D%3D%3D%20%22string%22%60%2C%20so%20%60%7B%20code%3A%20%22anything%22%2C%20message%3A%20%22x%22%20%7D%60%20passes%20the%20predicate%20and%20is%20type-narrowed%20to%20%60RpcError%60.%20Any%20untrusted%20wire%20payload%20with%20an%20unrecognized%20code%20string%20silently%20passes%20through%20to%20callers%20that%20switch%20on%20%60RpcErrorCode%60.%20Adding%20a%20membership%20check%20keeps%20the%20guard%20tight%20and%20consistent%20with%20the%20tagged-union%20intent%3A%0A%0A%60%60%60suggestion%0Aconst%20VALID_CODES%20%3D%20new%20Set%3Cstring%3E%28%5B%0A%20%20%22connection%22%2C%20%22sql%22%2C%20%22validation%22%2C%20%22transport%22%2C%20%22not_found%22%2C%20%22internal%22%2C%0A%5D%29%3B%0Aexport%20function%20isRpcError%28value%3A%20unknown%29%3A%20value%20is%20RpcError%20%7B%0A%20%20if%20%28typeof%20value%20!%3D%3D%20%22object%22%20%7C%7C%20value%20%3D%3D%3D%20null%29%20return%20false%3B%0A%20%20const%20v%20%3D%20value%20as%20Record%3Cstring%2C%20unknown%3E%3B%0A%20%20return%20%28%0A%20%20%20%20typeof%20v.code%20%3D%3D%3D%20%22string%22%20%26%26%0A%20%20%20%20VALID_CODES.has%28v.code%29%20%26%26%0A%20%20%20%20typeof%20v.message%20%3D%3D%3D%20%22string%22%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22feat%2Fv0.2-transport-phase1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fv0.2-transport-phase1%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Ftransport%2Fsrc%2Fipc%2Fmain.ts%3A142-146%0A**%60destroyed%60%20listener%20accumulates%20across%20subscription%20lifetimes**%0A%0AA%20new%20%60once%28%22destroyed%22%2C%20...%29%60%20listener%20is%20registered%20on%20%60wc%60%20every%20time%20a%20subscription%20is%20opened%2C%20but%20the%20%60unsubscribeHandler%60%20%28lines%20162%E2%80%93168%29%20only%20calls%20%60subs.delete%60%20%2B%20%60handle.complete%60%20%E2%80%94%20it%20never%20removes%20the%20listener.%20In%20a%20long-lived%20window%20that%20opens%20and%20closes%20many%20subscriptions%2C%20stale%20%60once%60%20listeners%20pile%20up%20on%20the%20%60WebContents%60%20EventEmitter.%20Node.js%20emits%20%60MaxListenersExceededWarning%60%20after%2010.%20The%20comment%20above%20reads%20%22Track%20per-WebContents%20teardown%20once%22%20but%20the%20implementation%20registers%20once-per-subscription%2C%20not%20once-per-WebContents.%0A%0AThe%20fix%20is%20to%20guard%20the%20registration%20with%20a%20%60Set%3CWebContents%3E%60%20so%20only%20the%20first%20subscription%20from%20a%20given%20%60wc%60%20adds%20the%20listener%3A%0A%0A%60%60%60typescript%0A%2F%2F%20Add%20before%20%60subscribeHandler%60%3A%0Aconst%20watchedContents%20%3D%20new%20Set%3CWebContents%3E%28%29%3B%0A%0A%2F%2F%20Replace%20the%20unconditional%20wc.once%28...%29%20at%20line%20146%20with%3A%0Aif%20%28!watchedContents.has%28wc%29%29%20%7B%0A%20%20watchedContents.add%28wc%29%3B%0A%20%20wc.once%28%22destroyed%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20watchedContents.delete%28wc%29%3B%0A%20%20%20%20clearSubsForContents%28wc%29%3B%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0AAlso%20clear%20%60watchedContents%60%20in%20%60dispose%28%29%60%20to%20avoid%20any%20stale%20references%20when%20the%20transport%20is%20torn%20down.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A68%0A**%60dispose%28%29%60%20is%20unreachable%20%E2%80%94%20return%20value%20discarded**%0A%0A%60registerIpcMainTransport%60%20returns%20an%20%60IpcMainTransport%60%20with%20a%20%60dispose%28%29%60%20method%20that%20removes%20all%20%60ipcMain%60%20handlers%20and%20closes%20live%20subs%2C%20but%20the%20return%20value%20is%20never%20captured.%20If%20the%20main%20process%20wants%20to%20cleanly%20shut%20down%20the%20transport%20%28e.g.%20on%20%60app.before-quit%60%29%2C%20there%20is%20no%20way%20to%20call%20%60dispose%28%29%60.%0A%0A%60%60%60suggestion%0Aconst%20ipcTransport%20%3D%20registerIpcMainTransport%28%7B%20ipcMain%2C%20router%20%7D%29%3B%0A%60%60%60%0A%0AThen%20wire%20it%20up%3A%0A%60%60%60typescript%0Aapp.on%28%22before-quit%22%2C%20%28%29%20%3D%3E%20ipcTransport.dispose%28%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Ftypes%2Fsrc%2Frpc.ts%3A42-46%0A**%60isRpcError%60%20accepts%20any%20%60code%60%20string%2C%20not%20just%20%60RpcErrorCode%60%20values**%0A%0AThe%20guard%20validates%20%60typeof%20v.code%20%3D%3D%3D%20%22string%22%60%2C%20so%20%60%7B%20code%3A%20%22anything%22%2C%20message%3A%20%22x%22%20%7D%60%20passes%20the%20predicate%20and%20is%20type-narrowed%20to%20%60RpcError%60.%20Any%20untrusted%20wire%20payload%20with%20an%20unrecognized%20code%20string%20silently%20passes%20through%20to%20callers%20that%20switch%20on%20%60RpcErrorCode%60.%20Adding%20a%20membership%20check%20keeps%20the%20guard%20tight%20and%20consistent%20with%20the%20tagged-union%20intent%3A%0A%0A%60%60%60suggestion%0Aconst%20VALID_CODES%20%3D%20new%20Set%3Cstring%3E%28%5B%0A%20%20%22connection%22%2C%20%22sql%22%2C%20%22validation%22%2C%20%22transport%22%2C%20%22not_found%22%2C%20%22internal%22%2C%0A%5D%29%3B%0Aexport%20function%20isRpcError%28value%3A%20unknown%29%3A%20value%20is%20RpcError%20%7B%0A%20%20if%20%28typeof%20value%20!%3D%3D%20%22object%22%20%7C%7C%20value%20%3D%3D%3D%20null%29%20return%20false%3B%0A%20%20const%20v%20%3D%20value%20as%20Record%3Cstring%2C%20unknown%3E%3B%0A%20%20return%20%28%0A%20%20%20%20typeof%20v.code%20%3D%3D%3D%20%22string%22%20%26%26%0A%20%20%20%20VALID_CODES.has%28v.code%29%20%26%26%0A%20%20%20%20typeof%20v.message%20%3D%3D%3D%20%22string%22%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Ftransport%2Fsrc%2Fipc%2Fmain.ts%3A142-146%0A**%60destroyed%60%20listener%20accumulates%20across%20subscription%20lifetimes**%0A%0AA%20new%20%60once%28%22destroyed%22%2C%20...%29%60%20listener%20is%20registered%20on%20%60wc%60%20every%20time%20a%20subscription%20is%20opened%2C%20but%20the%20%60unsubscribeHandler%60%20%28lines%20162%E2%80%93168%29%20only%20calls%20%60subs.delete%60%20%2B%20%60handle.complete%60%20%E2%80%94%20it%20never%20removes%20the%20listener.%20In%20a%20long-lived%20window%20that%20opens%20and%20closes%20many%20subscriptions%2C%20stale%20%60once%60%20listeners%20pile%20up%20on%20the%20%60WebContents%60%20EventEmitter.%20Node.js%20emits%20%60MaxListenersExceededWarning%60%20after%2010.%20The%20comment%20above%20reads%20%22Track%20per-WebContents%20teardown%20once%22%20but%20the%20implementation%20registers%20once-per-subscription%2C%20not%20once-per-WebContents.%0A%0AThe%20fix%20is%20to%20guard%20the%20registration%20with%20a%20%60Set%3CWebContents%3E%60%20so%20only%20the%20first%20subscription%20from%20a%20given%20%60wc%60%20adds%20the%20listener%3A%0A%0A%60%60%60typescript%0A%2F%2F%20Add%20before%20%60subscribeHandler%60%3A%0Aconst%20watchedContents%20%3D%20new%20Set%3CWebContents%3E%28%29%3B%0A%0A%2F%2F%20Replace%20the%20unconditional%20wc.once%28...%29%20at%20line%20146%20with%3A%0Aif%20%28!watchedContents.has%28wc%29%29%20%7B%0A%20%20watchedContents.add%28wc%29%3B%0A%20%20wc.once%28%22destroyed%22%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20watchedContents.delete%28wc%29%3B%0A%20%20%20%20clearSubsForContents%28wc%29%3B%0A%20%20%7D%29%3B%0A%7D%0A%60%60%60%0A%0AAlso%20clear%20%60watchedContents%60%20in%20%60dispose%28%29%60%20to%20avoid%20any%20stale%20references%20when%20the%20transport%20is%20torn%20down.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A68%0A**%60dispose%28%29%60%20is%20unreachable%20%E2%80%94%20return%20value%20discarded**%0A%0A%60registerIpcMainTransport%60%20returns%20an%20%60IpcMainTransport%60%20with%20a%20%60dispose%28%29%60%20method%20that%20removes%20all%20%60ipcMain%60%20handlers%20and%20closes%20live%20subs%2C%20but%20the%20return%20value%20is%20never%20captured.%20If%20the%20main%20process%20wants%20to%20cleanly%20shut%20down%20the%20transport%20%28e.g.%20on%20%60app.before-quit%60%29%2C%20there%20is%20no%20way%20to%20call%20%60dispose%28%29%60.%0A%0A%60%60%60suggestion%0Aconst%20ipcTransport%20%3D%20registerIpcMainTransport%28%7B%20ipcMain%2C%20router%20%7D%29%3B%0A%60%60%60%0A%0AThen%20wire%20it%20up%3A%0A%60%60%60typescript%0Aapp.on%28%22before-quit%22%2C%20%28%29%20%3D%3E%20ipcTransport.dispose%28%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Ftypes%2Fsrc%2Frpc.ts%3A42-46%0A**%60isRpcError%60%20accepts%20any%20%60code%60%20string%2C%20not%20just%20%60RpcErrorCode%60%20values**%0A%0AThe%20guard%20validates%20%60typeof%20v.code%20%3D%3D%3D%20%22string%22%60%2C%20so%20%60%7B%20code%3A%20%22anything%22%2C%20message%3A%20%22x%22%20%7D%60%20passes%20the%20predicate%20and%20is%20type-narrowed%20to%20%60RpcError%60.%20Any%20untrusted%20wire%20payload%20with%20an%20unrecognized%20code%20string%20silently%20passes%20through%20to%20callers%20that%20switch%20on%20%60RpcErrorCode%60.%20Adding%20a%20membership%20check%20keeps%20the%20guard%20tight%20and%20consistent%20with%20the%20tagged-union%20intent%3A%0A%0A%60%60%60suggestion%0Aconst%20VALID_CODES%20%3D%20new%20Set%3Cstring%3E%28%5B%0A%20%20%22connection%22%2C%20%22sql%22%2C%20%22validation%22%2C%20%22transport%22%2C%20%22not_found%22%2C%20%22internal%22%2C%0A%5D%29%3B%0Aexport%20function%20isRpcError%28value%3A%20unknown%29%3A%20value%20is%20RpcError%20%7B%0A%20%20if%20%28typeof%20value%20!%3D%3D%20%22object%22%20%7C%7C%20value%20%3D%3D%3D%20null%29%20return%20false%3B%0A%20%20const%20v%20%3D%20value%20as%20Record%3Cstring%2C%20unknown%3E%3B%0A%20%20return%20%28%0A%20%20%20%20typeof%20v.code%20%3D%3D%3D%20%22string%22%20%26%26%0A%20%20%20%20VALID_CODES.has%28v.code%29%20%26%26%0A%20%20%20%20typeof%20v.message%20%3D%3D%3D%20%22string%22%0A%20%20%29%3B%0A%7D%0A%60%60%60%0A%0A&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/transport/src/ipc/main.ts
Line: 142-146

Comment:
**`destroyed` listener accumulates across subscription lifetimes**

A new `once("destroyed", ...)` listener is registered on `wc` every time a subscription is opened, but the `unsubscribeHandler` (lines 162–168) only calls `subs.delete` + `handle.complete` — it never removes the listener. In a long-lived window that opens and closes many subscriptions, stale `once` listeners pile up on the `WebContents` EventEmitter. Node.js emits `MaxListenersExceededWarning` after 10. The comment above reads "Track per-WebContents teardown once" but the implementation registers once-per-subscription, not once-per-WebContents.

The fix is to guard the registration with a `Set<WebContents>` so only the first subscription from a given `wc` adds the listener:

```typescript
// Add before `subscribeHandler`:
const watchedContents = new Set<WebContents>();

// Replace the unconditional wc.once(...) at line 146 with:
if (!watchedContents.has(wc)) {
  watchedContents.add(wc);
  wc.once("destroyed", () => {
    watchedContents.delete(wc);
    clearSubsForContents(wc);
  });
}
```

Also clear `watchedContents` in `dispose()` to avoid any stale references when the transport is torn down.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main.ts
Line: 68

Comment:
**`dispose()` is unreachable — return value discarded**

`registerIpcMainTransport` returns an `IpcMainTransport` with a `dispose()` method that removes all `ipcMain` handlers and closes live subs, but the return value is never captured. If the main process wants to cleanly shut down the transport (e.g. on `app.before-quit`), there is no way to call `dispose()`.

```suggestion
const ipcTransport = registerIpcMainTransport({ ipcMain, router });
```

Then wire it up:
```typescript
app.on("before-quit", () => ipcTransport.dispose());
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/types/src/rpc.ts
Line: 42-46

Comment:
**`isRpcError` accepts any `code` string, not just `RpcErrorCode` values**

The guard validates `typeof v.code === "string"`, so `{ code: "anything", message: "x" }` passes the predicate and is type-narrowed to `RpcError`. Any untrusted wire payload with an unrecognized code string silently passes through to callers that switch on `RpcErrorCode`. Adding a membership check keeps the guard tight and consistent with the tagged-union intent:

```suggestion
const VALID_CODES = new Set<string>([
  "connection", "sql", "validation", "transport", "not_found", "internal",
]);
export function isRpcError(value: unknown): value is RpcError {
  if (typeof value !== "object" || value === null) return false;
  const v = value as Record<string, unknown>;
  return (
    typeof v.code === "string" &&
    VALID_CODES.has(v.code) &&
    typeof v.message === "string"
  );
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(v0.2): WyStack transport Phase 1 — ..."](https://github.com/youhaowei/dashframe/commit/077fb12ab47f4bed69190210e4e8b5145ab7172a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29718002)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->