### PR TITLE
feat(desktop): wire WyStack server+client over Electron IPC (YW-69)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/main.js",
   "scripts": {
-    "build:main": "esbuild src/main.ts --bundle --platform=node --packages=external --format=esm --outfile=dist/main.js",
+    "build:main": "esbuild src/main.ts --bundle --platform=node --external:electron --external:@dashframe/* --external:@electric-sql/pglite --external:postgres --format=esm --outfile=dist/main.js",
     "build:preload": "esbuild src/preload.ts --bundle --platform=node --external:electron --format=cjs --outfile=dist/preload.cjs",
     "build": "bun run build:main && bun run build:preload",
     "dev": "bun scripts/dev.mjs",
@@ -17,7 +17,8 @@
     "@dashframe/desktop-types": "workspace:*",
     "@dashframe/server-core": "workspace:*",
     "@electric-sql/pglite": "^0.3.14",
-    "electron": "^33.2.1"
+    "electron": "^33.2.1",
+    "@wystack/server": "workspace:*"
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,6 +3,9 @@ import {
   openProject,
   type ProjectHandle,
 } from "@dashframe/server-core";
+import type { WyStackApp } from "@wystack/server";
+import { createSubscriptionManager } from "@wystack/server";
+import { attachElectronTransport } from "@wystack/server/electron";
 import type { Event as ElectronEvent } from "electron";
 import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import path from "node:path";
@@ -26,7 +29,48 @@ async function closeProjectBeforeQuit(event: ElectronEvent): Promise<void> {
   }
 }
 
-function createWindow(): void {
+/**
+ * Build a WyStackApp that serves the `projectInfo` query directly from the
+ * ProjectHandle's in-memory meta — no DB round-trip needed for this data.
+ * The app interface is satisfied manually (no `createWyStack`) to avoid an
+ * extra DB connection and the async setup overhead.
+ */
+function buildWyStackApp(handle: ProjectHandle): WyStackApp {
+  return {
+    functions: new Map([
+      [
+        "projectInfo",
+        {
+          type: "query" as const,
+          path: "projectInfo",
+          args: {},
+          handler: async () => ({
+            projectId: handle.meta.projectId,
+            name: handle.meta.name,
+            version: handle.meta.version,
+            schemaVersion: handle.meta.schemaVersion,
+            createdAt: handle.meta.createdAt.toISOString(),
+            createdBy: handle.meta.createdBy,
+          }),
+        },
+      ],
+    ]),
+    subscriptions: createSubscriptionManager(),
+    async call(funcPath, args) {
+      const fn = this.functions.get(funcPath);
+      if (!fn) throw new Error(`Unknown function: ${funcPath}`);
+      // projectInfo has no args and doesn't use ctx.db — pass a minimal context
+      const result = await fn.handler({ db: null as never }, args);
+      return {
+        result,
+        tablesRead: new Set<string>(),
+        tablesWritten: new Set<string>(),
+      };
+    },
+  };
+}
+
+function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -51,6 +95,8 @@ function createWindow(): void {
         ),
       );
   loaded.catch((err) => console.error("[dashframe] window load failed:", err));
+
+  return win;
 }
 
 function registerIpc(handle: ProjectHandle): void {
@@ -96,6 +142,19 @@ app
     console.log(`[dashframe] project ready at ${project.dir}`);
     registerIpc(project);
     app.on("before-quit", closeProjectBeforeQuit);
+
+    // Mount the WyStack server over Electron IPC.
+    // `getWebContents` defaults to `event.sender` — no window ref needed at
+    // mount time; each renderer's first frame opens its own connection.
+    const wyStackApp = buildWyStackApp(project);
+    const { detach } = attachElectronTransport({
+      app: wyStackApp,
+      ipcMain,
+      // No resolveContext — trusted in-process transport, no auth handshake.
+    });
+    app.on("before-quit", () => detach());
+
+    console.log("[dashframe] WyStack IPC transport mounted");
 
     console.log(`[dashframe] creating window with DEV_URL=${DEV_URL}...`);
     createWindow();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -17,3 +17,54 @@ const api: DashFrameApi = {
 } as const;
 
 contextBridge.exposeInMainWorld("dashframe", api);
+
+/**
+ * WyStack IPC bridge — exposes a minimal IpcRendererLike surface scoped to
+ * the `wystack:c2s` / `wystack:s2c` channels. Satisfies the structural
+ * interface the `@wystack/client/electron` adapter expects without leaking
+ * raw ipcRenderer into the renderer process.
+ *
+ * `contextBridge.exposeInMainWorld` can't transport class instances or
+ * functions with non-serializable closures — every method is a plain function
+ * that re-dispatches to ipcRenderer. `removeListener` must correlate the same
+ * wrapper reference the adapter registered via `on`, so we keep a WeakMap of
+ * original→wrapper to survive the context bridge crossing.
+ */
+const WYSTACK_CHANNELS = new Set(["wystack:c2s", "wystack:s2c"]);
+
+// Map from the renderer-side callback to the ipcRenderer wrapper so
+// removeListener can unregister the exact function that was registered.
+const listenerMap = new WeakMap<
+  (...args: unknown[]) => void,
+  (event: Electron.IpcRendererEvent, ...args: unknown[]) => void
+>();
+
+contextBridge.exposeInMainWorld("wysIpc", {
+  send(channel: string, ...args: unknown[]): void {
+    if (!WYSTACK_CHANNELS.has(channel)) return;
+    ipcRenderer.send(channel, ...args);
+  },
+  on(channel: string, listener: (...args: unknown[]) => void): void {
+    if (!WYSTACK_CHANNELS.has(channel)) return;
+    // The adapter receives (event, message) from ipcRenderer but only reads
+    // args[1] (the message) via the IpcRendererLike interface which gives
+    // (event, ...args). We pass (null, payload) so the adapter sees event=null
+    // and the payload as the first variadic arg.
+    const wrapper = (_event: Electron.IpcRendererEvent, ...rest: unknown[]) => {
+      listener(null, ...rest);
+    };
+    listenerMap.set(listener, wrapper);
+    ipcRenderer.on(channel, wrapper);
+  },
+  removeListener(
+    channel: string,
+    listener: (...args: unknown[]) => void,
+  ): void {
+    if (!WYSTACK_CHANNELS.has(channel)) return;
+    const wrapper = listenerMap.get(listener);
+    if (wrapper) {
+      ipcRenderer.removeListener(channel, wrapper);
+      listenerMap.delete(listener);
+    }
+  },
+});

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -15,7 +15,9 @@
     "@dashframe/desktop-types": "workspace:*",
     "@tanstack/react-router": "^1.95.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "@wystack/client": "workspace:*",
+    "@tanstack/react-query": "^5.90.0"
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",

--- a/apps/renderer/src/dashframe-api.d.ts
+++ b/apps/renderer/src/dashframe-api.d.ts
@@ -1,8 +1,11 @@
 import type { DashFrameApi } from "@dashframe/desktop-types";
+import type { IpcRendererLike } from "@wystack/client/electron";
 
 declare global {
   interface Window {
     dashframe: DashFrameApi;
+    /** WyStack IPC bridge exposed by preload — satisfies IpcRendererLike. */
+    wysIpc: IpcRendererLike;
   }
 }
 

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -1,8 +1,11 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
+import { WyStackProvider } from "@wystack/client";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { routeTree } from "./routeTree.gen";
+import { ipcClient } from "./wystack";
 
 const router = createRouter({ routeTree });
 
@@ -12,6 +15,8 @@ declare module "@tanstack/react-router" {
   }
 }
 
+const queryClient = new QueryClient();
+
 const container = document.getElementById("root");
 if (!container) {
   throw new Error("Root container #root not found");
@@ -19,6 +24,10 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <WyStackProvider client={ipcClient}>
+        <RouterProvider router={router} />
+      </WyStackProvider>
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/renderer/src/routes/index.tsx
+++ b/apps/renderer/src/routes/index.tsx
@@ -1,14 +1,41 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useProjectInfo } from "../wystack";
 
 export const Route = createFileRoute("/")({
   component: HelloView,
 });
 
 function HelloView() {
+  // Fetch project info via WyStack IPC query (YW-69 / T7 smoke test).
+  // This call goes over the Electron IPC transport: renderer → preload bridge →
+  // ipcMain (wystack:c2s) → WyStack engine → projectInfo handler →
+  // ipcMain (wystack:s2c) → renderer.
+  const { data, isLoading, isError, error } = useProjectInfo();
+
   return (
     <main className="p-8 font-sans">
       <h1>DashFrame v0.2</h1>
-      <p>hello - desktop shell boot</p>
+      {isLoading && <p>Loading project info…</p>}
+      {isError && <p style={{ color: "red" }}>Error: {error?.message}</p>}
+      {data && (
+        <section>
+          <p>
+            <strong>Project:</strong> {data.name}
+          </p>
+          <p>
+            <strong>Version:</strong> {data.version}
+          </p>
+          <p>
+            <strong>Schema version:</strong> {data.schemaVersion}
+          </p>
+          <p>
+            <strong>Project ID:</strong> {data.projectId}
+          </p>
+          <p>
+            <small>Fetched via WyStack IPC query over Electron transport</small>
+          </p>
+        </section>
+      )}
     </main>
   );
 }

--- a/apps/renderer/src/wystack.ts
+++ b/apps/renderer/src/wystack.ts
@@ -1,0 +1,153 @@
+/**
+ * WyStack client setup for the DashFrame renderer (YW-69 / T7).
+ *
+ * Wires the Electron IPC transport into a custom WyStackClient-compatible
+ * object. The standard `createClient` from `@wystack/client` uses HTTP + WS,
+ * which is wrong for Electron — queries must go over IPC, not HTTP.
+ *
+ * Design:
+ *   - Queries/mutations are sent as `call` frames over the IPC pipe and
+ *     resolved via a per-call correlator (id → {resolve, reject}).
+ *   - The `ws` field is a no-op WsManager: non-reactive slice only — live
+ *     invalidation is gated off until YW-62.
+ *   - Query refs are manually typed so `useQuery` gets the correct arg/return
+ *     types without needing to pull `@wystack/server` into the renderer bundle.
+ *
+ * NOTE: The call→result correlator over IPC is hand-rolled here because
+ * `@wystack/client` has no built-in IPC call transport — the client engine
+ * only owns the reactive (subscribe/invalidate) tier. A proper IPC call
+ * transport should land in `@wystack/client` as follow-up work.
+ */
+import type { ProjectInfo } from "@dashframe/desktop-types";
+import type { MutationRef, QueryRef, WyStackClient } from "@wystack/client";
+import { WyStackProvider, useQuery as useWyQuery } from "@wystack/client";
+import { createElectronPipe } from "@wystack/client/electron";
+
+// Re-export for consumers that only need the provider/hook
+export { WyStackProvider, useWyQuery as useQuery };
+
+// ---------------------------------------------------------------------------
+// Typed query refs — manually branded for the `projectInfo` query.
+// Using the QueryRef phantom type so useQuery gets proper TReturn inference.
+// ---------------------------------------------------------------------------
+
+// Unique brand symbol for this module's refs (not exported — internal only)
+declare const QueryBrand: unique symbol;
+/** A typed reference to a WyStack query in the DashFrame function registry. */
+type TypedQueryRef<TArgs, TReturn> = {
+  readonly _path: string;
+  readonly [QueryBrand]: { args: TArgs; return: TReturn };
+};
+
+function queryRef<TArgs, TReturn>(path: string): TypedQueryRef<TArgs, TReturn> {
+  return { _path: path } as TypedQueryRef<TArgs, TReturn>;
+}
+
+// DashFrame function registry refs
+export const api = {
+  /** Fetches project info from the WyStack server over IPC. */
+  projectInfo: queryRef<Record<string, never>, ProjectInfo>("projectInfo"),
+} as const;
+
+// ---------------------------------------------------------------------------
+// IPC call/result correlator
+// ---------------------------------------------------------------------------
+
+let callSeq = 0;
+function nextCallId(): string {
+  return `call_${++callSeq}`;
+}
+
+type PendingCall = {
+  resolve: (data: unknown) => void;
+  reject: (err: Error) => void;
+};
+
+const pending = new Map<string, PendingCall>();
+
+// ---------------------------------------------------------------------------
+// Build the IPC pipe and attach the result dispatcher
+// ---------------------------------------------------------------------------
+
+const pipe = createElectronPipe({ ipcRenderer: window.wysIpc });
+
+// Listen for result/error frames and dispatch to waiting correlators.
+// The server sends `{ type: 'result', id, data }` for success,
+// `{ type: 'error', id, error }` for failure.
+pipe.onMessage((msg) => {
+  if (msg.type === "result") {
+    const p = pending.get(msg.id);
+    if (p) {
+      pending.delete(msg.id);
+      p.resolve(msg.data);
+    }
+  } else if (msg.type === "error" && msg.id) {
+    const p = pending.get(msg.id);
+    if (p) {
+      pending.delete(msg.id);
+      p.reject(new Error(msg.error));
+    }
+  }
+  // authenticated / subscribed / invalidate frames are no-ops in this slice.
+});
+
+// ---------------------------------------------------------------------------
+// Call helper — sends a `call` frame and awaits the `result` response
+// ---------------------------------------------------------------------------
+
+function ipcCall(
+  funcPath: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const id = nextCallId();
+    pending.set(id, { resolve, reject });
+    pipe.send({ type: "call", id, path: funcPath, args });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// No-op WsManager — non-reactive; subscribe/unsubscribe are stubs until YW-62
+// ---------------------------------------------------------------------------
+
+const noopWs: WyStackClient["ws"] = {
+  connect() {},
+  disconnect() {},
+  subscribe() {},
+  unsubscribe() {},
+  isConnected: () => false,
+};
+
+// ---------------------------------------------------------------------------
+// Custom WyStackClient over IPC (satisfies the WyStackClient interface).
+// query/mutate use `as unknown as` cast because `ipcCall` returns
+// `Promise<unknown>` — the runtime value IS the correct type but TypeScript
+// can't prove it. The cast is safe: the server handler returns `ProjectInfo`.
+// ---------------------------------------------------------------------------
+
+export const ipcClient: WyStackClient = {
+  url: "ipc://electron",
+  prefix: "",
+  ws: noopWs,
+  query: ((ref: QueryRef, args?: unknown) =>
+    ipcCall(
+      ref._path,
+      (args ?? {}) as Record<string, unknown>,
+    )) as WyStackClient["query"],
+  mutate: ((ref: MutationRef, args?: unknown) =>
+    ipcCall(
+      ref._path,
+      (args ?? {}) as Record<string, unknown>,
+    )) as WyStackClient["mutate"],
+};
+
+// ---------------------------------------------------------------------------
+// useProjectInfo — convenience hook for the projectInfo WyStack query
+// ---------------------------------------------------------------------------
+
+export function useProjectInfo() {
+  return useWyQuery(
+    // TypedQueryRef is structurally compatible with QueryRef from @wystack/client
+    api.projectInfo as unknown as QueryRef<Record<string, never>, ProjectInfo>,
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -231,6 +231,9 @@
     "libs/wystack/packages/client": {
       "name": "@wystack/client",
       "version": "0.0.1",
+      "dependencies": {
+        "@wystack/transport": "workspace:*",
+      },
       "devDependencies": {
         "@electric-sql/pglite": ">=0.3.0",
         "@tanstack/react-query": "^5.90.0",
@@ -282,20 +285,6 @@
         "pino-pretty",
       ],
     },
-    "libs/wystack/packages/runtime": {
-      "name": "@wystack/runtime",
-      "version": "0.0.1",
-      "dependencies": {
-        "@wystack/server": "workspace:*",
-      },
-      "devDependencies": {
-        "@electric-sql/pglite": "^0.3.16",
-        "@types/node": "^22.0.0",
-        "@wystack/db": "workspace:*",
-        "drizzle-orm": "^0.45.1",
-        "typescript": "^5.8.3",
-      },
-    },
     "libs/wystack/packages/server": {
       "name": "@wystack/server",
       "version": "0.0.1",
@@ -303,12 +292,20 @@
         "@hono/node-server": "^1.19.12",
         "@hono/node-ws": "^1.3.0",
         "@wystack/db": "workspace:*",
+        "@wystack/transport": "workspace:*",
         "hono": "^4.12.9",
         "zod": "^4.3.6",
       },
       "devDependencies": {
         "@electric-sql/pglite": "^0.3.16",
         "drizzle-orm": "^0.45.1",
+        "typescript": "^5.8.3",
+      },
+    },
+    "libs/wystack/packages/transport": {
+      "name": "@wystack/transport",
+      "version": "0.0.1",
+      "devDependencies": {
         "typescript": "^5.8.3",
       },
     },
@@ -430,6 +427,7 @@
         "@dashframe/types": "workspace:*",
       },
       "devDependencies": {
+        "@types/bun": "^1.2.0",
         "typescript": "^5.6.0",
       },
     },
@@ -1553,9 +1551,9 @@
 
     "@wystack/log": ["@wystack/log@workspace:libs/wystack/packages/log"],
 
-    "@wystack/runtime": ["@wystack/runtime@workspace:libs/wystack/packages/runtime"],
-
     "@wystack/server": ["@wystack/server@workspace:libs/wystack/packages/server"],
+
+    "@wystack/transport": ["@wystack/transport@workspace:libs/wystack/packages/transport"],
 
     "@wystack/types": ["@wystack/types@workspace:libs/wystack/packages/types"],
 
@@ -3479,9 +3477,9 @@
 
     "@wystack/log/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@wystack/runtime/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
     "@wystack/server/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@wystack/transport/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@wystack/types/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@dashframe/desktop-types": "workspace:*",
         "@dashframe/server-core": "workspace:*",
         "@electric-sql/pglite": "^0.3.14",
+        "@wystack/server": "workspace:*",
         "electron": "^33.2.1",
       },
       "devDependencies": {
@@ -50,7 +51,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@dashframe/desktop-types": "workspace:*",
+        "@tanstack/react-query": "^5.90.0",
         "@tanstack/react-router": "^1.95.0",
+        "@wystack/client": "workspace:*",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write --loglevel=error"
   },
   "scripts": {
-    "setup": "git submodule update --init --recursive && bun install",
+    "setup": "git submodule update --init --recursive && bun install && node scripts/build-wystack.mjs",
     "dev": "turbo dev --filter=@dashframe/web...",
     "dev:all": "turbo dev",
     "dev:desktop": "bun --filter @dashframe/desktop dev",
@@ -46,7 +46,8 @@
     "changeset:ai": "node scripts/ai-changeset.mjs",
     "changeset:status": "changeset status",
     "version": "changeset version && node scripts/annotate-web-changelog.mjs",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "build:wystack": "node scripts/build-wystack.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/scripts/build-wystack.mjs
+++ b/scripts/build-wystack.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * build-wystack.mjs — builds the @wystack/* packages for use in DashFrame.
+ *
+ * The wystack submodule's packages ship source-first (no committed dists).
+ * Their `build` scripts use `tsc` with configs that include test files, which
+ * import `bun:test` — types that are only available under Bun's test runner,
+ * not a plain `tsc` invocation. This script builds the subset of files DashFrame
+ * needs (index + electron adapter) while excluding test files.
+ *
+ * Called from the DashFrame `setup` script and CI as a prerequisite to
+ * `bun check`, ensuring the dists are present before turbo's `^build` chain
+ * runs for `@dashframe/desktop` and `@dashframe/renderer`.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const WYSTACK = path.join(ROOT, 'libs/wystack');
+
+const packages = [
+  {
+    name: '@wystack/transport',
+    dir: path.join(WYSTACK, 'packages/transport'),
+    include: [
+      'src/index.ts',
+      'src/loopback.ts',
+      'src/pipe.ts',
+      'src/protocol.ts',
+      'src/typed.ts',
+    ],
+  },
+  {
+    name: '@wystack/server',
+    dir: path.join(WYSTACK, 'packages/server'),
+    include: ['src'],
+    exclude: [
+      'src/serve-bun.ts',
+      'src/**/__tests__/**',
+      'src/**/*.test.ts',
+    ],
+  },
+  {
+    name: '@wystack/client',
+    dir: path.join(WYSTACK, 'packages/client'),
+    include: ['src'],
+    exclude: [
+      'src/**/__tests__/**',
+      'src/**/*.test.ts',
+    ],
+  },
+];
+
+const BASE_COMPILER_OPTIONS = {
+  target: 'ES2022',
+  lib: ['ES2022', 'DOM'],
+  module: 'ESNext',
+  moduleResolution: 'bundler',
+  declaration: true,
+  declarationMap: true,
+  sourceMap: true,
+  strict: true,
+  esModuleInterop: true,
+  skipLibCheck: true,
+  forceConsistentCasingInFileNames: true,
+  resolveJsonModule: true,
+  verbatimModuleSyntax: true,
+  jsx: 'react-jsx',
+};
+
+for (const pkg of packages) {
+  const distDir = path.join(pkg.dir, 'dist');
+  if (existsSync(distDir)) {
+    console.log(`[build-wystack] ${pkg.name}: dist already exists, skipping`);
+    continue;
+  }
+
+  console.log(`[build-wystack] ${pkg.name}: building...`);
+
+  const tsconfig = {
+    compilerOptions: {
+      ...BASE_COMPILER_OPTIONS,
+      outDir: distDir,
+      rootDir: path.join(pkg.dir, 'src'),
+    },
+    include: pkg.include.map(p => path.join(pkg.dir, p)),
+    exclude: (pkg.exclude ?? []).map(p => path.join(pkg.dir, p)),
+  };
+
+  const tmpFile = path.join(ROOT, `tsconfig.wystack-build-${pkg.name.replace('/', '-')}.tmp.json`);
+  writeFileSync(tmpFile, JSON.stringify(tsconfig, null, 2));
+
+  try {
+    execSync(`bun x tsc -p ${tmpFile}`, { stdio: 'inherit' });
+    console.log(`[build-wystack] ${pkg.name}: done`);
+  } catch (err) {
+    console.error(`[build-wystack] ${pkg.name}: build failed`);
+    process.exit(1);
+  } finally {
+    try { execSync(`rm -f ${tmpFile}`); } catch {}
+  }
+}
+
+console.log('[build-wystack] all done');

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,42 @@
     },
     "clean": {
       "cache": false
+    },
+    "@wystack/transport#build": {
+      "outputs": ["dist/**"]
+    },
+    "@wystack/server#build": {
+      "outputs": ["dist/**"]
+    },
+    "@wystack/client#build": {
+      "outputs": ["dist/**"]
+    },
+    "@wystack/db#build": {
+      "outputs": ["dist/**"]
+    },
+    "@wystack/types#build": {
+      "outputs": ["dist/**"]
+    },
+    "@wystack/version#build": {
+      "outputs": ["dist/**"]
+    },
+    "@wystack/log#build": {
+      "outputs": ["dist/**"]
+    },
+    "@dashframe/desktop#typecheck": {
+      "dependsOn": [
+        "@dashframe/server-core#build",
+        "@dashframe/desktop-types#build"
+      ]
+    },
+    "@dashframe/renderer#typecheck": {
+      "dependsOn": ["@dashframe/desktop-types#build"]
+    },
+    "@dashframe/desktop#test": {
+      "dependsOn": []
+    },
+    "@dashframe/renderer#test": {
+      "dependsOn": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Main process**: `buildWyStackApp()` registers a `projectInfo` query backed by `ProjectHandle.meta`, then `attachElectronTransport({ app, ipcMain })` mounts the WyStack server over the `wystack:c2s` / `wystack:s2c` IPC channels. No auth — trusted in-process transport.
- **Preload bridge**: `window.wysIpc` exposes a minimal `IpcRendererLike` surface scoped to the wystack channels via `contextBridge`. A `WeakMap` bridges original callbacks through context isolation so `removeListener` correlates correctly.
- **Renderer client** (`apps/renderer/src/wystack.ts`): custom `WyStackClient` over IPC using `createElectronPipe` + a hand-rolled call→result correlator (`Map<id, {resolve,reject}>`). No-op `WsManager` — non-reactive only (YW-62 gates subscriptions). `useProjectInfo()` convenience hook using `useQuery`.
- **Renderer entry** (`main.tsx`): wraps app in `QueryClientProvider + WyStackProvider`.
- **Index route**: calls `useProjectInfo()` and renders project name/version from the WyStack response.
- **Build system**: desktop `build:main` now bundles `@wystack/*` and transitive deps (drizzle-orm, zod, hono) inline via esbuild, keeping only `electron`, `@dashframe/*`, `@electric-sql/pglite`, and `postgres` as externals. `turbo.json` per-package task overrides prevent turbo from re-running wystack builds through the dependency chain. New `scripts/build-wystack.mjs` + `bun build:wystack` builds the wystack package dists (excluding test files and `serve-bun.ts`).

**Implementation note**: The call→result correlator over IPC is hand-rolled in the renderer because `@wystack/client` has no built-in IPC call transport — the client engine only owns the reactive (subscribe/invalidate) tier. A `@wystack/client`-side IPC call transport should land as follow-up work.

## Runtime evidence

Electron main process launched headless; full log:

```
[dashframe] main process started, waiting for app ready...
[dashframe] app ready, opening project...
[dashframe] project ready at /Users/youhaowei/.DashFrame/default-project
[dashframe] WyStack IPC transport mounted
[dashframe] creating window with DEV_URL=http://localhost:5173...
[dashframe] window created
(node:51161) electron: Failed to load URL: http://localhost:5173/ with error: ERR_CONNECTION_REFUSED
```

The `ERR_CONNECTION_REFUSED` is expected — no Vite dev server was running in the headless test environment. The WyStack transport mounts and the window opens successfully. Full app-launch verification with the renderer showing project info requires `bun run dev:desktop` with a display.

## `bun check` result

```
Tasks:    59 successful, 59 total
Cached:    56 cached, 59 total
```

All 59 tasks pass.

## Test plan

- [ ] `bun run dev:desktop` — app launches, renderer shows project name/version in the index route
- [ ] Chrome DevTools Network tab (CDP): `wystack:c2s` send visible on connect; `wystack:s2c` carries `{type:"result",id:"call_1",data:{name:...,version:...}}`
- [ ] Console: no errors; `[dashframe] WyStack IPC transport mounted` visible in main process logs

Closes YW-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires WyStack (the project's custom query engine) over Electron IPC, replacing the previous static "hello" screen with a live `projectInfo` query from the main process. The transport is three-layered: main process registers a WyStack server over `wystack:c2s`/`wystack:s2c` IPC channels, the preload bridges them through `contextBridge`, and the renderer runs a hand-rolled call/result correlator wrapped in a `WyStackClient`-compatible object.

- **Main + preload**: `buildWyStackApp` serves `projectInfo` from `ProjectHandle.meta` in-memory; the preload `wysIpc` bridge uses a channel allowlist and a `WeakMap` to correlate `removeListener` calls correctly across context isolation.
- **Renderer client** (`wystack.ts`): custom `WyStackClient` over IPC with a per-call correlator (`Map<id, {resolve,reject}>`); no-op `WsManager` stubs subscriptions until YW-62; `useProjectInfo` hook surfaced via TanStack Query.
- **Build system**: `build:main` now bundles `@wystack/*` inline; a new `scripts/build-wystack.mjs` pre-builds wystack submodule dists excluding test files; Turbo overrides prevent re-running wystack builds through the dependency chain.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the current smoke-test scope; the IPC wiring is correct and the contextBridge allowlist is properly scoped, but two areas around lifecycle cleanup and the build script are worth addressing before the codebase grows.

The IPC protocol is straightforward and the preload bridge is well-guarded. The main concerns are: `detach()` being called twice in the quit sequence (both `before-quit` handlers fire on the first quit attempt, and again on the second), the hand-rolled correlator having no timeout or send-failure cleanup path, and the `build-wystack.mjs` script silently skipping stale `dist/` directories and using unquoted paths that would break on space-containing repo roots. None of these cause visible breakage in the happy path, but they are latent issues that could surface during development or on certain developer machines.

`apps/desktop/src/main.ts` (quit-sequence `detach` call ordering), `apps/renderer/src/wystack.ts` (correlator cleanup), and `scripts/build-wystack.mjs` (stale-dist skip + unquoted paths).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main.ts | Adds WyStack IPC transport mount and `buildWyStackApp`; the `detach()` registration on `before-quit` fires twice during the quit sequence, and the `projectInfo` data shape is duplicated from `registerIpc`. |
| apps/desktop/src/preload.ts | Adds `window.wysIpc` bridge via `contextBridge`; channel allowlist and WeakMap-based listener correlation are well-implemented. The null-event wrapper (`listener(null, ...rest)`) is correctly documented. |
| apps/renderer/src/wystack.ts | New module wiring WyStack IPC client; hand-rolled correlator has no timeout or error cleanup on send failure, leaving `pending` entries that can never settle. |
| apps/renderer/src/main.tsx | Wraps the app in `QueryClientProvider` + `WyStackProvider`; straightforward provider composition, no issues. |
| apps/renderer/src/routes/index.tsx | Adds `useProjectInfo()` to render project name/version; loading/error states are handled correctly. |
| scripts/build-wystack.mjs | New build script for wystack submodule dists; unquoted path variables in execSync break on space-containing paths, and the `dist` existence check silently skips stale builds. |
| turbo.json | Adds per-package task overrides to prevent turbo from re-running wystack builds and to break circular typecheck dependencies; appears correct. |
| apps/desktop/package.json | Switches `build:main` from `--packages=external` to explicit externals so `@wystack/*` and transitive deps are bundled; adds `@wystack/server` as a workspace dependency. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Renderer (wystack.ts)
    participant PB as Preload Bridge (wysIpc)
    participant IM as ipcMain (Electron)
    participant WS as WyStack Server
    participant PH as ProjectHandle.meta

    R->>PB: "wysIpc.send("wystack:c2s", {type:"call", id:"call_1", path:"projectInfo"})"
    PB->>IM: ipcRenderer.send("wystack:c2s", msg)
    IM->>WS: attachElectronTransport routes call frame
    WS->>PH: "handler({ db: null }, args)"
    PH-->>WS: "{ projectId, name, version, ... }"
    WS-->>IM: "{type:"result", id:"call_1", data:{...}}"
    IM-->>PB: ipcRenderer "wystack:s2c" event
    PB-->>R: "listener(null, {type:"result", id:"call_1", data:{...}})"
    R->>R: pending.get("call_1").resolve(data)
    R->>R: useProjectInfo() renders project name/version
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Frenderer%2Fsrc%2Fwystack.ts%3A98-107%0A**Pending%20calls%20never%20time%20out%20or%20clean%20up%20on%20send%20failure**%0A%0A%60ipcCall%60%20stores%20a%20%60%7Bresolve%2C%20reject%7D%60%20in%20%60pending%60%20before%20calling%20%60pipe.send%60.%20If%20the%20send%20throws%20synchronously%20%28e.g.%2C%20context-bridge%20serialization%20error%29%2C%20the%20Promise%20constructor%20catches%20it%20and%20rejects%E2%80%94but%20the%20%60pending%60%20entry%20for%20that%20%60id%60%20is%20never%20deleted%2C%20so%20it%20leaks.%20More%20critically%2C%20if%20the%20IPC%20response%20is%20silently%20dropped%20for%20any%20reason%20%28renderer%20reload%20mid-call%2C%20transient%20IPC%20error%2C%20unexpected%20frame%20type%29%2C%20the%20promise%20hangs%20indefinitely%20and%20the%20%60pending%60%20entry%20accumulates.%20Adding%20a%20timeout%20%28e.g.%2C%20via%20%60AbortSignal%60%20or%20%60setTimeout%60%2B%60pending.delete%60%29%20and%20a%20%60try%2Ffinally%60%20cleanup%20around%20%60pipe.send%60%20would%20make%20this%20more%20robust.%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A150-156%0A**%60detach%28%29%60%20is%20called%20twice%20during%20the%20quit%20sequence**%0A%0ABoth%20%60closeProjectBeforeQuit%60%20and%20%60%28%29%20%3D%3E%20detach%28%29%60%20are%20registered%20on%20the%20same%20%60before-quit%60%20event.%20On%20the%20first%20quit%2C%20both%20fire%3A%20%60closeProjectBeforeQuit%60%20calls%20%60event.preventDefault%28%29%60%20then%20asynchronously%20closes%20the%20project%20and%20calls%20%60app.quit%28%29%60%20again%3B%20%60detach%28%29%60%20runs%20in%20that%20same%20first-event%20pass.%20The%20second%20%60app.quit%28%29%60%20fires%20%60before-quit%60%20again%E2%80%94%60closeProjectBeforeQuit%60%20exits%20early%2C%20and%20%60%28%29%20%3D%3E%20detach%28%29%60%20runs%20a%20second%20time.%20If%20%60attachElectronTransport%60's%20%60detach%60%20is%20not%20idempotent%20%28e.g.%2C%20it%20warns%20or%20throws%20when%20a%20handler%20is%20removed%20twice%29%2C%20the%20quit%20sequence%20would%20be%20noisy%20or%20broken.%20Consider%20guarding%20with%20a%20%60let%20detached%20%3D%20false%60%20flag%2C%20or%20move%20the%20%60detach%28%29%60%20call%20inside%20%60closeProjectBeforeQuit%60%20so%20it's%20subject%20to%20the%20same%20%60isClosingProject%60%20guard.%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A38-71%0A**Duplicate%20%60projectInfo%60%20data%20construction**%0A%0A%60buildWyStackApp%60%20and%20the%20existing%20%60registerIpc%60%20both%20read%20the%20same%20six%20fields%20from%20%60handle.meta%60%20and%20construct%20an%20identical%20shape%20%28%60projectId%60%2C%20%60name%60%2C%20%60version%60%2C%20%60schemaVersion%60%2C%20%60createdAt.toISOString%28%29%60%2C%20%60createdBy%60%29.%20If%20%60ProjectInfo%60%20evolves%20%28a%20new%20field%20added%2C%20a%20field%20renamed%29%2C%20the%20two%20sites%20will%20drift.%20Consider%20extracting%20a%20small%20helper%20like%20%60projectInfoFromHandle%28handle%3A%20ProjectHandle%29%3A%20ProjectInfo%60%20and%20calling%20it%20from%20both%20places.%0A%0A%23%23%23%20Issue%204%20of%205%0Ascripts%2Fbuild-wystack.mjs%3A97-104%0AUnquoted%20path%20variables%20in%20%60execSync%60%20template%20literals%20will%20break%20on%20any%20machine%20whose%20repo%20root%20contains%20spaces%20%28common%20on%20macOS%20home%20directories%20like%20%60%2FUsers%2FJohn%20Doe%2F%60%29.%20The%20%60tsc%60%20invocation%20and%20%60rm%20-f%60%20both%20interpolate%20%60tmpFile%60%20without%20quoting.%0A%0A%60%60%60suggestion%0A%20%20%20%20execSync%28%60bun%20x%20tsc%20-p%20%22%24%7BtmpFile%7D%22%60%2C%20%7B%20stdio%3A%20'inherit'%20%7D%29%3B%0A%20%20%20%20console.log%28%60%5Bbuild-wystack%5D%20%24%7Bpkg.name%7D%3A%20done%60%29%3B%0A%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20console.error%28%60%5Bbuild-wystack%5D%20%24%7Bpkg.name%7D%3A%20build%20failed%60%29%3B%0A%20%20%20%20process.exit%281%29%3B%0A%20%20%7D%20finally%20%7B%0A%20%20%20%20try%20%7B%20execSync%28%60rm%20-f%20%22%24%7BtmpFile%7D%22%60%29%3B%20%7D%20catch%20%7B%7D%0A%20%20%7D%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=youhaowei%2Fdashframe&pr=44&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22claude%2Fcrazy-banzai-07aa05%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fcrazy-banzai-07aa05%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Frenderer%2Fsrc%2Fwystack.ts%3A98-107%0A**Pending%20calls%20never%20time%20out%20or%20clean%20up%20on%20send%20failure**%0A%0A%60ipcCall%60%20stores%20a%20%60%7Bresolve%2C%20reject%7D%60%20in%20%60pending%60%20before%20calling%20%60pipe.send%60.%20If%20the%20send%20throws%20synchronously%20%28e.g.%2C%20context-bridge%20serialization%20error%29%2C%20the%20Promise%20constructor%20catches%20it%20and%20rejects%E2%80%94but%20the%20%60pending%60%20entry%20for%20that%20%60id%60%20is%20never%20deleted%2C%20so%20it%20leaks.%20More%20critically%2C%20if%20the%20IPC%20response%20is%20silently%20dropped%20for%20any%20reason%20%28renderer%20reload%20mid-call%2C%20transient%20IPC%20error%2C%20unexpected%20frame%20type%29%2C%20the%20promise%20hangs%20indefinitely%20and%20the%20%60pending%60%20entry%20accumulates.%20Adding%20a%20timeout%20%28e.g.%2C%20via%20%60AbortSignal%60%20or%20%60setTimeout%60%2B%60pending.delete%60%29%20and%20a%20%60try%2Ffinally%60%20cleanup%20around%20%60pipe.send%60%20would%20make%20this%20more%20robust.%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A150-156%0A**%60detach%28%29%60%20is%20called%20twice%20during%20the%20quit%20sequence**%0A%0ABoth%20%60closeProjectBeforeQuit%60%20and%20%60%28%29%20%3D%3E%20detach%28%29%60%20are%20registered%20on%20the%20same%20%60before-quit%60%20event.%20On%20the%20first%20quit%2C%20both%20fire%3A%20%60closeProjectBeforeQuit%60%20calls%20%60event.preventDefault%28%29%60%20then%20asynchronously%20closes%20the%20project%20and%20calls%20%60app.quit%28%29%60%20again%3B%20%60detach%28%29%60%20runs%20in%20that%20same%20first-event%20pass.%20The%20second%20%60app.quit%28%29%60%20fires%20%60before-quit%60%20again%E2%80%94%60closeProjectBeforeQuit%60%20exits%20early%2C%20and%20%60%28%29%20%3D%3E%20detach%28%29%60%20runs%20a%20second%20time.%20If%20%60attachElectronTransport%60's%20%60detach%60%20is%20not%20idempotent%20%28e.g.%2C%20it%20warns%20or%20throws%20when%20a%20handler%20is%20removed%20twice%29%2C%20the%20quit%20sequence%20would%20be%20noisy%20or%20broken.%20Consider%20guarding%20with%20a%20%60let%20detached%20%3D%20false%60%20flag%2C%20or%20move%20the%20%60detach%28%29%60%20call%20inside%20%60closeProjectBeforeQuit%60%20so%20it's%20subject%20to%20the%20same%20%60isClosingProject%60%20guard.%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A38-71%0A**Duplicate%20%60projectInfo%60%20data%20construction**%0A%0A%60buildWyStackApp%60%20and%20the%20existing%20%60registerIpc%60%20both%20read%20the%20same%20six%20fields%20from%20%60handle.meta%60%20and%20construct%20an%20identical%20shape%20%28%60projectId%60%2C%20%60name%60%2C%20%60version%60%2C%20%60schemaVersion%60%2C%20%60createdAt.toISOString%28%29%60%2C%20%60createdBy%60%29.%20If%20%60ProjectInfo%60%20evolves%20%28a%20new%20field%20added%2C%20a%20field%20renamed%29%2C%20the%20two%20sites%20will%20drift.%20Consider%20extracting%20a%20small%20helper%20like%20%60projectInfoFromHandle%28handle%3A%20ProjectHandle%29%3A%20ProjectInfo%60%20and%20calling%20it%20from%20both%20places.%0A%0A%23%23%23%20Issue%204%20of%205%0Ascripts%2Fbuild-wystack.mjs%3A97-104%0AUnquoted%20path%20variables%20in%20%60execSync%60%20template%20literals%20will%20break%20on%20any%20machine%20whose%20repo%20root%20contains%20spaces%20%28common%20on%20macOS%20home%20directories%20like%20%60%2FUsers%2FJohn%20Doe%2F%60%29.%20The%20%60tsc%60%20invocation%20and%20%60rm%20-f%60%20both%20interpolate%20%60tmpFile%60%20without%20quoting.%0A%0A%60%60%60suggestion%0A%20%20%20%20execSync%28%60bun%20x%20tsc%20-p%20%22%24%7BtmpFile%7D%22%60%2C%20%7B%20stdio%3A%20'inherit'%20%7D%29%3B%0A%20%20%20%20console.log%28%60%5Bbuild-wystack%5D%20%24%7Bpkg.name%7D%3A%20done%60%29%3B%0A%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20console.error%28%60%5Bbuild-wystack%5D%20%24%7Bpkg.name%7D%3A%20build%20failed%60%29%3B%0A%20%20%20%20process.exit%281%29%3B%0A%20%20%7D%20finally%20%7B%0A%20%20%20%20try%20%7B%20execSync%28%60rm%20-f%20%22%24%7BtmpFile%7D%22%60%29%3B%20%7D%20catch%20%7B%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Ascripts%2Fbuild-wystack.mjs%3A74-79%0A**Stale%20%60dist%2F%60%20directory%20skips%20rebuild%20silently**%0A%0AThe%20script%20checks%20%60existsSync%28distDir%29%60%20and%20skips%20the%20package%20entirely%20if%20%60dist%2F%60%20is%20present.%20A%20partially-built%20or%20outdated%20%60dist%60%20left%20over%20from%20a%20different%20commit%20or%20a%20failed%20prior%20build%20will%20never%20be%20replaced%20unless%20it%20is%20manually%20deleted.%20During%20active%20development%20on%20the%20wystack%20submodule%20this%20can%20be%20confusing%3A%20%60bun%20setup%60%20appears%20to%20succeed%20while%20the%20renderer%20actually%20loads%20stale%20code.%20Consider%20adding%20a%20%60--force%60%20flag%20or%20comparing%20a%20checksum%2Fmtimes%20against%20the%20source%20files.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Frenderer%2Fsrc%2Fwystack.ts%3A98-107%0A**Pending%20calls%20never%20time%20out%20or%20clean%20up%20on%20send%20failure**%0A%0A%60ipcCall%60%20stores%20a%20%60%7Bresolve%2C%20reject%7D%60%20in%20%60pending%60%20before%20calling%20%60pipe.send%60.%20If%20the%20send%20throws%20synchronously%20%28e.g.%2C%20context-bridge%20serialization%20error%29%2C%20the%20Promise%20constructor%20catches%20it%20and%20rejects%E2%80%94but%20the%20%60pending%60%20entry%20for%20that%20%60id%60%20is%20never%20deleted%2C%20so%20it%20leaks.%20More%20critically%2C%20if%20the%20IPC%20response%20is%20silently%20dropped%20for%20any%20reason%20%28renderer%20reload%20mid-call%2C%20transient%20IPC%20error%2C%20unexpected%20frame%20type%29%2C%20the%20promise%20hangs%20indefinitely%20and%20the%20%60pending%60%20entry%20accumulates.%20Adding%20a%20timeout%20%28e.g.%2C%20via%20%60AbortSignal%60%20or%20%60setTimeout%60%2B%60pending.delete%60%29%20and%20a%20%60try%2Ffinally%60%20cleanup%20around%20%60pipe.send%60%20would%20make%20this%20more%20robust.%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A150-156%0A**%60detach%28%29%60%20is%20called%20twice%20during%20the%20quit%20sequence**%0A%0ABoth%20%60closeProjectBeforeQuit%60%20and%20%60%28%29%20%3D%3E%20detach%28%29%60%20are%20registered%20on%20the%20same%20%60before-quit%60%20event.%20On%20the%20first%20quit%2C%20both%20fire%3A%20%60closeProjectBeforeQuit%60%20calls%20%60event.preventDefault%28%29%60%20then%20asynchronously%20closes%20the%20project%20and%20calls%20%60app.quit%28%29%60%20again%3B%20%60detach%28%29%60%20runs%20in%20that%20same%20first-event%20pass.%20The%20second%20%60app.quit%28%29%60%20fires%20%60before-quit%60%20again%E2%80%94%60closeProjectBeforeQuit%60%20exits%20early%2C%20and%20%60%28%29%20%3D%3E%20detach%28%29%60%20runs%20a%20second%20time.%20If%20%60attachElectronTransport%60's%20%60detach%60%20is%20not%20idempotent%20%28e.g.%2C%20it%20warns%20or%20throws%20when%20a%20handler%20is%20removed%20twice%29%2C%20the%20quit%20sequence%20would%20be%20noisy%20or%20broken.%20Consider%20guarding%20with%20a%20%60let%20detached%20%3D%20false%60%20flag%2C%20or%20move%20the%20%60detach%28%29%60%20call%20inside%20%60closeProjectBeforeQuit%60%20so%20it's%20subject%20to%20the%20same%20%60isClosingProject%60%20guard.%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain.ts%3A38-71%0A**Duplicate%20%60projectInfo%60%20data%20construction**%0A%0A%60buildWyStackApp%60%20and%20the%20existing%20%60registerIpc%60%20both%20read%20the%20same%20six%20fields%20from%20%60handle.meta%60%20and%20construct%20an%20identical%20shape%20%28%60projectId%60%2C%20%60name%60%2C%20%60version%60%2C%20%60schemaVersion%60%2C%20%60createdAt.toISOString%28%29%60%2C%20%60createdBy%60%29.%20If%20%60ProjectInfo%60%20evolves%20%28a%20new%20field%20added%2C%20a%20field%20renamed%29%2C%20the%20two%20sites%20will%20drift.%20Consider%20extracting%20a%20small%20helper%20like%20%60projectInfoFromHandle%28handle%3A%20ProjectHandle%29%3A%20ProjectInfo%60%20and%20calling%20it%20from%20both%20places.%0A%0A%23%23%23%20Issue%204%20of%205%0Ascripts%2Fbuild-wystack.mjs%3A97-104%0AUnquoted%20path%20variables%20in%20%60execSync%60%20template%20literals%20will%20break%20on%20any%20machine%20whose%20repo%20root%20contains%20spaces%20%28common%20on%20macOS%20home%20directories%20like%20%60%2FUsers%2FJohn%20Doe%2F%60%29.%20The%20%60tsc%60%20invocation%20and%20%60rm%20-f%60%20both%20interpolate%20%60tmpFile%60%20without%20quoting.%0A%0A%60%60%60suggestion%0A%20%20%20%20execSync%28%60bun%20x%20tsc%20-p%20%22%24%7BtmpFile%7D%22%60%2C%20%7B%20stdio%3A%20'inherit'%20%7D%29%3B%0A%20%20%20%20console.log%28%60%5Bbuild-wystack%5D%20%24%7Bpkg.name%7D%3A%20done%60%29%3B%0A%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20console.error%28%60%5Bbuild-wystack%5D%20%24%7Bpkg.name%7D%3A%20build%20failed%60%29%3B%0A%20%20%20%20process.exit%281%29%3B%0A%20%20%7D%20finally%20%7B%0A%20%20%20%20try%20%7B%20execSync%28%60rm%20-f%20%22%24%7BtmpFile%7D%22%60%29%3B%20%7D%20catch%20%7B%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Ascripts%2Fbuild-wystack.mjs%3A74-79%0A**Stale%20%60dist%2F%60%20directory%20skips%20rebuild%20silently**%0A%0AThe%20script%20checks%20%60existsSync%28distDir%29%60%20and%20skips%20the%20package%20entirely%20if%20%60dist%2F%60%20is%20present.%20A%20partially-built%20or%20outdated%20%60dist%60%20left%20over%20from%20a%20different%20commit%20or%20a%20failed%20prior%20build%20will%20never%20be%20replaced%20unless%20it%20is%20manually%20deleted.%20During%20active%20development%20on%20the%20wystack%20submodule%20this%20can%20be%20confusing%3A%20%60bun%20setup%60%20appears%20to%20succeed%20while%20the%20renderer%20actually%20loads%20stale%20code.%20Consider%20adding%20a%20%60--force%60%20flag%20or%20comparing%20a%20checksum%2Fmtimes%20against%20the%20source%20files.%0A%0A&pr=44&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
apps/renderer/src/wystack.ts:98-107
**Pending calls never time out or clean up on send failure**

`ipcCall` stores a `{resolve, reject}` in `pending` before calling `pipe.send`. If the send throws synchronously (e.g., context-bridge serialization error), the Promise constructor catches it and rejects—but the `pending` entry for that `id` is never deleted, so it leaks. More critically, if the IPC response is silently dropped for any reason (renderer reload mid-call, transient IPC error, unexpected frame type), the promise hangs indefinitely and the `pending` entry accumulates. Adding a timeout (e.g., via `AbortSignal` or `setTimeout`+`pending.delete`) and a `try/finally` cleanup around `pipe.send` would make this more robust.

### Issue 2 of 5
apps/desktop/src/main.ts:150-156
**`detach()` is called twice during the quit sequence**

Both `closeProjectBeforeQuit` and `() => detach()` are registered on the same `before-quit` event. On the first quit, both fire: `closeProjectBeforeQuit` calls `event.preventDefault()` then asynchronously closes the project and calls `app.quit()` again; `detach()` runs in that same first-event pass. The second `app.quit()` fires `before-quit` again—`closeProjectBeforeQuit` exits early, and `() => detach()` runs a second time. If `attachElectronTransport`'s `detach` is not idempotent (e.g., it warns or throws when a handler is removed twice), the quit sequence would be noisy or broken. Consider guarding with a `let detached = false` flag, or move the `detach()` call inside `closeProjectBeforeQuit` so it's subject to the same `isClosingProject` guard.

### Issue 3 of 5
apps/desktop/src/main.ts:38-71
**Duplicate `projectInfo` data construction**

`buildWyStackApp` and the existing `registerIpc` both read the same six fields from `handle.meta` and construct an identical shape (`projectId`, `name`, `version`, `schemaVersion`, `createdAt.toISOString()`, `createdBy`). If `ProjectInfo` evolves (a new field added, a field renamed), the two sites will drift. Consider extracting a small helper like `projectInfoFromHandle(handle: ProjectHandle): ProjectInfo` and calling it from both places.

### Issue 4 of 5
scripts/build-wystack.mjs:97-104
Unquoted path variables in `execSync` template literals will break on any machine whose repo root contains spaces (common on macOS home directories like `/Users/John Doe/`). The `tsc` invocation and `rm -f` both interpolate `tmpFile` without quoting.

```suggestion
    execSync(`bun x tsc -p "${tmpFile}"`, { stdio: 'inherit' });
    console.log(`[build-wystack] ${pkg.name}: done`);
  } catch (err) {
    console.error(`[build-wystack] ${pkg.name}: build failed`);
    process.exit(1);
  } finally {
    try { execSync(`rm -f "${tmpFile}"`); } catch {}
  }
```

### Issue 5 of 5
scripts/build-wystack.mjs:74-79
**Stale `dist/` directory skips rebuild silently**

The script checks `existsSync(distDir)` and skips the package entirely if `dist/` is present. A partially-built or outdated `dist` left over from a different commit or a failed prior build will never be replaced unless it is manually deleted. During active development on the wystack submodule this can be confusing: `bun setup` appears to succeed while the renderer actually loads stale code. Consider adding a `--force` flag or comparing a checksum/mtimes against the source files.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): wire WyStack server+clien..."](https://github.com/youhaowei/dashframe/commit/1ac1ca067a88135c7aa20e6b1149dcce6463a161) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34829066)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->