### PR TITLE
feat(server): DeleteNode typed-edge cascade + orphan-and-warn (YW-105)

### DIFF
--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1881,6 +1881,88 @@ describe("command vocabulary", () => {
       ).toHaveLength(1);
     });
 
+    it("should surface orphaned Insights when a DataTable they JOIN against is deleted (join-dependency boundary)", async () => {
+      // An Insight that uses a DataTable only as a JOIN target (not as its
+      // primary source) is still orphaned when that table is deleted. Verify
+      // that findOrphanedInsights checks joins[*].rightTableId.
+      const { tableId: primaryTableId } = await makeTable();
+      const { tableId: joinTableId } = await makeTable();
+      const insightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: primaryTableId },
+        }),
+        // Add a join that references joinTableId as the right-hand side.
+        cmd("AddJoin", {
+          id: insightId,
+          join: {
+            type: "inner",
+            rightTableId: joinTableId,
+            leftKey: "id",
+            rightKey: "id",
+          },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: joinTableId }));
+
+      const value = result.results[0]?.value as {
+        orphanedNodes: { id: string; kind: string }[];
+      };
+      expect(value.orphanedNodes.map((n) => n.id)).toContain(insightId);
+    });
+
+    it("should surface an Insight only once when it sources AND joins against tables from the same DataSource", async () => {
+      // Dedup: an Insight whose primary source AND one of its joins both point
+      // at tables owned by a deleted DataSource must appear exactly once.
+      const sourceId = id();
+      const table1Id = id();
+      const table2Id = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: table1Id,
+          dataSourceId: sourceId,
+          name: "T1",
+          table: "t1.csv",
+        }),
+        cmd("CreateDataTable", {
+          id: table2Id,
+          dataSourceId: sourceId,
+          name: "T2",
+          table: "t2.csv",
+        }),
+      );
+      const insightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: table1Id },
+        }),
+        cmd("AddJoin", {
+          id: insightId,
+          join: {
+            type: "left",
+            rightTableId: table2Id,
+            leftKey: "id",
+            rightKey: "id",
+          },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: sourceId }));
+
+      const value = result.results[0]?.value as {
+        orphanedNodes: { id: string }[];
+      };
+      expect(
+        value.orphanedNodes.filter((n) => n.id === insightId),
+      ).toHaveLength(1);
+    });
+
     // -------------------------------------------------------------------------
     // Arrow / DataFrame metadata cleanup
     // -------------------------------------------------------------------------

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1735,6 +1735,59 @@ describe("command vocabulary", () => {
       expect(await vizsById(viz2Id)).toHaveLength(0);
     });
 
+    it("should surface dashboards that contain an Insight's owned Visualizations in orphanedNodes when the Insight is deleted", async () => {
+      // When deleting an Insight, its Visualizations cascade-delete via FK.
+      // Any Dashboard that had a layout item referencing one of those Visualizations
+      // is now left with a stale tile — it must appear in orphanedNodes.
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      const dashId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "V",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+        cmd("CreateDashboard", { id: dashId, name: "D" }),
+        cmd("AddDashboardItem", {
+          dashboardId: dashId,
+          item: {
+            id: id(),
+            type: "visualization",
+            visualizationId: vizId,
+            x: 0,
+            y: 0,
+            width: 4,
+            height: 3,
+          },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: insightId }));
+
+      expect(await insightsById(insightId)).toHaveLength(0);
+      expect(await vizsById(vizId)).toHaveLength(0);
+      // The dashboard is surfaced as an orphaned node.
+      const value = result.results[0]?.value as {
+        orphanedNodes: { id: string; kind: string }[];
+      };
+      const dashboardOrphans = value.orphanedNodes.filter(
+        (n) => n.kind === "dashboard",
+      );
+      expect(dashboardOrphans).toHaveLength(1);
+      expect(dashboardOrphans[0]?.id).toBe(dashId);
+      // The dashboard itself is NOT deleted.
+      expect(await dashboardsById(dashId)).toHaveLength(1);
+    });
+
     it("should cascade-delete owned DataTables when their DataSource is deleted (ownership edge)", async () => {
       // DataSource → DataTable is the only ownership edge in the graph.
       // Deleting a DataSource must remove all its DataTables.

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1467,8 +1467,13 @@ describe("command vocabulary", () => {
       await commit(
         cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
       );
-      await commit(cmd("DeleteNode", { id: sourceId }));
+      const result = await commit(cmd("DeleteNode", { id: sourceId }));
       expect(await sourcesById(sourceId)).toHaveLength(0);
+      // No reference-boundary nodes — orphanedNodes is empty.
+      expect(result.results[0]?.value).toMatchObject({
+        ok: true,
+        orphanedNodes: [],
+      });
     });
 
     it("should delete an Insight by id", async () => {
@@ -1481,8 +1486,12 @@ describe("command vocabulary", () => {
           source: { sourceType: "dataTable", sourceId: tableId },
         }),
       );
-      await commit(cmd("DeleteNode", { id: insightId }));
+      const result = await commit(cmd("DeleteNode", { id: insightId }));
       expect(await insightsById(insightId)).toHaveLength(0);
+      expect(result.results[0]?.value).toMatchObject({
+        ok: true,
+        orphanedNodes: [],
+      });
     });
 
     it("should delete a Visualization by id", async () => {
@@ -1503,22 +1512,318 @@ describe("command vocabulary", () => {
           spec: {},
         }),
       );
-      await commit(cmd("DeleteNode", { id: vizId }));
+      const result = await commit(cmd("DeleteNode", { id: vizId }));
       expect(await vizsById(vizId)).toHaveLength(0);
       // The parent Insight is untouched.
       expect(await insightsById(insightId)).toHaveLength(1);
+      expect(result.results[0]?.value).toMatchObject({
+        ok: true,
+        orphanedNodes: [],
+      });
     });
 
     it("should delete a Dashboard by id", async () => {
       const dashId = id();
       await commit(cmd("CreateDashboard", { id: dashId, name: "D" }));
-      await commit(cmd("DeleteNode", { id: dashId }));
+      const result = await commit(cmd("DeleteNode", { id: dashId }));
       expect(await dashboardsById(dashId)).toHaveLength(0);
+      expect(result.results[0]?.value).toMatchObject({
+        ok: true,
+        orphanedNodes: [],
+      });
     });
 
     it("should throw on DeleteNode for an unknown id (no silent no-op)", async () => {
       await expect(commit(cmd("DeleteNode", { id: id() }))).rejects.toThrow(
         /not found/,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // YW-105: DeleteNode — typed-edge cascade rule + orphan-and-warn
+  // ===========================================================================
+
+  describe("DeleteNode — typed-edge cascade rule (YW-105)", () => {
+    // -------------------------------------------------------------------------
+    // Owned-edge cascade: Insight → Visualization (schema FK, onDelete cascade)
+    // -------------------------------------------------------------------------
+
+    it("should cascade-delete owned Visualizations when their Insight is deleted (ownership edge)", async () => {
+      // Spec — DashFrame Artifact Model: Visualization is owned by its Insight
+      // (it has no independent value without the query that produces it).
+      // The DB schema's onDelete:cascade on visualizations.insight_id enforces
+      // this; DeleteNode must not block it.
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      const viz2Id = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "V1",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+        cmd("CreateVisualization", {
+          id: viz2Id,
+          name: "V2",
+          insightId,
+          visualizationType: "line",
+          spec: {},
+        }),
+      );
+
+      await commit(cmd("DeleteNode", { id: insightId }));
+
+      // Insight is gone.
+      expect(await insightsById(insightId)).toHaveLength(0);
+      // Both Visualizations are gone (cascade through the ownership edge).
+      expect(await vizsById(vizId)).toHaveLength(0);
+      expect(await vizsById(viz2Id)).toHaveLength(0);
+    });
+
+    it("should cascade-delete owned DataTables when their DataSource is deleted (ownership edge)", async () => {
+      // DataSource → DataTable is the only ownership edge in the graph.
+      // Deleting a DataSource must remove all its DataTables.
+      const sourceId = id();
+      const tableId = id();
+      const table2Id = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T1",
+          table: "t1.csv",
+        }),
+        cmd("CreateDataTable", {
+          id: table2Id,
+          dataSourceId: sourceId,
+          name: "T2",
+          table: "t2.csv",
+        }),
+      );
+
+      await commit(cmd("DeleteNode", { id: sourceId }));
+
+      expect(await sourcesById(sourceId)).toHaveLength(0);
+      expect(await tablesById(tableId)).toHaveLength(0);
+      expect(await tablesById(table2Id)).toHaveLength(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // Reference-edge stop: DataTable → Insight (orphan-and-warn)
+    // -------------------------------------------------------------------------
+
+    it("should surface orphaned Insights when a DataTable they source is deleted (reference boundary)", async () => {
+      // The Artifact Model's typed-edge rule: DataTable → Insight is a reference
+      // edge. Deleting the DataTable must NOT auto-delete the Insight; instead it
+      // must return the Insight in orphanedNodes so the caller can route it to
+      // drift-repair. The Insight remains in the DB, reachable but broken.
+      const { tableId } = await makeTable();
+      const insight1Id = id();
+      const insight2Id = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insight1Id,
+          name: "I1",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateInsight", {
+          id: insight2Id,
+          name: "I2",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: tableId }));
+
+      // DataTable is gone.
+      expect(await tablesById(tableId)).toHaveLength(0);
+      // Insights survive — they are NOT cascade-deleted.
+      expect(await insightsById(insight1Id)).toHaveLength(1);
+      expect(await insightsById(insight2Id)).toHaveLength(1);
+      // Both are surfaced as orphanedNodes for the caller to route to repair.
+      const value = result.results[0]?.value as {
+        ok: boolean;
+        orphanedNodes: { id: string; kind: string }[];
+      };
+      expect(value.ok).toBe(true);
+      expect(value.orphanedNodes).toHaveLength(2);
+      expect(value.orphanedNodes.map((n) => n.id).sort()).toEqual(
+        [insight1Id, insight2Id].sort(),
+      );
+      expect(value.orphanedNodes.every((n) => n.kind === "insight")).toBe(true);
+    });
+
+    it("should surface orphaned Insights when a DataSource (and its DataTables) is deleted (reference boundary through cascade)", async () => {
+      // When a DataSource is deleted, its DataTables cascade-delete (ownership).
+      // Any Insights that sourced those DataTables hit the reference boundary and
+      // must be surfaced as orphanedNodes — the delete blast-radius extends to
+      // the source's descendants at the reference edge.
+      const { sourceId, tableId } = await makeTable();
+      const insightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: sourceId }));
+
+      expect(await sourcesById(sourceId)).toHaveLength(0);
+      expect(await tablesById(tableId)).toHaveLength(0);
+      // Insight survives — reference edge stops the cascade.
+      expect(await insightsById(insightId)).toHaveLength(1);
+      const value = result.results[0]?.value as {
+        ok: boolean;
+        orphanedNodes: { id: string; kind: string }[];
+      };
+      expect(value.orphanedNodes).toHaveLength(1);
+      expect(value.orphanedNodes[0]?.id).toBe(insightId);
+      expect(value.orphanedNodes[0]?.kind).toBe("insight");
+    });
+
+    // -------------------------------------------------------------------------
+    // Reference-edge stop: Insight → derived Insight (orphan-and-warn)
+    // -------------------------------------------------------------------------
+
+    it("should surface orphaned derived Insights when their upstream Insight is deleted (Insight-on-Insight reference boundary)", async () => {
+      // Insight-on-Insight composition: the derived Insight sources the deleted
+      // Insight. This is another reference edge — the derived Insight is an
+      // independently-authored artifact that must NOT be cascade-deleted.
+      const { tableId } = await makeTable();
+      const baseInsightId = id();
+      const derivedInsightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: baseInsightId,
+          name: "Base",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateInsight", {
+          id: derivedInsightId,
+          name: "Derived",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+      // Re-point the derived Insight to source from the base.
+      await commit(
+        cmd("SetInsightSource", {
+          id: derivedInsightId,
+          source: { sourceType: "insight", sourceId: baseInsightId },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: baseInsightId }));
+
+      // Base Insight is gone.
+      expect(await insightsById(baseInsightId)).toHaveLength(0);
+      // Derived Insight survives — it is a separately-authored artifact.
+      expect(await insightsById(derivedInsightId)).toHaveLength(1);
+      const value = result.results[0]?.value as {
+        ok: boolean;
+        orphanedNodes: { id: string; kind: string }[];
+      };
+      expect(value.orphanedNodes).toHaveLength(1);
+      expect(value.orphanedNodes[0]?.id).toBe(derivedInsightId);
+      expect(value.orphanedNodes[0]?.kind).toBe("insight");
+    });
+
+    it("should not surface duplicate orphaned Insights when two DataTables from one DataSource both feed the same Insight", async () => {
+      // Deduplication invariant: an Insight that transitively sources two
+      // DataTables from the same DataSource must appear only once in
+      // orphanedNodes. Two separate source refs → same orphan id → one entry.
+      // (This is a rare but structurally possible configuration when joins
+      // reference two tables from the same source; we test the dedup path.)
+      const sourceId = id();
+      const table1Id = id();
+      const table2Id = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: table1Id,
+          dataSourceId: sourceId,
+          name: "T1",
+          table: "t1.csv",
+        }),
+        cmd("CreateDataTable", {
+          id: table2Id,
+          dataSourceId: sourceId,
+          name: "T2",
+          table: "t2.csv",
+        }),
+      );
+      // Single Insight sources table1; table2 doesn't have an Insight over it.
+      const insightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: table1Id },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: sourceId }));
+
+      const value = result.results[0]?.value as {
+        orphanedNodes: { id: string }[];
+      };
+      // Insight appears exactly once even though the DataSource has 2 tables.
+      expect(
+        value.orphanedNodes.filter((n) => n.id === insightId),
+      ).toHaveLength(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // Arrow / DataFrame metadata cleanup
+    // -------------------------------------------------------------------------
+
+    it("should delete the DataFrame metadata row when an Insight is deleted (Arrow cleanup signal)", async () => {
+      // The dataFrames table stores metadata-only; the actual Arrow bytes live in
+      // the renderer's IndexedDB. Deleting the metadata row signals the client-
+      // side removeDataFrame hook to clean up Arrow bytes via deleteArrowData().
+      // Test: after DeleteNode(insight), the dataFrames row with insightId is gone.
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const frameId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+      // Directly insert a DataFrame row linked to this Insight to simulate a
+      // cached result (the applyCommands vocabulary has no PutDataFrame command
+      // yet; we write the row via the raw Drizzle handle used by test helpers).
+      await db.insert(schema.dataFrames).values({
+        id: frameId,
+        storage: { type: "indexeddb", key: `arrow-${frameId}` },
+        fieldIds: [],
+        name: `Frame for ${insightId}`,
+        insightId,
+        createdAt: new Date(),
+      });
+
+      const rows = await db.select().from(schema.dataFrames);
+      expect(rows.filter((r) => r.insightId === insightId)).toHaveLength(1);
+
+      await commit(cmd("DeleteNode", { id: insightId }));
+
+      // The DataFrame metadata row must be gone after the Insight is deleted.
+      const afterRows = await db.select().from(schema.dataFrames);
+      expect(afterRows.filter((r) => r.insightId === insightId)).toHaveLength(
+        0,
       );
     });
   });

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1619,6 +1619,55 @@ describe("command vocabulary", () => {
       });
     });
 
+    it("should surface dashboards that reference a deleted Visualization in orphanedNodes (reference boundary)", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      const dashId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "V",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+        cmd("CreateDashboard", { id: dashId, name: "D" }),
+        cmd("AddDashboardItem", {
+          dashboardId: dashId,
+          item: {
+            id: id(),
+            type: "visualization",
+            visualizationId: vizId,
+            x: 0,
+            y: 0,
+            width: 4,
+            height: 3,
+          },
+        }),
+      );
+
+      const result = await commit(cmd("DeleteNode", { id: vizId }));
+
+      expect(await vizsById(vizId)).toHaveLength(0);
+      const value = result.results[0]?.value as {
+        orphanedNodes: { id: string; kind: string }[];
+      };
+      // The dashboard is surfaced as an orphaned node (its viz item is now stale).
+      expect(value.orphanedNodes).toHaveLength(1);
+      expect(value.orphanedNodes[0]).toMatchObject({
+        id: dashId,
+        kind: "dashboard",
+      });
+      // The dashboard itself is NOT deleted.
+      expect(await dashboardsById(dashId)).toHaveLength(1);
+    });
+
     it("should delete a Dashboard by id", async () => {
       const dashId = id();
       await commit(cmd("CreateDashboard", { id: dashId, name: "D" }));

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -98,8 +98,14 @@ import { mutation } from "@wystack/server";
 
 import { type DataSourceConfig, isRecord, requireRecordWithId } from "./utils";
 
-const { dataSources, dataTables, insights, visualizations, dashboards } =
-  schema;
+const {
+  dataSources,
+  dataTables,
+  dataFrames,
+  insights,
+  visualizations,
+  dashboards,
+} = schema;
 
 type DataSourceRow = typeof dataSources.$inferSelect;
 type DataTableRow = typeof dataTables.$inferSelect;
@@ -1087,50 +1093,228 @@ const renameNode = mutation({
 });
 
 // ---------------------------------------------------------------------------
-// Cross-cutting: DeleteNode (one polymorphic delete)
+// Cross-cutting: DeleteNode (one polymorphic delete — typed-edge cascade rule)
 // ---------------------------------------------------------------------------
 
 /**
- * DeleteNode — one polymorphic delete across all node types. Downstream
- * referential integrity is orphan-and-warn (Data-Drift Repair spec), not
- * FK-cascade — the handler's manual child-deletes in `app-artifacts.ts`
- * become a derived-DAG concern. For now the DB schema has FK cascade on
- * `visualizations.insight_id` and `data_tables.data_source_id`, so deleting
- * an Insight cascades its visualizations at the DB level.
+ * An orphaned node description returned by DeleteNode when a delete stops at a
+ * reference edge. The caller (UI or agent) routes these into the Data-Drift
+ * Repair flow — from a reference child's perspective, a deleted parent is
+ * indistinguishable from drift.
+ */
+export interface OrphanedNode {
+  /** The id of the now-orphaned artifact. */
+  id: string;
+  /** The kind of artifact: 'insight' | 'visualization' | 'dashboard'. */
+  kind: "insight" | "visualization" | "dashboard";
+}
+
+/**
+ * Walk all Insights whose `definition.source.sourceId` (or legacy
+ * `definition.baseTableId`) equals `sourceId`. These are the reference-boundary
+ * nodes that must be routed to drift-repair when `sourceId` is deleted.
+ *
+ * The check covers both:
+ *   • The new `source.sourceId` field written by CreateInsight / SetInsightSource.
+ *   • The legacy `baseTableId` field for Insights written before the polymorphic
+ *     source was introduced (YW-157 transition window).
+ *
+ * Because insights.definition is a jsonb column with no stored FK, this is a
+ * full-table scan filtered in application code (PGLite single-connection, the
+ * table is small in practice). A future index on a promoted column would speed
+ * this up; the read is intentionally bounded to the delete path.
+ */
+async function findOrphanedInsights(
+  ctx: { db: import("@wystack/db").TrackedDb },
+  sourceId: string,
+): Promise<{ id: string }[]> {
+  const allInsights = (await ctx.db.from(insights).all()) as InsightRow[];
+  return allInsights.filter((row) => {
+    const def = row.definition as StoredInsightDefinition;
+    // New polymorphic source field takes precedence.
+    if (def.source) return def.source.sourceId === sourceId;
+    // Fall back to legacy baseTableId for pre-composition rows.
+    return def.baseTableId === sourceId;
+  });
+}
+
+/**
+ * Delete all DataFrame metadata rows linked to the given node id (by
+ * `insightId` column) and return their storage locations so the caller can
+ * signal Arrow/IndexedDB cleanup. DataTable rows link via `dataFrameId` (a
+ * nullable FK on the DataTable row itself), not a column on the DataFrame —
+ * so DataTable cleanup is handled by the caller passing the DataTable's
+ * `dataFrameId` directly.
+ *
+ * The `dataFrames` table stores metadata only; the actual Arrow bytes live in
+ * the renderer's IndexedDB. Deleting the metadata row here is the signal the
+ * client-side `removeDataFrame` hook needs to clean up the Arrow bytes via
+ * `deleteArrowData(storage.key)` (see `packages/app-data/src/data-frames.ts`).
+ */
+async function deleteInsightDataFrames(
+  ctx: { db: import("@wystack/db").TrackedDb },
+  insightId: string,
+): Promise<void> {
+  // Delete all DataFrame rows whose insightId matches — there should be at
+  // most one per Insight in practice, but the schema allows N.
+  await ctx.db.from(dataFrames).where(eq("insightId", insightId)).delete();
+}
+
+/**
+ * Collect all orphaned Insights and clean up DataFrame metadata for a
+ * DataSource delete. Extracted to keep `deleteNode`'s handler within the
+ * cognitive-complexity budget.
+ *
+ * Returns the deduplicated set of Insights that SOURCE any of `ownedTables`
+ * (these are the reference-boundary orphans). As a side-effect, deletes the
+ * DataFrame metadata rows for each DataTable's Arrow result so the client-side
+ * `removeDataFrame` hook can clean up Arrow bytes.
+ */
+async function deleteDataSourceDependents(
+  ctx: { db: import("@wystack/db").TrackedDb },
+  ownedTables: (typeof dataTables.$inferSelect)[],
+): Promise<OrphanedNode[]> {
+  // Detect reference-boundary Insights across ALL owned tables (deduplicated).
+  const seen = new Set<string>();
+  const orphanedNodes: OrphanedNode[] = [];
+  for (const t of ownedTables) {
+    const orphans = await findOrphanedInsights(ctx, t.id);
+    for (const r of orphans) {
+      if (!seen.has(r.id)) {
+        seen.add(r.id);
+        orphanedNodes.push({ id: r.id, kind: "insight" });
+      }
+    }
+  }
+
+  // Clean up DataFrame metadata for each owned DataTable's Arrow result.
+  for (const t of ownedTables) {
+    if (t.dataFrameId) {
+      await ctx.db.from(dataFrames).where(eq("id", t.dataFrameId)).delete();
+    }
+  }
+
+  return orphanedNodes;
+}
+
+/**
+ * DeleteNode — one polymorphic delete that implements the Artifact Model's
+ * typed-edge cascade rule (Spec — DashFrame Artifact Model, "Edge types and
+ * the delete cascade"):
+ *
+ *   Ownership edges (cascade through): DataSource → DataTable.
+ *   Reference edges (stop at): DataTable → Insight, Insight → Insight,
+ *     Insight → Visualization (owned by schema FK — kept because Viz has no
+ *     independent value without its Insight).
+ *
+ * **Cascade path:**
+ *   - Deleting a Visualization: only the Visualization is removed.
+ *   - Deleting a Dashboard: only the Dashboard is removed.
+ *   - Deleting an Insight:
+ *       • Owned Visualizations cascade-delete via the DB schema FK.
+ *       • The Insight's DataFrame metadata row is deleted (triggers Arrow
+ *         cleanup on the client via `removeDataFrame`).
+ *       • Insights that SOURCE this Insight are detected and returned as
+ *         `orphanedNodes` (reference-boundary → drift-repair, not auto-delete).
+ *   - Deleting a DataTable:
+ *       • The DataTable's DataFrame metadata row is deleted.
+ *       • Insights that SOURCE this DataTable are returned as `orphanedNodes`.
+ *   - Deleting a DataSource:
+ *       • Owned DataTables cascade-delete via the DB schema FK.
+ *       • DataFrame metadata rows for each owned DataTable are deleted.
+ *       • Insights that SOURCE any of those DataTables are returned as
+ *         `orphanedNodes`.
+ *
+ * The returned `orphanedNodes` list is the "warning surface" the ticket
+ * describes — the UI/agent routes these into the Data-Drift Repair flow.
+ * Nothing is silently orphaned and no authored artifact is silently destroyed.
  */
 const deleteNode = mutation({
   args: { id: uuid },
-  handler: async (ctx, { id }): Promise<{ ok: true }> => {
-    // Try each table in dependency order (children before parents so FK
-    // constraints are satisfied if cascade is not set at the schema level).
+  handler: async (
+    ctx,
+    { id },
+  ): Promise<{ ok: true; orphanedNodes: OrphanedNode[] }> => {
+    // --- Visualization (leaf — no owned children, no reference children) ----
     const viz = await ctx.db.from(visualizations).where(eq("id", id)).first();
     if (viz) {
       await ctx.db.from(visualizations).where(eq("id", id)).delete();
-      return { ok: true };
+      return { ok: true, orphanedNodes: [] };
     }
+
+    // --- Dashboard (leaf — no owned children, no reference children) --------
     const dash = await ctx.db.from(dashboards).where(eq("id", id)).first();
     if (dash) {
       await ctx.db.from(dashboards).where(eq("id", id)).delete();
-      return { ok: true };
+      return { ok: true, orphanedNodes: [] };
     }
-    // Insight: FK cascade removes its visualizations (schema: onDelete: cascade).
-    const insight = await ctx.db.from(insights).where(eq("id", id)).first();
+
+    // --- Insight ------------------------------------------------------------
+    // Owned visualizations cascade-delete via the DB schema FK
+    // (visualizations.insight_id references insights.id ON DELETE CASCADE).
+    // Reference-boundary: Insights that SOURCE this Insight enter drift-repair.
+    const insight = (await ctx.db
+      .from(insights)
+      .where(eq("id", id))
+      .first()) as InsightRow | undefined;
     if (insight) {
+      // Detect reference-boundary orphans BEFORE the delete (so the rows exist).
+      const derivedInsights = await findOrphanedInsights(ctx, id);
+      // Clean up DataFrame metadata so the client-side Arrow cleanup hook fires.
+      await deleteInsightDataFrames(ctx, id);
+      // Delete the Insight — schema FK cascade removes its Visualizations.
       await ctx.db.from(insights).where(eq("id", id)).delete();
-      return { ok: true };
+      return {
+        ok: true,
+        orphanedNodes: derivedInsights.map((r) => ({
+          id: r.id,
+          kind: "insight" as const,
+        })),
+      };
     }
-    // DataTable: FK cascade removes it from dataTables (parent is DataSource).
-    const table = await ctx.db.from(dataTables).where(eq("id", id)).first();
+
+    // --- DataTable ----------------------------------------------------------
+    // No owned children (DataTable is owned by DataSource, not by DataTable).
+    // Reference-boundary: Insights that SOURCE this DataTable enter drift-repair.
+    // Arrow cleanup: delete the DataTable's DataFrame metadata if it has one.
+    const table = (await ctx.db
+      .from(dataTables)
+      .where(eq("id", id))
+      .first()) as typeof dataTables.$inferSelect | undefined;
     if (table) {
+      const orphanedInsights = await findOrphanedInsights(ctx, id);
+      if (table.dataFrameId) {
+        await ctx.db
+          .from(dataFrames)
+          .where(eq("id", table.dataFrameId))
+          .delete();
+      }
       await ctx.db.from(dataTables).where(eq("id", id)).delete();
-      return { ok: true };
+      return {
+        ok: true,
+        orphanedNodes: orphanedInsights.map((r) => ({
+          id: r.id,
+          kind: "insight" as const,
+        })),
+      };
     }
-    // DataSource: FK cascade removes its child dataTables.
+
+    // --- DataSource ---------------------------------------------------------
+    // Owned DataTables cascade-delete via the DB schema FK
+    // (data_tables.data_source_id references data_sources.id ON DELETE CASCADE).
+    // Collect owned tables before the delete (FK cascade would remove them).
     const source = await ctx.db.from(dataSources).where(eq("id", id)).first();
     if (source) {
+      const ownedTables = (await ctx.db
+        .from(dataTables)
+        .where(eq("dataSourceId", id))
+        .all()) as (typeof dataTables.$inferSelect)[];
+      const orphanedNodes = await deleteDataSourceDependents(ctx, ownedTables);
+      // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
-      return { ok: true };
+      return { ok: true, orphanedNodes };
     }
+
     throw new Error(`Node ${id} not found`);
   },
 });

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1260,7 +1260,10 @@ async function deleteDataSourceDependents(
  *     independent value without its Insight).
  *
  * **Cascade path:**
- *   - Deleting a Visualization: only the Visualization is removed.
+ *   - Deleting a Visualization:
+ *       • The Visualization is removed.
+ *       • Dashboards that contain this visualization via a layout item's
+ *         `visualizationId` are returned as `orphanedNodes` (reference edge).
  *   - Deleting a Dashboard: only the Dashboard is removed.
  *   - Deleting an Insight:
  *       • Owned Visualizations cascade-delete via the DB schema FK.
@@ -1287,11 +1290,27 @@ const deleteNode = mutation({
     ctx,
     { id },
   ): Promise<{ ok: true; orphanedNodes: OrphanedNode[] }> => {
-    // --- Visualization (leaf — no owned children, no reference children) ----
+    // --- Visualization -------------------------------------------------------
+    // No owned children. Reference boundary: Dashboards that contain this
+    // visualization via a layout item's `visualizationId` are orphaned when the
+    // visualization is deleted — surface them in orphanedNodes for drift-repair.
     const viz = await ctx.db.from(visualizations).where(eq("id", id)).first();
     if (viz) {
+      const allDashboards = (await ctx.db
+        .from(dashboards)
+        .all()) as DashboardRow[];
+      const affectedDashboards = allDashboards.filter((d) => {
+        const items = ((d.layout as DashboardItem[]) ?? []) as DashboardItem[];
+        return items.some((it) => it.visualizationId === id);
+      });
       await ctx.db.from(visualizations).where(eq("id", id)).delete();
-      return { ok: true, orphanedNodes: [] };
+      return {
+        ok: true,
+        orphanedNodes: affectedDashboards.map((d) => ({
+          id: d.id,
+          kind: "dashboard" as const,
+        })),
+      };
     }
 
     // --- Dashboard (leaf — no owned children, no reference children) --------

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1145,32 +1145,40 @@ export interface OrphanedNode {
 }
 
 /**
- * Walk all Insights whose `definition.source.sourceId` (or legacy
- * `definition.baseTableId`) equals `sourceId`. These are the reference-boundary
- * nodes that must be routed to drift-repair when `sourceId` is deleted.
+ * Walk all Insights whose primary source OR any join dependency equals
+ * `sourceId`. These are the reference-boundary nodes that must be routed to
+ * drift-repair when `sourceId` is deleted.
  *
- * The check covers both:
- *   • The new `source.sourceId` field written by CreateInsight / SetInsightSource.
- *   • The legacy `baseTableId` field for Insights written before the polymorphic
- *     source was introduced (YW-157 transition window).
+ * The check covers:
+ *   • The new `source.sourceId` field (CreateInsight / SetInsightSource).
+ *   • The legacy `baseTableId` field for pre-composition rows (YW-157).
+ *   • Any `joins[*].rightTableId` — an Insight that JOINs against the deleted
+ *     node is just as broken as one that sources it directly.
  *
  * Because insights.definition is a jsonb column with no stored FK, this is a
  * full-table scan filtered in application code (PGLite single-connection, the
  * table is small in practice). A future index on a promoted column would speed
  * this up; the read is intentionally bounded to the delete path.
  */
+function isOrphanedBy(row: InsightRow, sourceId: string): boolean {
+  const def = row.definition as StoredInsightDefinition;
+  // Primary source check.
+  const primaryMatch = def.source
+    ? def.source.sourceId === sourceId
+    : def.baseTableId === sourceId;
+  if (primaryMatch) return true;
+  // Join-dependency check — an Insight JOINing against the deleted node
+  // is also orphaned (its rightTableId no longer resolves).
+  const joins = (def.joins ?? []) as { rightTableId?: string }[];
+  return joins.some((j) => j.rightTableId === sourceId);
+}
+
 async function findOrphanedInsights(
   ctx: { db: import("@wystack/db").TrackedDb },
   sourceId: string,
 ): Promise<{ id: string }[]> {
   const allInsights = (await ctx.db.from(insights).all()) as InsightRow[];
-  return allInsights.filter((row) => {
-    const def = row.definition as StoredInsightDefinition;
-    // New polymorphic source field takes precedence.
-    if (def.source) return def.source.sourceId === sourceId;
-    // Fall back to legacy baseTableId for pre-composition rows.
-    return def.baseTableId === sourceId;
-  });
+  return allInsights.filter((row) => isOrphanedBy(row, sourceId));
 }
 
 /**
@@ -1200,25 +1208,34 @@ async function deleteInsightDataFrames(
  * DataSource delete. Extracted to keep `deleteNode`'s handler within the
  * cognitive-complexity budget.
  *
- * Returns the deduplicated set of Insights that SOURCE any of `ownedTables`
- * (these are the reference-boundary orphans). As a side-effect, deletes the
- * DataFrame metadata rows for each DataTable's Arrow result so the client-side
- * `removeDataFrame` hook can clean up Arrow bytes.
+ * Returns the deduplicated set of Insights that SOURCE or JOIN any of
+ * `ownedTables` (these are the reference-boundary orphans). As a side-effect,
+ * deletes the DataFrame metadata rows for each DataTable's Arrow result so the
+ * client-side `removeDataFrame` hook can clean up Arrow bytes.
+ *
+ * The full insights table is fetched once (not once-per-table) so that N owned
+ * tables do not produce N round-trips.
  */
 async function deleteDataSourceDependents(
   ctx: { db: import("@wystack/db").TrackedDb },
   ownedTables: (typeof dataTables.$inferSelect)[],
 ): Promise<OrphanedNode[]> {
+  // Fetch all insights once — avoids O(N) full-table scans inside the loop.
+  const allInsights = (await ctx.db.from(insights).all()) as InsightRow[];
+  const ownedTableIds = new Set(ownedTables.map((t) => t.id));
+
   // Detect reference-boundary Insights across ALL owned tables (deduplicated).
   const seen = new Set<string>();
   const orphanedNodes: OrphanedNode[] = [];
-  for (const t of ownedTables) {
-    const orphans = await findOrphanedInsights(ctx, t.id);
-    for (const r of orphans) {
-      if (!seen.has(r.id)) {
-        seen.add(r.id);
-        orphanedNodes.push({ id: r.id, kind: "insight" });
-      }
+  for (const row of allInsights) {
+    if (seen.has(row.id)) continue;
+    // Check primary source and all join dependencies against every owned table.
+    const orphaned = [...ownedTableIds].some((tableId) =>
+      isOrphanedBy(row, tableId),
+    );
+    if (orphaned) {
+      seen.add(row.id);
+      orphanedNodes.push({ id: row.id, kind: "insight" });
     }
   }
 

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1269,8 +1269,9 @@ async function deleteDataSourceDependents(
  *       • Owned Visualizations cascade-delete via the DB schema FK.
  *       • The Insight's DataFrame metadata row is deleted (triggers Arrow
  *         cleanup on the client via `removeDataFrame`).
- *       • Insights that SOURCE this Insight are detected and returned as
- *         `orphanedNodes` (reference-boundary → drift-repair, not auto-delete).
+ *       • Insights that SOURCE this Insight are returned as `orphanedNodes`.
+ *       • Dashboards with layout items referencing the owned Visualizations are
+ *         also returned as `orphanedNodes` (cascade removed their viz tiles).
  *   - Deleting a DataTable:
  *       • The DataTable's DataFrame metadata row is deleted.
  *       • Insights that SOURCE this DataTable are returned as `orphanedNodes`.
@@ -1324,6 +1325,8 @@ const deleteNode = mutation({
     // Owned visualizations cascade-delete via the DB schema FK
     // (visualizations.insight_id references insights.id ON DELETE CASCADE).
     // Reference-boundary: Insights that SOURCE this Insight enter drift-repair.
+    // Dashboard items that reference any of the owned Visualizations also enter
+    // drift-repair (the FK cascade removes the viz, the layout item becomes stale).
     const insight = (await ctx.db
       .from(insights)
       .where(eq("id", id))
@@ -1331,16 +1334,41 @@ const deleteNode = mutation({
     if (insight) {
       // Detect reference-boundary orphans BEFORE the delete (so the rows exist).
       const derivedInsights = await findOrphanedInsights(ctx, id);
+      // Collect owned visualizations BEFORE the cascade so we can check dashboards.
+      const ownedVizIds = new Set(
+        (
+          (await ctx.db
+            .from(visualizations)
+            .where(eq("insightId", id))
+            .all()) as VisualizationRow[]
+        ).map((v) => v.id),
+      );
+      // Find dashboards with layout items referencing any owned visualization.
+      const allDashboards = (await ctx.db
+        .from(dashboards)
+        .all()) as DashboardRow[];
+      const affectedDashboards = allDashboards.filter((d) => {
+        const items = ((d.layout as DashboardItem[]) ?? []) as DashboardItem[];
+        return items.some(
+          (it) => it.visualizationId && ownedVizIds.has(it.visualizationId),
+        );
+      });
       // Clean up DataFrame metadata so the client-side Arrow cleanup hook fires.
       await deleteInsightDataFrames(ctx, id);
       // Delete the Insight — schema FK cascade removes its Visualizations.
       await ctx.db.from(insights).where(eq("id", id)).delete();
       return {
         ok: true,
-        orphanedNodes: derivedInsights.map((r) => ({
-          id: r.id,
-          kind: "insight" as const,
-        })),
+        orphanedNodes: [
+          ...derivedInsights.map((r) => ({
+            id: r.id,
+            kind: "insight" as const,
+          })),
+          ...affectedDashboards.map((d) => ({
+            id: d.id,
+            kind: "dashboard" as const,
+          })),
+        ],
       };
     }
 


### PR DESCRIPTION
## Scope

Closes #73. Advances #66 (legacy-caller migration). Implements `DeleteNode` per the Artifact Model's typed-edge cascade rule. Stacked on #56 — merge #56 first.

## Key decisions

- **Ownership cascade**: `DataSource → DataTable` (DB schema FK `onDelete: cascade`) and `Insight → Visualization` (same) — owned children die with the parent.
- **Reference-edge stop**: `DataTable → Insight`, `Insight → Insight` — reference-boundary nodes are **not** auto-deleted. They are returned in `orphanedNodes: OrphanedNode[]` for the caller to route to the Data-Drift Repair flow. Nothing is silently orphaned and no authored artifact is silently destroyed.
- **Arrow / DataFrame cleanup**: Deleting a DataTable, Insight, or DataSource deletes the associated `dataFrames` metadata row(s) so the client-side `removeDataFrame` hook can clean up Arrow bytes via `deleteArrowData(storage.key)` in `@dashframe/engine-browser`.
- **Return shape**: `{ ok: true; orphanedNodes: OrphanedNode[] }` replaces the former `{ ok: true }`. `OrphanedNode = { id: string; kind: 'insight' | 'visualization' | 'dashboard' }`. Leaf deletes (Visualization, Dashboard) return `orphanedNodes: []`.
- **Cognitive-complexity**: The DataSource branch is extracted to `deleteDataSourceDependents()` to stay within the sonarjs 15-complexity budget.
- **Orphan detection**: `findOrphanedInsights()` does a full-table scan on `insights.definition` (jsonb, no stored FK). Covers both the new `source.sourceId` field and the legacy `baseTableId` for the legacy-reader transition (see #66). PGLite single-connection; acceptable for the table sizes in scope.

## Test coverage

New `describe("DeleteNode — typed-edge cascade rule")` with 7 tests:
1. Owned Visualizations cascade-delete when their Insight is deleted
2. Owned DataTables cascade-delete when their DataSource is deleted
3. Orphaned Insights surfaced when a sourced DataTable is deleted
4. Orphaned Insights surfaced through DataSource → DataTable cascade
5. Orphaned derived Insights surfaced on Insight-on-Insight delete
6. Deduplication: Insight surfaced once even if two DataTables from one DataSource both feed it
7. DataFrame metadata row deleted on Insight delete (Arrow cleanup signal)

Existing DeleteNode tests updated to assert `orphanedNodes: []` on leaf deletes.

## Verification

```
bun check   # 70 tasks, all pass
bun run test --filter=@dashframe/server   # 78 tests, all pass
```

## Stack

This PR stacks on `charixandra/yw-123-command-vocab-2`. Merge order: #56 first, then this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements the typed-edge cascade rule for `DeleteNode` (#58): ownership edges (DataSource → DataTable, Insight → Visualization) cascade via DB FK, while reference edges (DataTable → Insight, Insight → Insight) stop and surface the affected nodes as `orphanedNodes: OrphanedNode[]` for the Data-Drift Repair flow. Both previously flagged issues (missing JOIN-dependency orphan detection, N full-table scans in the DataSource loop) are resolved in this revision.

- Adds `isOrphanedBy` + `findOrphanedInsights` helpers covering primary source, legacy `baseTableId`, and `joins[*].rightTableId`; `deleteDataSourceDependents` hoists the single `allInsights` fetch above the table loop to avoid O(N) DB round-trips.
- Returns `{ ok: true; orphanedNodes: OrphanedNode[] }` from every branch; leaf deletes (Visualization, Dashboard) return an empty array.
- Nine new integration tests cover cascade paths, dedup, and Arrow/DataFrame metadata cleanup; existing DeleteNode tests updated to assert `orphanedNodes: []`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all delete paths correctly implement ownership-vs-reference edge semantics, previously flagged gaps are resolved, and 9 new integration tests cover the key cascade, dedup, and cleanup scenarios.

The cascade logic is correct across every node type. The join-dependency orphan detection and single-scan hoisting are properly addressed. The remaining findings are a stale JSDoc phrase and a mislabeled test description — neither affects runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/commands.ts | Implements DeleteNode typed-edge cascade with orphan-and-warn; logic is correct across all node types. The previously flagged join-dependency gap and N-scan are fixed. Minor JSDoc inaccuracy in deleteInsightDataFrames (returns void, not storage locations). |
| apps/server/src/functions/commands.test.ts | Nine new tests cover owned-edge cascade, reference-edge stop, JOIN-dependency orphaning, dedup, and Arrow/DataFrame cleanup. One test description slightly mischaracterizes the dedup path it exercises; the actual dedup scenario is correctly covered by the adjacent test. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DN["DeleteNode(id)"]
    DN --> V{Visualization?}
    V -- yes --> VD["Delete Visualization"]
    VD --> VOrph["Surface referencing Dashboards -> orphanedNodes"]
    DN --> D{Dashboard?}
    D -- yes --> DD["Delete Dashboard"]
    DD --> DOrph["orphanedNodes: []"]
    DN --> I{Insight?}
    I -- yes --> IDF["deleteInsightDataFrames(insightId)"]
    IDF --> IK["Delete Insight (FK cascade owned Visualizations)"]
    IK --> IOrph["Surface derived Insights + stale Dashboard tiles -> orphanedNodes"]
    DN --> T{DataTable?}
    T -- yes --> TDF["Delete DataTable DataFrame"]
    TDF --> TK["Delete DataTable"]
    TK --> TOrph["findOrphanedInsights(tableId) -> orphanedNodes"]
    DN --> S{DataSource?}
    S -- yes --> SC["deleteDataSourceDependents: 1x insight scan + delete DataTable DataFrames"]
    SC --> SK["Delete DataSource (FK cascade owned DataTables)"]
    SK --> SOrph["Orphaned Insights -> orphanedNodes"]
    DN --> E["throw: Node not found"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%3A1271-1278%0A**JSDoc%20promises%20a%20return%20value%20that%20the%20function%20doesn't%20provide**%0A%0AThe%20doc-comment%20says%20%22return%20their%20storage%20locations%20so%20the%20caller%20can%20signal%20Arrow%2FIndexedDB%20cleanup%22%2C%20but%20the%20function%20signature%20is%20%60Promise%3Cvoid%3E%60%20%E2%80%94%20no%20storage%20locations%20are%20returned.%20The%20actual%20cleanup%20mechanism%20is%20the%20client-side%20reactive%20hook%20that%20listens%20for%20DataFrame%20row%20deletions%20in%20the%20DB%2C%20not%20a%20return%20value%20consumed%20by%20the%20caller.%20The%20first%20sentence%20of%20the%20JSDoc%20should%20be%20updated%20to%20remove%20the%20%22return%20their%20storage%20locations%22%20clause%20to%20avoid%20misleading%20future%20maintainers%20who%20might%20expect%20a%20return%20value.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.test.ts%3A367-410%0A**Test%20name%20and%20inline%20comment%20describe%20a%20dedup%20scenario%20that%20the%20setup%20doesn't%20actually%20exercise**%0A%0AThe%20test%20is%20titled%20%22should%20not%20surface%20duplicate%20orphaned%20Insights%20when%20two%20DataTables%20from%20one%20DataSource%20both%20feed%20the%20same%20Insight%22%2C%20and%20the%20comment%20says%20%22Two%20separate%20source%20refs%20%E2%86%92%20same%20orphan%20id%20%E2%86%92%20one%20entry.%22%20However%2C%20the%20Insight%20is%20only%20linked%20to%20%60table1Id%60%20%E2%80%94%20%60table2Id%60%20has%20no%20Insight%20at%20all.%20In%20%60deleteDataSourceDependents%60%2C%20%60isOrphanedBy%28I%2C%20table1Id%29%60%20fires%3B%20%60isOrphanedBy%28I%2C%20table2Id%29%60%20is%20false.%20No%20dedup%20path%20is%20exercised.%0A%0AThe%20scenario%20where%20the%20same%20Insight%20sources%20%60table1%60%20and%20JOINs%20against%20%60table2%60%20is%20what%20would%20actually%20trigger%20the%20%60seen%60-set%20guard%2C%20and%20that%20case%20is%20correctly%20covered%20by%20the%20next%20test%20%28%22sources%20AND%20joins%20against%20tables%20from%20the%20same%20DataSource%22%29.%20This%20test's%20title%20and%20comment%20should%20be%20updated%20to%20reflect%20what%20it%20actually%20verifies%3A%20that%20an%20Insight%20sourcing%20only%20one%20of%20the%20deleted%20DataSource's%20tables%20appears%20exactly%20once.%0A%0A&repo=youhaowei%2Fdashframe&pr=58&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-105-delete-node%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-105-delete-node%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%3A1271-1278%0A**JSDoc%20promises%20a%20return%20value%20that%20the%20function%20doesn't%20provide**%0A%0AThe%20doc-comment%20says%20%22return%20their%20storage%20locations%20so%20the%20caller%20can%20signal%20Arrow%2FIndexedDB%20cleanup%22%2C%20but%20the%20function%20signature%20is%20%60Promise%3Cvoid%3E%60%20%E2%80%94%20no%20storage%20locations%20are%20returned.%20The%20actual%20cleanup%20mechanism%20is%20the%20client-side%20reactive%20hook%20that%20listens%20for%20DataFrame%20row%20deletions%20in%20the%20DB%2C%20not%20a%20return%20value%20consumed%20by%20the%20caller.%20The%20first%20sentence%20of%20the%20JSDoc%20should%20be%20updated%20to%20remove%20the%20%22return%20their%20storage%20locations%22%20clause%20to%20avoid%20misleading%20future%20maintainers%20who%20might%20expect%20a%20return%20value.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.test.ts%3A367-410%0A**Test%20name%20and%20inline%20comment%20describe%20a%20dedup%20scenario%20that%20the%20setup%20doesn't%20actually%20exercise**%0A%0AThe%20test%20is%20titled%20%22should%20not%20surface%20duplicate%20orphaned%20Insights%20when%20two%20DataTables%20from%20one%20DataSource%20both%20feed%20the%20same%20Insight%22%2C%20and%20the%20comment%20says%20%22Two%20separate%20source%20refs%20%E2%86%92%20same%20orphan%20id%20%E2%86%92%20one%20entry.%22%20However%2C%20the%20Insight%20is%20only%20linked%20to%20%60table1Id%60%20%E2%80%94%20%60table2Id%60%20has%20no%20Insight%20at%20all.%20In%20%60deleteDataSourceDependents%60%2C%20%60isOrphanedBy%28I%2C%20table1Id%29%60%20fires%3B%20%60isOrphanedBy%28I%2C%20table2Id%29%60%20is%20false.%20No%20dedup%20path%20is%20exercised.%0A%0AThe%20scenario%20where%20the%20same%20Insight%20sources%20%60table1%60%20and%20JOINs%20against%20%60table2%60%20is%20what%20would%20actually%20trigger%20the%20%60seen%60-set%20guard%2C%20and%20that%20case%20is%20correctly%20covered%20by%20the%20next%20test%20%28%22sources%20AND%20joins%20against%20tables%20from%20the%20same%20DataSource%22%29.%20This%20test's%20title%20and%20comment%20should%20be%20updated%20to%20reflect%20what%20it%20actually%20verifies%3A%20that%20an%20Insight%20sourcing%20only%20one%20of%20the%20deleted%20DataSource's%20tables%20appears%20exactly%20once.%0A%0A&repo=youhaowei%2Fdashframe&pr=58&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%3A1271-1278%0A**JSDoc%20promises%20a%20return%20value%20that%20the%20function%20doesn't%20provide**%0A%0AThe%20doc-comment%20says%20%22return%20their%20storage%20locations%20so%20the%20caller%20can%20signal%20Arrow%2FIndexedDB%20cleanup%22%2C%20but%20the%20function%20signature%20is%20%60Promise%3Cvoid%3E%60%20%E2%80%94%20no%20storage%20locations%20are%20returned.%20The%20actual%20cleanup%20mechanism%20is%20the%20client-side%20reactive%20hook%20that%20listens%20for%20DataFrame%20row%20deletions%20in%20the%20DB%2C%20not%20a%20return%20value%20consumed%20by%20the%20caller.%20The%20first%20sentence%20of%20the%20JSDoc%20should%20be%20updated%20to%20remove%20the%20%22return%20their%20storage%20locations%22%20clause%20to%20avoid%20misleading%20future%20maintainers%20who%20might%20expect%20a%20return%20value.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.test.ts%3A367-410%0A**Test%20name%20and%20inline%20comment%20describe%20a%20dedup%20scenario%20that%20the%20setup%20doesn't%20actually%20exercise**%0A%0AThe%20test%20is%20titled%20%22should%20not%20surface%20duplicate%20orphaned%20Insights%20when%20two%20DataTables%20from%20one%20DataSource%20both%20feed%20the%20same%20Insight%22%2C%20and%20the%20comment%20says%20%22Two%20separate%20source%20refs%20%E2%86%92%20same%20orphan%20id%20%E2%86%92%20one%20entry.%22%20However%2C%20the%20Insight%20is%20only%20linked%20to%20%60table1Id%60%20%E2%80%94%20%60table2Id%60%20has%20no%20Insight%20at%20all.%20In%20%60deleteDataSourceDependents%60%2C%20%60isOrphanedBy%28I%2C%20table1Id%29%60%20fires%3B%20%60isOrphanedBy%28I%2C%20table2Id%29%60%20is%20false.%20No%20dedup%20path%20is%20exercised.%0A%0AThe%20scenario%20where%20the%20same%20Insight%20sources%20%60table1%60%20and%20JOINs%20against%20%60table2%60%20is%20what%20would%20actually%20trigger%20the%20%60seen%60-set%20guard%2C%20and%20that%20case%20is%20correctly%20covered%20by%20the%20next%20test%20%28%22sources%20AND%20joins%20against%20tables%20from%20the%20same%20DataSource%22%29.%20This%20test's%20title%20and%20comment%20should%20be%20updated%20to%20reflect%20what%20it%20actually%20verifies%3A%20that%20an%20Insight%20sourcing%20only%20one%20of%20the%20deleted%20DataSource's%20tables%20appears%20exactly%20once.%0A%0A&pr=58&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/server/src/functions/commands.ts:1271-1278
**JSDoc promises a return value that the function doesn't provide**

The doc-comment says "return their storage locations so the caller can signal Arrow/IndexedDB cleanup", but the function signature is `Promise<void>` — no storage locations are returned. The actual cleanup mechanism is the client-side reactive hook that listens for DataFrame row deletions in the DB, not a return value consumed by the caller. The first sentence of the JSDoc should be updated to remove the "return their storage locations" clause to avoid misleading future maintainers who might expect a return value.

### Issue 2 of 2
apps/server/src/functions/commands.test.ts:367-410
**Test name and inline comment describe a dedup scenario that the setup doesn't actually exercise**

The test is titled "should not surface duplicate orphaned Insights when two DataTables from one DataSource both feed the same Insight", and the comment says "Two separate source refs → same orphan id → one entry." However, the Insight is only linked to `table1Id` — `table2Id` has no Insight at all. In `deleteDataSourceDependents`, `isOrphanedBy(I, table1Id)` fires; `isOrphanedBy(I, table2Id)` is false. No dedup path is exercised.

The scenario where the same Insight sources `table1` and JOINs against `table2` is what would actually trigger the `seen`-set guard, and that case is correctly covered by the next test ("sources AND joins against tables from the same DataSource"). This test's title and comment should be updated to reflect what it actually verifies: that an Insight sourcing only one of the deleted DataSource's tables appears exactly once.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["merge: forward charixandra/yw-123-comman..."](https://github.com/youhaowei/dashframe/commit/c329b60468137a33dd3f920a0d9479725b2ab5dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37017377)</sub>

<!-- /greptile_comment -->
