### PR TITLE
Migrate web to Vite + TanStack Router; add portless dev flow

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -4,3 +4,8 @@ name = "DashFrame"
 
 [setup]
 script = "bun install"
+
+[[actions]]
+name = "Preview Web"
+icon = "run"
+command = "bun run --cwd apps/web dev"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **This project uses Bun** as the package manager and runtime. Use `bun` instead of `npm`, `yarn`, or `pnpm`.
 
-| Task           | Command                             |
-| -------------- | ----------------------------------- |
-| Validate all   | `bun check`                         |
-| Run unit tests | `bun run test`                      |
-| Run E2E tests  | `cd e2e/web && bun run test:e2e`    |
-| Filter package | `bun check --filter @dashframe/web` |
-| Storybook      | `bun storybook`                     |
+| Task            | Command                             |
+| --------------- | ----------------------------------- |
+| Validate all    | `bun check`                         |
+| Run unit tests  | `bun run test`                      |
+| Run E2E tests   | `cd e2e/web && bun run test:e2e`    |
+| Run desktop app | `bun run dev:desktop`               |
+| Filter package  | `bun check --filter @dashframe/web` |
+| Storybook       | `bun storybook`                     |
 
 **⚠️ NEVER run `bun build` or `bun dev` unless explicitly requested.** User manages their own dev environment.
 
@@ -41,7 +42,7 @@ bun check --filter @dashframe/web  # Target specific package
 - **Functional utilities**: For data conversion and transformation or utilities, prefer pure functions over classes for simplicity and testability.
 - **OOP Design**: Use classes and inheritance when make sense for entities with behavior, for encapsulation and code organization.
 - **Entity hierarchy**: DataSource → Insight → DataFrame → Visualization
-- **tRPC for APIs**: Server-side proxy to avoid CORS issues
+- **tRPC for APIs**: Server-side proxy to avoid CORS issues (web app only — the desktop app uses Electron IPC)
 
 ### Backend Plugin System
 
@@ -58,7 +59,7 @@ NEXT_PUBLIC_STORAGE_IMPL=custom
 **How it works**:
 
 1. `@dashframe/core/backend.ts` exports from stub package `@dashframe/core-store`
-2. Webpack aliases `@dashframe/core-store` → `@dashframe/core-${NEXT_PUBLIC_STORAGE_IMPL}`
+2. Vite aliases `@dashframe/core-store` → `@dashframe/core-${NEXT_PUBLIC_STORAGE_IMPL}` (configured in `apps/web/vite.config.ts`)
 3. TypeScript resolves `@dashframe/core-store` as a normal workspace package (no path aliases needed)
 4. Only the selected backend is bundled; unused backends are tree-shaken away
 
@@ -80,6 +81,24 @@ See `docs/backend-architecture.md` for full details on creating custom backends.
 3. Extend `apps/web/lib/stores/` (types + actions)
 4. Update the data sources UI components in `apps/web/components/data-sources/`
 
+## Desktop App (Electron)
+
+The desktop app is the primary surface (v0.2 reboot). Three-process model:
+
+- **Main** (`apps/desktop/src/main.ts`) — Node.js process. Owns the filesystem and project DB lifecycle via `@dashframe/server-core`. Registers `ipcMain` handlers.
+- **Preload** (`apps/desktop/src/preload.ts`) — context-isolated bridge. Exposes a narrow `window.dashframe` API; no direct DB or filesystem access.
+- **Renderer** (`apps/renderer/`) — React + Vite + TanStack Router UI. No Node.js access; reaches the main process only through `window.dashframe`.
+
+**IPC contract**: `@dashframe/desktop-types` defines the `DashFrameApi` interface shared by preload and renderer. Add a new IPC call there first, then implement it in both `main.ts` (handler) and `preload.ts` (bridge).
+
+**Boundary rule**: `contextIsolation: true`, `nodeIntegration: false`. The renderer **cannot** import `@dashframe/server-core` — it is bundled into the main process only.
+
+**Project storage**: `server-core` uses PGLite + Drizzle. `openProject()` initializes the artifact DB at `~/.DashFrame/<name>/artifacts.db`.
+
+**Dev**: `bun run dev:desktop` runs `apps/desktop/scripts/dev.mjs` — builds `server-core`, bundles main + preload (esbuild), starts the renderer Vite server, then launches Electron with `DEV_URL`.
+
+**Build**: esbuild — `main.ts` → ESM, `preload.ts` → CJS.
+
 ## tRPC for External APIs
 
 **Why**: External APIs (like Notion) block direct browser requests with CORS.
@@ -93,22 +112,33 @@ See `docs/backend-architecture.md` for full details on creating custom backends.
 ## Monorepo Structure
 
 ```
-apps/web/                  # Next.js 16 (App Router)
+apps/
+  desktop/                 # Electron main + preload (project lifecycle, IPC, windowing)
+  renderer/                # Electron renderer UI — React + Vite + TanStack Router
+  server/                  # Headless CLI stub (`dashframe serve`, v0.2 — not yet implemented)
+  web/                     # Standalone web SPA — Vite + TanStack Router
 libs/
   stdui/                   # Git submodule → github.com/youhaowei/stdui.git
                            # Design system: primitives, tokens, theme provider
 packages/
   types/                   # Pure type contracts (zero deps)
-  core/                    # Backend selector (env-based)
-  core-dexie/              # Dexie/IndexedDB backend
-  engine/                  # Abstract engine interfaces
-  engine-browser/          # DuckDB-WASM + IndexedDB
-  connector-csv/           # CSV file connector
+  core/                    # Backend selector (env-aliased)
+  core-store/              # Stub package for backend type resolution
+  core-dexie/              # Dexie/IndexedDB backend (default)
+  server-core/             # Project + artifact DB lifecycle (PGLite + Drizzle)
+  desktop-types/           # IPC contract shared by preload + renderer
+  engine/                  # Abstract query engine interfaces
+  engine-browser/          # DuckDB-WASM + IndexedDB engine
   connector-notion/        # Notion API connector
+  connector-local/         # Local file connector
+  csv/                     # CSV connector
+  json/                    # JSON → Arrow transform
   visualization/           # Vega-Lite chart rendering
-  ui/                      # DashFrame-specific components only (VirtualTable,
+  ui/                      # DashFrame-specific components (VirtualTable,
                            #   SortableList, Breadcrumb, ItemSelector, chart-icons)
                            # Includes Storybook for component development
+  transport/               # Reserved (empty) — future renderer↔server transport
+  app/                     # Reserved (empty)
   eslint-config/           # Shared ESLint 9 flat config
 ```
 
@@ -166,17 +196,9 @@ If any submodule has uncommitted changes, commit and push them first (step 1 abo
 import { useDataSources, useDataSourceMutations } from "@dashframe/core";
 ```
 
-This keeps components backend-agnostic. The backend implementation is selected via `NEXT_PUBLIC_DATA_BACKEND` env var.
+This keeps components backend-agnostic. The backend implementation is selected via the `NEXT_PUBLIC_STORAGE_IMPL` env var.
 
 ## Critical Gotchas
-
-### Vega-Lite SSR
-
-**Must** dynamically import VegaChart with `ssr: false` - Vega-Lite uses Set objects that can't be serialized during Next.js SSR.
-
-```typescript
-const VegaChart = dynamic(() => import("./VegaChart"), { ssr: false });
-```
 
 ### Naming Conventions
 
@@ -205,8 +227,8 @@ All tRPC endpoints calling external APIs use rate limiting. Use `rateLimitedProc
 ### When Modifying Packages
 
 1. Make changes in `packages/*/src/`
-2. TypeScript watch mode auto-compiles (if `bun dev` running)
-3. Next.js hot reload picks up changes immediately
+2. TypeScript watch mode auto-compiles (if a dev server is running)
+3. Vite HMR picks up changes immediately
 4. No manual rebuild needed
 
 ### When Adding Features
@@ -278,8 +300,8 @@ vi.mock("@dashframe/core", () => ({
   useInsightMutations: () => ({ create: vi.fn() }),
 }));
 
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
 }));
 ```
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,6 +71,7 @@
     "baseline-browser-mapping": "^2.9.0",
     "jsdom": "^26.1.0",
     "postcss": "8.5.6",
+    "portless": "0.13.0",
     "tailwindcss": "4.1.16",
     "tw-animate-css": "^1.4.0",
     "type-fest": "5.1.0",
@@ -83,7 +84,8 @@
   "scripts": {
     "build": "vite build",
     "clean": "rm -rf dist *.tsbuildinfo",
-    "dev": "vite",
+    "dev": "portless",
+    "dev:direct": "vite --host 127.0.0.1",
     "lint": "bunx eslint .",
     "preview": "vite preview",
     "start": "vite preview",

--- a/apps/web/portless.json
+++ b/apps/web/portless.json
@@ -1,0 +1,4 @@
+{
+  "name": "dashframe",
+  "script": "dev:direct"
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -135,7 +135,9 @@ export default defineConfig(({ mode }) => {
       "process.env.PORT": JSON.stringify(env.PORT ?? "3000"),
     },
     server: {
-      port: 3000,
+      // Honor PORT when set (portless injects it; Claude Preview sets it
+      // too). Falls back to 3000 for a plain `vite` invocation.
+      port: Number(env.PORT) || 3000,
       strictPort: false,
     },
     build: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -103,6 +103,17 @@ export default defineConfig(({ mode }) => {
   const env = { ...process.env, ...loadEnv(mode, __dirname, "") };
   const storageImpl = env.NEXT_PUBLIC_STORAGE_IMPL || "dexie";
 
+  // Resolve PORT once: portless injects it, Claude Preview sets it too.
+  // Validate to a usable TCP port (1–65535) so the dev server config and
+  // the client-injected `process.env.PORT` never disagree — a raw `"0"`,
+  // non-numeric, or out-of-range value would otherwise leave them split.
+  // Falls back to 3000 for a plain `vite` invocation.
+  const rawPort = Number(env.PORT);
+  const port =
+    Number.isInteger(rawPort) && rawPort >= 1 && rawPort <= 65535
+      ? rawPort
+      : 3000;
+
   return {
     plugins: [
       tanstackRouter({
@@ -132,12 +143,10 @@ export default defineConfig(({ mode }) => {
         env.NEXT_PUBLIC_POSTHOG_HOST ?? "",
       ),
       "process.env.NEXT_PUBLIC_STORAGE_IMPL": JSON.stringify(storageImpl),
-      "process.env.PORT": JSON.stringify(env.PORT ?? "3000"),
+      "process.env.PORT": JSON.stringify(String(port)),
     },
     server: {
-      // Honor PORT when set (portless injects it; Claude Preview sets it
-      // too). Falls back to 3000 for a plain `vite` invocation.
-      port: Number(env.PORT) || 3000,
+      port,
       strictPort: false,
     },
     build: {

--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,7 @@
         "@vitest/coverage-v8": "^4.0.16",
         "baseline-browser-mapping": "^2.9.0",
         "jsdom": "^26.1.0",
+        "portless": "0.13.0",
         "postcss": "8.5.6",
         "tailwindcss": "4.1.16",
         "tw-animate-css": "^1.4.0",
@@ -2753,6 +2754,8 @@
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "portless": ["portless@0.13.0", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-PxMZ5BHH+ZZi9rTq4T8m003aZxh56qI0aBdNsxLn7jrTtvNJYBWYD3lc5PuQrom/aVh6z8iLb+tKUI6b7QNYQw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/packages/core-store/src/index.ts
+++ b/packages/core-store/src/index.ts
@@ -4,18 +4,18 @@
  * Stub package for storage backend selection.
  *
  * TypeScript sees the type declarations from @dashframe/core-dexie (default backend).
- * Webpack replaces this module at build time based on NEXT_PUBLIC_DATA_BACKEND env var.
+ * Vite replaces this module at build time based on the NEXT_PUBLIC_STORAGE_IMPL env var.
  *
  * @example
  * ```bash
  * # Use Dexie backend (default)
- * NEXT_PUBLIC_DATA_BACKEND=dexie bun dev
+ * NEXT_PUBLIC_STORAGE_IMPL=dexie bun dev
  *
  * # Use custom backend
- * NEXT_PUBLIC_DATA_BACKEND=custom bun dev
+ * NEXT_PUBLIC_STORAGE_IMPL=custom bun dev
  * ```
  */
 
 // Re-export all types and implementations from the default storage backend
-// Webpack will replace this entire module at build time
+// Vite will replace this entire module at build time
 export * from "@dashframe/core-dexie";

--- a/packages/core/src/backend.ts
+++ b/packages/core/src/backend.ts
@@ -5,14 +5,14 @@
  * that gets aliased at build time to the chosen storage implementation.
  *
  * The alias is configured in:
- * - apps/web/next.config.mjs (webpack alias)
+ * - apps/web/vite.config.ts (Vite alias)
  *
- * Storage selection is controlled by NEXT_PUBLIC_DATA_BACKEND env var:
+ * Storage selection is controlled by the NEXT_PUBLIC_STORAGE_IMPL env var:
  * - "dexie" (default) → @dashframe/core-dexie
  * - "custom" → @dashframe/core-custom
  *
  * TypeScript sees hook declarations from @dashframe/core-dexie (via types.d.ts).
- * Webpack replaces the runtime implementation based on the env var.
+ * Vite replaces the runtime implementation based on the env var.
  * Only the selected storage implementation is bundled; others are tree-shaken away.
  */
 


### PR DESCRIPTION
## Summary

Migrates the web app off Next.js and bundles the related dev-flow changes. Despite the branch name, the headline change is the framework migration.

- **Vite + TanStack Router** — replaces Next.js 16 / App Router with Vite 6 and TanStack file-based routing. CSP + COOP/COEP security headers (needed for DuckDB-WASM's `SharedArrayBuffer`) carry across to Vite's dev/preview servers and to static deploys (`_headers`, `_redirects`, `vercel.json`).
- **Portless dev flow** — `bun run dev` now launches via portless (named HTTPS URL, conflict-free port); `dev:direct` (`vite --host 127.0.0.1`) kept as a plain fallback. `portless@0.13.0` pinned.
- **PORT resolution** — `vite.config.ts` resolves `PORT` once with TCP-range validation (1–65535), so `server.port` and the client-injected `process.env.PORT` always agree. `"0"`, non-numeric, and out-of-range values fall back to 3000.
- **Codex preview action** — adds a Preview Web action in `.codex/environments/environment.toml`.
- **Docs** — `CLAUDE.md` and package comments refreshed for Vite/TanStack; new Electron desktop architecture section; corrected monorepo structure and `NEXT_PUBLIC_STORAGE_IMPL`.

## Verification

- `bun check` — 59 turbo tasks pass, 417 web tests pass
- CI green: E2E, CodeQL, Analyze, Lint/Type/Format, Greptile
- `npm view portless version` → 0.13.0

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires in Portless as the default `dev` launcher for the web app, keeping `dev:direct` (`vite --host 127.0.0.1`) as a plain fallback. It also fixes the previous split between the Vite server port and the client-injected `process.env.PORT` by resolving and validating `PORT` once in `vite.config.ts`.

- **portless integration**: `portless.json` config added; `dev` script replaced with `portless`, which injects a free `PORT` and delegates to `dev:direct`; `portless@0.13.0` pinned in devDependencies.
- **PORT validation**: `rawPort` is now validated as an integer in `[1, 65535]`; `NaN`, `0`, empty string, floats, and out-of-range values all fall back to `3000`, keeping `server.port` and the `define` block in agreement.
- **Docs cleanup**: `CLAUDE.md` and package comments updated throughout to replace Next.js/Webpack/old-env-var references with Vite/`NEXT_PUBLIC_STORAGE_IMPL` equivalents; desktop app architecture section added.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to the dev launcher setup, port resolution logic, and documentation updates with no production code path affected.

The port validation correctly handles every edge case (NaN, 0, floats, out-of-range), the portless config is minimal and correct, and the fallback dev:direct script keeps a plain Vite path available. Documentation and comment changes are accurate. No logic visible to production builds is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/vite.config.ts | Adds PORT validation logic (NaN/0/out-of-range all fall back to 3000) and wires the resolved port into both server.port and the client-side define block — the two values now stay in sync |
| apps/web/portless.json | New portless config pointing to the dev:direct script; minimal and correct |
| apps/web/package.json | dev script replaced with portless; dev:direct added as localhost-only Vite fallback; portless pinned at 0.13.0 in devDependencies |
| .codex/environments/environment.toml | Adds a Preview Web action that runs bun run --cwd apps/web dev, which now invokes portless |
| CLAUDE.md | Documentation refresh: Webpack→Vite, Next.js→Vite SPA, adds desktop app section and updated monorepo structure |
| packages/core-store/src/index.ts | Comment-only update replacing Webpack/NEXT_PUBLIC_DATA_BACKEND references with Vite/NEXT_PUBLIC_STORAGE_IMPL |
| packages/core/src/backend.ts | Comment-only update replacing Webpack and old env var references with Vite equivalents |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Portless as portless CLI
    participant Vite as Vite dev server
    participant Browser as Browser

    Dev->>Portless: bun run dev (reads portless.json)
    Portless->>Portless: Allocate free port P
    Portless->>Vite: "Run dev:direct with PORT=P injected"
    Note over Vite: vite.config.ts reads PORT=P<br/>validates 1≤P≤65535<br/>sets server.port=P<br/>defines process.env.PORT="P"
    Vite-->>Portless: Listening on 127.0.0.1:P
    Portless-->>Dev: Tunnel / preview URL
    Browser->>Portless: HTTP request
    Portless->>Vite: Proxy to 127.0.0.1:P

    Note over Dev: Fallback: bun run dev:direct<br/>vite --host 127.0.0.1<br/>(no portless, PORT env optional)
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): resolve PORT once so server an..."](https://github.com/youhaowei/dashframe/commit/7c17e715423f738762ba7ba208a23a787fd7b640) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32741440)</sub>

<!-- /greptile_comment -->
