### PR TITLE
Add desktop transport foundation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@dashframe/desktop-types": "workspace:*",
     "@dashframe/server-core": "workspace:*",
+    "@dashframe/transport": "workspace:*",
     "@electric-sql/pglite": "^0.3.14",
     "electron": "^33.2.1"
   },

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -1,0 +1,80 @@
+import {
+  ARTIFACTS_DB_FILENAME,
+  attachTransportDispatcher,
+  type ProjectHandle,
+} from "@dashframe/server-core";
+import type {
+  ClientTransportMessage,
+  TransportEndpoint,
+  TransportMessage,
+  TransportMessageHandler,
+} from "@dashframe/transport";
+import { BrowserWindow, ipcMain, shell } from "electron";
+import path from "node:path";
+
+function projectInfo(handle: ProjectHandle) {
+  return {
+    projectId: handle.meta.projectId,
+    name: handle.meta.name,
+    version: handle.meta.version,
+    schemaVersion: handle.meta.schemaVersion,
+    createdAt: handle.meta.createdAt.toISOString(),
+    createdBy: handle.meta.createdBy,
+  };
+}
+
+function createDesktopTransportEndpoint(): TransportEndpoint {
+  const handlers = new Set<TransportMessageHandler>();
+
+  ipcMain.handle(
+    "dashframe:transport:send",
+    (_event, message: ClientTransportMessage) => {
+      for (const handler of handlers) {
+        handler(message);
+      }
+    },
+  );
+
+  return {
+    send(message: TransportMessage) {
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send("dashframe:transport:message", message);
+      }
+    },
+    onMessage(handler: TransportMessageHandler) {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+    close() {
+      handlers.clear();
+      ipcMain.removeHandler("dashframe:transport:send");
+    },
+  };
+}
+
+export function registerDesktopIpc(handle: ProjectHandle): void {
+  ipcMain.handle("dashframe:project:info", () => projectInfo(handle));
+  ipcMain.handle("dashframe:project:reveal", () => {
+    shell.showItemInFolder(path.join(handle.dir, ARTIFACTS_DB_FILENAME));
+  });
+
+  attachTransportDispatcher(createDesktopTransportEndpoint(), {
+    queries: {
+      "project.info": () => ({
+        data: projectInfo(handle),
+        tablesRead: ["project"],
+      }),
+    },
+    mutations: {
+      "project.revealFolder": () => {
+        shell.showItemInFolder(path.join(handle.dir, ARTIFACTS_DB_FILENAME));
+        return {
+          data: { ok: true },
+          tablesWritten: [],
+        };
+      },
+    },
+  });
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,11 +1,9 @@
-import {
-  ARTIFACTS_DB_FILENAME,
-  openProject,
-  type ProjectHandle,
-} from "@dashframe/server-core";
+import { openProject, type ProjectHandle } from "@dashframe/server-core";
 import type { Event as ElectronEvent } from "electron";
-import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import path from "node:path";
+
+import { registerDesktopIpc } from "./ipc";
 
 const DEV_URL = process.env.DEV_URL ?? "http://localhost:5173";
 const isDev = !app.isPackaged;
@@ -53,20 +51,6 @@ function createWindow(): void {
   loaded.catch((err) => console.error("[dashframe] window load failed:", err));
 }
 
-function registerIpc(handle: ProjectHandle): void {
-  ipcMain.handle("dashframe:project:info", () => ({
-    projectId: handle.meta.projectId,
-    name: handle.meta.name,
-    version: handle.meta.version,
-    schemaVersion: handle.meta.schemaVersion,
-    createdAt: handle.meta.createdAt.toISOString(),
-    createdBy: handle.meta.createdBy,
-  }));
-  ipcMain.handle("dashframe:project:reveal", () => {
-    shell.showItemInFolder(path.join(handle.dir, ARTIFACTS_DB_FILENAME));
-  });
-}
-
 console.log("[dashframe] main process started, waiting for app ready...");
 
 app.on("window-all-closed", () => {
@@ -94,7 +78,7 @@ app
     }
 
     console.log(`[dashframe] project ready at ${project.dir}`);
-    registerIpc(project);
+    registerDesktopIpc(project);
     app.on("before-quit", closeProjectBeforeQuit);
 
     console.log(`[dashframe] creating window with DEV_URL=${DEV_URL}...`);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,6 +1,10 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from "electron";
 
 import type { DashFrameApi, ProjectInfo } from "@dashframe/desktop-types";
+import type {
+  ClientTransportMessage,
+  ServerTransportMessage,
+} from "@dashframe/transport";
 
 /**
  * IPC surface exposed to the renderer. Keep the shape narrow and serializable:
@@ -13,6 +17,21 @@ const api: DashFrameApi = {
       ipcRenderer.invoke("dashframe:project:info"),
     revealFolder: (): Promise<void> =>
       ipcRenderer.invoke("dashframe:project:reveal"),
+  },
+  transport: {
+    send: (message: ClientTransportMessage): Promise<void> =>
+      ipcRenderer.invoke("dashframe:transport:send", message),
+    onMessage: (
+      handler: (message: ServerTransportMessage) => void,
+    ): (() => void) => {
+      const listener = (_event: IpcRendererEvent, message: unknown) => {
+        handler(message as ServerTransportMessage);
+      };
+      ipcRenderer.on("dashframe:transport:message", listener);
+      return () => {
+        ipcRenderer.removeListener("dashframe:transport:message", listener);
+      };
+    },
   },
 } as const;
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
       "dependencies": {
         "@dashframe/desktop-types": "workspace:*",
         "@dashframe/server-core": "workspace:*",
+        "@dashframe/transport": "workspace:*",
         "@electric-sql/pglite": "^0.3.14",
         "electron": "^33.2.1",
       },
@@ -418,6 +419,9 @@
     "packages/desktop-types": {
       "name": "@dashframe/desktop-types",
       "version": "0.0.0",
+      "dependencies": {
+        "@dashframe/transport": "workspace:*",
+      },
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
         "typescript": "5.7.2",
@@ -430,6 +434,7 @@
         "@dashframe/types": "workspace:*",
       },
       "devDependencies": {
+        "@types/bun": "^1.2.0",
         "typescript": "^5.6.0",
       },
     },
@@ -478,6 +483,7 @@
       "name": "@dashframe/server-core",
       "version": "0.0.0",
       "dependencies": {
+        "@dashframe/transport": "workspace:*",
         "@electric-sql/pglite": "^0.3.14",
         "drizzle-orm": "^0.45.1",
       },
@@ -486,6 +492,16 @@
         "esbuild": "^0.28.0",
         "typescript": "5.7.2",
         "vitest": "^4.1.6",
+      },
+    },
+    "packages/transport": {
+      "name": "@dashframe/transport",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@dashframe/eslint-config": "workspace:*",
+        "@types/bun": "^1.2.0",
+        "esbuild": "^0.28.0",
+        "typescript": "5.7.2",
       },
     },
     "packages/types": {
@@ -734,6 +750,8 @@
     "@dashframe/server": ["@dashframe/server@workspace:apps/server"],
 
     "@dashframe/server-core": ["@dashframe/server-core@workspace:packages/server-core"],
+
+    "@dashframe/transport": ["@dashframe/transport@workspace:packages/transport"],
 
     "@dashframe/types": ["@dashframe/types@workspace:packages/types"],
 

--- a/packages/desktop-types/package.json
+++ b/packages/desktop-types/package.json
@@ -10,6 +10,9 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "check": "bun run typecheck"
   },
+  "dependencies": {
+    "@dashframe/transport": "workspace:*"
+  },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
     "typescript": "5.7.2"

--- a/packages/desktop-types/src/index.ts
+++ b/packages/desktop-types/src/index.ts
@@ -1,3 +1,8 @@
+import type {
+  ClientTransportMessage,
+  ServerTransportMessage,
+} from "@dashframe/transport";
+
 export interface ProjectInfo {
   projectId: string;
   name: string;
@@ -11,5 +16,9 @@ export interface DashFrameApi {
   project: {
     getInfo(): Promise<ProjectInfo>;
     revealFolder(): Promise<void>;
+  };
+  transport: {
+    send(message: ClientTransportMessage): Promise<void>;
+    onMessage(handler: (message: ServerTransportMessage) => void): () => void;
   };
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -29,4 +29,12 @@ export {
   type ResolveProjectDirOptions,
 } from "./project-dir";
 export { schema, type Schema } from "./schema";
+export {
+  attachTransportDispatcher,
+  type TransportDispatcher,
+  type TransportProcedure,
+  type TransportProcedureContext,
+  type TransportProcedureResult,
+  type TransportRegistry,
+} from "./transport";
 export { DASHFRAME_PROJECT_VERSION } from "./version";

--- a/packages/server-core/src/transport.test.ts
+++ b/packages/server-core/src/transport.test.ts
@@ -1,0 +1,122 @@
+import {
+  createLoopbackPair,
+  type TransportMessage,
+} from "@dashframe/transport";
+import { describe, expect, it } from "vitest";
+
+import { attachTransportDispatcher } from "./transport";
+
+async function waitForMessage(
+  messages: TransportMessage[],
+  predicate: (message: TransportMessage) => boolean = () => true,
+): Promise<TransportMessage> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const index = messages.findIndex(predicate);
+    if (index >= 0) {
+      const [message] = messages.splice(index, 1);
+      return message!;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for transport message");
+}
+
+describe("attachTransportDispatcher", () => {
+  it("returns query results", async () => {
+    const { client, server } = createLoopbackPair();
+    const messages: TransportMessage[] = [];
+    client.onMessage((message) => messages.push(message));
+    attachTransportDispatcher(server, {
+      queries: {
+        "project.info": () => ({
+          data: { name: "DashFrame" },
+          tablesRead: ["project"],
+        }),
+      },
+    });
+
+    client.send({ type: "query", id: "q1", path: "project.info" });
+
+    expect(await waitForMessage(messages)).toEqual({
+      type: "result",
+      id: "q1",
+      data: { name: "DashFrame" },
+    });
+  });
+
+  it("invalidates subscriptions after related mutations", async () => {
+    const { client, server } = createLoopbackPair();
+    const messages: TransportMessage[] = [];
+    let name = "Before";
+    client.onMessage((message) => messages.push(message));
+    attachTransportDispatcher(server, {
+      queries: {
+        "project.info": () => ({
+          data: { name },
+          tablesRead: ["project"],
+        }),
+      },
+      mutations: {
+        "project.rename": (args) => {
+          name =
+            typeof args === "object" &&
+            args !== null &&
+            !Array.isArray(args) &&
+            typeof args.name === "string"
+              ? args.name
+              : name;
+          return {
+            data: { ok: true },
+            tablesWritten: ["project"],
+          };
+        },
+      },
+    });
+
+    client.send({ type: "subscribe", id: "s1", path: "project.info" });
+    expect(await waitForMessage(messages)).toEqual({
+      type: "subscribed",
+      id: "s1",
+    });
+
+    client.send({
+      type: "mutation",
+      id: "m1",
+      path: "project.rename",
+      args: { name: "After" },
+    });
+
+    expect(
+      await waitForMessage(messages, (message) => message.type === "result"),
+    ).toEqual({
+      type: "result",
+      id: "m1",
+      data: { ok: true },
+    });
+    expect(
+      await waitForMessage(
+        messages,
+        (message) => message.type === "invalidate",
+      ),
+    ).toEqual({
+      type: "invalidate",
+      id: "s1",
+      data: { name: "After" },
+    });
+  });
+
+  it("returns errors for unknown procedures", async () => {
+    const { client, server } = createLoopbackPair();
+    const messages: TransportMessage[] = [];
+    client.onMessage((message) => messages.push(message));
+    attachTransportDispatcher(server, {});
+
+    client.send({ type: "query", id: "q1", path: "missing" });
+
+    expect(await waitForMessage(messages)).toMatchObject({
+      type: "error",
+      id: "q1",
+      code: "NOT_FOUND",
+    });
+  });
+});

--- a/packages/server-core/src/transport.ts
+++ b/packages/server-core/src/transport.ts
@@ -1,0 +1,199 @@
+import {
+  parseClientMessage,
+  type JsonValue,
+  type ServerTransportMessage,
+  type TransportEndpoint,
+  type TransportErrorMessage,
+} from "@dashframe/transport";
+
+export type TransportProcedureContext = {
+  subscriptionId?: string;
+};
+
+export type TransportProcedureResult = {
+  data: JsonValue;
+  tablesRead?: readonly string[];
+  tablesWritten?: readonly string[];
+};
+
+export type TransportProcedure = (
+  args: JsonValue | undefined,
+  context: TransportProcedureContext,
+) => Promise<TransportProcedureResult> | TransportProcedureResult;
+
+export type TransportRegistry = {
+  queries?: Record<string, TransportProcedure>;
+  mutations?: Record<string, TransportProcedure>;
+};
+
+export type TransportDispatcher = {
+  dispose(): void;
+};
+
+type Subscription = {
+  id: string;
+  path: string;
+  args: JsonValue | undefined;
+  tablesRead: Set<string>;
+};
+
+function errorMessage(
+  message: string,
+  options: { id?: string; code?: string; issues?: JsonValue } = {},
+): TransportErrorMessage {
+  return {
+    type: "error",
+    id: options.id,
+    code: options.code ?? "BAD_REQUEST",
+    message,
+    issues: options.issues,
+  };
+}
+
+function intersects(left: Set<string>, right: readonly string[]): boolean {
+  return right.some((value) => left.has(value));
+}
+
+export function attachTransportDispatcher(
+  endpoint: TransportEndpoint,
+  registry: TransportRegistry,
+): TransportDispatcher {
+  const subscriptions = new Map<string, Subscription>();
+
+  async function send(message: ServerTransportMessage): Promise<void> {
+    await endpoint.send(message);
+  }
+
+  async function runQuery(
+    id: string,
+    path: string,
+    args: JsonValue | undefined,
+    subscriptionId?: string,
+  ): Promise<TransportProcedureResult | null> {
+    const procedure = registry.queries?.[path];
+    if (!procedure) {
+      await send(
+        errorMessage(`Unknown query: ${path}`, { id, code: "NOT_FOUND" }),
+      );
+      return null;
+    }
+
+    try {
+      return await procedure(args, { subscriptionId });
+    } catch (err) {
+      await send(
+        errorMessage(err instanceof Error ? err.message : String(err), {
+          id,
+          code: "QUERY_FAILED",
+        }),
+      );
+      return null;
+    }
+  }
+
+  async function runMutation(
+    id: string,
+    path: string,
+    args: JsonValue | undefined,
+  ): Promise<void> {
+    const procedure = registry.mutations?.[path];
+    if (!procedure) {
+      await send(
+        errorMessage(`Unknown mutation: ${path}`, { id, code: "NOT_FOUND" }),
+      );
+      return;
+    }
+
+    let result: TransportProcedureResult;
+    try {
+      result = await procedure(args, {});
+    } catch (err) {
+      await send(
+        errorMessage(err instanceof Error ? err.message : String(err), {
+          id,
+          code: "MUTATION_FAILED",
+        }),
+      );
+      return;
+    }
+
+    await send({ type: "result", id, data: result.data });
+    const tablesWritten = result.tablesWritten ?? [];
+    for (const subscription of subscriptions.values()) {
+      if (intersects(subscription.tablesRead, tablesWritten)) {
+        const queryResult = await runQuery(
+          subscription.id,
+          subscription.path,
+          subscription.args,
+          subscription.id,
+        );
+        if (queryResult) {
+          subscription.tablesRead = new Set(queryResult.tablesRead ?? []);
+          await send({
+            type: "invalidate",
+            id: subscription.id,
+            data: queryResult.data,
+          });
+        }
+      }
+    }
+  }
+
+  async function handleMessage(value: unknown): Promise<void> {
+    let message;
+    try {
+      message = parseClientMessage(value);
+    } catch (err) {
+      await send(
+        errorMessage(err instanceof Error ? err.message : String(err), {
+          code: "INVALID_MESSAGE",
+        }),
+      );
+      return;
+    }
+
+    if (message.type === "unsubscribe") {
+      subscriptions.delete(message.id);
+      return;
+    }
+
+    if (message.type === "query") {
+      const result = await runQuery(message.id, message.path, message.args);
+      if (result) {
+        await send({ type: "result", id: message.id, data: result.data });
+      }
+      return;
+    }
+
+    if (message.type === "mutation") {
+      await runMutation(message.id, message.path, message.args);
+      return;
+    }
+
+    const result = await runQuery(
+      message.id,
+      message.path,
+      message.args,
+      message.id,
+    );
+    if (!result) return;
+    subscriptions.set(message.id, {
+      id: message.id,
+      path: message.path,
+      args: message.args,
+      tablesRead: new Set(result.tablesRead ?? []),
+    });
+    await send({ type: "subscribed", id: message.id });
+  }
+
+  const unsubscribe = endpoint.onMessage((message) => {
+    void handleMessage(message);
+  });
+
+  return {
+    dispose() {
+      subscriptions.clear();
+      unsubscribe();
+    },
+  };
+}

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "@dashframe/server-core",
+  "name": "@dashframe/transport",
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "description": "JSON-frame transport protocol and adapters for DashFrame",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },
@@ -19,20 +20,15 @@
     "build:js": "esbuild src/index.ts --bundle --platform=node --packages=external --format=esm --outfile=dist/index.js",
     "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "node -e \"require('node:fs/promises').rm('dist',{recursive:true,force:true})\"",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src",
-    "test": "vitest run",
+    "test": "bun test src",
     "check": "bun run typecheck && bun run lint && bun run test"
-  },
-  "dependencies": {
-    "@dashframe/transport": "workspace:*",
-    "@electric-sql/pglite": "^0.3.14",
-    "drizzle-orm": "^0.45.1"
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
+    "@types/bun": "^1.2.0",
     "esbuild": "^0.28.0",
-    "typescript": "5.7.2",
-    "vitest": "^4.1.6"
+    "typescript": "5.7.2"
   }
 }

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,0 +1,17 @@
+export type { TransportEndpoint, TransportMessageHandler } from "./interface";
+export { createLoopbackPair } from "./loopback";
+export { isJsonValue, isRecord, parseClientMessage } from "./messages";
+export type {
+  ClientTransportMessage,
+  JsonPrimitive,
+  JsonValue,
+  ServerTransportMessage,
+  TransportErrorMessage,
+  TransportInvalidateMessage,
+  TransportMessage,
+  TransportRequestMessage,
+  TransportRequestType,
+  TransportResultMessage,
+  TransportSubscribedMessage,
+  TransportUnsubscribeMessage,
+} from "./messages";

--- a/packages/transport/src/interface.ts
+++ b/packages/transport/src/interface.ts
@@ -1,0 +1,9 @@
+import type { TransportMessage } from "./messages";
+
+export type TransportMessageHandler = (message: TransportMessage) => void;
+
+export type TransportEndpoint = {
+  send(message: TransportMessage): void | Promise<void>;
+  onMessage(handler: TransportMessageHandler): () => void;
+  close(): void | Promise<void>;
+};

--- a/packages/transport/src/loopback.test.ts
+++ b/packages/transport/src/loopback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+
+import { createLoopbackPair } from "./loopback";
+import type { TransportMessage } from "./messages";
+import { isJsonValue, parseClientMessage } from "./messages";
+
+function nextMessage(received: TransportMessage[]): Promise<TransportMessage> {
+  return new Promise((resolve) => {
+    const poll = () => {
+      const message = received.shift();
+      if (message) {
+        resolve(message);
+        return;
+      }
+      setTimeout(poll, 0);
+    };
+    poll();
+  });
+}
+
+describe("createLoopbackPair", () => {
+  it("delivers messages in both directions asynchronously", async () => {
+    const { client, server } = createLoopbackPair();
+    const serverMessages: TransportMessage[] = [];
+    const clientMessages: TransportMessage[] = [];
+    server.onMessage((message) => serverMessages.push(message));
+    client.onMessage((message) => clientMessages.push(message));
+
+    client.send({ type: "query", id: "q1", path: "project.info" });
+    server.send({ type: "result", id: "q1", data: { ok: true } });
+
+    expect(await nextMessage(serverMessages)).toEqual({
+      type: "query",
+      id: "q1",
+      path: "project.info",
+    });
+    expect(await nextMessage(clientMessages)).toEqual({
+      type: "result",
+      id: "q1",
+      data: { ok: true },
+    });
+  });
+
+  it("stops delivering messages after unsubscribe and close", async () => {
+    const { client, server } = createLoopbackPair();
+    let count = 0;
+    const unsubscribe = server.onMessage(() => count++);
+
+    unsubscribe();
+    client.send({ type: "query", id: "q1", path: "project.info" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(count).toBe(0);
+
+    server.onMessage(() => count++);
+    server.close();
+    client.send({ type: "query", id: "q2", path: "project.info" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(count).toBe(0);
+  });
+});
+
+describe("message validation", () => {
+  it("accepts JSON strings, booleans, numbers, arrays, and records", () => {
+    expect(isJsonValue("value")).toBe(true);
+    expect(isJsonValue(true)).toBe(true);
+    expect(isJsonValue(1)).toBe(true);
+    expect(isJsonValue(["value", false, 2])).toBe(true);
+    expect(isJsonValue({ name: "DashFrame", ok: true })).toBe(true);
+  });
+
+  it("parses request messages with object args", () => {
+    expect(
+      parseClientMessage({
+        type: "mutation",
+        id: "m1",
+        path: "project.rename",
+        args: { name: "After" },
+      }),
+    ).toEqual({
+      type: "mutation",
+      id: "m1",
+      path: "project.rename",
+      args: { name: "After" },
+    });
+  });
+});

--- a/packages/transport/src/loopback.ts
+++ b/packages/transport/src/loopback.ts
@@ -1,0 +1,43 @@
+import type { TransportEndpoint, TransportMessageHandler } from "./interface";
+import type { TransportMessage } from "./messages";
+
+class LoopbackEndpoint implements TransportEndpoint {
+  #handlers = new Set<TransportMessageHandler>();
+  #closed = false;
+  peer?: LoopbackEndpoint;
+
+  send(message: TransportMessage): void {
+    if (this.#closed || !this.peer || this.peer.#closed) return;
+    const peer = this.peer;
+    queueMicrotask(() => peer.deliver(message));
+  }
+
+  onMessage(handler: TransportMessageHandler): () => void {
+    if (this.#closed) return () => {};
+    this.#handlers.add(handler);
+    return () => this.#handlers.delete(handler);
+  }
+
+  close(): void {
+    this.#closed = true;
+    this.#handlers.clear();
+  }
+
+  private deliver(message: TransportMessage): void {
+    if (this.#closed) return;
+    for (const handler of this.#handlers) {
+      handler(message);
+    }
+  }
+}
+
+export function createLoopbackPair(): {
+  client: TransportEndpoint;
+  server: TransportEndpoint;
+} {
+  const client = new LoopbackEndpoint();
+  const server = new LoopbackEndpoint();
+  client.peer = server;
+  server.peer = client;
+  return { client, server };
+}

--- a/packages/transport/src/messages.ts
+++ b/packages/transport/src/messages.ts
@@ -1,0 +1,116 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type TransportRequestType = "query" | "mutation" | "subscribe";
+
+export type TransportRequestMessage = {
+  type: TransportRequestType;
+  id: string;
+  path: string;
+  args?: JsonValue;
+};
+
+export type TransportUnsubscribeMessage = {
+  type: "unsubscribe";
+  id: string;
+};
+
+export type ClientTransportMessage =
+  | TransportRequestMessage
+  | TransportUnsubscribeMessage;
+
+export type TransportResultMessage = {
+  type: "result";
+  id: string;
+  data: JsonValue;
+};
+
+export type TransportSubscribedMessage = {
+  type: "subscribed";
+  id: string;
+};
+
+export type TransportInvalidateMessage = {
+  type: "invalidate";
+  id: string;
+  data?: JsonValue;
+};
+
+export type TransportErrorMessage = {
+  type: "error";
+  id?: string;
+  code: string;
+  message: string;
+  issues?: JsonValue;
+};
+
+export type ServerTransportMessage =
+  | TransportResultMessage
+  | TransportSubscribedMessage
+  | TransportInvalidateMessage
+  | TransportErrorMessage;
+
+export type TransportMessage = ClientTransportMessage | ServerTransportMessage;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return true;
+    case "number":
+      return Number.isFinite(value);
+    case "object":
+      if (Array.isArray(value)) {
+        return value.every(isJsonValue);
+      }
+      return Object.values(value as Record<string, unknown>).every(isJsonValue);
+    default:
+      return false;
+  }
+}
+
+export function parseClientMessage(value: unknown): ClientTransportMessage {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    throw new Error("Transport message must be an object with a type.");
+  }
+
+  if (value.type === "unsubscribe") {
+    if (typeof value.id !== "string" || value.id.length === 0) {
+      throw new Error("Transport unsubscribe message requires an id.");
+    }
+    return { type: "unsubscribe", id: value.id };
+  }
+
+  if (
+    value.type !== "query" &&
+    value.type !== "mutation" &&
+    value.type !== "subscribe"
+  ) {
+    throw new Error(`Unsupported transport message type: ${value.type}`);
+  }
+
+  if (typeof value.id !== "string" || value.id.length === 0) {
+    throw new Error("Transport request message requires an id.");
+  }
+  if (typeof value.path !== "string" || value.path.length === 0) {
+    throw new Error("Transport request message requires a path.");
+  }
+  if ("args" in value && !isJsonValue(value.args)) {
+    throw new Error("Transport request args must be JSON-serializable.");
+  }
+
+  return {
+    type: value.type,
+    id: value.id,
+    path: value.path,
+    args: value.args as JsonValue | undefined,
+  };
+}

--- a/packages/transport/tsconfig.build.json
+++ b/packages/transport/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "exclude": ["**/*.test.ts", "dist"]
+}

--- a/packages/transport/tsconfig.json
+++ b/packages/transport/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add @dashframe/transport JSON frame protocol with loopback transport and validation tests
- add server-core transport dispatcher for query, mutation, subscribe, unsubscribe, result, error, subscribed, and invalidate frames
- expose a narrow Electron IPC transport bridge while preserving the existing project IPC API

## Verification
- bun run --filter @dashframe/transport check
- bun run --filter @dashframe/server-core test
- bun run --filter @dashframe/server-core typecheck
- bun run --filter @dashframe/desktop-types typecheck
- bun run --filter @dashframe/desktop typecheck
- bun run --filter @dashframe/renderer typecheck
- bun check

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `@dashframe/transport` package with a JSON-frame protocol, loopback transport, and runtime message validation, then wires it into `@dashframe/server-core` as a `TransportDispatcher` and into the Electron main/preload layer as a narrow IPC bridge.

- **`@dashframe/transport`**: New `messages.ts` defines all frame types and a `parseClientMessage` validator; `loopback.ts` implements an in-process pair using `queueMicrotask` for asynchronous delivery; both are covered by co-located tests.
- **`@dashframe/server-core/transport`**: `attachTransportDispatcher` routes query/mutation/subscribe frames, tracks subscriptions by table read-set, and fans out `invalidate` frames after mutations; `dispose()` correctly clears subscriptions and detaches the message listener but does not call `endpoint.close()`, leaving the IPC channel registered even if `dispose()` is properly invoked.
- **Electron IPC bridge**: `createDesktopTransportEndpoint` in the new `ipc.ts` registers `ipcMain.handle("dashframe:transport:send")` and broadcasts server frames to all open windows; `registerDesktopIpc` also duplicates `project.info` / `project.revealFolder` as both legacy IPC handlers and new transport procedures, keeping backward compatibility.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: `dispose()` must call `endpoint.close()` or the IPC handler for `dashframe:transport:send` will outlive any intended cleanup.

The transport foundation is well-structured and the tests are solid. The one concrete defect is in `dispose()`: it removes the message listener but does not call `endpoint.close()`, so `ipcMain.removeHandler` is never reached — the IPC channel leaks for the process lifetime even when disposal is properly triggered.

packages/server-core/src/transport.ts — the `dispose()` method needs `endpoint.close()`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server-core/src/transport.ts | New file: Dispatcher correctly wires queries/mutations/subscriptions, but `dispose()` omits `endpoint.close()`, leaving the IPC handler registered even after disposal. |
| apps/desktop/src/ipc.ts | New file: Extracts IPC registration; `attachTransportDispatcher` return value is discarded and `dispose()` itself omits `endpoint.close()`, so the IPC channel never gets de-registered. |
| packages/transport/src/messages.ts | New file: JSON-frame type definitions and `parseClientMessage` validator with solid runtime checks for all message types. |
| packages/transport/src/loopback.ts | New file: Clean `LoopbackEndpoint` implementation using `queueMicrotask` for async delivery; correctly guards `#closed` state. |
| packages/transport/src/loopback.test.ts | New test file: `nextMessage` polls indefinitely (already flagged); test naming deviates from `"should ..."` project convention. |
| apps/desktop/src/preload.ts | Updated with transport bridge; incoming IPC frame cast to `ServerTransportMessage` without validation (previously flagged). |
| apps/desktop/src/main.ts | Thin refactor: `registerIpc` moved to `ipc.ts` and renamed; no new logic introduced here. |
| packages/desktop-types/src/index.ts | Extended `DashFrameApi` with `transport` surface; types correctly mirror the preload implementation. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant P as Preload
    participant M as Main (ipc.ts)
    participant D as TransportDispatcher
    participant Q as Query/Mutation Registry

    R->>P: window.dashframe.transport.send(frame)
    P->>M: ipcRenderer.invoke("dashframe:transport:send", frame)
    M->>D: handler(message)
    D->>D: parseClientMessage(value)
    alt query
        D->>Q: registry.queries[path](args)
        Q-->>D: "{ data, tablesRead }"
        D->>M: "endpoint.send({ type:"result" })"
        M->>R: webContents.send("dashframe:transport:message", frame)
    else subscribe
        D->>Q: registry.queries[path](args)
        Q-->>D: "{ data, tablesRead }"
        D->>D: subscriptions.set(id, ...)
        D->>M: "endpoint.send({ type:"subscribed" })"
        M->>R: webContents.send("dashframe:transport:message", frame)
    else mutation
        D->>Q: registry.mutations[path](args)
        Q-->>D: "{ data, tablesWritten }"
        D->>M: "endpoint.send({ type:"result" })"
        loop each affected subscription
            D->>Q: re-run query
            Q-->>D: "{ data, tablesRead }"
            D->>M: "endpoint.send({ type:"invalidate" })"
            M->>R: webContents.send("dashframe:transport:message", frame)
        end
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fserver-core%2Fsrc%2Ftransport.ts%3A193-198%0A%60dispose%28%29%60%20removes%20the%20message%20listener%20via%20%60unsubscribe%28%29%60%20but%20never%20calls%20%60endpoint.close%28%29%60.%20In%20the%20desktop%20integration%2C%20%60endpoint.close%28%29%60%20is%20the%20only%20path%20that%20calls%20%60ipcMain.removeHandler%28%22dashframe%3Atransport%3Asend%22%29%60.%20Even%20if%20a%20caller%20correctly%20stores%20the%20dispatcher%20and%20calls%20%60dispose%28%29%60%20on%20project%20close%20%28the%20fix%20suggested%20for%20the%20prior%20comment%29%2C%20the%20IPC%20channel%20will%20remain%20registered%20for%20the%20lifetime%20of%20the%20process.%0A%0A%60%60%60suggestion%0A%20%20return%20%7B%0A%20%20%20%20dispose%28%29%20%7B%0A%20%20%20%20%20%20subscriptions.clear%28%29%3B%0A%20%20%20%20%20%20unsubscribe%28%29%3B%0A%20%20%20%20%20%20void%20endpoint.close%28%29%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fserver-core%2Fsrc%2Ftransport.ts%3A189-191%0A**Unhandled%20rejection%20from%20%60handleMessage%60**%0A%0A%60void%20handleMessage%28message%29%60%20discards%20the%20returned%20promise%2C%20so%20any%20rejection%20that%20escapes%20%60handleMessage%60%20%28e.g.%20an%20uncaught%20throw%20from%20%60endpoint.send%28%29%60%20mid-mutation%20when%20the%20renderer%20window%20is%20being%20destroyed%29%20is%20silently%20dropped.%20In%20Electron%20this%20surfaces%20as%20a%20Node.js%20%60UnhandledPromiseRejection%60%20warning%20rather%20than%20a%20hard%20crash%2C%20but%20it%20can%20leave%20a%20mutation%20half-executed%20with%20no%20error%20frame%20reaching%20the%20client.%20Adding%20a%20%60.catch%60%20to%20log%20or%20surface%20the%20failure%20would%20make%20this%20safer.%0A%0A&repo=youhaowei%2Fdashframe&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22task-548-transport-phase1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22task-548-transport-phase1%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fserver-core%2Fsrc%2Ftransport.ts%3A193-198%0A%60dispose%28%29%60%20removes%20the%20message%20listener%20via%20%60unsubscribe%28%29%60%20but%20never%20calls%20%60endpoint.close%28%29%60.%20In%20the%20desktop%20integration%2C%20%60endpoint.close%28%29%60%20is%20the%20only%20path%20that%20calls%20%60ipcMain.removeHandler%28%22dashframe%3Atransport%3Asend%22%29%60.%20Even%20if%20a%20caller%20correctly%20stores%20the%20dispatcher%20and%20calls%20%60dispose%28%29%60%20on%20project%20close%20%28the%20fix%20suggested%20for%20the%20prior%20comment%29%2C%20the%20IPC%20channel%20will%20remain%20registered%20for%20the%20lifetime%20of%20the%20process.%0A%0A%60%60%60suggestion%0A%20%20return%20%7B%0A%20%20%20%20dispose%28%29%20%7B%0A%20%20%20%20%20%20subscriptions.clear%28%29%3B%0A%20%20%20%20%20%20unsubscribe%28%29%3B%0A%20%20%20%20%20%20void%20endpoint.close%28%29%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fserver-core%2Fsrc%2Ftransport.ts%3A189-191%0A**Unhandled%20rejection%20from%20%60handleMessage%60**%0A%0A%60void%20handleMessage%28message%29%60%20discards%20the%20returned%20promise%2C%20so%20any%20rejection%20that%20escapes%20%60handleMessage%60%20%28e.g.%20an%20uncaught%20throw%20from%20%60endpoint.send%28%29%60%20mid-mutation%20when%20the%20renderer%20window%20is%20being%20destroyed%29%20is%20silently%20dropped.%20In%20Electron%20this%20surfaces%20as%20a%20Node.js%20%60UnhandledPromiseRejection%60%20warning%20rather%20than%20a%20hard%20crash%2C%20but%20it%20can%20leave%20a%20mutation%20half-executed%20with%20no%20error%20frame%20reaching%20the%20client.%20Adding%20a%20%60.catch%60%20to%20log%20or%20surface%20the%20failure%20would%20make%20this%20safer.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fserver-core%2Fsrc%2Ftransport.ts%3A193-198%0A%60dispose%28%29%60%20removes%20the%20message%20listener%20via%20%60unsubscribe%28%29%60%20but%20never%20calls%20%60endpoint.close%28%29%60.%20In%20the%20desktop%20integration%2C%20%60endpoint.close%28%29%60%20is%20the%20only%20path%20that%20calls%20%60ipcMain.removeHandler%28%22dashframe%3Atransport%3Asend%22%29%60.%20Even%20if%20a%20caller%20correctly%20stores%20the%20dispatcher%20and%20calls%20%60dispose%28%29%60%20on%20project%20close%20%28the%20fix%20suggested%20for%20the%20prior%20comment%29%2C%20the%20IPC%20channel%20will%20remain%20registered%20for%20the%20lifetime%20of%20the%20process.%0A%0A%60%60%60suggestion%0A%20%20return%20%7B%0A%20%20%20%20dispose%28%29%20%7B%0A%20%20%20%20%20%20subscriptions.clear%28%29%3B%0A%20%20%20%20%20%20unsubscribe%28%29%3B%0A%20%20%20%20%20%20void%20endpoint.close%28%29%3B%0A%20%20%20%20%7D%2C%0A%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fserver-core%2Fsrc%2Ftransport.ts%3A189-191%0A**Unhandled%20rejection%20from%20%60handleMessage%60**%0A%0A%60void%20handleMessage%28message%29%60%20discards%20the%20returned%20promise%2C%20so%20any%20rejection%20that%20escapes%20%60handleMessage%60%20%28e.g.%20an%20uncaught%20throw%20from%20%60endpoint.send%28%29%60%20mid-mutation%20when%20the%20renderer%20window%20is%20being%20destroyed%29%20is%20silently%20dropped.%20In%20Electron%20this%20surfaces%20as%20a%20Node.js%20%60UnhandledPromiseRejection%60%20warning%20rather%20than%20a%20hard%20crash%2C%20but%20it%20can%20leave%20a%20mutation%20half-executed%20with%20no%20error%20frame%20reaching%20the%20client.%20Adding%20a%20%60.catch%60%20to%20log%20or%20surface%20the%20failure%20would%20make%20this%20safer.%0A%0A&pr=43&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/server-core/src/transport.ts:193-198
`dispose()` removes the message listener via `unsubscribe()` but never calls `endpoint.close()`. In the desktop integration, `endpoint.close()` is the only path that calls `ipcMain.removeHandler("dashframe:transport:send")`. Even if a caller correctly stores the dispatcher and calls `dispose()` on project close (the fix suggested for the prior comment), the IPC channel will remain registered for the lifetime of the process.

```suggestion
  return {
    dispose() {
      subscriptions.clear();
      unsubscribe();
      void endpoint.close();
    },
  };
```

### Issue 2 of 2
packages/server-core/src/transport.ts:189-191
**Unhandled rejection from `handleMessage`**

`void handleMessage(message)` discards the returned promise, so any rejection that escapes `handleMessage` (e.g. an uncaught throw from `endpoint.send()` mid-mutation when the renderer window is being destroyed) is silently dropped. In Electron this surfaces as a Node.js `UnhandledPromiseRejection` warning rather than a hard crash, but it can leave a mutation half-executed with no error frame reaching the client. Adding a `.catch` to log or surface the failure would make this safer.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add desktop transport foundation"](https://github.com/youhaowei/dashframe/commit/9a262eefeacf5fce8ef4d53ea544d3a5598476ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33365319)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->