### PR TITLE
[codex] Migrate apps/server test to Vitest

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "start": "bun run src/index.ts",
-    "test": "bun test src",
+    "test": "vitest run",
     "build": "bun run build:js && bun run build:types",
     "build:js": "esbuild src/index.ts src/app.ts src/functions.ts --bundle --platform=node --packages=external --format=esm --outdir=dist",
     "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
@@ -43,6 +43,7 @@
     "@dashframe/eslint-config": "workspace:*",
     "@types/bun": "^1.2.0",
     "esbuild": "^0.28.0",
-    "typescript": "5.7.2"
+    "typescript": "5.7.2",
+    "vitest": "^4.1.6"
   }
 }

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { openProject, type ProjectHandle } from "@dashframe/server-core";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createDashframeServer, type DashframeServer } from "./app";
 import type { ProjectInfoResult } from "./functions";
@@ -32,26 +32,28 @@ describe("createDashframeServer", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  test("serves projectInfo over loopback HTTP from the project DB", async () => {
-    project = await openProject({ dir: join(root, "proj"), name: "Smoke Co" });
-    server = await createDashframeServer({ db: project.db });
+  describe("HTTP API", () => {
+    it("should serve projectInfo over loopback HTTP from the project DB", async () => {
+      project = await openProject({
+        dir: join(root, "proj"),
+        name: "Smoke Co",
+      });
+      server = await createDashframeServer({ db: project.db });
 
-    // Bound to an ephemeral loopback port.
-    expect(server.port).toBeGreaterThan(0);
-    expect(server.url).toBe(`http://127.0.0.1:${server.port}`);
+      // Bound to an ephemeral loopback port.
+      expect(server.port).toBeGreaterThan(0);
+      expect(server.url).toBe(`http://127.0.0.1:${server.port}`);
 
-    // Same request the WyStack client issues for a query: GET /api/:fn?args=.
-    const res = await fetch(
-      `${server.url}/api/projectInfo?args=${encodeURIComponent("{}")}`,
-    );
-    expect(res.status).toBe(200);
+      // Same request the WyStack client issues for a query: GET /api/:fn?args=.
+      const res = await fetch(
+        `${server.url}/api/projectInfo?args=${encodeURIComponent("{}")}`,
+      );
+      expect(res.status).toBe(200);
 
-    const body = (await res.json()) as { data: ProjectInfoResult };
-    expect(body.data.name).toBe("Smoke Co");
-    expect(body.data.projectId).toBe(project.meta.projectId);
-    expect(body.data.version).toBe(project.meta.version);
-    // 30s timeout: PGLite cold-start (WASM instantiate + schema sync) takes
-    // ~20s+ on a cold CI runner vs <1s warm locally. Matches server-core's
-    // vitest testTimeout for the same reason — the default 5s flakes in CI.
-  }, 30_000);
+      const body = (await res.json()) as { data: ProjectInfoResult };
+      expect(body.data.name).toBe("Smoke Co");
+      expect(body.data.projectId).toBe(project.meta.projectId);
+      expect(body.data.version).toBe(project.meta.version);
+    });
+  });
 });

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -8,7 +8,6 @@ const configDir = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   test: {
     environment: "node",
-    globals: true,
     include: ["**/*.test.{ts,tsx}"],
     // PGLite cold-start can exceed Vitest's default 5s timeout in CI.
     testTimeout: 30_000,

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,6 +1,9 @@
-import path from "node:path";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vitest/config";
+
+const configDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
@@ -13,19 +16,19 @@ export default defineConfig({
   resolve: {
     alias: {
       "@dashframe/server-core": path.resolve(
-        __dirname,
+        configDir,
         "../../packages/server-core/src",
       ),
       "@wystack/db": path.resolve(
-        __dirname,
+        configDir,
         "../../libs/wystack/packages/db/src",
       ),
       "@wystack/server": path.resolve(
-        __dirname,
+        configDir,
         "../../libs/wystack/packages/server/src",
       ),
       "@wystack/transport": path.resolve(
-        __dirname,
+        configDir,
         "../../libs/wystack/packages/transport/src",
       ),
     },

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.{ts,tsx}"],
+    // PGLite cold-start can exceed Vitest's default 5s timeout in CI.
+    testTimeout: 30_000,
+  },
+  resolve: {
+    alias: {
+      "@dashframe/server-core": path.resolve(
+        __dirname,
+        "../../packages/server-core/src",
+      ),
+      "@wystack/db": path.resolve(
+        __dirname,
+        "../../libs/wystack/packages/db/src",
+      ),
+      "@wystack/server": path.resolve(
+        __dirname,
+        "../../libs/wystack/packages/server/src",
+      ),
+      "@wystack/transport": path.resolve(
+        __dirname,
+        "../../libs/wystack/packages/transport/src",
+      ),
+    },
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,7 @@
         "@types/bun": "^1.2.0",
         "esbuild": "^0.28.0",
         "typescript": "5.7.2",
+        "vitest": "^4.1.6",
       },
     },
     "apps/web": {


### PR DESCRIPTION
## Summary
- migrate apps/server integration smoke test from bun:test to Vitest
- add apps/server Vitest config with node environment, 30s PGLite timeout, and source aliases for workspace packages
- switch apps/server test script to vitest run and add the direct Vitest dev dependency

## Verification
- bun check
- bun run test

## Notes
- YW-101

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates `apps/server`'s integration smoke test from `bun:test` to Vitest, adding a dedicated `vitest.config.ts` and updating the `package.json` test script accordingly.

- **Test migration**: `bun:test` imports replaced with `vitest`, `test()` renamed to `it()`, and the per-test 30 s timeout moved to the global `testTimeout` in the config; the test is now nested inside a `describe("HTTP API")` block.
- **New config**: `apps/server/vitest.config.ts` sets `environment: "node"`, a 30 s `testTimeout` for PGLite cold-start, and resolve aliases for all workspace packages (`@dashframe/server-core`, `@wystack/*`).
- **Dependency**: `vitest@^4.1.6` added as a dev dependency; `bun.lock` updated accordingly.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a clean test-infrastructure migration with no logic changes.

The change only swaps the test runner from bun:test to Vitest. All test assertions are identical to the original; the timeout is correctly moved to the global config; workspace aliases cover every import the test needs. No runtime or production code is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/vitest.config.ts | New Vitest config with node environment, 30 s PGLite timeout, and workspace package aliases; well-structured and consistent with other packages. |
| apps/server/src/app.test.ts | Migrated from bun:test to vitest imports; timeout moved to config, test wrapped in nested describe — logic is unchanged and correct. |
| apps/server/package.json | Test script changed to `vitest run` and vitest added as dev dependency; straightforward and correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun run test] --> B[vitest run]
    B --> C[Load apps/server/vitest.config.ts]
    C --> D{Resolve workspace aliases}
    D --> E["@dashframe/server-core → packages/server-core/src"]
    D --> F["@wystack/db → libs/wystack/packages/db/src"]
    D --> G["@wystack/server → libs/wystack/packages/server/src"]
    D --> H["@wystack/transport → libs/wystack/packages/transport/src"]
    C --> I[testTimeout: 30s, environment: node]
    I --> J[src/app.test.ts]
    J --> K[beforeEach: mkdtemp]
    K --> L[describe: HTTP API]
    L --> M["it: should serve projectInfo over loopback HTTP"]
    M --> N[openProject + createDashframeServer]
    N --> O[fetch /api/projectInfo]
    O --> P[Assert status 200 + body fields]
    P --> Q[afterEach: server.stop + project.close + rmSync]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: remove unused vitest globals"](https://github.com/youhaowei/dashframe/commit/e94b36af706e232af2e0bfaa8df469be71f7e834) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36279239)</sub>

<!-- /greptile_comment -->