### PR TITLE
feat(server): dashframe serve CLI --token flag (YW-73)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
-    "dashframe": "src/index.ts",
-    "dashframe-serve": "src/index.ts"
+    "dashframe": "src/index.ts"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
+    "dashframe": "src/index.ts",
     "dashframe-serve": "src/index.ts"
   },
   "exports": {

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { parseArgs, printHelp } from "./index";
+
+describe("dashframe serve CLI", () => {
+  it("should parse the serve subcommand with project, bind, and token", () => {
+    expect(
+      parseArgs([
+        "serve",
+        "--project",
+        "/Users/example/DashFrameProject",
+        "--bind",
+        "127.0.0.1:4100",
+        "--token",
+        "secret",
+      ]),
+    ).toEqual({
+      project: "/Users/example/DashFrameProject",
+      hostname: "127.0.0.1",
+      port: 4100,
+      token: "secret",
+    });
+  });
+
+  it("should parse port-only and IPv6 bind addresses", () => {
+    expect(parseArgs(["--bind", ":4123"])).toEqual({ port: 4123 });
+    expect(parseArgs(["--bind", "[::1]:4124"])).toEqual({
+      hostname: "::1",
+      port: 4124,
+    });
+  });
+
+  it("should reject malformed bind ports", () => {
+    expect(() => parseArgs(["--bind", "127.0.0.1:"])).toThrow(
+      'Invalid --port ""',
+    );
+    expect(() => parseArgs(["--bind", "127.0.0.1:not-a-port"])).toThrow(
+      'Invalid --port "not-a-port"',
+    );
+  });
+
+  it("should document the security boundary in help", () => {
+    const originalLog = console.log;
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => {
+      output.push(args.join(" "));
+    };
+
+    try {
+      printHelp();
+    } finally {
+      console.log = originalLog;
+    }
+
+    const helpText = output.join("\n");
+    expect(helpText).toContain("--bind <addr>");
+    expect(helpText).toContain("--token <token>");
+    expect(helpText).toContain("Security boundary:");
+    expect(helpText).toContain("non-loopback bind");
+  });
+});

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -3,65 +3,78 @@ import { describe, expect, it } from "vitest";
 import { assertBindIsSafe, parseArgs, printHelp } from "./index";
 
 describe("dashframe serve CLI", () => {
-  it("should parse the serve subcommand with project, bind, and token", () => {
-    expect(
-      parseArgs([
-        "serve",
-        "--project",
-        "/Users/example/DashFrameProject",
-        "--bind",
-        "127.0.0.1:4100",
-        "--token",
-        "secret",
-      ]),
-    ).toEqual({
-      project: "/Users/example/DashFrameProject",
-      hostname: "127.0.0.1",
-      port: 4100,
-      token: "secret",
+  describe("parseArgs", () => {
+    it("should parse the serve subcommand with project, bind, and token", () => {
+      expect(
+        parseArgs([
+          "serve",
+          "--project",
+          "/Users/example/DashFrameProject",
+          "--bind",
+          "127.0.0.1:4100",
+          "--token",
+          "secret",
+        ]),
+      ).toEqual({
+        project: "/Users/example/DashFrameProject",
+        hostname: "127.0.0.1",
+        port: 4100,
+        token: "secret",
+      });
+    });
+
+    it("should parse port-only and IPv6 bind addresses", () => {
+      expect(parseArgs(["--bind", ":4123"])).toEqual({ port: 4123 });
+      expect(parseArgs(["--bind", "[::1]:4124"])).toEqual({
+        hostname: "::1",
+        port: 4124,
+      });
+    });
+
+    it("should reject an unbracketed IPv6 bind with a bracket hint", () => {
+      // eslint-disable-next-line sonarjs/no-hardcoded-ip -- the malformed literal is the input under test
+      expect(() => parseArgs(["--bind", "::1:4000"])).toThrow(
+        /bracket IPv6 addresses as \[host\]:port/,
+      );
+    });
+
+    it("should reject malformed bind ports", () => {
+      expect(() => parseArgs(["--bind", "127.0.0.1:"])).toThrow(
+        'Invalid --port ""',
+      );
+      expect(() => parseArgs(["--bind", "127.0.0.1:not-a-port"])).toThrow(
+        'Invalid --port "not-a-port"',
+      );
     });
   });
 
-  it("should parse port-only and IPv6 bind addresses", () => {
-    expect(parseArgs(["--bind", ":4123"])).toEqual({ port: 4123 });
-    expect(parseArgs(["--bind", "[::1]:4124"])).toEqual({
-      hostname: "::1",
-      port: 4124,
+  describe("printHelp", () => {
+    it("should document the security boundary in help", () => {
+      const originalLog = console.log;
+      const output: string[] = [];
+      console.log = (...args: unknown[]) => {
+        output.push(args.join(" "));
+      };
+
+      try {
+        printHelp();
+      } finally {
+        console.log = originalLog;
+      }
+
+      const helpText = output.join("\n");
+      expect(helpText).toContain("--bind <addr>");
+      expect(helpText).toContain("--token <token>");
+      expect(helpText).toContain("Security boundary:");
+      expect(helpText).toContain("non-loopback bind");
     });
-  });
-
-  it("should reject malformed bind ports", () => {
-    expect(() => parseArgs(["--bind", "127.0.0.1:"])).toThrow(
-      'Invalid --port ""',
-    );
-    expect(() => parseArgs(["--bind", "127.0.0.1:not-a-port"])).toThrow(
-      'Invalid --port "not-a-port"',
-    );
-  });
-
-  it("should document the security boundary in help", () => {
-    const originalLog = console.log;
-    const output: string[] = [];
-    console.log = (...args: unknown[]) => {
-      output.push(args.join(" "));
-    };
-
-    try {
-      printHelp();
-    } finally {
-      console.log = originalLog;
-    }
-
-    const helpText = output.join("\n");
-    expect(helpText).toContain("--bind <addr>");
-    expect(helpText).toContain("--token <token>");
-    expect(helpText).toContain("Security boundary:");
-    expect(helpText).toContain("non-loopback bind");
   });
 
   describe("assertBindIsSafe", () => {
     it("should allow a loopback bind without a token", () => {
       expect(() => assertBindIsSafe({ hostname: "127.0.0.1" })).not.toThrow();
+      // Anywhere in 127.0.0.0/8, not just 127.0.0.1.
+      expect(() => assertBindIsSafe({ hostname: "127.0.0.2" })).not.toThrow();
       expect(() => assertBindIsSafe({})).not.toThrow();
     });
 

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseArgs, printHelp } from "./index";
+import { assertBindIsSafe, parseArgs, printHelp } from "./index";
 
 describe("dashframe serve CLI", () => {
   it("should parse the serve subcommand with project, bind, and token", () => {
@@ -57,5 +57,30 @@ describe("dashframe serve CLI", () => {
     expect(helpText).toContain("--token <token>");
     expect(helpText).toContain("Security boundary:");
     expect(helpText).toContain("non-loopback bind");
+  });
+
+  describe("assertBindIsSafe", () => {
+    it("should allow a loopback bind without a token", () => {
+      expect(() => assertBindIsSafe({ hostname: "127.0.0.1" })).not.toThrow();
+      expect(() => assertBindIsSafe({})).not.toThrow();
+    });
+
+    it("should reject a non-loopback bind without a token", () => {
+      expect(() => assertBindIsSafe({ hostname: "0.0.0.0" })).toThrow(
+        /Refusing to bind 0\.0\.0\.0 without --token/,
+      );
+    });
+
+    it("should allow a non-loopback bind when a token is set", () => {
+      expect(() =>
+        assertBindIsSafe({ hostname: "0.0.0.0", token: "secret" }),
+      ).not.toThrow();
+    });
+
+    it("should allow a non-loopback bind when --insecure opts out", () => {
+      expect(() =>
+        assertBindIsSafe({ hostname: "0.0.0.0", insecure: true }),
+      ).not.toThrow();
+    });
   });
 });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -93,6 +93,16 @@ function applyBind(opts: CliOptions, raw: string): void {
     throw new Error("--bind requires a non-empty address");
   }
 
+  // A full-form IPv6 literal (e.g. `::1`, `fe80::1`) has multiple colons and
+  // must be bracketed to disambiguate the host from a `:port` suffix. Catch it
+  // before the port-only branch below, which would otherwise misread `::1:4000`
+  // as port `:1:4000`.
+  if (!raw.startsWith("[") && raw.indexOf(":") !== raw.lastIndexOf(":")) {
+    throw new Error(
+      `Invalid --bind "${raw}": bracket IPv6 addresses as [host]:port, e.g. [::1]:4000`,
+    );
+  }
+
   if (raw.startsWith(":")) {
     opts.port = parsePort(raw.slice(1));
     return;
@@ -182,7 +192,8 @@ function isLoopback(hostname: string | undefined): boolean {
   return (
     hostname === undefined ||
     hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
+    // Entire 127.0.0.0/8 block is loopback (RFC 3330), not just 127.0.0.1.
+    hostname.startsWith("127.") ||
     hostname === "::1"
   );
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -19,6 +19,7 @@ interface CliOptions {
   name?: string;
   corsOrigin?: string | string[];
   token?: string;
+  insecure?: boolean;
   help?: boolean;
 }
 
@@ -39,13 +40,15 @@ Options:
   --port <port>           Bind port alias (default: 0, OS-assigned)
   --name <name>           Project display name when initializing
   --cors-origin <origin>  Allowed browser origin; repeat or comma-separate for multiple
+  --insecure              Allow a non-loopback bind without --token (opt out of the auth requirement)
   --help                  Show this help
 
 Security boundary:
   The server exposes the selected local DashFrame project over HTTP and WebSocket.
-  The default bind is loopback-only. Binding to 0.0.0.0 or another network
-  interface makes the project reachable from that network. Use --token for any
-  non-loopback bind, and do not treat it as TLS or multi-user authorization.
+  The default bind is loopback-only and safe to run without a token. Binding to
+  0.0.0.0 or another network interface makes the project reachable from that
+  network, so a non-loopback bind requires --token; pass --insecure to opt out
+  deliberately. A token is not TLS and not multi-user authorization.
 `);
 }
 
@@ -167,6 +170,9 @@ function parseArgAt(opts: CliOptions, args: string[], index: number): number {
     case "--token":
       opts.token = readValue(args, index, arg);
       return index + 1;
+    case "--insecure":
+      opts.insecure = true;
+      return index;
     default:
       throw new Error(`Unknown argument "${arg}"`);
   }
@@ -178,6 +184,23 @@ function isLoopback(hostname: string | undefined): boolean {
     hostname === "localhost" ||
     hostname === "127.0.0.1" ||
     hostname === "::1"
+  );
+}
+
+/**
+ * Fail-closed auth gate. Loopback binds are reachable only from this machine,
+ * so a token is optional there. A non-loopback bind exposes the project to the
+ * network and must carry `--token`; `--insecure` is the deliberate opt-out.
+ * Throws (rather than warns) so a forgotten token never silently exposes data.
+ */
+export function assertBindIsSafe(opts: CliOptions): void {
+  if (isLoopback(opts.hostname) || opts.token || opts.insecure) {
+    return;
+  }
+  throw new Error(
+    `Refusing to bind ${opts.hostname} without --token: a non-loopback bind ` +
+      `exposes this project to the network. Pass --token <token>, or ` +
+      `--insecure to opt out deliberately.`,
   );
 }
 
@@ -201,9 +224,11 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
     return;
   }
 
-  if (!opts.token && !isLoopback(opts.hostname)) {
+  assertBindIsSafe(opts);
+
+  if (opts.insecure && !opts.token && !isLoopback(opts.hostname)) {
     console.warn(
-      "[dashframe] warning: non-loopback bind without --token exposes this project to the network",
+      "[dashframe] warning: --insecure non-loopback bind without --token exposes this project to the network",
     );
   }
 
@@ -230,5 +255,12 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
 }
 
 if (import.meta.main) {
-  await main();
+  try {
+    await main();
+  } catch (err) {
+    // Operator-facing CLI: print a one-line reason and exit non-zero rather
+    // than dumping a stack trace for expected failures like the auth gate.
+    console.error(`[dashframe] ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -18,6 +18,8 @@ interface CliOptions {
   project?: string;
   name?: string;
   corsOrigin?: string | string[];
+  token?: string;
+  help?: boolean;
 }
 
 const DEFAULT_WEB_PROJECT_DIR = path.join(
@@ -26,16 +28,24 @@ const DEFAULT_WEB_PROJECT_DIR = path.join(
   "web-project",
 );
 
-function printHelp(): void {
+export function printHelp(): void {
   console.log(`dashframe serve
 
 Options:
-  --host <host>           Bind host (default: 127.0.0.1)
-  --port <port>           Bind port (default: 0, OS-assigned)
   --project <dir>         Project directory (default: DASHFRAME_PROJECT_DIR or ~/.DashFrame/web-project)
+  --bind <addr>           Bind address as host[:port] (default: 127.0.0.1:0)
+  --token <token>         Require Bearer token auth for HTTP and WebSocket clients
+  --host <host>           Bind host alias (default: 127.0.0.1)
+  --port <port>           Bind port alias (default: 0, OS-assigned)
   --name <name>           Project display name when initializing
   --cors-origin <origin>  Allowed browser origin; repeat or comma-separate for multiple
   --help                  Show this help
+
+Security boundary:
+  The server exposes the selected local DashFrame project over HTTP and WebSocket.
+  The default bind is loopback-only. Binding to 0.0.0.0 or another network
+  interface makes the project reachable from that network. Use --token for any
+  non-loopback bind, and do not treat it as TLS or multi-user authorization.
 `);
 }
 
@@ -47,7 +57,10 @@ function readValue(args: string[], index: number, flag: string): string {
   return value;
 }
 
-function parsePort(raw: string): number {
+export function parsePort(raw: string): number {
+  if (!raw.trim()) {
+    throw new Error(`Invalid --port "${raw}"`);
+  }
   const port = Number(raw);
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`Invalid --port "${raw}"`);
@@ -72,53 +85,100 @@ function appendCorsOrigins(
   return [...existing, ...values];
 }
 
-function parseArgs(args: string[]): CliOptions {
+function applyBind(opts: CliOptions, raw: string): void {
+  if (!raw.trim()) {
+    throw new Error("--bind requires a non-empty address");
+  }
+
+  if (raw.startsWith(":")) {
+    opts.port = parsePort(raw.slice(1));
+    return;
+  }
+
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end === -1) {
+      throw new Error(`Invalid --bind "${raw}"`);
+    }
+    opts.hostname = raw.slice(1, end);
+    const suffix = raw.slice(end + 1);
+    if (suffix) {
+      if (!suffix.startsWith(":")) {
+        throw new Error(`Invalid --bind "${raw}"`);
+      }
+      opts.port = parsePort(suffix.slice(1));
+    }
+    return;
+  }
+
+  const colon = raw.lastIndexOf(":");
+  if (colon > 0 && raw.indexOf(":") === colon) {
+    opts.hostname = raw.slice(0, colon);
+    opts.port = parsePort(raw.slice(colon + 1));
+    return;
+  }
+
+  opts.hostname = raw;
+}
+
+export function parseArgs(args: string[]): CliOptions {
   const opts: CliOptions = {};
 
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i]!;
-    if (arg === "--help" || arg === "-h") {
-      printHelp();
-      process.exit(0);
-    }
+  const normalizedArgs = args[0] === "serve" ? args.slice(1) : args;
 
-    if (arg === "--host") {
-      opts.hostname = readValue(args, i, arg);
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--port") {
-      opts.port = parsePort(readValue(args, i, arg));
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--project") {
-      opts.project = readValue(args, i, arg);
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--name") {
-      opts.name = readValue(args, i, arg);
-      i += 1;
-      continue;
-    }
-
-    if (arg === "--cors-origin") {
-      opts.corsOrigin = appendCorsOrigins(
-        opts.corsOrigin,
-        readValue(args, i, arg),
-      );
-      i += 1;
-      continue;
-    }
-
-    throw new Error(`Unknown argument "${arg}"`);
+  let i = 0;
+  while (i < normalizedArgs.length) {
+    i = parseArgAt(opts, normalizedArgs, i);
+    i += 1;
   }
 
   return opts;
+}
+
+function parseArgAt(opts: CliOptions, args: string[], index: number): number {
+  const arg = args[index]!;
+
+  switch (arg) {
+    case "--help":
+    case "-h":
+      opts.help = true;
+      return index;
+    case "--bind":
+      applyBind(opts, readValue(args, index, arg));
+      return index + 1;
+    case "--host":
+      opts.hostname = readValue(args, index, arg);
+      return index + 1;
+    case "--port":
+      opts.port = parsePort(readValue(args, index, arg));
+      return index + 1;
+    case "--project":
+      opts.project = readValue(args, index, arg);
+      return index + 1;
+    case "--name":
+      opts.name = readValue(args, index, arg);
+      return index + 1;
+    case "--cors-origin":
+      opts.corsOrigin = appendCorsOrigins(
+        opts.corsOrigin,
+        readValue(args, index, arg),
+      );
+      return index + 1;
+    case "--token":
+      opts.token = readValue(args, index, arg);
+      return index + 1;
+    default:
+      throw new Error(`Unknown argument "${arg}"`);
+  }
+}
+
+function isLoopback(hostname: string | undefined): boolean {
+  return (
+    hostname === undefined ||
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1"
+  );
 }
 
 function closeOnSignal(project: ProjectHandle, server: DashframeServer): void {
@@ -134,23 +194,41 @@ function closeOnSignal(project: ProjectHandle, server: DashframeServer): void {
   process.on("SIGTERM", () => void close());
 }
 
-const opts = parseArgs(process.argv.slice(2));
-const project = await openProject({
-  dir:
-    opts.project ??
-    process.env.DASHFRAME_PROJECT_DIR ??
-    DEFAULT_WEB_PROJECT_DIR,
-  name: opts.name,
-});
-const server = await createDashframeServer({
-  db: project.db,
-  hostname: opts.hostname,
-  port: opts.port,
-  corsOrigin: opts.corsOrigin,
-});
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  const opts = parseArgs(args);
+  if (opts.help) {
+    printHelp();
+    return;
+  }
 
-closeOnSignal(project, server);
+  if (!opts.token && !isLoopback(opts.hostname)) {
+    console.warn(
+      "[dashframe] warning: non-loopback bind without --token exposes this project to the network",
+    );
+  }
 
-console.log(`[dashframe] project: ${project.dir}`);
-console.log(`[dashframe] server: ${server.url}`);
-console.log("[dashframe] ready");
+  const project = await openProject({
+    dir:
+      opts.project ??
+      process.env.DASHFRAME_PROJECT_DIR ??
+      DEFAULT_WEB_PROJECT_DIR,
+    name: opts.name,
+  });
+  const server = await createDashframeServer({
+    db: project.db,
+    hostname: opts.hostname,
+    port: opts.port,
+    corsOrigin: opts.corsOrigin,
+    authToken: opts.token,
+  });
+
+  closeOnSignal(project, server);
+
+  console.log(`[dashframe] project: ${project.dir}`);
+  console.log(`[dashframe] listening: ${server.url}`);
+  console.log("[dashframe] ready");
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary
Adds the operator-facing `dashframe serve` CLI surface for YW-73, rebased onto current `main` after #47 landed the auth *mechanism* on `createDashframeServer`.

This PR is now **CLI-only** — the auth mechanism (`app.ts` token resolver + tests) is owned by #47. This PR consumes it via the factory's `authToken` option.

- **`index.ts`**: `--bind` parsing (`host[:port]`, `:port`, `[ipv6]:port`), `--host`/`--port` aliases, `--project`, `--name`, `--cors-origin`, `--token`, `--help`; loopback-default bind; non-loopback-without-token warning; security-boundary help text; SIGINT/SIGTERM graceful shutdown; testable `main()` + exports.
- **`--token`** wires the CLI flag into `createDashframeServer({ authToken })` (#47's constant-time, WS-aware auth).
- **`dashframe` bin** added alongside `dashframe-serve`.

## Tests (Vitest)
- `index.test.ts` — CLI arg parsing: serve subcommand, port-only/IPv6 bind, malformed-port rejection, help security boundary (4 tests).
- Auth integration tests live in #47's `app.test.ts` (HTTP 401, Origin null, WebSocket) — not duplicated here.

## Verification
- `bun check --filter @dashframe/server` green (typecheck + lint + format + 7 tests).
- Run-the-app smoke: `dashframe serve --bind 127.0.0.1:0 --token …` boots, binds loopback, returns **401 without bearer / 200 with** against the real server.

## History
Originally carried a competing auth mechanism; superseded by #47. Rebased to drop the redundant/inferior auth half (raw `!==` vs #47's `timingSafeEqual`; missing CORS `allowHeaders`) and keep only the unique CLI delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the `dashframe serve` CLI surface: `--bind` address parsing (IPv4, port-only, bracketed IPv6), `--token` wired into `createDashframeServer`'s `authToken` option, a fail-closed `assertBindIsSafe` gate that requires a token for non-loopback binds, and a testable `main()` with clean one-line error output. The bin entry is renamed from `dashframe-serve` to `dashframe`.

- **`index.ts`**: New `applyBind`, `isLoopback`, `assertBindIsSafe`, and `main()` functions; `printHelp` and `parseArgs`/`parsePort` exported for testing; top-level entry wrapped in `try/catch` for operator-friendly errors.
- **`index.test.ts`**: 8 new tests covering arg parsing, IPv6 bracket-hint rejection, malformed ports, help security-boundary text, and the bind-safety gate.
- **`package.json`**: `bin` renamed from `dashframe-serve` to `dashframe`; `bun.lock` will need a `bun install` to resync.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the auth gate is fail-closed and consistent with how createDashframeServer resolves its default hostname.

The security-critical path (assertBindIsSafe → createDashframeServer({ authToken })) is correct end-to-end: isLoopback(undefined) maps to the server's own '127.0.0.1' default, so no bind escapes the gate unintentionally. IPv6 parsing, malformed-port rejection, and the --insecure opt-out are all tested. The only gap is that '::1' and 'localhost' are not exercised in the assertBindIsSafe test suite, which is a test-coverage nit and does not affect runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/package.json | Renames the bin entry from `dashframe-serve` to `dashframe`; the `bun.lock` still contains the old name and will need a `bun install` to resync. |
| apps/server/src/index.ts | Adds `--bind`, `--token`, `--insecure`, and `--help` CLI flags; extracts a testable `main()`; adds `assertBindIsSafe` fail-closed gate and `isLoopback` covering 127.0.0.0/8, localhost, and ::1; wraps the entry point in a try/catch for clean error output. Logic is correct and consistent with createDashframeServer's own '127.0.0.1' default for undefined hostname. |
| apps/server/src/index.test.ts | New test suite covering arg parsing, IPv6 bracket rejection, malformed ports, help text, and the bind-safety gate; misses `::1` and `localhost` loopback cases in assertBindIsSafe. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as dashframe (index.ts)
    participant Auth as assertBindIsSafe
    participant Factory as createDashframeServer (app.ts)
    participant Server as HTTP+WS Server

    User->>CLI: dashframe serve --bind 0.0.0.0:4000 --token secret
    CLI->>CLI: "parseArgs() → { hostname, port, token }"
    CLI->>Auth: "assertBindIsSafe({ hostname, token })"
    Auth-->>CLI: ok (token present)
    CLI->>Factory: "createDashframeServer({ hostname, port, authToken })"
    Factory->>Server: nodeServe (bind 0.0.0.0:4000)
    Server-->>Factory: listening
    Factory-->>CLI: "{ url, port, stop }"
    CLI->>CLI: closeOnSignal(project, server)
    CLI->>User: [dashframe] listening: http://0.0.0.0:4000
    Note over CLI,Server: Every request passes through createTokenResolver (timingSafeEqual)
    User->>CLI: SIGINT / SIGTERM
    CLI->>Server: server.stop()
    CLI->>CLI: await project.close()
    CLI->>User: process.exit(0)
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fserver%2Fsrc%2Findex.test.ts%3A73-97%0A**%60assertBindIsSafe%60%20tests%20don't%20cover%20IPv6%20and%20named%20loopback%20cases**%0A%0A%60isLoopback%60%20explicitly%20handles%20%60%22%3A%3A1%22%60%20and%20%60%22localhost%22%60%20as%20loopback%2C%20but%20neither%20is%20exercised%20by%20the%20%60assertBindIsSafe%60%20suite.%20Since%20the%20previous%20review%20explicitly%20added%20%60%22%3A%3A1%22%60%20support%20%28and%20the%20test%20already%20documents%20the%20%60127.0.0.0%2F8%60%20extension%20for%20%60127.0.0.2%60%29%2C%20adding%20%60%7B%20hostname%3A%20%22%3A%3A1%22%20%7D%60%20and%20%60%7B%20hostname%3A%20%22localhost%22%20%7D%60%20assertions%20to%20the%20%22should%20allow%20a%20loopback%20bind%20without%20a%20token%22%20test%20would%20close%20the%20coverage%20gap%20and%20guard%20against%20future%20regressions%20in%20%60isLoopback%60.%0A%0A&repo=youhaowei%2Fdashframe&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22codex%2FYW-73-dashframe-serve-cli%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2FYW-73-dashframe-serve-cli%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fserver%2Fsrc%2Findex.test.ts%3A73-97%0A**%60assertBindIsSafe%60%20tests%20don't%20cover%20IPv6%20and%20named%20loopback%20cases**%0A%0A%60isLoopback%60%20explicitly%20handles%20%60%22%3A%3A1%22%60%20and%20%60%22localhost%22%60%20as%20loopback%2C%20but%20neither%20is%20exercised%20by%20the%20%60assertBindIsSafe%60%20suite.%20Since%20the%20previous%20review%20explicitly%20added%20%60%22%3A%3A1%22%60%20support%20%28and%20the%20test%20already%20documents%20the%20%60127.0.0.0%2F8%60%20extension%20for%20%60127.0.0.2%60%29%2C%20adding%20%60%7B%20hostname%3A%20%22%3A%3A1%22%20%7D%60%20and%20%60%7B%20hostname%3A%20%22localhost%22%20%7D%60%20assertions%20to%20the%20%22should%20allow%20a%20loopback%20bind%20without%20a%20token%22%20test%20would%20close%20the%20coverage%20gap%20and%20guard%20against%20future%20regressions%20in%20%60isLoopback%60.%0A%0A&repo=youhaowei%2Fdashframe&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fserver%2Fsrc%2Findex.test.ts%3A73-97%0A**%60assertBindIsSafe%60%20tests%20don't%20cover%20IPv6%20and%20named%20loopback%20cases**%0A%0A%60isLoopback%60%20explicitly%20handles%20%60%22%3A%3A1%22%60%20and%20%60%22localhost%22%60%20as%20loopback%2C%20but%20neither%20is%20exercised%20by%20the%20%60assertBindIsSafe%60%20suite.%20Since%20the%20previous%20review%20explicitly%20added%20%60%22%3A%3A1%22%60%20support%20%28and%20the%20test%20already%20documents%20the%20%60127.0.0.0%2F8%60%20extension%20for%20%60127.0.0.2%60%29%2C%20adding%20%60%7B%20hostname%3A%20%22%3A%3A1%22%20%7D%60%20and%20%60%7B%20hostname%3A%20%22localhost%22%20%7D%60%20assertions%20to%20the%20%22should%20allow%20a%20loopback%20bind%20without%20a%20token%22%20test%20would%20close%20the%20coverage%20gap%20and%20guard%20against%20future%20regressions%20in%20%60isLoopback%60.%0A%0A&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/server/src/index.test.ts:73-97
**`assertBindIsSafe` tests don't cover IPv6 and named loopback cases**

`isLoopback` explicitly handles `"::1"` and `"localhost"` as loopback, but neither is exercised by the `assertBindIsSafe` suite. Since the previous review explicitly added `"::1"` support (and the test already documents the `127.0.0.0/8` extension for `127.0.0.2`), adding `{ hostname: "::1" }` and `{ hostname: "localhost" }` assertions to the "should allow a loopback bind without a token" test would close the coverage gap and guard against future regressions in `isLoopback`.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["chore(server): drop redundant dashframe-..."](https://github.com/youhaowei/dashframe/commit/2642718c857f3c236493f925fe1db66ce7816298) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36570066)</sub>

<!-- /greptile_comment -->