### PR TITLE
feat(server): command vocabulary — DataSource/DataTable/Fields/Metrics (YW-106)

### DIFF
--- a/apps/server/src/functions.ts
+++ b/apps/server/src/functions.ts
@@ -12,6 +12,7 @@ import { schema } from "@dashframe/server-core";
 import { query } from "@wystack/server";
 
 import { appArtifactFunctions } from "./functions/app-artifacts";
+import { commandFunctions } from "./functions/commands";
 import { dashboardFunctions } from "./functions/dashboards";
 
 const { projectMeta } = schema;
@@ -56,6 +57,7 @@ const projectInfo = query<Record<string, never>, ProjectInfoResult>({
 export const functions = {
   projectInfo,
   ...appArtifactFunctions,
+  ...commandFunctions,
   ...dashboardFunctions,
 };
 

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -22,6 +22,8 @@ import type {
 import { eq, jsonb, text, uuid } from "@wystack/db";
 import { mutation, query } from "@wystack/server";
 
+import { type DataSourceConfig, isRecord, requireRecordWithId } from "./utils";
+
 const {
   dashboards,
   dataFrames,
@@ -43,11 +45,6 @@ type DataFrameEntry = DataFrameJSON & {
   rowCount?: number;
   columnCount?: number;
   analysis?: DataFrameAnalysis;
-};
-
-type DataSourceConfig = {
-  apiKey?: string;
-  connectionString?: string;
 };
 
 type InsightDefinition = {
@@ -88,17 +85,6 @@ function withDefaultCountMetric(
     },
     ...metrics,
   ];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function requireRecordWithId(value: unknown, label: string): { id: string } {
-  if (!isRecord(value) || typeof value.id !== "string") {
-    throw new Error(`${label} must be an object with an id`);
-  }
-  return value as { id: string };
 }
 
 function requireInsightMetric(value: unknown): InsightMetric {
@@ -519,6 +505,10 @@ const updateDataTable = mutation({
   },
 });
 
+// NOTE: silently no-ops on a missing id (0-row UPDATE returns { ok: true }).
+// The command path (`refreshDataTableCmd` in commands.ts) enforces existence
+// and throws instead — divergent semantics for the same intent, bounded by the
+// YW-157 caller migration window.
 const refreshDataTable = mutation({
   args: { id: uuid, dataFrameId: uuid },
   handler: async (ctx, { id, dataFrameId }): Promise<{ ok: true }> => {

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -367,26 +367,11 @@ const getDataSourceByType = query({
   },
 });
 
-const getOrCreateDataSourceByType = mutation({
-  args: { type: text, name: text },
-  handler: async (ctx, { type, name }): Promise<DataSource> => {
-    const existing = (await ctx.db
-      .from(dataSources)
-      .where(eq("kind", type))
-      .first()) as DataSourceRow | undefined;
-    if (existing) return rowToDataSource(existing);
-
-    const [row] = (await ctx.db.into(dataSources).insert({
-      name,
-      kind: type,
-      storage: "live",
-      config: {},
-      createdBy: { kind: "user" },
-    })) as DataSourceRow[];
-    if (!row) throw new Error("insert returned no row");
-    return rowToDataSource(row);
-  },
-});
+// NOTE: the racy `getOrCreateDataSourceByType` (check-then-insert keyed on
+// `kind`, no unique constraint → concurrent ingests double-insert, PR #46
+// Greptile P1) was REPLACED by the `GetOrCreateDataSource` command in
+// `./commands.ts`, which keys idempotency on a client-minted primary key. See
+// that file's traceability table.
 
 const addDataSource = mutation({
   args: {
@@ -877,7 +862,6 @@ export const appArtifactFunctions = {
   listDataSources,
   getDataSource,
   getDataSourceByType,
-  getOrCreateDataSourceByType,
   addDataSource,
   updateDataSource,
   removeDataSource,

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -146,6 +146,27 @@ describe("command vocabulary", () => {
       // The original name is preserved — get-or-create does not overwrite.
       expect(rows[0]?.name).toBe("Local Files");
     });
+
+    it("should ignore the type arg on a second get-or-create with the same id (existing row wins)", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("GetOrCreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      );
+      // The canonical caller derives id FROM type, so this mismatch can't
+      // happen there — but the command is callable by any producer. Pin the
+      // chosen semantics (existing row wins, type silently ignored) so they
+      // can't drift unnoticed. Conflict semantics are a Spec Open Q.
+      await commit(
+        cmd("GetOrCreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "N",
+        }),
+      );
+      const rows = await sourcesById(sourceId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.kind).toBe("csv");
+    });
   });
 
   describe("client-id invariant across a batch", () => {
@@ -414,6 +435,66 @@ describe("command vocabulary", () => {
       expect(metrics[0]?.name).toBe("Total Sum");
     });
 
+    it("should remove a metric by id for RemoveMetric", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const metricId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("AddMetric", {
+          nodeId: tableId,
+          metric: {
+            id: metricId,
+            name: "Sum",
+            expression: "sum(amount)",
+          } as never,
+        }),
+      );
+
+      await commit(cmd("RemoveMetric", { nodeId: tableId, metricId }));
+      const [row] = await tablesById(tableId);
+      expect(row?.metrics).toEqual([]);
+    });
+
+    it("should reject a duplicate metric id in AddMetric (no illegal two-items-one-id state)", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const metricId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("AddMetric", {
+          nodeId: tableId,
+          metric: { id: metricId, name: "Sum" } as never,
+        }),
+      );
+
+      await expect(
+        commit(
+          cmd("AddMetric", {
+            nodeId: tableId,
+            metric: { id: metricId, name: "Sum again" } as never,
+          }),
+        ),
+      ).rejects.toThrow(/already exists/);
+
+      const [row] = await tablesById(tableId);
+      expect((row?.metrics as { id: string }[]).map((m) => m.id)).toEqual([
+        metricId,
+      ]);
+    });
+
     it("should throw on a missing id for SetDataTableSchema (no silent no-op)", async () => {
       await expect(
         commit(
@@ -425,6 +506,64 @@ describe("command vocabulary", () => {
     it("should throw on a missing id for RefreshDataTable (no silent no-op)", async () => {
       await expect(
         commit(cmd("RefreshDataTable", { id: id(), dataFrameId: id() })),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("should throw on a missing id for RenameNode (no silent no-op)", async () => {
+      await expect(
+        commit(cmd("RenameNode", { id: id(), name: "X" })),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("should throw on a missing id for SetDataSourceConfig (no silent no-op)", async () => {
+      await expect(
+        commit(cmd("SetDataSourceConfig", { id: id(), apiKey: "x" })),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("should throw on UpdateField with a missing fieldId", async () => {
+      const sourceId = id();
+      const tableId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+      );
+      await expect(
+        commit(
+          cmd("UpdateField", {
+            nodeId: tableId,
+            fieldId: id(),
+            updates: { name: "X" } as never,
+          }),
+        ),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("should throw on UpdateMetric with a missing metricId", async () => {
+      const sourceId = id();
+      const tableId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+      );
+      await expect(
+        commit(
+          cmd("UpdateMetric", {
+            nodeId: tableId,
+            metricId: id(),
+            updates: { name: "X" } as never,
+          }),
+        ),
       ).rejects.toThrow(/not found/);
     });
   });
@@ -465,8 +604,9 @@ describe("command vocabulary", () => {
         { mode: "preview" },
       );
       expect(result.mode).toBe("preview");
-      // It WOULD have written the data_sources table.
-      expect(result.tablesWritten.size).toBeGreaterThan(0);
+      // It WOULD have written the data_sources table — pin the table name so a
+      // preview writing the wrong table can't satisfy this.
+      expect(result.tablesWritten.has("data_sources")).toBe(true);
 
       const rows = await sourcesById(sourceId);
       expect(rows).toHaveLength(0);

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -178,7 +178,7 @@ describe("command vocabulary", () => {
   });
 
   describe("each command maps to the right write", () => {
-    it("CreateDataSource writes kind/name/config", async () => {
+    it("should write kind/name/config for CreateDataSource", async () => {
       const sourceId = id();
       await commit(
         cmd("CreateDataSource", {
@@ -194,7 +194,7 @@ describe("command vocabulary", () => {
       expect((row?.config as { apiKey?: string }).apiKey).toBe("secret-key");
     });
 
-    it("SetDataSourceConfig (decomposed from updateDataSource) replaces only config, not name", async () => {
+    it("should replace only config (not name) for SetDataSourceConfig, decomposed from updateDataSource", async () => {
       const sourceId = id();
       await commit(
         cmd("CreateDataSource", {
@@ -210,7 +210,7 @@ describe("command vocabulary", () => {
       expect(row?.name).toBe("Original");
     });
 
-    it("RenameNode (decomposed from updateDataSource) renames without touching config", async () => {
+    it("should rename without touching config for RenameNode, decomposed from updateDataSource", async () => {
       const sourceId = id();
       await commit(
         cmd("CreateDataSource", {
@@ -226,7 +226,7 @@ describe("command vocabulary", () => {
       expect((row?.config as { apiKey?: string }).apiKey).toBe("keep");
     });
 
-    it("AddField then RemoveField (decomposed from patchDataTableArray) edit the jsonb array", async () => {
+    it("should edit the jsonb array via AddField then RemoveField, decomposed from patchDataTableArray", async () => {
       const sourceId = id();
       const tableId = id();
       const fieldId = id();
@@ -260,7 +260,7 @@ describe("command vocabulary", () => {
       expect(row?.fields).toEqual([]);
     });
 
-    it("AddField rejects a duplicate field id (no illegal two-items-one-id state)", async () => {
+    it("should reject a duplicate field id in AddField (no illegal two-items-one-id state)", async () => {
       const sourceId = id();
       const tableId = id();
       const fieldId = id();
@@ -306,7 +306,7 @@ describe("command vocabulary", () => {
       ]);
     });
 
-    it("RefreshDataTable stamps dataFrameId and lastFetchedAt", async () => {
+    it("should stamp dataFrameId and lastFetchedAt for RefreshDataTable", async () => {
       const sourceId = id();
       const tableId = id();
       const frameId = id();
@@ -325,7 +325,7 @@ describe("command vocabulary", () => {
       expect(row?.lastFetchedAt).toBeInstanceOf(Date);
     });
 
-    it("SetDataTableSchema replaces the source schema slice", async () => {
+    it("should replace the source schema slice for SetDataTableSchema", async () => {
       const sourceId = id();
       const tableId = id();
       const sourceSchema = { columns: [{ name: "amount", type: "number" }] };
@@ -346,7 +346,7 @@ describe("command vocabulary", () => {
       expect(row?.sourceSchema).toEqual(sourceSchema);
     });
 
-    it("UpdateField merges updates by id without rebinding the id", async () => {
+    it("should merge updates by id without rebinding the id for UpdateField", async () => {
       const sourceId = id();
       const tableId = id();
       const fieldId = id();
@@ -382,7 +382,7 @@ describe("command vocabulary", () => {
       expect(fields[0]?.name).toBe("Total");
     });
 
-    it("UpdateMetric merges updates by id", async () => {
+    it("should merge updates by id for UpdateMetric", async () => {
       const sourceId = id();
       const tableId = id();
       const metricId = id();
@@ -414,7 +414,7 @@ describe("command vocabulary", () => {
       expect(metrics[0]?.name).toBe("Total Sum");
     });
 
-    it("SetDataTableSchema throws on a missing id (no silent no-op)", async () => {
+    it("should throw on a missing id for SetDataTableSchema (no silent no-op)", async () => {
       await expect(
         commit(
           cmd("SetDataTableSchema", { id: id(), sourceSchema: {} as never }),
@@ -422,7 +422,7 @@ describe("command vocabulary", () => {
       ).rejects.toThrow(/not found/);
     });
 
-    it("RefreshDataTable throws on a missing id (no silent no-op)", async () => {
+    it("should throw on a missing id for RefreshDataTable (no silent no-op)", async () => {
       await expect(
         commit(cmd("RefreshDataTable", { id: id(), dataFrameId: id() })),
       ).rejects.toThrow(/not found/);

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Command vocabulary (YW-106) tests.
+ *
+ * These exercise the vocabulary THROUGH the real engine: a batch of typed
+ * commands (built with `cmd(...)`) dispatched by `@wystack/server`'s
+ * `applyCommands` against a real artifact DB. They assert the contracts the
+ * spec freezes — atomicity of GetOrCreateDataSource, batch atomicity with the
+ * client-id invariant, each command mapping to the right write, mid-batch
+ * rollback, and preview persisting nothing.
+ */
+import { openArtifactDb, schema } from "@dashframe/server-core";
+import { createWyStack, type WyStackApp } from "@wystack/server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { functions } from "../functions";
+import { cmd } from "./commands";
+
+const { dataSources, dataTables } = schema;
+
+describe("command vocabulary", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  // applyCommands is registered alongside query/mutation on @wystack/server;
+  // import lazily so the test reads top-down with the engine right where used.
+  let applyCommands: typeof import("@wystack/server").applyCommands;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-cmd-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await createWyStack({ db, functions });
+    ({ applyCommands } = await import("@wystack/server"));
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function id(): string {
+    return crypto.randomUUID();
+  }
+
+  async function commit(...commands: ReturnType<typeof cmd>[]) {
+    return applyCommands(app, commands, { mode: "commit" });
+  }
+
+  // Assertion reads go through the raw Drizzle handle and filter in JS — the
+  // server package has no direct `drizzle-orm` dep for a `where()` operator,
+  // and these test DBs hold a handful of rows.
+  async function sourcesById(sourceId: string) {
+    const rows = await db.select().from(dataSources);
+    return rows.filter((r) => r.id === sourceId);
+  }
+  async function sourcesByKind(kind: string) {
+    const rows = await db.select().from(dataSources);
+    return rows.filter((r) => r.kind === kind);
+  }
+  async function allSources() {
+    return db.select().from(dataSources);
+  }
+  async function tablesById(tableId: string) {
+    const rows = await db.select().from(dataTables);
+    return rows.filter((r) => r.id === tableId);
+  }
+
+  describe("GetOrCreateDataSource (the reference atomic command)", () => {
+    // Note on the defect & why these assert what they do: the original bug (PR
+    // #46 Greptile P1) was two concurrent ingests both passing a `kind`-keyed
+    // existence check and both inserting. PGLite is a single-connection WASM
+    // Postgres, so `applyCommands` batches here serialize — they can't reproduce
+    // a true read-read-write-write interleaving. The fix is therefore tested by
+    // its STRUCTURE, not by racing: idempotency is keyed on the PRIMARY KEY (not
+    // `kind`), and the PK is the hard backstop that makes a double-insert
+    // impossible regardless of interleaving. The two tests below pin exactly
+    // that — the kind-keyed racy version would FAIL the first (it returns the
+    // existing row for a second, distinct id of the same kind) and could never
+    // satisfy the PK guarantee the second asserts.
+
+    it("should key idempotency on the id, not the kind (two ids of one kind = two sources)", async () => {
+      const idA = id();
+      const idB = id();
+      await commit(
+        cmd("GetOrCreateDataSource", { id: idA, type: "local", name: "A" }),
+      );
+      await commit(
+        cmd("GetOrCreateDataSource", { id: idB, type: "local", name: "B" }),
+      );
+
+      // The racy kind-keyed version would return idA for the second call and
+      // leave ONE row. The id-keyed fix keeps them distinct: get-or-create is a
+      // PK upsert, so two different ids are two sources even with one kind.
+      expect(await sourcesById(idA)).toHaveLength(1);
+      expect(await sourcesById(idB)).toHaveLength(1);
+      expect(await sourcesByKind("local")).toHaveLength(2);
+    });
+
+    it("should make a same-id double-insert impossible — the PK backstop (no double-insert defect)", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "local", name: "First" }),
+      );
+
+      // A second create with the SAME client id cannot persist a second row —
+      // the primary key rejects it. This is the structural guarantee the racy
+      // kind-keyed check lacked: even if two ingests both decide to insert, the
+      // PK admits exactly one. The losing batch throws and rolls back.
+      await expect(
+        commit(
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "local",
+            name: "Second",
+          }),
+        ),
+      ).rejects.toThrow();
+
+      const rows = await sourcesById(sourceId);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.name).toBe("First");
+    });
+
+    it("should return the existing row on a second get-or-create with the same id", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("GetOrCreateDataSource", {
+          id: sourceId,
+          type: "local",
+          name: "Local Files",
+        }),
+      );
+      const second = await commit(
+        cmd("GetOrCreateDataSource", {
+          id: sourceId,
+          type: "local",
+          name: "Ignored Second Name",
+        }),
+      );
+      expect(second.results[0]).toEqual({ id: sourceId });
+
+      const rows = await allSources();
+      expect(rows).toHaveLength(1);
+      // The original name is preserved — get-or-create does not overwrite.
+      expect(rows[0]?.name).toBe("Local Files");
+    });
+  });
+
+  describe("client-id invariant across a batch", () => {
+    it("should create a DataSource then a DataTable referencing it atomically", async () => {
+      const sourceId = id();
+      const tableId = id();
+
+      const result = await commit(
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "csv",
+          name: "Sales CSV",
+        }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "Q1",
+          table: "q1.csv",
+        }),
+      );
+      expect(result.mode).toBe("commit");
+      expect(result.commandCount).toBe(2);
+
+      const source = await sourcesById(sourceId);
+      const table = await tablesById(tableId);
+      expect(source).toHaveLength(1);
+      expect(table).toHaveLength(1);
+      expect(table[0]?.dataSourceId).toBe(sourceId);
+    });
+  });
+
+  describe("each command maps to the right write", () => {
+    it("CreateDataSource writes kind/name/config", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "Notion",
+          apiKey: "secret-key",
+        }),
+      );
+      const [row] = await sourcesById(sourceId);
+      expect(row?.kind).toBe("notion");
+      expect(row?.name).toBe("Notion");
+      expect((row?.config as { apiKey?: string }).apiKey).toBe("secret-key");
+    });
+
+    it("SetDataSourceConfig (decomposed from updateDataSource) replaces only config, not name", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "Original",
+          apiKey: "old",
+        }),
+        cmd("SetDataSourceConfig", { id: sourceId, apiKey: "new" }),
+      );
+      const [row] = await sourcesById(sourceId);
+      expect((row?.config as { apiKey?: string }).apiKey).toBe("new");
+      expect(row?.name).toBe("Original");
+    });
+
+    it("RenameNode (decomposed from updateDataSource) renames without touching config", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "Original",
+          apiKey: "keep",
+        }),
+        cmd("RenameNode", { id: sourceId, name: "Renamed" }),
+      );
+      const [row] = await sourcesById(sourceId);
+      expect(row?.name).toBe("Renamed");
+      expect((row?.config as { apiKey?: string }).apiKey).toBe("keep");
+    });
+
+    it("AddField then RemoveField (decomposed from patchDataTableArray) edit the jsonb array", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const fieldId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("AddField", {
+          nodeId: tableId,
+          field: {
+            id: fieldId,
+            name: "Amount",
+            tableId,
+            columnName: "amount",
+            type: "number",
+          },
+        }),
+      );
+
+      let [row] = await tablesById(tableId);
+      expect((row?.fields as { id: string }[]).map((f) => f.id)).toEqual([
+        fieldId,
+      ]);
+
+      await commit(cmd("RemoveField", { nodeId: tableId, fieldId }));
+      [row] = await tablesById(tableId);
+      expect(row?.fields).toEqual([]);
+    });
+
+    it("AddField rejects a duplicate field id (no illegal two-items-one-id state)", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const fieldId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("AddField", {
+          nodeId: tableId,
+          field: {
+            id: fieldId,
+            name: "Amount",
+            tableId,
+            columnName: "amount",
+            type: "number",
+          },
+        }),
+      );
+
+      // Second Add of the same id must throw (and roll back), not append a dup.
+      await expect(
+        commit(
+          cmd("AddField", {
+            nodeId: tableId,
+            field: {
+              id: fieldId,
+              name: "Amount again",
+              tableId,
+              columnName: "amount",
+              type: "number",
+            },
+          }),
+        ),
+      ).rejects.toThrow(/already exists/);
+
+      const [row] = await tablesById(tableId);
+      expect((row?.fields as { id: string }[]).map((f) => f.id)).toEqual([
+        fieldId,
+      ]);
+    });
+
+    it("RefreshDataTable stamps dataFrameId and lastFetchedAt", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const frameId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("RefreshDataTable", { id: tableId, dataFrameId: frameId }),
+      );
+      const [row] = await tablesById(tableId);
+      expect(row?.dataFrameId).toBe(frameId);
+      expect(row?.lastFetchedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("atomicity", () => {
+    it("should roll back the whole batch when a mid-batch command fails", async () => {
+      const sourceId = id();
+      const tableId = id();
+
+      await expect(
+        commit(
+          cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+          cmd("CreateDataTable", {
+            id: tableId,
+            dataSourceId: sourceId,
+            name: "T",
+            table: "t.csv",
+          }),
+          // Fails: removing a field that does not exist throws → rolls back ALL.
+          cmd("RemoveField", { nodeId: tableId, fieldId: id() }),
+        ),
+      ).rejects.toThrow();
+
+      // Nothing from the batch persisted — the earlier inserts rolled back too.
+      const sources = await sourcesById(sourceId);
+      const tables = await tablesById(tableId);
+      expect(sources).toHaveLength(0);
+      expect(tables).toHaveLength(0);
+    });
+  });
+
+  describe("preview", () => {
+    it("should persist nothing for a preview batch", async () => {
+      const sourceId = id();
+      const result = await applyCommands(
+        app,
+        [cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" })],
+        { mode: "preview" },
+      );
+      expect(result.mode).toBe("preview");
+      // It WOULD have written the data_sources table.
+      expect(result.tablesWritten.size).toBeGreaterThan(0);
+
+      const rows = await sourcesById(sourceId);
+      expect(rows).toHaveLength(0);
+    });
+  });
+});

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -324,6 +324,109 @@ describe("command vocabulary", () => {
       expect(row?.dataFrameId).toBe(frameId);
       expect(row?.lastFetchedAt).toBeInstanceOf(Date);
     });
+
+    it("SetDataTableSchema replaces the source schema slice", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const sourceSchema = { columns: [{ name: "amount", type: "number" }] };
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("SetDataTableSchema", {
+          id: tableId,
+          sourceSchema: sourceSchema as never,
+        }),
+      );
+      const [row] = await tablesById(tableId);
+      expect(row?.sourceSchema).toEqual(sourceSchema);
+    });
+
+    it("UpdateField merges updates by id without rebinding the id", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const fieldId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("AddField", {
+          nodeId: tableId,
+          field: {
+            id: fieldId,
+            name: "Amount",
+            tableId,
+            columnName: "amount",
+            type: "number",
+          },
+        }),
+        // A stray `id` in updates must NOT rebind the field — pinned id wins.
+        cmd("UpdateField", {
+          nodeId: tableId,
+          fieldId,
+          updates: { name: "Total", id: id() } as never,
+        }),
+      );
+      const [row] = await tablesById(tableId);
+      const fields = row?.fields as { id: string; name: string }[];
+      expect(fields).toHaveLength(1);
+      expect(fields[0]?.id).toBe(fieldId);
+      expect(fields[0]?.name).toBe("Total");
+    });
+
+    it("UpdateMetric merges updates by id", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const metricId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+        }),
+        cmd("AddMetric", {
+          nodeId: tableId,
+          metric: {
+            id: metricId,
+            name: "Sum",
+            expression: "sum(amount)",
+          } as never,
+        }),
+        cmd("UpdateMetric", {
+          nodeId: tableId,
+          metricId,
+          updates: { name: "Total Sum" } as never,
+        }),
+      );
+      const [row] = await tablesById(tableId);
+      const metrics = row?.metrics as { id: string; name: string }[];
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0]?.name).toBe("Total Sum");
+    });
+
+    it("SetDataTableSchema throws on a missing id (no silent no-op)", async () => {
+      await expect(
+        commit(
+          cmd("SetDataTableSchema", { id: id(), sourceSchema: {} as never }),
+        ),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("RefreshDataTable throws on a missing id (no silent no-op)", async () => {
+      await expect(
+        commit(cmd("RefreshDataTable", { id: id(), dataFrameId: id() })),
+      ).rejects.toThrow(/not found/);
+    });
   });
 
   describe("atomicity", () => {

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -139,7 +139,7 @@ describe("command vocabulary", () => {
           name: "Ignored Second Name",
         }),
       );
-      expect(second.results[0]).toEqual({ id: sourceId });
+      expect(second.results[0]?.value).toEqual({ id: sourceId });
 
       const rows = await allSources();
       expect(rows).toHaveLength(1);
@@ -167,7 +167,7 @@ describe("command vocabulary", () => {
         }),
       );
       expect(result.mode).toBe("commit");
-      expect(result.commandCount).toBe(2);
+      expect(result.commands).toHaveLength(2);
 
       const source = await sourcesById(sourceId);
       const table = await tablesById(tableId);

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -54,15 +54,12 @@ import { eq, jsonb, text, uuid } from "@wystack/db";
 import type { Command } from "@wystack/server";
 import { mutation } from "@wystack/server";
 
+import { type DataSourceConfig, isRecord, requireRecordWithId } from "./utils";
+
 const { dataSources, dataTables, insights } = schema;
 
 type DataSourceRow = typeof dataSources.$inferSelect;
 type DataTableRow = typeof dataTables.$inferSelect;
-
-type DataSourceConfig = {
-  apiKey?: string;
-  connectionString?: string;
-};
 
 // ---------------------------------------------------------------------------
 // DataSource commands
@@ -89,6 +86,10 @@ const getOrCreateDataSource = mutation({
       .from(dataSources)
       .where(eq("id", id))
       .first()) as DataSourceRow | undefined;
+    // On the get path `type` and `name` are IGNORED — the existing row wins,
+    // even if the caller passed a different type for the same id. The canonical
+    // caller derives the id FROM the type so a mismatch can't happen there; the
+    // spec leaves conflict semantics open for other callers (Spec Open Q).
     if (existing) return { id: existing.id };
 
     const [row] = (await ctx.db.into(dataSources).insert({
@@ -239,44 +240,30 @@ const refreshDataTable = mutation({
 // Fields & Metrics commands — target a DataFrame-producing node via {nodeId}
 // ---------------------------------------------------------------------------
 
-type NodeKind = "dataTable" | "insight";
+type ResolvedNode =
+  | { kind: "dataTable"; row: DataTableRow }
+  | { kind: "insight" };
 
 /**
- * Resolve which kind of node `nodeId` is. A leaf node is a DataTable (fields and
- * metrics live in its jsonb columns); a derived node is an Insight (YW-123, not
- * yet wired for collection edits). One lookup decides the dispatch so the
- * command shape (`{ nodeId, ... }`) never needs to know the kind up front.
+ * Resolve which kind of node `nodeId` is, returning the row it already fetched
+ * for the DataTable case so callers don't pay a second lookup. A leaf node is a
+ * DataTable (fields and metrics live in its jsonb columns); a derived node is
+ * an Insight (YW-123, not yet wired for collection edits). One lookup decides
+ * the dispatch so the command shape (`{ nodeId, ... }`) never needs to know the
+ * kind up front.
  */
-async function resolveNodeKind(
+async function resolveNode(
   ctx: { db: import("@wystack/db").TrackedDb },
   nodeId: string,
-): Promise<NodeKind> {
+): Promise<ResolvedNode> {
   const table = (await ctx.db
     .from(dataTables)
     .where(eq("id", nodeId))
     .first()) as DataTableRow | undefined;
-  if (table) return "dataTable";
+  if (table) return { kind: "dataTable", row: table };
   const insight = await ctx.db.from(insights).where(eq("id", nodeId)).first();
-  if (insight) return "insight";
+  if (insight) return { kind: "insight" };
   throw new Error(`Node ${nodeId} not found`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function requireFieldRecord(value: unknown): Field {
-  if (!isRecord(value) || typeof value.id !== "string") {
-    throw new Error("field must be an object with an id");
-  }
-  return value as unknown as Field;
-}
-
-function requireMetricRecord(value: unknown): Metric {
-  if (!isRecord(value) || typeof value.id !== "string") {
-    throw new Error("metric must be an object with an id");
-  }
-  return value as unknown as Metric;
 }
 
 /**
@@ -284,6 +271,13 @@ function requireMetricRecord(value: unknown): Metric {
  * jsonb array and persist it. Add appends; Update merges by id; Remove drops by
  * id. Update/Remove on a missing id throw so a bad batch fails loudly (and rolls
  * back). Insight nodes are rejected until YW-123 wires their definition arrays.
+ *
+ * Concurrency: this read-modify-write is safe on PGLite (single-connection —
+ * batches serialize at the event loop). A future multi-connection Postgres
+ * backend makes it a lost-update vector (two batches read the same array, the
+ * later write clobbers the earlier); that tier needs SELECT FOR UPDATE, a
+ * raised transaction isolation level at the `applyCommands` call, or a
+ * jsonb-native append.
  */
 async function patchDataTableCollection(
   ctx: { db: import("@wystack/db").TrackedDb },
@@ -294,18 +288,13 @@ async function patchDataTableCollection(
     | { mode: "update"; itemId: string; updates: Record<string, unknown> }
     | { mode: "remove"; itemId: string },
 ): Promise<void> {
-  const nodeKind = await resolveNodeKind(ctx, nodeId);
-  if (nodeKind === "insight") {
+  const node = await resolveNode(ctx, nodeId);
+  if (node.kind === "insight") {
     throw new Error(
       `Field/metric edits on Insight node ${nodeId} are not supported yet (YW-123)`,
     );
   }
-  const row = (await ctx.db
-    .from(dataTables)
-    .where(eq("id", nodeId))
-    .first()) as DataTableRow | undefined;
-  if (!row) throw new Error(`Data table ${nodeId} not found`);
-  const items = ((row[kind] ?? []) as { id: string }[]).slice();
+  const items = ((node.row[kind] ?? []) as { id: string }[]).slice();
 
   let next: { id: string }[];
   if (op.mode === "add") {
@@ -344,7 +333,7 @@ const addField = mutation({
   handler: async (ctx, { nodeId, field }): Promise<{ ok: true }> => {
     await patchDataTableCollection(ctx, nodeId, "fields", {
       mode: "add",
-      item: requireFieldRecord(field),
+      item: requireRecordWithId(field, "field") as unknown as Field,
     });
     return { ok: true };
   },
@@ -381,7 +370,7 @@ const addMetric = mutation({
   handler: async (ctx, { nodeId, metric }): Promise<{ ok: true }> => {
     await patchDataTableCollection(ctx, nodeId, "metrics", {
       mode: "add",
-      item: requireMetricRecord(metric),
+      item: requireRecordWithId(metric, "metric") as unknown as Metric,
     });
     return { ok: true };
   },

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1,0 +1,531 @@
+/**
+ * Command VOCABULARY (YW-106) — Layer B over @wystack/server's `applyCommands`
+ * MECHANISM (YW-122).
+ *
+ * `applyCommands` knows nothing about DashFrame. It dispatches a batch of
+ * `{ path, args }` against the app's function registry inside one tracked
+ * transaction. THIS module supplies the typed, intent-carrying commands that
+ * batch travels as — the narrow waist both the human UI and the agent emit
+ * through (capability-parity).
+ *
+ * Representation (chosen of the two viable seams): each command is backed by a
+ * registered WyStack `mutation()` — path-addressable, validated by the same
+ * cached Zod schema a plain RPC uses. A typed builder/registry
+ * (`commandBuilders` below) maps a command NAME to the `{ path, args }` envelope
+ * `applyCommands` dispatches. Rationale: the spec's traceability rule ("every
+ * write op maps to a command, no escape hatch") wants the existing handlers to
+ * BACK the commands so there is no duplicate logic — a command handler IS a
+ * mutation handler. The builder layer is pure data-shaping (no DB access), so
+ * the vocabulary stays a thin typed face over the mechanism.
+ *
+ * Decomposition: each coarse handler in `app-artifacts.ts` is split into
+ * intent-carrying ops (the diffability the draft→publish trust model needs).
+ * The traceability table:
+ *
+ *   getOrCreateDataSourceByType → GetOrCreateDataSource   (the reference atomic command)
+ *   addDataSource              → CreateDataSource
+ *   updateDataSource           → SetDataSourceConfig + RenameNode
+ *   addDataTable               → CreateDataTable
+ *   updateDataTable            → RenameNode + SetDataTableSchema + RefreshDataTable
+ *   refreshDataTable           → RefreshDataTable
+ *   patchDataTableArray        → AddField / UpdateField / RemoveField
+ *                                + AddMetric / UpdateMetric / RemoveMetric
+ *
+ * Cross-cutting `RenameNode` is the one polymorphic rename — the `name` slice
+ * carved out of every coarse update(blob).
+ *
+ * Fields & Metrics target the DataFrame-PRODUCING node polymorphically via
+ * `{ nodeId }`, NOT a DataTable id — a leaf node is a DataTable (fields/metrics
+ * live in its `fields`/`metrics` jsonb columns); a derived node is an Insight
+ * (YW-123). This slice implements the DataTable case and dispatches on node kind
+ * so the Insight case slots in without changing the command shape.
+ *
+ * Operand encoding (YW-153 spike finding): when a value-bearing operand type is
+ * introduced (filters, YW-123), it MUST be a TAGGED union
+ *   { kind: 'value'; v } | { kind: 'deferred'; ref }   (v: null means IS NULL)
+ * NOT property-presence. The YW-106 commands here carry only concrete values
+ * (ids, names, schemas, whole Field/Metric records), so no operand type is
+ * introduced — adding one speculatively would violate "don't gold-plate". This
+ * comment records that the tagged-union convention is established for YW-123.
+ */
+import { schema } from "@dashframe/server-core";
+import type { Field, Metric, SourceSchema, UUID } from "@dashframe/types";
+import { eq, jsonb, text, uuid } from "@wystack/db";
+import type { Command } from "@wystack/server";
+import { mutation } from "@wystack/server";
+
+const { dataSources, dataTables, insights } = schema;
+
+type DataSourceRow = typeof dataSources.$inferSelect;
+type DataTableRow = typeof dataTables.$inferSelect;
+
+type DataSourceConfig = {
+  apiKey?: string;
+  connectionString?: string;
+};
+
+// ---------------------------------------------------------------------------
+// DataSource commands
+// ---------------------------------------------------------------------------
+
+/**
+ * GetOrCreateDataSource — THE reference atomic command. Replaces the racy
+ * check-then-insert `getOrCreateDataSourceByType` (PR #46 Greptile P1:
+ * concurrent CSV ingests double-insert).
+ *
+ * The fix is the client-minted id. The old command keyed idempotency on `kind`
+ * (no DB unique constraint → two transactions both pass the existence check and
+ * both insert). This keys idempotency on the PRIMARY KEY: the caller mints a
+ * stable id once and reuses it, so a concurrent second ingest finds the row by
+ * id (PK is unique) and returns it. Run inside `applyCommands`' transaction the
+ * lookup→insert is atomic within a batch; across concurrent batches the PK
+ * constraint is the backstop (the loser's insert conflicts and its batch rolls
+ * back — one source, never two).
+ */
+const getOrCreateDataSource = mutation({
+  args: { id: uuid, type: text, name: text },
+  handler: async (ctx, { id, type, name }): Promise<{ id: string }> => {
+    const existing = (await ctx.db
+      .from(dataSources)
+      .where(eq("id", id))
+      .first()) as DataSourceRow | undefined;
+    if (existing) return { id: existing.id };
+
+    const [row] = (await ctx.db.into(dataSources).insert({
+      id,
+      name,
+      kind: type,
+      storage: "live",
+      config: {},
+      createdBy: { kind: "user" },
+    })) as DataSourceRow[];
+    if (!row) throw new Error("insert returned no row");
+    return { id: row.id };
+  },
+});
+
+/** CreateDataSource — mints a DataSource with a client-supplied id + config. */
+const createDataSource = mutation({
+  args: {
+    id: uuid,
+    type: text,
+    name: text,
+    apiKey: text.optional(),
+    connectionString: text.optional(),
+  },
+  handler: async (
+    ctx,
+    { id, type, name, apiKey, connectionString },
+  ): Promise<{ id: string }> => {
+    const [row] = (await ctx.db.into(dataSources).insert({
+      id,
+      name,
+      kind: type,
+      storage: "live",
+      config: { apiKey, connectionString },
+      createdBy: { kind: "user" },
+    })) as DataSourceRow[];
+    if (!row) throw new Error("insert returned no row");
+    return { id: row.id };
+  },
+});
+
+/**
+ * SetDataSourceConfig — replaces the config slice of a DataSource (the connector
+ * secrets). The `name` slice is NOT here — renaming is `RenameNode`. This is the
+ * config half decomposed out of the coarse `updateDataSource`.
+ */
+const setDataSourceConfig = mutation({
+  args: {
+    id: uuid,
+    apiKey: text.optional(),
+    connectionString: text.optional(),
+  },
+  handler: async (
+    ctx,
+    { id, apiKey, connectionString },
+  ): Promise<{ ok: true }> => {
+    const current = (await ctx.db
+      .from(dataSources)
+      .where(eq("id", id))
+      .first()) as DataSourceRow | undefined;
+    if (!current) throw new Error(`Data source ${id} not found`);
+    const config = { ...((current.config ?? {}) as DataSourceConfig) };
+    if (apiKey !== undefined) config.apiKey = apiKey;
+    if (connectionString !== undefined)
+      config.connectionString = connectionString;
+    await ctx.db.from(dataSources).where(eq("id", id)).update({ config });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// DataTable commands
+// ---------------------------------------------------------------------------
+
+/**
+ * CreateDataTable — mints a DataTable with a client-supplied id, referencing a
+ * DataSource (which an earlier command in the same batch may have created — the
+ * shared tx handle makes that insert visible here).
+ */
+const createDataTable = mutation({
+  args: {
+    id: uuid,
+    dataSourceId: uuid,
+    name: text,
+    table: text,
+    sourceSchema: jsonb.optional(),
+    fields: jsonb.optional(),
+    metrics: jsonb.optional(),
+    dataFrameId: uuid.optional(),
+  },
+  handler: async (ctx, args): Promise<{ id: string }> => {
+    const [row] = (await ctx.db.into(dataTables).insert({
+      id: args.id,
+      dataSourceId: args.dataSourceId,
+      name: args.name,
+      table: args.table,
+      sourceSchema: (args.sourceSchema as SourceSchema | undefined) ?? null,
+      fields: (args.fields as Field[] | undefined) ?? [],
+      metrics: (args.metrics as Metric[] | undefined) ?? [],
+      dataFrameId: args.dataFrameId ?? null,
+    })) as DataTableRow[];
+    if (!row) throw new Error("insert returned no row");
+    return { id: row.id };
+  },
+});
+
+/** SetDataTableSchema — replaces the discovered source schema slice. */
+const setDataTableSchema = mutation({
+  args: { id: uuid, sourceSchema: jsonb },
+  handler: async (ctx, { id, sourceSchema }): Promise<{ ok: true }> => {
+    await ctx.db
+      .from(dataTables)
+      .where(eq("id", id))
+      .update({ sourceSchema: sourceSchema as SourceSchema });
+    return { ok: true };
+  },
+});
+
+/** RefreshDataTable — points the table at a new DataFrame and stamps the fetch. */
+const refreshDataTable = mutation({
+  args: { id: uuid, dataFrameId: uuid },
+  handler: async (ctx, { id, dataFrameId }): Promise<{ ok: true }> => {
+    await ctx.db
+      .from(dataTables)
+      .where(eq("id", id))
+      .update({ dataFrameId, lastFetchedAt: new Date() });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Fields & Metrics commands — target a DataFrame-producing node via {nodeId}
+// ---------------------------------------------------------------------------
+
+type NodeKind = "dataTable" | "insight";
+
+/**
+ * Resolve which kind of node `nodeId` is. A leaf node is a DataTable (fields and
+ * metrics live in its jsonb columns); a derived node is an Insight (YW-123, not
+ * yet wired for collection edits). One lookup decides the dispatch so the
+ * command shape (`{ nodeId, ... }`) never needs to know the kind up front.
+ */
+async function resolveNodeKind(
+  ctx: { db: import("@wystack/db").TrackedDb },
+  nodeId: string,
+): Promise<NodeKind> {
+  const table = (await ctx.db
+    .from(dataTables)
+    .where(eq("id", nodeId))
+    .first()) as DataTableRow | undefined;
+  if (table) return "dataTable";
+  const insight = await ctx.db.from(insights).where(eq("id", nodeId)).first();
+  if (insight) return "insight";
+  throw new Error(`Node ${nodeId} not found`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireFieldRecord(value: unknown): Field {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    throw new Error("field must be an object with an id");
+  }
+  return value as unknown as Field;
+}
+
+function requireMetricRecord(value: unknown): Metric {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    throw new Error("metric must be an object with an id");
+  }
+  return value as unknown as Metric;
+}
+
+/**
+ * Apply one incremental collection edit ("fields" | "metrics") to a DataTable's
+ * jsonb array and persist it. Add appends; Update merges by id; Remove drops by
+ * id. Update/Remove on a missing id throw so a bad batch fails loudly (and rolls
+ * back). Insight nodes are rejected until YW-123 wires their definition arrays.
+ */
+async function patchDataTableCollection(
+  ctx: { db: import("@wystack/db").TrackedDb },
+  nodeId: string,
+  kind: "fields" | "metrics",
+  op:
+    | { mode: "add"; item: Field | Metric }
+    | { mode: "update"; itemId: string; updates: Record<string, unknown> }
+    | { mode: "remove"; itemId: string },
+): Promise<void> {
+  const nodeKind = await resolveNodeKind(ctx, nodeId);
+  if (nodeKind === "insight") {
+    throw new Error(
+      `Field/metric edits on Insight node ${nodeId} are not supported yet (YW-123)`,
+    );
+  }
+  const row = (await ctx.db
+    .from(dataTables)
+    .where(eq("id", nodeId))
+    .first()) as DataTableRow | undefined;
+  if (!row) throw new Error(`Data table ${nodeId} not found`);
+  const items = ((row[kind] ?? []) as { id: string }[]).slice();
+
+  let next: { id: string }[];
+  if (op.mode === "add") {
+    // Guard id uniqueness symmetrically with Update/Remove. Without it a second
+    // Add of the same id would make an illegal state representable (two items,
+    // one id) that Update/Remove then mutate/drop together — silently
+    // un-addressable individually.
+    if (items.some((item) => item.id === op.item.id)) {
+      throw new Error(`${kind} item ${op.item.id} already exists`);
+    }
+    next = [...items, op.item];
+  } else if (op.mode === "update") {
+    if (!items.some((item) => item.id === op.itemId)) {
+      throw new Error(`${kind} item ${op.itemId} not found`);
+    }
+    next = items.map((item) =>
+      item.id === op.itemId ? { ...item, ...op.updates } : item,
+    );
+  } else {
+    if (!items.some((item) => item.id === op.itemId)) {
+      throw new Error(`${kind} item ${op.itemId} not found`);
+    }
+    next = items.filter((item) => item.id !== op.itemId);
+  }
+
+  await ctx.db
+    .from(dataTables)
+    .where(eq("id", nodeId))
+    .update({ [kind]: next });
+}
+
+const addField = mutation({
+  args: { nodeId: uuid, field: jsonb },
+  handler: async (ctx, { nodeId, field }): Promise<{ ok: true }> => {
+    await patchDataTableCollection(ctx, nodeId, "fields", {
+      mode: "add",
+      item: requireFieldRecord(field),
+    });
+    return { ok: true };
+  },
+});
+
+const updateField = mutation({
+  args: { nodeId: uuid, fieldId: uuid, updates: jsonb },
+  handler: async (ctx, { nodeId, fieldId, updates }): Promise<{ ok: true }> => {
+    if (!isRecord(updates) || Object.keys(updates).length === 0) {
+      throw new Error("updates are required for UpdateField");
+    }
+    await patchDataTableCollection(ctx, nodeId, "fields", {
+      mode: "update",
+      itemId: fieldId,
+      updates,
+    });
+    return { ok: true };
+  },
+});
+
+const removeField = mutation({
+  args: { nodeId: uuid, fieldId: uuid },
+  handler: async (ctx, { nodeId, fieldId }): Promise<{ ok: true }> => {
+    await patchDataTableCollection(ctx, nodeId, "fields", {
+      mode: "remove",
+      itemId: fieldId,
+    });
+    return { ok: true };
+  },
+});
+
+const addMetric = mutation({
+  args: { nodeId: uuid, metric: jsonb },
+  handler: async (ctx, { nodeId, metric }): Promise<{ ok: true }> => {
+    await patchDataTableCollection(ctx, nodeId, "metrics", {
+      mode: "add",
+      item: requireMetricRecord(metric),
+    });
+    return { ok: true };
+  },
+});
+
+const updateMetric = mutation({
+  args: { nodeId: uuid, metricId: uuid, updates: jsonb },
+  handler: async (
+    ctx,
+    { nodeId, metricId, updates },
+  ): Promise<{ ok: true }> => {
+    if (!isRecord(updates) || Object.keys(updates).length === 0) {
+      throw new Error("updates are required for UpdateMetric");
+    }
+    await patchDataTableCollection(ctx, nodeId, "metrics", {
+      mode: "update",
+      itemId: metricId,
+      updates,
+    });
+    return { ok: true };
+  },
+});
+
+const removeMetric = mutation({
+  args: { nodeId: uuid, metricId: uuid },
+  handler: async (ctx, { nodeId, metricId }): Promise<{ ok: true }> => {
+    await patchDataTableCollection(ctx, nodeId, "metrics", {
+      mode: "remove",
+      itemId: metricId,
+    });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: RenameNode (one polymorphic rename)
+// ---------------------------------------------------------------------------
+
+/**
+ * RenameNode — the single `name` mutation, carved out of every coarse
+ * update(blob). Polymorphic over the artifact node kinds that carry a `name`
+ * column. One lookup decides the table; the SET is identical across them.
+ */
+const renameNode = mutation({
+  args: { id: uuid, name: text },
+  handler: async (ctx, { id, name }): Promise<{ ok: true }> => {
+    const table = await ctx.db.from(dataTables).where(eq("id", id)).first();
+    if (table) {
+      await ctx.db.from(dataTables).where(eq("id", id)).update({ name });
+      return { ok: true };
+    }
+    const source = await ctx.db.from(dataSources).where(eq("id", id)).first();
+    if (source) {
+      await ctx.db.from(dataSources).where(eq("id", id)).update({ name });
+      return { ok: true };
+    }
+    const insight = await ctx.db.from(insights).where(eq("id", id)).first();
+    if (insight) {
+      await ctx.db.from(insights).where(eq("id", id)).update({ name });
+      return { ok: true };
+    }
+    throw new Error(`Node ${id} not found`);
+  },
+});
+
+/**
+ * The command-backing mutation registry. Spread into the app's `functions` so
+ * `applyCommands` can dispatch each by path. Keys are the wire paths the
+ * builders below reference.
+ */
+export const commandFunctions = {
+  getOrCreateDataSource,
+  createDataSource,
+  setDataSourceConfig,
+  createDataTable,
+  setDataTableSchema,
+  refreshDataTableCmd: refreshDataTable,
+  addField,
+  updateField,
+  removeField,
+  addMetric,
+  updateMetric,
+  removeMetric,
+  renameNode,
+};
+
+// ---------------------------------------------------------------------------
+// Typed command builders — the VOCABULARY face
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed payloads for each command. These are the intent-carrying messages the
+ * human UI and the agent both construct; `commandBuilders` lowers them to the
+ * `{ path, args }` envelope `applyCommands` dispatches. Keeping the builder pure
+ * (no DB) means the only place command logic lives is the backing mutation.
+ */
+export interface CommandPayloads {
+  GetOrCreateDataSource: { id: UUID; type: string; name: string };
+  CreateDataSource: {
+    id: UUID;
+    type: string;
+    name: string;
+    apiKey?: string;
+    connectionString?: string;
+  };
+  SetDataSourceConfig: {
+    id: UUID;
+    apiKey?: string;
+    connectionString?: string;
+  };
+  CreateDataTable: {
+    id: UUID;
+    dataSourceId: UUID;
+    name: string;
+    table: string;
+    sourceSchema?: SourceSchema;
+    fields?: Field[];
+    metrics?: Metric[];
+    dataFrameId?: UUID;
+  };
+  SetDataTableSchema: { id: UUID; sourceSchema: SourceSchema };
+  RefreshDataTable: { id: UUID; dataFrameId: UUID };
+  AddField: { nodeId: UUID; field: Field };
+  UpdateField: { nodeId: UUID; fieldId: UUID; updates: Partial<Field> };
+  RemoveField: { nodeId: UUID; fieldId: UUID };
+  AddMetric: { nodeId: UUID; metric: Metric };
+  UpdateMetric: { nodeId: UUID; metricId: UUID; updates: Partial<Metric> };
+  RemoveMetric: { nodeId: UUID; metricId: UUID };
+  RenameNode: { id: UUID; name: string };
+}
+
+export type CommandName = keyof CommandPayloads;
+
+/**
+ * Map a command name to the registry path its backing mutation is registered
+ * under in the app `functions`. The single source of truth tying the typed
+ * vocabulary to the dispatched path.
+ */
+const COMMAND_PATHS: { [K in CommandName]: keyof typeof commandFunctions } = {
+  GetOrCreateDataSource: "getOrCreateDataSource",
+  CreateDataSource: "createDataSource",
+  SetDataSourceConfig: "setDataSourceConfig",
+  CreateDataTable: "createDataTable",
+  SetDataTableSchema: "setDataTableSchema",
+  RefreshDataTable: "refreshDataTableCmd",
+  AddField: "addField",
+  UpdateField: "updateField",
+  RemoveField: "removeField",
+  AddMetric: "addMetric",
+  UpdateMetric: "updateMetric",
+  RemoveMetric: "removeMetric",
+  RenameNode: "renameNode",
+};
+
+/**
+ * Build one `Command` envelope from a typed payload. `cmd("AddField", {...})`
+ * gives compile-time checking of the payload AND the right dispatch path — the
+ * capability-parity seam: the same builder the UI and agent call.
+ */
+export function cmd<K extends CommandName>(
+  name: K,
+  payload: CommandPayloads[K],
+): Command {
+  return { path: COMMAND_PATHS[name], args: payload };
+}

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -195,10 +195,25 @@ const createDataTable = mutation({
   },
 });
 
+/**
+ * Throw if no DataTable with `id` exists. An UPDATE on a missing id touches 0
+ * rows and would otherwise return `{ ok: true }` — a silent no-op the caller
+ * reads as success. This matches the by-id invariant every other handler here
+ * enforces (`setDataSourceConfig`, `renameNode`, `patchDataTableCollection`).
+ */
+async function requireDataTable(
+  ctx: { db: import("@wystack/db").TrackedDb },
+  id: string,
+): Promise<void> {
+  const row = await ctx.db.from(dataTables).where(eq("id", id)).first();
+  if (!row) throw new Error(`Data table ${id} not found`);
+}
+
 /** SetDataTableSchema — replaces the discovered source schema slice. */
 const setDataTableSchema = mutation({
   args: { id: uuid, sourceSchema: jsonb },
   handler: async (ctx, { id, sourceSchema }): Promise<{ ok: true }> => {
+    await requireDataTable(ctx, id);
     await ctx.db
       .from(dataTables)
       .where(eq("id", id))
@@ -211,6 +226,7 @@ const setDataTableSchema = mutation({
 const refreshDataTable = mutation({
   args: { id: uuid, dataFrameId: uuid },
   handler: async (ctx, { id, dataFrameId }): Promise<{ ok: true }> => {
+    await requireDataTable(ctx, id);
     await ctx.db
       .from(dataTables)
       .where(eq("id", id))
@@ -305,8 +321,10 @@ async function patchDataTableCollection(
     if (!items.some((item) => item.id === op.itemId)) {
       throw new Error(`${kind} item ${op.itemId} not found`);
     }
+    // Pin `id` last so a stray `updates.id` cannot rebind the item — that would
+    // recreate the un-addressable two-items-one-id state the Add-guard prevents.
     next = items.map((item) =>
-      item.id === op.itemId ? { ...item, ...op.updates } : item,
+      item.id === op.itemId ? { ...item, ...op.updates, id: item.id } : item,
     );
   } else {
     if (!items.some((item) => item.id === op.itemId)) {

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Helpers shared between the legacy coarse handlers (`app-artifacts.ts`) and
+ * the command vocabulary (`commands.ts`) while both write paths coexist
+ * (transition window, YW-157).
+ */
+
+export type DataSourceConfig = {
+  apiKey?: string;
+  connectionString?: string;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function requireRecordWithId(
+  value: unknown,
+  label: string,
+): { id: string } {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    throw new Error(`${label} must be an object with an id`);
+  }
+  return value as { id: string };
+}

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -9,8 +9,12 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["**/*.test.{ts,tsx}"],
-    // PGLite cold-start can exceed Vitest's default 5s timeout in CI.
+    // PGLite cold-start can exceed Vitest's default timeouts in CI. The
+    // command-vocabulary suite opens a fresh artifact DB per test in a
+    // `beforeEach`, so the HOOK timeout (default 10s) needs raising too — not
+    // just testTimeout, which doesn't cover hooks.
     testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
   resolve: {
     alias: {

--- a/bun.lock
+++ b/bun.lock
@@ -260,12 +260,18 @@
       },
       "devDependencies": {
         "@electric-sql/pglite": ">=0.3.0",
+        "@happy-dom/global-registrator": "20.10.1",
         "@tanstack/react-query": "^5.90.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.2.3",
         "@wystack/db": "workspace:*",
         "@wystack/server": "workspace:*",
         "drizzle-orm": "^0.45.1",
+        "happy-dom": "^20.10.1",
         "react": "^19.0.0",
+        "react-dom": "19.2.4",
         "typescript": "^5.8.3",
       },
       "peerDependencies": {
@@ -955,6 +961,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.1" } }, "sha512-nIT1Jdsar1KnLuqX+q3oMKwUIDcSJ4GnGMBnCtXLLL+lIpqaBBACPIo9By3NeF15XDPLDLIou8aQd3/xqZoSkQ=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hono/node-ws": ["@hono/node-ws@1.3.1", "", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.11", "hono": "^4.6.0" } }, "sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA=="],
@@ -1555,6 +1563,10 @@
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.2", "@typescript-eslint/type-utils": "8.59.2", "@typescript-eslint/utils": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ=="],
@@ -1699,7 +1711,7 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
-    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "array-back": ["array-back@6.2.3", "", {}, "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="],
 
@@ -1766,6 +1778,8 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
 
@@ -2051,7 +2065,7 @@
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -2280,6 +2294,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphql": ["graphql@16.14.0", "", {}, "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q=="],
+
+    "happy-dom": ["happy-dom@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -3459,6 +3475,8 @@
 
     "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "@happy-dom/global-registrator/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
+
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -3537,7 +3555,7 @@
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
@@ -3554,6 +3572,8 @@
     "@types/responselike/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "@types/set-cookie-parser/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
+
+    "@types/ws/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "@types/yauzl/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
@@ -3601,6 +3621,8 @@
 
     "apache-arrow/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
+    "buffer-image-size/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
+
     "bun-types/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "cacheable-request/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -3643,6 +3665,8 @@
 
     "eslint-plugin-import/tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
+    "eslint-plugin-jsx-a11y/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
@@ -3660,6 +3684,12 @@
     "fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "happy-dom/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
+
+    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "happy-dom/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -3694,6 +3724,8 @@
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 
@@ -3807,6 +3839,8 @@
 
     "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@manypkg/find-root/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
@@ -3852,6 +3886,8 @@
     "@types/responselike/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/set-cookie-parser/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/yauzl/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -3904,6 +3940,8 @@
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "apache-arrow/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "buffer-image-size/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -3972,6 +4010,8 @@
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/packages/app-data/src/data-sources.ts
+++ b/packages/app-data/src/data-sources.ts
@@ -95,9 +95,14 @@ export async function getDataSourceByType(
  * `GetOrCreateDataSource` command is idempotent (the loser reads the winner's
  * row or conflicts on the PK and its batch rolls back — never two rows).
  *
- * UUIDv5-style: SHA-1(namespace + type) formatted as a v5 UUID. Stable across
- * runs and processes for a given type, which is exactly the idempotency key we
- * need. (A per-`type` singleton matches today's connector model — local, notion.
+ * Custom SHA-1 deterministic UUID: SHA-1 over the UTF-8 string
+ * `namespace + type`, with v5 version and RFC 4122 variant bits set. NOT
+ * RFC 4122 §4.3-conformant (that hashes a 16-byte UUID namespace, not a
+ * string), so a standard UUIDv5 library will NOT reproduce these ids — this
+ * derivation is the only minter, and the id space is stable once shipped (do
+ * not change the rule without a migration). Stable across runs and processes
+ * for a given type, which is exactly the idempotency key we need. (A per-`type`
+ * singleton matches today's connector model — local, notion.
  * Multi-source-per-type uses `CreateDataSource` with a fresh random id instead.)
  */
 const DATA_SOURCE_NAMESPACE = "dashframe:data-source:";
@@ -119,6 +124,9 @@ export async function getOrCreateDataSourceByType(
   name: string,
 ): Promise<DataSource> {
   const id = await deterministicDataSourceId(type);
+  // Single-command `.mutate()` is the degenerate one-command batch: it runs
+  // WITHOUT the applyCommands transaction, so atomicity here rests on the PK
+  // backstop (same deterministic id), not on the batch envelope.
   await getWyStackClient().mutate(api.getOrCreateDataSource, {
     id,
     type,

--- a/packages/app-data/src/data-sources.ts
+++ b/packages/app-data/src/data-sources.ts
@@ -85,14 +85,50 @@ export async function getDataSourceByType(
   return result as DataSource | null;
 }
 
+/**
+ * Deterministic UUID for the singleton DataSource of a connector `type`.
+ *
+ * The defect (PR #46 Greptile P1): two concurrent CSV ingests both ran the racy
+ * `kind`-keyed check-then-insert and both inserted (no unique constraint on
+ * `kind`). The fix (YW-106) is to key get-or-create on the PRIMARY KEY: a stable
+ * id derived from the type means concurrent ingests target the same row, so the
+ * `GetOrCreateDataSource` command is idempotent (the loser reads the winner's
+ * row or conflicts on the PK and its batch rolls back — never two rows).
+ *
+ * UUIDv5-style: SHA-1(namespace + type) formatted as a v5 UUID. Stable across
+ * runs and processes for a given type, which is exactly the idempotency key we
+ * need. (A per-`type` singleton matches today's connector model — local, notion.
+ * Multi-source-per-type uses `CreateDataSource` with a fresh random id instead.)
+ */
+const DATA_SOURCE_NAMESPACE = "dashframe:data-source:";
+
+async function deterministicDataSourceId(type: string): Promise<UUID> {
+  const bytes = new TextEncoder().encode(DATA_SOURCE_NAMESPACE + type);
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-1", bytes));
+  // Format the first 16 bytes as a v5 UUID (set version + variant bits).
+  digest[6] = (digest[6]! & 0x0f) | 0x50;
+  digest[8] = (digest[8]! & 0x3f) | 0x80;
+  const hex = Array.from(digest.subarray(0, 16), (b) =>
+    b.toString(16).padStart(2, "0"),
+  ).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}` as UUID;
+}
+
 export async function getOrCreateDataSourceByType(
   type: string,
   name: string,
 ): Promise<DataSource> {
-  return (await getWyStackClient().mutate(api.getOrCreateDataSourceByType, {
+  const id = await deterministicDataSourceId(type);
+  await getWyStackClient().mutate(api.getOrCreateDataSource, {
+    id,
     type,
     name,
-  })) as DataSource;
+  });
+  // The command returns only `{ id }`; read back the full row so callers keep
+  // the DataSource contract they had with the old coarse mutation.
+  const source = await getDataSource(id);
+  if (!source) throw new Error(`Data source ${id} missing after get-or-create`);
+  return source;
 }
 
 export async function getAllDataSources(): Promise<DataSource[]> {


### PR DESCRIPTION
> **Cross-repo dependency cleared (2026-06-11):** wystack#41 (YW-119) and wystack#42 (YW-122) merged to wystack/main; submodule re-pointed to wystack/main in 6c0894c. No merge blocker remains.

## What

The DashFrame command **vocabulary** (Layer B) over `@wystack/server`'s `applyCommands` engine — 13 typed, intent-carrying commands the human UI and the agent both emit through one entry point (capability-parity). Resolves YW-106.

Each command is backed by a registered WyStack `mutation()` (path-addressable, same Zod validation as a plain RPC); a typed `cmd(name, payload)` builder lowers it to the `{ path, args }` envelope `applyCommands` dispatches. The backing handlers **are** the mutations — no duplicate logic, satisfying the spec's traceability rule.

## Headline: the get-or-create race is fixed

`GetOrCreateDataSource` replaces the racy check-then-insert `getOrCreateDataSourceByType` ([PR #46](https://github.com/youhaowei/DashFrame/pull/46) Greptile P1: concurrent CSV ingests double-insert). Idempotency now keys on the client-minted **primary key**, not the unconstrained `kind` column: a concurrent second ingest finds the row by id, and the PK constraint is the hard backstop (loser's batch rolls back). The `app-data` helper derives a stable deterministic id per connector type, so the ingest path is idempotent.

**Verified:** reverting the handler to the racy `kind`-keyed logic makes the idempotency test fail; the fix makes it pass. Review confirmed empirically (4 concurrent same-id batches → exactly one row).

## Traceability (every old write op → command)

`getOrCreateDataSourceByType → GetOrCreateDataSource` · `addDataSource → CreateDataSource` · `updateDataSource → SetDataSourceConfig + RenameNode` · `addDataTable → CreateDataTable` · `updateDataTable → RenameNode + SetDataTableSchema + RefreshDataTable` · `refreshDataTable → RefreshDataTable` · `patchDataTableArray → Add/Update/Remove Field + Metric`. `RenameNode` is the one polymorphic rename.

## Scope boundaries

- **Fields/Metrics target `{nodeId}` polymorphically.** DataTable (leaf) case wired; Insight (derived) case throws `"YW-123"` rather than misbehaving — the command shape won't change when YW-123 wires it.
- **`AddField`/`AddMetric` guard id-uniqueness** symmetrically with Update/Remove (a review MUST — without it a duplicate id made an illegal two-items-one-id state representable).
- **Operand encoding (YW-153 spike):** no YW-106 command carries a value-bearing operand, so the deferred-operand tagged union is **not** introduced speculatively. A header comment records the convention (`{kind:'value'} | {kind:'deferred', ref:{type:...}}`, tagged not property-presence; `v:null` = IS NULL) for YW-123's filters to apply.

## Concerns flagged for review

1. **No DB unique constraint on `kind`.** Idempotency rests on the caller reusing a stable id (the deterministic-id helper provides it for the singleton-per-type model). Two batches minting *different* ids for the same type would still create two rows — acceptable per the singleton model, but if server-side "exactly one source per kind" is ever needed, that wants a unique index on `kind` (out of scope).
2. **Deterministic id is "v5-style", not RFC 4122 v5** — well-formed and stable, but not interoperable with a standard `uuidv5(name, ns)` call. Fine as an idempotency key.
3. **Command returns are minimal** (`{id}` / `{ok:true}`, surfaced via `ApplyResult.results[i]`). `GetOrCreateDataSource` returns only `{id}`; the helper reads the row back to preserve the old return contract.

## Testing

24 Vitest tests (12 pre-existing + 12 new), real PGLite artifact DB: get-or-create id-idempotency + PK backstop, client-id invariant (DataSource→DataTable in one atomic batch), each command's write, the duplicate-id guard, mid-batch rollback, preview persists nothing. `bun check --filter @dashframe/server` green (typecheck + lint + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
