### PR TITLE
chore: land local-main fixes — pre-push GIT_DIR guard, codex setup, MCP config

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,7 +3,7 @@ version = 1
 name = "DashFrame"
 
 [setup]
-script = "bun install"
+script = "bun run setup"
 
 [[actions]]
 name = "Preview Web"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# If the pusher was invoked with --git-dir or GIT_DIR set, git exports an
+# absolute GIT_DIR into the hook environment. `git init`/`git fetch` honor
+# GIT_DIR over -C, so the scratch-repo commands below would re-initialize
+# THIS repo as bare (core.bare=true) and break every worktree operation.
+# Hooks run at the top of the working tree, so cwd discovery is always right.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 # Verify pushed submodule pointers are reachable from their configured remotes.
 # pre-push can push refs other than HEAD, so validate each local ref update from
 # stdin instead of assuming the current checkout is the commit being pushed.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,7 +4,11 @@
 # absolute GIT_DIR into the hook environment. `git init`/`git fetch` honor
 # GIT_DIR over -C, so the scratch-repo commands below would re-initialize
 # THIS repo as bare (core.bare=true) and break every worktree operation.
-# Hooks run at the top of the working tree, so cwd discovery is always right.
+# Capture the repo root FIRST while the env is still intact so that pushes
+# launched with explicit repo context (--git-dir / absolute hooksPath) still
+# resolve the correct working tree. Then cd + unset so scratch commands are safe.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
 # Verify pushed submodule pointers are reachable from their configured remotes.

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,13 +7,6 @@
     "shadcn": {
       "args": ["shadcn@latest", "mcp"],
       "command": "npx"
-    },
-    "storybook": {
-      "url": "http://localhost:6006/mcp",
-      "type": "http",
-      "headers": {
-        "X-MCP-Toolsets": "docs,dev"
-      }
     }
   }
 }


### PR DESCRIPTION
## What

Three commits that lived only on the local main checkout, now upstreamed:

- **fix(hooks): unset GIT_DIR in pre-push** — the load-bearing one. The pre-push hook's scratch `git init --bare` honored a leaked absolute `GIT_DIR` from the invoking process and re-initialized the main repo as bare, corrupting the checkout. `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE` at the top of the hook stops the class. Without this upstream, every fresh clone and CI checkout is unprotected.
- chore(codex): run full setup script in Codex environment
- chore(mcp): drop storybook MCP server config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upstreams three local-main commits: the critical pre-push hook fix that prevents `GIT_DIR` leakage from corrupting the repository, a Codex setup script update, and removal of the storybook MCP server entry.

- **`.husky/pre-push`**: Captures `repo_root` via `git rev-parse --show-toplevel` before clearing `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE`, so the scratch `git init --bare` calls can no longer re-initialize the main repo as bare. The ordering (capture → cd → unset) is correct and the comment explains the reasoning clearly.
- **`.codex/environments/environment.toml`**: Switches the Codex setup command from `bun install` to `bun run setup` to run the full project bootstrap.
- **`.mcp.json`**: Removes the storybook local MCP server entry (`localhost:6006/mcp`), leaving the npx-based next-devtools and shadcn entries intact.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the pre-push hook fix is correct, minimal in scope, and directly addresses the repo-corruption scenario described in the PR.

The hook change captures repo_root before clearing the git env vars, which is the right ordering: git rev-parse needs GIT_DIR intact to resolve the toplevel, and the subsequent scratch git init calls need GIT_DIR absent so they don't redirect back at the main repo. The other two changes are straightforward config updates with no functional risk.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .husky/pre-push | Adds GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE unset guard at the top of the hook, capturing repo_root first to preserve context before clearing the environment — the load-bearing fix that prevents scratch `git init --bare` from corrupting the main checkout. |
| .codex/environments/environment.toml | Changes setup script from `bun install` to `bun run setup` so Codex runs the full project setup script instead of a bare install. |
| .mcp.json | Removes the storybook MCP server entry (localhost:6006/mcp); the remaining next-devtools and shadcn entries are untouched. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.codex/environments/environment.toml`, line 1 ([link](https://github.com/youhaowei/dashframe/blob/36a8bdfccf1e387388cb7f909f16c355b0716e3d/.codex/environments/environment.toml#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Autogenerated file edited manually**

   The file opens with `# THIS IS AUTOGENERATED. DO NOT EDIT MANUALLY`. If there is a generator (e.g. a script or CI step) that produces this file, editing it by hand risks having those changes silently overwritten the next time the generator runs. Worth confirming whether the generator is still in use or whether this header is stale and can be removed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .codex/environments/environment.toml
   Line: 1

   Comment:
   **Autogenerated file edited manually**

   The file opens with `# THIS IS AUTOGENERATED. DO NOT EDIT MANUALLY`. If there is a generator (e.g. a script or CI step) that produces this file, editing it by hand risks having those changes silently overwritten the next time the generator runs. Worth confirming whether the generator is still in use or whether this header is stale and can be removed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.codex%2Fenvironments%2Fenvironment.toml%0ALine%3A%201%0A%0AComment%3A%0A**Autogenerated%20file%20edited%20manually**%0A%0AThe%20file%20opens%20with%20%60%23%20THIS%20IS%20AUTOGENERATED.%20DO%20NOT%20EDIT%20MANUALLY%60.%20If%20there%20is%20a%20generator%20%28e.g.%20a%20script%20or%20CI%20step%29%20that%20produces%20this%20file%2C%20editing%20it%20by%20hand%20risks%20having%20those%20changes%20silently%20overwritten%20the%20next%20time%20the%20generator%20runs.%20Worth%20confirming%20whether%20the%20generator%20is%20still%20in%20use%20or%20whether%20this%20header%20is%20stale%20and%20can%20be%20removed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=62&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22chore%2Flocal-main-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Flocal-main-fixes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.codex%2Fenvironments%2Fenvironment.toml%0ALine%3A%201%0A%0AComment%3A%0A**Autogenerated%20file%20edited%20manually**%0A%0AThe%20file%20opens%20with%20%60%23%20THIS%20IS%20AUTOGENERATED.%20DO%20NOT%20EDIT%20MANUALLY%60.%20If%20there%20is%20a%20generator%20%28e.g.%20a%20script%20or%20CI%20step%29%20that%20produces%20this%20file%2C%20editing%20it%20by%20hand%20risks%20having%20those%20changes%20silently%20overwritten%20the%20next%20time%20the%20generator%20runs.%20Worth%20confirming%20whether%20the%20generator%20is%20still%20in%20use%20or%20whether%20this%20header%20is%20stale%20and%20can%20be%20removed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=62&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.codex%2Fenvironments%2Fenvironment.toml%0ALine%3A%201%0A%0AComment%3A%0A**Autogenerated%20file%20edited%20manually**%0A%0AThe%20file%20opens%20with%20%60%23%20THIS%20IS%20AUTOGENERATED.%20DO%20NOT%20EDIT%20MANUALLY%60.%20If%20there%20is%20a%20generator%20%28e.g.%20a%20script%20or%20CI%20step%29%20that%20produces%20this%20file%2C%20editing%20it%20by%20hand%20risks%20having%20those%20changes%20silently%20overwritten%20the%20next%20time%20the%20generator%20runs.%20Worth%20confirming%20whether%20the%20generator%20is%20still%20in%20use%20or%20whether%20this%20header%20is%20stale%20and%20can%20be%20removed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=62&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(hooks): capture repo\_root before uns..."](https://github.com/youhaowei/dashframe/commit/5353ac3cfe7514a43310ef6c83d5c8157f1e6941) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37038223)</sub>

<!-- /greptile_comment -->