### PR TITLE
fix(dashboard): Text/Markdown widget add — replace Infinity y-position with computed bottomY

### DIFF
--- a/apps/server/src/functions/dashboards.test.ts
+++ b/apps/server/src/functions/dashboards.test.ts
@@ -57,7 +57,10 @@ describe("addDashboardItem — markdown widget persistence", () => {
       position,
     })) as { itemId: string };
 
-    expect(typeof itemId).toBe("string");
+    // itemId is minted with crypto.randomUUID() server-side.
+    expect(itemId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
 
     // The item should appear in the dashboard's items list.
     const dashboardList = (await call("listDashboards", {})) as Array<{
@@ -116,9 +119,11 @@ describe("addDashboardItem — markdown widget persistence", () => {
     }>;
 
     const dashboard = dashboardList.find((d) => d.id === dashboardId);
+    expect(dashboard).toBeDefined();
     expect(dashboard!.items).toHaveLength(2);
 
     const second = dashboard!.items.find((i) => i.id === secondId);
+    expect(second).toBeDefined();
     expect(second!.y).toBe(4);
   });
 });

--- a/apps/server/src/functions/dashboards.test.ts
+++ b/apps/server/src/functions/dashboards.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the addDashboardItem server mutation.
+ *
+ * Regression: the client previously passed position.y = Infinity which JSON
+ * serialized to null, causing parsePosition to throw and the dialog to stay
+ * open with no widget added. The fix moves position calculation to the client
+ * (compute bottomY from existing items). This suite covers the
+ * server contract that a markdown item with a finite position is persisted
+ * and readable via listDashboards.
+ *
+ * Pattern matches commands.test.ts / app-artifacts.test.ts: real PGLite,
+ * 'should ...' names.
+ */
+import { openArtifactDb } from "@dashframe/server-core";
+import { createWyStack, type WyStackApp } from "@wystack/server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { functions } from "../functions";
+
+describe("addDashboardItem — markdown widget persistence", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-dash-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await createWyStack({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function call(path: string, args: unknown): Promise<unknown> {
+    const { result } = await app.call(path, args);
+    return result;
+  }
+
+  it("should persist a markdown item and return it in listDashboards", async () => {
+    // Create a dashboard first.
+    const { id: dashboardId } = (await call("createDashboard", {
+      name: "Test Dashboard",
+    })) as { id: string };
+
+    // Add a markdown widget using a finite y position (the pattern the fix
+    // enforces — no Infinity that would become null via JSON serialization).
+    const position = { x: 0, y: 0, width: 4, height: 4 };
+    const { itemId } = (await call("addDashboardItem", {
+      dashboardId,
+      type: "markdown",
+      content: "## New Text Widget\n\nEdit this text...",
+      position,
+    })) as { itemId: string };
+
+    expect(typeof itemId).toBe("string");
+
+    // The item should appear in the dashboard's items list.
+    const dashboardList = (await call("listDashboards", {})) as Array<{
+      id: string;
+      items: Array<{
+        id: string;
+        type: string;
+        content?: string;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      }>;
+    }>;
+
+    const dashboard = dashboardList.find((d) => d.id === dashboardId);
+    expect(dashboard).toBeDefined();
+    expect(dashboard!.items).toHaveLength(1);
+
+    const item = dashboard!.items[0]!;
+    expect(item.id).toBe(itemId);
+    expect(item.type).toBe("markdown");
+    expect(item.content).toBe("## New Text Widget\n\nEdit this text...");
+    expect(item.x).toBe(0);
+    expect(item.y).toBe(0);
+    expect(item.width).toBe(4);
+    expect(item.height).toBe(4);
+  });
+
+  it("should place a second markdown item below the first when y is computed from layout", async () => {
+    // This mirrors the bottomY computation in DashboardDetailContent:
+    //   bottomY = items.reduce((max, item) => Math.max(max, item.y + item.height), 0)
+    // Confirms the server accepts the resulting finite position.
+    const { id: dashboardId } = (await call("createDashboard", {
+      name: "Multi-item Dashboard",
+    })) as { id: string };
+
+    // First widget at y=0, height=4 → bottomY for second = 4.
+    await call("addDashboardItem", {
+      dashboardId,
+      type: "markdown",
+      content: "# Header",
+      position: { x: 0, y: 0, width: 4, height: 4 },
+    });
+
+    const { itemId: secondId } = (await call("addDashboardItem", {
+      dashboardId,
+      type: "markdown",
+      content: "Some notes",
+      position: { x: 0, y: 4, width: 4, height: 4 },
+    })) as { itemId: string };
+
+    const dashboardList = (await call("listDashboards", {})) as Array<{
+      id: string;
+      items: Array<{ id: string; y: number }>;
+    }>;
+
+    const dashboard = dashboardList.find((d) => d.id === dashboardId);
+    expect(dashboard!.items).toHaveLength(2);
+
+    const second = dashboard!.items.find((i) => i.id === secondId);
+    expect(second!.y).toBe(4);
+  });
+});

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -81,11 +81,19 @@ export default function DashboardDetailContent({
   }
 
   const handleAddItem = async () => {
+    // Compute the bottom of the current layout so the new widget is appended
+    // below all existing items. Using Infinity here would serialize to null in
+    // JSON and cause the server-side position validator to reject the mutation.
+    const bottomY = dashboard.items.reduce(
+      (max, item) => Math.max(max, item.y + item.height),
+      0,
+    );
+
     await addItem(dashboardId, {
       type: addType,
       position: {
         x: 0,
-        y: Infinity, // Put at bottom
+        y: bottomY,
         width: addType === "visualization" ? 6 : 4,
         height: addType === "visualization" ? 6 : 4,
       },

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -28,6 +28,7 @@ import {
   PlusIcon,
 } from "@wystack/ui-icons";
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 interface DashboardDetailContentProps {
   dashboardId: string;
@@ -56,6 +57,7 @@ export default function DashboardDetailContent({
   // Local state
   const [isEditable, setIsEditable] = useState(false);
   const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isAddPending, setIsAddPending] = useState(false);
   const [addType, setAddType] = useState<DashboardItemType>("visualization");
   const [selectedVizId, setSelectedVizId] = useState<string>("");
 
@@ -89,20 +91,31 @@ export default function DashboardDetailContent({
       0,
     );
 
-    await addItem(dashboardId, {
-      type: addType,
-      position: {
-        x: 0,
-        y: bottomY,
-        width: addType === "visualization" ? 6 : 4,
-        height: addType === "visualization" ? 6 : 4,
-      },
-      visualizationId: addType === "visualization" ? selectedVizId : undefined,
-      content:
-        addType === "markdown"
-          ? "## New Text Widget\n\nEdit this text..."
-          : undefined,
-    });
+    setIsAddPending(true);
+    try {
+      await addItem(dashboardId, {
+        type: addType,
+        position: {
+          x: 0,
+          y: bottomY,
+          width: addType === "visualization" ? 6 : 4,
+          height: addType === "visualization" ? 6 : 4,
+        },
+        visualizationId:
+          addType === "visualization" ? selectedVizId : undefined,
+        content:
+          addType === "markdown"
+            ? "## New Text Widget\n\nEdit this text..."
+            : undefined,
+      });
+    } catch (error) {
+      // Keep the dialog open so the user's selection isn't lost.
+      console.error("Failed to add dashboard widget", error);
+      toast.error("Couldn't add widget");
+      return;
+    } finally {
+      setIsAddPending(false);
+    }
 
     setIsAddOpen(false);
     setAddType("visualization");
@@ -236,7 +249,9 @@ export default function DashboardDetailContent({
             <Button
               label="Add Widget"
               onClick={handleAddItem}
-              disabled={addType === "visualization" && !selectedVizId}
+              disabled={
+                isAddPending || (addType === "visualization" && !selectedVizId)
+              }
             />
           </div>
         </DialogContent>


### PR DESCRIPTION
## Summary

* `Infinity` JSON-serializes to `null`, causing the WyStack server's `parsePosition` validator to throw on `addDashboardItem` — the mutation never persisted, `setIsAddOpen(false)` was never reached, and no widget appeared
* Fix computes the actual bottom `y` of the existing grid layout (`dashboard.items.reduce(...)`) before calling `addItem`, replacing the `y: Infinity` that was in the position object
* Adds server-level tests for the full `addDashboardItem` → `listDashboards` round-trip to cover markdown item persistence with finite position coordinates

## Visual evidence

The dialog closes and the widget renders on the canvas:

![Markdown widget on canvas](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/44388bd6-a09e-42b9-a105-df44adfcaebf/78905f48-ad9c-4973-8980-33971bb614b6?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi80NDM4OGJkNi1hMDllLTQyYjktYTEwNS1kZjQ0YWRmY2FlYmYvNzg5MDVmNDgtYWQ5Yy00OTczLTg5ODAtMzM5NzFiYjYxNGI2IiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.LIwDyS1LNf2J7F8cIuuLjnyycaJWOxRDi6_B6LbruR0)

Screenshot path (taken from running app): `/tmp/markdown-widget-verify.png`

**"New Text Widget" heading and "Edit this text..." body are visible on the canvas; header shows "1 items"; dialog is closed.**

## Test plan

- [X] `bun check` green (70 tasks, 82 tests pass)
- [X] Run-the-app: boot web dev server + wystack server, create dashboard, add Text/Markdown widget → dialog closes, widget appears on canvas
- [X] Server tests: `addDashboardItem` with `type: "markdown"` and finite position → item persisted and readable via `listDashboards`
- [X] No ticket refs in source (CI enforced)

Closes [#82](<https://github.com/youhaowei/DashFrame/issues/82>)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

<details><summary>Greptile Summary</summary>

This PR fixes a bug where adding a Text/Markdown widget silently failed: `y: Infinity` in the position object serialized to `null` in JSON, causing the server's `parsePosition` validator to throw, leaving the dialog open with no widget rendered. The fix computes `bottomY` from the existing layout before calling `addItem`, and adds server-side integration tests for the full `addDashboardItem → listDashboards` round-trip.

* **Client fix** (`DashboardDetailContent.tsx`): replaces the sentinel `Infinity` y-value with a `reduce`-computed bottom edge of the current grid, ensuring a valid finite coordinate is always sent.
* **New tests** (`dashboards.test.ts`): two integration tests using real PGLite verify that a markdown item with a finite position persists and that the computed `bottomY` placement pattern is accepted by the server.

</details>

<details><summary>Confidence Score: 4/5</summary>

Safe to merge — the root cause is correctly fixed and backed by new integration tests; one UX gap remains where a failed mutation leaves the dialog open.

The core fix is straightforward and correct: swapping Infinity for a computed finite value eliminates the JSON serialization issue. The new tests exercise the full server round-trip and would catch a regression. The remaining gap — no try/catch in handleAddItem — means any future server-side failure still leaves the dialog stuck open, but this is a robustness concern rather than a current data-integrity problem.

The error-handling path in DashboardDetailContent.tsx around handleAddItem is worth a follow-up to ensure the dialog can always close even when the mutation fails.

</details>

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| packages/app/src/app/dashboards/\[dashboardId\]/\_components/DashboardDetailContent.tsx | Replaces `y: Infinity` with a computed `bottomY` from `dashboard.items.reduce(...)`, correctly fixing JSON serialization of `Infinity → null` that caused the server validator to reject the mutation. No error handling around `addItem` means any future mutation failure still leaves the dialog open. |
| apps/server/src/functions/dashboards.test.ts | New regression test covering the `addDashboardItem → listDashboards` round-trip with finite position coordinates. Tests are well-structured, use real PGLite, and isolate state with `beforeEach`/`afterEach`. Both the single-item and multi-item placement scenarios are covered. |

</details>

### Flowchart

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Add Widget] --> B[handleAddItem called]
    B --> C["Compute bottomY = dashboard.items.reduce(max, item.y + item.height, 0)"]
    C --> D["Call addItem with position {x:0, y:bottomY, width, height}"]
    D --> E{Server validates position}
    E -- "Finite number ✓" --> F[Item persisted to DB]
    F --> G[setIsAddOpen false]
    G --> H[Dialog closes, widget on canvas]
    E -- "Was null from Infinity ✗ BEFORE FIX" --> I[Server throws parsePosition error]
    I --> J[Dialog stays open, no widget added]
    D -- "Any other error" --> J
```

### Comments Outside Diff (1)

1. `packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx`, line 83-110 ([link](<https://github.com/youhaowei/dashframe/blob/796ed7bc04e85b5428e746c6a429050e4c7932ac/packages/app/src/app/dashboards/%5BdashboardId%5D/_components/DashboardDetailContent.tsx#L83-L110>))

   [![P2](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/6626978c-3aa3-4f2a-bb69-f63eda319f30/fcb2a83b-88c9-4413-98a2-733d69d480cc?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi82NjI2OTc4Yy0zYWEzLTRmMmEtYmI2OS1mNjNlZGEzMTlmMzAvZmNiMmE4M2ItODhjOS00NDEzLTk4YTItNzMzZDY5ZDQ4MGNjIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.Y7cjcgVxZucLRMPc8VmriLkJcLJoDpeg0JlvgBAVE0M)](<#>) **Unhandled rejection leaves dialog permanently open**

   `handleAddItem` still has no `try/catch` around `await addItem(...)`. If the mutation fails for any reason — network timeout, server validation error, auth issue — execution never reaches `setIsAddOpen(false)`, so the dialog hangs open with no feedback to the user. The original bug (dialog stuck open due to `Infinity → null`) was a special case of this broader gap; fixing the position value doesn't fix the general failure path.

   <details><summary>Prompt To Fix With AI</summary>

   ```markdown
   This is a comment left during a code review.
   Path: packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
   Line: 83-110
   
   Comment:
   **Unhandled rejection leaves dialog permanently open**
   
   `handleAddItem` still has no `try/catch` around `await addItem(...)`. If the mutation fails for any reason — network timeout, server validation error, auth issue — execution never reaches `setIsAddOpen(false)`, so the dialog hangs open with no feedback to the user. The original bug (dialog stuck open due to `Infinity → null`) was a special case of this broader gap; fixing the position value doesn't fix the general failure path.
   
   How can I resolve this? If you propose a fix, please make it concise.
   ```

   </details>

   [![Fix in Claude Code](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/5262db0e-8ad8-4167-bdd0-508888c3fc7f/e88001ae-7c22-496a-a951-ee9e1dbdadcf?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi81MjYyZGIwZS04YWQ4LTQxNjctYmRkMC01MDg4ODhjM2ZjN2YvZTg4MDAxYWUtN2MyMi00OTZhLWE5NTEtZWU5ZTFkYmRhZGNmIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.9zJibaCDQfz4s26Xuzt7ZOoc6T9Kve--KHjo0F1rzl8)](<https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%2083-110%0A%0AComment%3A%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix in Codex](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/7eaa7fb0-aa85-42a7-a9de-68a594aa0fc1/61e60aea-c301-4f3d-b8c8-7f607e5f8305?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi83ZWFhN2ZiMC1hYTg1LTQyYTctYTlkZS02OGE1OTRhYTBmYzEvNjFlNjBhZWEtYzMwMS00ZjNkLWI4YzgtN2Y2MDdlNWY4MzA1IiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.p3mRyNr0pGjjSCeA3YZpNRBNqsH_ROTWwvFEZD3AMBw)](<https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-224-markdown-widget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-224-markdown-widget%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%2083-110%0A%0AComment%3A%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix in Cursor](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/7168a544-f2f2-47fb-81a7-7e678d50c51b/261c1bd0-47fa-4b5b-a866-1b647e9ade22?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi83MTY4YTU0NC1mMmYyLTQ3ZmItODFhNy03ZTY3OGQ1MGM1MWIvMjYxYzFiZDAtNDdmYS00YjViLWE4NjYtMWI2NDdlOWFkZTIyIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.upnjOvLEsfwaqgd4Tqzo0pFQ0fF0zbtBNSgqOWROQww)](<https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%2083-110%0A%0AComment%3A%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=86&platform=github>)

   [![Fix All in Claude Code](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/815e916b-cbe6-4891-bad3-58da86b99e7b/41a8aef3-f480-4e24-b934-635a698ccb0a?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi84MTVlOTE2Yi1jYmU2LTQ4OTEtYmFkMy01OGRhODZiOTllN2IvNDFhOGFlZjMtZjQ4MC00ZTI0LWI5MzQtNjM1YTY5OGNjYjBhIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.KvbluL3QhbBqSKG3uUFkOCjwFj7DBnv14TihMCLBeB4)](<https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%3A83-110%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0A&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix All in Codex](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/fe5aa164-32e7-4241-b0c9-6cb0b9a1f5c4/c0419642-e3c3-4e72-8c42-cc83588b1c6a?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi9mZTVhYTE2NC0zMmU3LTQyNDEtYjBjOS02Y2IwYjlhMWY1YzQvYzA0MTk2NDItZTNjMy00ZTcyLThjNDItY2M4MzU4OGIxYzZhIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.GHztrEL_f8-w4afjljbHgIJPA2HDRExlQo84JMazhCU)](<https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-224-markdown-widget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-224-markdown-widget%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%3A83-110%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0A&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix All in Cursor](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/3d59a275-6f49-4e25-b2d1-1531852b9376/725c4b3b-c89e-4ead-93d2-fde50175cd46?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi8zZDU5YTI3NS02ZjQ5LTRlMjUtYjJkMS0xNTMxODUyYjkzNzYvNzI1YzRiM2ItYzg5ZS00ZWFkLTkzZDItZmRlNTAxNzVjZDQ2IiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.NnbeFHKj34OeuIIe4eGoQXixlmlgwBEHXK8ono3rq8g)](<https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%3A83-110%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0A&pr=86&platform=github>)

   Prompt To Fix All With AI

   ```markdown
   Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.
   
   ---
   
   ### Issue 1 of 1
   packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx:83-110
   **Unhandled rejection leaves dialog permanently open**
   
   `handleAddItem` still has no `try/catch` around `await addItem(...)`. If the mutation fails for any reason — network timeout, server validation error, auth issue — execution never reaches `setIsAddOpen(false)`, so the dialog hangs open with no feedback to the user. The original bug (dialog stuck open due to `Infinity → null`) was a special case of this broader gap; fixing the position value doesn't fix the general failure path.
   
   
   ```

   Reviews (1): Last reviewed commit: ["fix(dashboard): replace Infinity y-posit..."](<https://github.com/youhaowei/dashframe/commit/796ed7bc04e85b5428e746c6a429050e4c7932ac>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=37108736>)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a silent widget-add failure where `y: Infinity` serialized to `null` in JSON, causing the server's position validator to reject every Text/Markdown `addDashboardItem` mutation. The dialog would stay open indefinitely with no widget rendered.

- **Client fix** (`DashboardDetailContent.tsx`): replaces the sentinel `Infinity` with a `reduce`-computed `bottomY` from existing grid items, adds `isAddPending` state to disable the button during in-flight mutations, and wraps `addItem` in `try/catch/finally` with a `sonner` error toast — addressing both the root cause and the broader unhandled-rejection gap noted in the prior review.
- **New regression tests** (`dashboards.test.ts`): two PGLite-backed integration tests verify the full `addDashboardItem → listDashboards` round-trip with finite coordinates and confirm the `bottomY` placement pattern is accepted by the server.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — root cause fixed, error path handled, and regression tests in place.

The change is narrow and well-contained: a one-line arithmetic fix eliminates the JSON serialization problem, the new try/catch/finally ensures the dialog can always recover from a failed mutation, and the two new integration tests exercise the exact server contract that was broken. No existing behavior is altered beyond the broken code path.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx | Replaces `y: Infinity` with a `reduce`-computed `bottomY`, adds `isAddPending` guard state, wraps `addItem` in try/catch/finally with a toast on failure — all issues from the prior review have been addressed. |
| apps/server/src/functions/dashboards.test.ts | New integration test file covering `addDashboardItem → listDashboards` round-trip with finite position coordinates and a second test that mirrors the client-side `bottomY` computation; well-structured with real PGLite and proper teardown. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Dialog
    participant handleAddItem
    participant Server

    User->>Dialog: clicks "Add Widget"
    Dialog->>handleAddItem: onClick
    handleAddItem->>handleAddItem: "compute bottomY = items.reduce(max, item.y+item.height, 0)"
    handleAddItem->>handleAddItem: setIsAddPending(true)
    handleAddItem->>Server: "addItem({ position: { y: bottomY, ... } })"
    alt success
        Server-->>handleAddItem: "{ itemId }"
        handleAddItem->>handleAddItem: setIsAddPending(false) [finally]
        handleAddItem->>Dialog: setIsAddOpen(false)
        Dialog-->>User: dialog closes, widget on canvas
    else error
        Server-->>handleAddItem: throws
        handleAddItem->>handleAddItem: setIsAddPending(false) [finally]
        handleAddItem->>User: toast.error("Couldn't add widget")
        Note over Dialog: dialog stays open, selection preserved
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx`, line 83-110 ([link](<https://github.com/youhaowei/dashframe/blob/796ed7bc04e85b5428e746c6a429050e4c7932ac/packages/app/src/app/dashboards/%5BdashboardId%5D/_components/DashboardDetailContent.tsx#L83-L110>))

   [![P2](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/6626978c-3aa3-4f2a-bb69-f63eda319f30/fcb2a83b-88c9-4413-98a2-733d69d480cc?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi82NjI2OTc4Yy0zYWEzLTRmMmEtYmI2OS1mNjNlZGEzMTlmMzAvZmNiMmE4M2ItODhjOS00NDEzLTk4YTItNzMzZDY5ZDQ4MGNjIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.Y7cjcgVxZucLRMPc8VmriLkJcLJoDpeg0JlvgBAVE0M)](<#>) **Unhandled rejection leaves dialog permanently open**

   `handleAddItem` still has no `try/catch` around `await addItem(...)`. If the mutation fails for any reason — network timeout, server validation error, auth issue — execution never reaches `setIsAddOpen(false)`, so the dialog hangs open with no feedback to the user. The original bug (dialog stuck open due to `Infinity → null`) was a special case of this broader gap; fixing the position value doesn't fix the general failure path.

   <details><summary>Prompt To Fix With AI</summary>

   ```markdown
   This is a comment left during a code review.
   Path: packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
   Line: 83-110
   
   Comment:
   **Unhandled rejection leaves dialog permanently open**
   
   `handleAddItem` still has no `try/catch` around `await addItem(...)`. If the mutation fails for any reason — network timeout, server validation error, auth issue — execution never reaches `setIsAddOpen(false)`, so the dialog hangs open with no feedback to the user. The original bug (dialog stuck open due to `Infinity → null`) was a special case of this broader gap; fixing the position value doesn't fix the general failure path.
   
   How can I resolve this? If you propose a fix, please make it concise.
   ```

   </details>

   [![Fix in Claude Code](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/5262db0e-8ad8-4167-bdd0-508888c3fc7f/e88001ae-7c22-496a-a951-ee9e1dbdadcf?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi81MjYyZGIwZS04YWQ4LTQxNjctYmRkMC01MDg4ODhjM2ZjN2YvZTg4MDAxYWUtN2MyMi00OTZhLWE5NTEtZWU5ZTFkYmRhZGNmIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.9zJibaCDQfz4s26Xuzt7ZOoc6T9Kve--KHjo0F1rzl8)](<https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%2083-110%0A%0AComment%3A%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix in Codex](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/7eaa7fb0-aa85-42a7-a9de-68a594aa0fc1/61e60aea-c301-4f3d-b8c8-7f607e5f8305?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi83ZWFhN2ZiMC1hYTg1LTQyYTctYTlkZS02OGE1OTRhYTBmYzEvNjFlNjBhZWEtYzMwMS00ZjNkLWI4YzgtN2Y2MDdlNWY4MzA1IiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.p3mRyNr0pGjjSCeA3YZpNRBNqsH_ROTWwvFEZD3AMBw)](<https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-224-markdown-widget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-224-markdown-widget%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%2083-110%0A%0AComment%3A%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix in Cursor](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/7168a544-f2f2-47fb-81a7-7e678d50c51b/261c1bd0-47fa-4b5b-a866-1b647e9ade22?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi83MTY4YTU0NC1mMmYyLTQ3ZmItODFhNy03ZTY3OGQ1MGM1MWIvMjYxYzFiZDAtNDdmYS00YjViLWE4NjYtMWI2NDdlOWFkZTIyIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.upnjOvLEsfwaqgd4Tqzo0pFQ0fF0zbtBNSgqOWROQww)](<https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%2083-110%0A%0AComment%3A%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=86&platform=github>)

   [![Fix All in Claude Code](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/815e916b-cbe6-4891-bad3-58da86b99e7b/41a8aef3-f480-4e24-b934-635a698ccb0a?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi84MTVlOTE2Yi1jYmU2LTQ4OTEtYmFkMy01OGRhODZiOTllN2IvNDFhOGFlZjMtZjQ4MC00ZTI0LWI5MzQtNjM1YTY5OGNjYjBhIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.KvbluL3QhbBqSKG3uUFkOCjwFj7DBnv14TihMCLBeB4)](<https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%3A83-110%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0A&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix All in Codex](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/fe5aa164-32e7-4241-b0c9-6cb0b9a1f5c4/c0419642-e3c3-4e72-8c42-cc83588b1c6a?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi9mZTVhYTE2NC0zMmU3LTQyNDEtYjBjOS02Y2IwYjlhMWY1YzQvYzA0MTk2NDItZTNjMy00ZTcyLThjNDItY2M4MzU4OGIxYzZhIiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.GHztrEL_f8-w4afjljbHgIJPA2HDRExlQo84JMazhCU)](<https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-224-markdown-widget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-224-markdown-widget%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%3A83-110%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0A&repo=youhaowei%2Fdashframe&pr=86&platform=github>) [![Fix All in Cursor](https://uploads.linear.app/bd239c5b-3ae9-47e6-83aa-acfc934acbeb/3d59a275-6f49-4e25-b2d1-1531852b9376/725c4b3b-c89e-4ead-93d2-fde50175cd46?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2JkMjM5YzViLTNhZTktNDdlNi04M2FhLWFjZmM5MzRhY2JlYi8zZDU5YTI3NS02ZjQ5LTRlMjUtYjJkMS0xNTMxODUyYjkzNzYvNzI1YzRiM2ItYzg5ZS00ZWFkLTkzZDItZmRlNTAxNzVjZDQ2IiwiaWF0IjoxNzgxMjE5Mjc2LCJleHAiOjE4MTI3ODk4MzZ9.NnbeFHKj34OeuIIe4eGoQXixlmlgwBEHXK8ono3rq8g)](<https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%3A83-110%0A**Unhandled%20rejection%20leaves%20dialog%20permanently%20open**%0A%0A%60handleAddItem%60%20still%20has%20no%20%60try%2Fcatch%60%20around%20%60await%20addItem%28...%29%60.%20If%20the%20mutation%20fails%20for%20any%20reason%20%E2%80%94%20network%20timeout%2C%20server%20validation%20error%2C%20auth%20issue%20%E2%80%94%20execution%20never%20reaches%20%60setIsAddOpen%28false%29%60%2C%20so%20the%20dialog%20hangs%20open%20with%20no%20feedback%20to%20the%20user.%20The%20original%20bug%20%28dialog%20stuck%20open%20due%20to%20%60Infinity%20%E2%86%92%20null%60%29%20was%20a%20special%20case%20of%20this%20broader%20gap%3B%20fixing%20the%20position%20value%20doesn't%20fix%20the%20general%20failure%20path.%0A%0A&pr=86&platform=github>)

   Prompt To Fix All With AI

   ```markdown
   Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.
   
   ---
   
   ### Issue 1 of 1
   packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx:83-110
   **Unhandled rejection leaves dialog permanently open**
   
   `handleAddItem` still has no `try/catch` around `await addItem(...)`. If the mutation fails for any reason — network timeout, server validation error, auth issue — execution never reaches `setIsAddOpen(false)`, so the dialog hangs open with no feedback to the user. The original bug (dialog stuck open due to `Infinity → null`) was a special case of this broader gap; fixing the position value doesn't fix the general failure path.
   
   
   ```

   Reviews (1): Last reviewed commit: ["fix(dashboard): replace Infinity y-posit..."](<https://github.com/youhaowei/dashframe/commit/796ed7bc04e85b5428e746c6a429050e4c7932ac>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=37108736>)
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(server): address review — defined c..."](https://github.com/youhaowei/dashframe/commit/b16a00ad6bf0563c6083150172e4d958e46b423e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37108736)</sub>

<!-- /greptile_comment -->