### PR TITLE
chore(dev): per-worktree dev URLs — track portless wiring in git

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "./.claude/portless-shim.sh",
+      "runtimeArgs": ["bunx", "vite"],
+      "port": 3000,
+      "autoPort": true
+    },
+    {
+      "name": "renderer",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "--filter", "@dashframe/renderer", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "desktop",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "dev:desktop"],
+      "port": 5173
+    },
+    {
+      "name": "web + desktop",
+      "runtimeExecutable": "./.claude/preview-both.sh",
+      "port": 3000,
+      "autoPort": true
+    },
+    {
+      "name": "storybook",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "--filter", "@dashframe/ui", "storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/.claude/portless-shim.sh
+++ b/.claude/portless-shim.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Single entrypoint for terminal dev and Claude Preview, for the
+# @dashframe/web app. Runs vite through portless so it gets a stable
+# https://dashframe.localhost URL. In a git worktree, portless prepends
+# the branch slug as a subdomain (<branch>.dashframe.localhost), so every
+# worktree runs its own copy without port conflicts; `portless list` shows
+# which route maps to which port.
+# - No PORT env (terminal): portless auto-assigns a random free port.
+# - PORT env set (Preview MCP): forward as --app-port so portless binds
+#   where Preview will iframe.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../apps/web"
+
+if [[ -n "${PORT:-}" ]]; then
+  exec portless run --app-port "${PORT}" "$@"
+else
+  exec portless run "$@"
+fi

--- a/.claude/preview-both.sh
+++ b/.claude/preview-both.sh
@@ -31,7 +31,7 @@ trap cleanup EXIT INT TERM
 # 1. Desktop in the background. dev handles its own build + launch and
 #    its own child-process cleanup on SIGTERM.
 echo "[preview-both] starting desktop (Electron native window)…"
-bun run dev &
+(cd "${ROOT}" && bun run dev) &
 desktop_pid=$!
 
 # 2. Web in the foreground through portless-shim — Preview iframes this. The

--- a/.claude/preview-both.sh
+++ b/.claude/preview-both.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Launch the web app (previewable in Claude's Preview pane) AND the desktop
+# Electron app (native window) at the same time, from one action.
+#
+# Why this shape:
+#   - The web app must stay a single foreground portless process so Claude
+#     Preview can iframe it (it owns the PORT env and the iframe URL). So web
+#     runs in the FOREGROUND through the existing portless-shim, unchanged.
+#   - The desktop app is a native Electron window, not an iframe-able URL. It
+#     runs in the BACKGROUND via `bun run dev` (which builds the
+#     wystack→server-core→server→main chain, starts its own renderer Vite
+#     server on :5173, and launches Electron). It pops as its own window.
+#
+# Lifecycle: dev's own dev.mjs installs SIGTERM handlers that kill its
+# Electron + Vite children, so on exit we just signal that one process and its
+# handler cascades the teardown. (No setsid — not available on macOS.)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+desktop_pid=""
+cleanup() {
+  if [[ -n "${desktop_pid}" ]] && kill -0 "${desktop_pid}" 2>/dev/null; then
+    # dev.mjs traps SIGTERM and kills its electron + vite children.
+    kill -TERM "${desktop_pid}" 2>/dev/null || true
+    wait "${desktop_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# 1. Desktop in the background. dev handles its own build + launch and
+#    its own child-process cleanup on SIGTERM.
+echo "[preview-both] starting desktop (Electron native window)…"
+bun run dev &
+desktop_pid=$!
+
+# 2. Web in the foreground through portless-shim — Preview iframes this. The
+#    shim forwards the Preview-injected PORT to portless as --app-port.
+#    Not `exec`: the script must stay alive so the EXIT trap can tear down the
+#    desktop process when Preview stops the web.
+echo "[preview-both] starting web (previewable) on portless…"
+"${ROOT}/.claude/portless-shim.sh" bunx vite

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,11 @@ out
 .cursor/
 Support/
 .claude_settings.json
-.claude/
+# Ignore .claude/ except the shared dev-server wiring (needed in every worktree)
+.claude/*
+!.claude/launch.json
+!.claude/portless-shim.sh
+!.claude/preview-both.sh
 CLAUDE.local.md
 
 # Local build/debug logs

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,1 @@
+{ "name": "dashframe" }


### PR DESCRIPTION
## What

The portless shim, `.claude/launch.json`, and `preview-both.sh` were trapped under the `.claude/` gitignore — worktrees never received them, so parallel dev servers had no stable URLs and collided on ports.

- `.gitignore`: `.claude/` → `.claude/*` with negations for exactly the three shared dev files (settings, plans, hookify rules stay ignored)
- `portless.json` at root pins the project name, so worktree URLs are always `<branch>.dashframe.localhost` regardless of checkout directory
- Shim docstring documents the worktree-prefix behavior

## Why

Each worktree now runs its own app copy on a dynamically assigned port behind a branch-named HTTPS URL — `portless list` shows which route maps to which port, making parallel PR review trivial.

## Verification

Live worktree test (yw-151): `portless run bunx vite` → `https://yw-151-…-ee5288.dashframe.localhost -> localhost:4118`, curl 200 through the proxy, route cleaned up on kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the git-tracking gap that prevented `.claude/` dev-server wiring from propagating to git worktrees, enabling per-worktree portless HTTPS URLs for parallel PR review. The `.gitignore` rule is narrowed from `.claude/` to `.claude/*` with explicit negations for the three shared files, while a new `portless.json` pins the project name so branch-slug subdomains are stable regardless of checkout directory.

- `.gitignore` now uses `.claude/*` + negations so `launch.json`, `portless-shim.sh`, and `preview-both.sh` are tracked while settings, plans, and hook rules stay ignored.
- `portless-shim.sh` resolves `apps/web` via `BASH_SOURCE`-relative path and forwards the Preview MCP `PORT` env as `--app-port`; `preview-both.sh` wraps both the Electron and web dev targets with a proper EXIT/INT/TERM trap for clean teardown.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are dev-tooling and gitignore wiring with no runtime or production impact.

The changes are confined to `.claude/` scripts and gitignore patterns. The shell scripts use `BASH_SOURCE`-relative path resolution (avoiding cwd sensitivity), correct `set -euo pipefail` discipline, and a properly wired EXIT trap for cleanup. The gitignore negation pattern is structured correctly so that secrets, plans, and settings stay ignored while only the three shared dev files are tracked.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitignore | Switches `.claude/` to `.claude/*` with negations for the three shared dev files; correctly allows negations to work since the directory itself is not pattern-ignored. |
| .claude/portless-shim.sh | New shim that `cd`s to `apps/web` via `BASH_SOURCE`-relative resolution then delegates to `portless run`, forwarding `PORT` as `--app-port` when set by Preview MCP. |
| .claude/preview-both.sh | New script that starts the desktop Electron app in the background and the web app in the foreground via portless-shim; EXIT/INT/TERM trap correctly tears down the desktop process on exit. |
| .claude/launch.json | New launch configuration wiring up web, renderer, desktop, combined, and storybook targets; `autoPort: true` on the two portless-backed configs is correct. |
| portless.json | Single-line project-name pin ensures portless always uses `dashframe` as the subdomain base regardless of worktree checkout directory name. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.gitignore`, line 52 ([link](https://github.com/youhaowei/dashframe/blob/afcff57c81971fb1a700fefbd85479b28cabed71/.gitignore#L52)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant ignore entry** — `.claude/plans` is now fully covered by `.claude/*` on line 24, so this line has no effect. It's harmless, but it may mislead readers into thinking plans require special treatment beyond the glob.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .gitignore
   Line: 52

   Comment:
   **Redundant ignore entry** — `.claude/plans` is now fully covered by `.claude/*` on line 24, so this line has no effect. It's harmless, but it may mislead readers into thinking plans require special treatment beyond the glob.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.gitignore%0ALine%3A%2052%0A%0AComment%3A%0A**Redundant%20ignore%20entry**%20%E2%80%94%20%60.claude%2Fplans%60%20is%20now%20fully%20covered%20by%20%60.claude%2F*%60%20on%20line%2024%2C%20so%20this%20line%20has%20no%20effect.%20It's%20harmless%2C%20but%20it%20may%20mislead%20readers%20into%20thinking%20plans%20require%20special%20treatment%20beyond%20the%20glob.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22chore%2Fportless-worktree-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fportless-worktree-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.gitignore%0ALine%3A%2052%0A%0AComment%3A%0A**Redundant%20ignore%20entry**%20%E2%80%94%20%60.claude%2Fplans%60%20is%20now%20fully%20covered%20by%20%60.claude%2F*%60%20on%20line%2024%2C%20so%20this%20line%20has%20no%20effect.%20It's%20harmless%2C%20but%20it%20may%20mislead%20readers%20into%20thinking%20plans%20require%20special%20treatment%20beyond%20the%20glob.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.gitignore%0ALine%3A%2052%0A%0AComment%3A%0A**Redundant%20ignore%20entry**%20%E2%80%94%20%60.claude%2Fplans%60%20is%20now%20fully%20covered%20by%20%60.claude%2F*%60%20on%20line%2024%2C%20so%20this%20line%20has%20no%20effect.%20It's%20harmless%2C%20but%20it%20may%20mislead%20readers%20into%20thinking%20plans%20require%20special%20treatment%20beyond%20the%20glob.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=61&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(dev): cd to ROOT before background d..."](https://github.com/youhaowei/dashframe/commit/6af96b075cd5c9aed07046699697588b5f6372ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37028328)</sub>

<!-- /greptile_comment -->