### PR TITLE
fix: address PR #38 review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,32 +153,10 @@ DashFrame supports importing data directly from Notion databases:
 
 ## License
 
-DashFrame is MIT licensed.
+DashFrame is licensed under [AGPL-3.0-only](./LICENSE).
 
-You are welcome to:
+You are free to use, modify, and distribute DashFrame under the terms of the
+GNU Affero General Public License v3.0. Any modified version you deploy over a
+network must also be made available under AGPL-3.0.
 
-- use it locally or in production,
-- view and modify the code,
-- fork and redistribute it,
-- and build commercial or open-source products with it.
-
-The only requirement is to include the copyright notice and MIT license
-in copies or substantial portions of the software. See the full text in
-the [`LICENSE`](./LICENSE) file.
-
-### FAQ
-
-**Can I run DashFrame locally for my personal projects or learning?**  
-Yes — the MIT License permits personal and educational use.
-
-**Can I use DashFrame at my company or in commercial products?**  
-Yes — commercial use is allowed under the MIT License.
-
-**Can I host DashFrame or offer it as SaaS?**  
-Yes. You can host, resell, or integrate it, provided you keep the MIT license and copyright notice and comply with any third-party API terms.
-
-**Can I fork the project?**  
-Yes. MIT allows forking and redistribution as long as the license and copyright notice remain.
-
-**Do I need to attribute DashFrame?**  
-MIT requires preserving the copyright notice and license. Additional attribution is appreciated but not required.
+See the full text in the [`LICENSE`](./LICENSE) file.

--- a/e2e/web/lib/test-fixtures.ts
+++ b/e2e/web/lib/test-fixtures.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(__dirname, "..", "fixtures");
-const isCI = process.env.CI === "true";
+const isCI = !!process.env.CI;
 const BASE_PORT = Number(process.env.E2E_BASE_PORT ?? 3100);
 
 /**

--- a/e2e/web/support/port-finder.ts
+++ b/e2e/web/support/port-finder.ts
@@ -1,24 +1,6 @@
 import * as net from "net";
 
 /**
- * Finds an available port starting from the given port number.
- * In CI, returns the start port without checking.
- *
- * @param startPort - Port number to start searching from (default: 3100)
- * @returns Available port number
- */
-export async function findAvailablePort(
-  startPort: number = 3100,
-): Promise<number> {
-  if (process.env.CI) return startPort;
-
-  for (let port = startPort; port < startPort + 20; port++) {
-    if (await isPortFree(port)) return port;
-  }
-  return startPort;
-}
-
-/**
  * Find a base port such that [base, base+count) are all free.
  * Used by the local E2E config to reserve one port per worker without
  * collision-by-assumption (P2 finding from PR #34 review).


### PR DESCRIPTION
## Summary
Follow-up from code review of PR #38 (3/3 desktop bootstrap).

- **README license**: corrected from MIT to AGPL-3.0-only (matches package.json)
- **E2E isCI**: unified to `!!process.env.CI` across playwright.config.ts and test-fixtures.ts
- **Dead code**: removed unused `findAvailablePort` export from port-finder.ts

## Test plan
- [ ] `bun check` green
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This follow-up PR addresses three findings from the PR #38 review: a license mismatch in the README, an inconsistent `isCI` check in the E2E fixtures, and dead code in the port-finder module.

- **README.md**: Replaces the incorrect MIT license description with the correct AGPL-3.0-only text, including the network-copyleft clause, matching `package.json`.
- **e2e/web/lib/test-fixtures.ts**: Changes `process.env.CI === \"true\"` to `!!process.env.CI`, making it consistent with `playwright.config.ts` and correctly detecting CI environments that set `CI=1` (GitHub Actions, GitLab CI, etc.).
- **e2e/web/support/port-finder.ts**: Removes the now-unused `findAvailablePort` export; the only remaining export `findAvailablePortBlock` is consumed by `playwright.config.ts`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All three changes are narrow, targeted corrections with no new logic introduced; safe to merge.

The README change fixes a factual error. The isCI change is a one-line boolean coercion that now matches the identical pattern already in playwright.config.ts, and the removed findAvailablePort function had no callers in the repo. No new behaviour is introduced and no existing logic is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | License section corrected from MIT to AGPL-3.0-only, matching package.json; old permissive FAQ removed and replaced with a brief AGPL network-copyleft notice |
| e2e/web/lib/test-fixtures.ts | isCI changed from `=== "true"` to `!!process.env.CI`, aligning with playwright.config.ts and correctly handling standard CI environments that set CI=1 |
| e2e/web/support/port-finder.ts | Removed unused `findAvailablePort` export; only `findAvailablePortBlock` (consumed by playwright.config.ts) remains |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["process.env.CI"] -->|"before: === 'true'"| B["test-fixtures.ts isCI\n(missed CI=1, CI=yes)"]
    A -->|"after: !!process.env.CI"| C["test-fixtures.ts isCI\n(matches playwright.config.ts)"]
    D["playwright.config.ts\n!!process.env.CI"] -.->|"now consistent"| C

    E["port-finder.ts"] -->|"removed"| F["findAvailablePort (unused)"]
    E -->|"kept"| G["findAvailablePortBlock\n(used by playwright.config.ts)"]

    H["README.md"] -->|"corrected"| I["AGPL-3.0-only\n(matches package.json)"]
    H -->|"removed"| J["MIT license FAQ\n(was incorrect)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address PR #38 review findings"](https://github.com/youhaowei/dashframe/commit/a7de5302fae2f84cdfe94653b3cbeb516499aeea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31842142)</sub>

<!-- /greptile_comment -->