### PR TITLE
fix(types): downstream provenance carries kind+id (PreviewDiff via)

### DIFF
--- a/apps/server/src/functions/preview-diff.test.ts
+++ b/apps/server/src/functions/preview-diff.test.ts
@@ -414,6 +414,46 @@ describe("PreviewDiff builder", () => {
         table: "t.csv",
       });
     });
+
+    it("via.kind disambiguates the direct root when two artifacts share a UUID and a downstream node hangs off exactly one of them", async () => {
+      // This is the Codex P2 finding (PRRT_kwDOQKlCpM6I8-JO on PR #54):
+      // a batch mints CreateDataSource(X) + CreateDataTable(X). A downstream
+      // insight references the dataTable (not the dataSource). With via: UUID
+      // the renderer could not tell which direct node owns the blast radius;
+      // via: { kind, id } makes it unambiguous.
+      const sharedId = id();
+      const insightId = id();
+      // Seed a canonical insight that references sharedId as its baseTableId so
+      // the DAG walk finds it as downstream of the dataTable direct node.
+      await db.insert(insights).values({
+        id: insightId,
+        name: "InsightUnderTable",
+        definition: { baseTableId: sharedId },
+        createdBy: PROV,
+      });
+
+      const diff = await preview(
+        cmd("CreateDataSource", { id: sharedId, type: "csv", name: "Src" }),
+        cmd("CreateDataTable", {
+          id: sharedId,
+          dataSourceId: sharedId,
+          name: "Tbl",
+          table: "t.csv",
+        }),
+      );
+
+      // The insight must be in affectedDownstream and attributed to the
+      // dataTable direct node — not the dataSource.
+      const insightHit = diff.affectedDownstream.find(
+        (n) => n.nodeId === insightId,
+      );
+      expect(insightHit).toBeDefined();
+      expect(insightHit!.edge).toBe("dataTable->insight");
+      // via.kind must be "dataTable" so the renderer resolves the correct root.
+      expect(insightHit!.via).toEqual({ kind: "dataTable", id: sharedId });
+      // Sanity: must NOT point at the dataSource which also carries sharedId.
+      expect(insightHit!.via.kind).not.toBe("dataSource");
+    });
   });
 
   // --------------------------------------------------------------------------
@@ -439,7 +479,7 @@ describe("PreviewDiff builder", () => {
       expect(diff.directNodes[0]!.change).toBe("noop");
       // ...but contributes zero downstream flags.
       const fromSource = diff.affectedDownstream.filter(
-        (n) => n.via === sourceId,
+        (n) => n.via.id === sourceId,
       );
       expect(fromSource).toEqual([]);
       expect(diff.affectedDownstream).toEqual([]);
@@ -464,7 +504,7 @@ describe("PreviewDiff builder", () => {
       );
 
       const viaNoOp = diff.affectedDownstream.filter(
-        (n) => n.via === noopSourceId,
+        (n) => n.via.id === noopSourceId,
       );
       expect(viaNoOp).toEqual([]);
       const changedTable = diff.affectedDownstream.find(
@@ -472,7 +512,7 @@ describe("PreviewDiff builder", () => {
       );
       expect(changedTable).toMatchObject({
         edge: "dataSource->dataTable",
-        via: changedSourceId,
+        via: { kind: "dataSource", id: changedSourceId },
       });
     });
   });
@@ -495,7 +535,7 @@ describe("PreviewDiff builder", () => {
       expect(table).toMatchObject({
         kind: "dataTable",
         edge: "dataSource->dataTable",
-        via: sourceId,
+        via: { kind: "dataSource", id: sourceId },
       });
     });
 
@@ -510,7 +550,7 @@ describe("PreviewDiff builder", () => {
       expect(ins).toMatchObject({
         kind: "insight",
         edge: "dataTable->insight",
-        via: tableId,
+        via: { kind: "dataTable", id: tableId },
       });
     });
 
@@ -538,7 +578,7 @@ describe("PreviewDiff builder", () => {
       const ins = diff.affectedDownstream.find((n) => n.nodeId === insightId);
       expect(ins).toMatchObject({
         edge: "dataTable->insight",
-        via: joinTableId,
+        via: { kind: "dataTable", id: joinTableId },
       });
     });
 
@@ -650,7 +690,10 @@ describe("PreviewDiff builder", () => {
       const child = diff.affectedDownstream.find(
         (n) => n.nodeId === childInsightId,
       );
-      expect(child).toMatchObject({ edge: "parentArtifact", via: sourceId });
+      expect(child).toMatchObject({
+        edge: "parentArtifact",
+        via: { kind: "dataSource", id: sourceId },
+      });
     });
 
     it("descendants of an upgraded node walk with the upgraded via/edge, not the stale one", async () => {
@@ -697,7 +740,7 @@ describe("PreviewDiff builder", () => {
       expect(insightHit).toBeDefined();
       expect(insightHit!.flag).toBe("recompute");
       expect(insightHit!.edge).toBe("dataTable->insight");
-      expect(insightHit!.via).toBe(tableId);
+      expect(insightHit!.via).toEqual({ kind: "dataTable", id: tableId });
 
       // The dataFrame is downstream of the insight. Its via must propagate the
       // UPGRADED insight provenance (the tableId that delivered the strongest
@@ -709,7 +752,7 @@ describe("PreviewDiff builder", () => {
         (n) => n.nodeId === frameId,
       );
       expect(frameHit).toBeDefined();
-      expect(frameHit!.via).toBe(tableId);
+      expect(frameHit!.via).toEqual({ kind: "dataTable", id: tableId });
     });
 
     it("should flag each downstream node once even when reached by two paths", async () => {

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -629,7 +629,7 @@ function flagStrength(flag: DownstreamFlag): number {
 function tryUpgrade(
   existing: PreviewDownstreamNode,
   hit: { edge: DownstreamEdge; flag: DownstreamFlag },
-  via: UUID,
+  via: { kind: ArtifactKind; id: UUID },
 ): boolean {
   if (flagStrength(hit.flag) <= flagStrength(existing.flag)) return false;
   existing.flag = hit.flag;
@@ -646,7 +646,7 @@ function tryUpgrade(
 function seedWalkState(
   direct: PreviewDirectNode[],
   visited: Map<string, PreviewDownstreamNode | null>,
-  viaOf: Map<string, UUID>,
+  viaOf: Map<string, { kind: ArtifactKind; id: UUID }>,
 ): Array<{ id: string; kind: ArtifactKind }> {
   for (const node of direct) {
     const key = `${node.kind}:${node.nodeId}`;
@@ -655,7 +655,7 @@ function seedWalkState(
     // Typing the map `| null` makes the `existing !== null` guard below
     // type-visible — a future edit can't treat the sentinel as a node.
     visited.set(key, null);
-    viaOf.set(key, node.nodeId);
+    viaOf.set(key, { kind: node.kind, id: node.nodeId });
   }
   return direct.map((d) => ({ id: d.nodeId, kind: d.kind }));
 }
@@ -683,7 +683,7 @@ async function walkDownstream(
   // node was queued is visible to its descendants — fixing the stale-provenance
   // bug where the already-queued frontier entry carried an old via after an
   // upgrade mutated the emitted object.
-  const viaOf = new Map<string, UUID>();
+  const viaOf = new Map<string, { kind: ArtifactKind; id: UUID }>();
   const frontier = seedWalkState(direct, visited, viaOf);
 
   while (frontier.length > 0) {
@@ -716,6 +716,8 @@ async function walkDownstream(
         flag: hit.flag,
       };
       visited.set(key, emitted);
+      // Record the via for this downstream node so its own descendants can read
+      // it from viaOf at dequeue time (not a stale frontier snapshot).
       viaOf.set(key, currentVia);
       out.push(emitted);
       // Queue the identifier only — via is resolved from viaOf at dequeue time.

--- a/packages/types/src/preview-diff.ts
+++ b/packages/types/src/preview-diff.ts
@@ -168,8 +168,17 @@ export interface PreviewDownstreamNode {
   kind: ArtifactKind;
   /** The edge by which this node was reached from the directly-touched node. */
   edge: DownstreamEdge;
-  /** The direct node whose change propagated to this one. */
-  via: UUID;
+  /**
+   * The direct node whose change propagated to this one — identified by both
+   * kind AND id. A batch can legitimately create two artifacts that share a
+   * client-minted UUID under different kinds (e.g. CreateDataSource(X) +
+   * CreateDataTable(X)); the preview builder keys direct nodes as
+   * `${kind}:${id}` for exactly this reason. Carrying only `id` here would
+   * leave a renderer unable to resolve which of those two direct nodes owns
+   * the blast radius. The structural identity mirrors the key the builder
+   * already uses internally.
+   */
+  via: { kind: ArtifactKind; id: UUID };
   flag: DownstreamFlag;
 }
 


### PR DESCRIPTION
## What changed

`PreviewDownstreamNode.via` was typed as `UUID`. That is ambiguous when a batch legitimately creates two artifacts under the same client-supplied UUID with different kinds — e.g. `CreateDataSource(X)` + `CreateDataTable(X)`. A downstream node reached from that batch emits `via: X` and a renderer cannot resolve which direct node owns the blast radius.

The preview builder already keys direct nodes as `${kind}:${id}` precisely to handle this identity collision. `via` now carries the same structural identity:

```ts
// before
via: UUID

// after
via: { kind: ArtifactKind; id: UUID }
```

## Files changed

- **`packages/types/src/preview-diff.ts`** — `PreviewDownstreamNode.via` type + updated docstring explaining the ambiguity.
- **`apps/server/src/functions/preview-diff.ts`** — `viaOf` map value type, `seedWalkState`, `tryUpgrade`, and the emitted downstream node construction all thread `{ kind, id }` instead of bare `UUID`.
- **`apps/server/src/functions/preview-diff.test.ts`** — updated all existing `via: someId` assertions to `via: { kind: ..., id: someId }`; added the disambiguating case: batch with `CreateDataSource(X)` + `CreateDataTable(X)`, downstream insight hanging off exactly the dataTable, asserting `via.kind === "dataTable"`.

## No compatibility shim needed

`PreviewDownstreamNode` has zero consumers today (renderer fill is future work). Pre-release, no-backward-compat policy.

## Context

Follow-up to #54. Addresses Codex P2 finding [PRRT_kwDOQKlCpM6I8-JO](https://github.com/youhaowei/DashFrame/pull/54#pullrequestreview-2974310094) — the thread is open on the merged PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `PreviewDownstreamNode.via` from a bare `UUID` to `{ kind: ArtifactKind; id: UUID }`, eliminating an ambiguity that arises when a batch creates two artifacts of different kinds that share a client-minted UUID (e.g. `CreateDataSource(X)` + `CreateDataTable(X)`). All three layers — types, builder, and tests — are updated atomically.

- **`packages/types/src/preview-diff.ts`**: `via` type widened to `{ kind; id }` with an explanatory docstring covering the collision scenario.
- **`apps/server/src/functions/preview-diff.ts`**: `viaOf` map, `seedWalkState`, `tryUpgrade`, and the emitted node literal all thread the full `{kind, id}` identity.
- **`apps/server/src/functions/preview-diff.test.ts`**: All existing `via` assertions migrated from `.toBe(id)` to `.toEqual({kind, id})`; a new disambiguating test verifies the insight is attributed to `dataTable`, not `dataSource`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — well-contained type narrowing with no consumers yet, all three changed files updated consistently.

The type change, implementation threading, and test migration are all internally consistent. The disambiguation relies on classifyDownstream using parentKind to look up the typed edge label, correctly resolving dataTable->insight while rejecting the non-existent dataSource->insight edge. The upgrade path in tryUpgrade keeps emitted.via and viaOf[key] in sync. The new test exercises the exact shared-UUID collision that motivated the fix.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/types/src/preview-diff.ts | Type-only change: `PreviewDownstreamNode.via` widened from `UUID` to `{ kind: ArtifactKind; id: UUID }` with a clear docstring explaining the shared-UUID collision scenario. No issues. |
| apps/server/src/functions/preview-diff.ts | Implementation updated to carry `{kind, id}` through `viaOf`, `seedWalkState`, `tryUpgrade`, and the emitted downstream node. `emitted.via` and `viaOf[key]` are kept in sync on both first-emit and upgrade paths. No issues. |
| apps/server/src/functions/preview-diff.test.ts | All `via` assertions migrated from `.toBe(uuid)` to `.toEqual({kind, id})`; new disambiguation test correctly seeds a shared-UUID batch and verifies insight is attributed to the `dataTable` direct node. No issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Batch
    participant walkDownstream
    participant classifyDownstream

    Batch->>walkDownstream: "direct=[{kind:dataSource,id:X},{kind:dataTable,id:X}]"
    Note over walkDownstream: viaOf[dataSource:X]={kind:dataSource,id:X}<br/>viaOf[dataTable:X]={kind:dataTable,id:X}

    walkDownstream->>classifyDownstream: "insight, parentKind=dataSource"
    classifyDownstream-->>walkDownstream: "dataSource->insight not found, null"

    walkDownstream->>classifyDownstream: "insight, parentKind=dataTable"
    classifyDownstream-->>walkDownstream: "dataTable->insight found, recompute"

    Note over walkDownstream: insight.via={kind:dataTable,id:X}
    walkDownstream-->>Batch: "affectedDownstream=[{via:{kind:dataTable,id:X},...}]"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(types): downstream provenance carrie..."](https://github.com/youhaowei/dashframe/commit/f8e04e5b7cf56afebe29705e41a13567320abbe6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37097808)</sub>

<!-- /greptile_comment -->