### PR TITLE
fix: DuckDB WASM init in sandboxed Electron renderer (bundle worker/wasm locally)

### DIFF
--- a/apps/web/vite-env.d.ts
+++ b/apps/web/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+// Brings in Vite's ambient module declarations (notably `*?url` asset imports)
+// so shared @dashframe/app code typechecks here. @dashframe/app introduces
+// `?url` imports for DuckDB's local worker/wasm assets; web compiles that source
+// via the `@/*` path map, so the declarations must be visible in this project.

--- a/packages/app/src/lib/duckdb/init.ts
+++ b/packages/app/src/lib/duckdb/init.ts
@@ -1,10 +1,74 @@
 /**
  * Lazy DuckDB initialization module.
- * Uses dynamic import to separate the ~10MB @duckdb/duckdb-wasm bundle from the main chunk.
- * This improves initial page load time by only loading DuckDB when needed.
+ *
+ * Uses dynamic import to separate the ~10MB @duckdb/duckdb-wasm bundle from the
+ * main chunk, so it only loads when first needed.
+ *
+ * Worker + wasm assets are bundled **locally** (via Vite `?url` imports below) —
+ * never fetched from a CDN at runtime. This is required for the desktop
+ * (Electron) build: the renderer loads from `file://`, and a runtime CDN
+ * dependency would (a) fail entirely offline / behind a proxy and (b) stall the
+ * duckdb-wasm worker handshake silently, because that protocol has no built-in
+ * timeout. Local assets make init offline-correct, deterministic, and tighten
+ * the supply chain.
+ *
+ * The worker is created from a **blob URL** that `importScripts()` the local
+ * asset, rather than `new Worker(localUrl)` directly. On `file://` under COEP
+ * `require-corp`, a worker loaded straight from a `file://` URL is blocked and
+ * fails with an empty (untyped) error event — duckdb-wasm surfaces this as an
+ * indefinite hang. A blob-URL worker inherits the document's origin and is
+ * COEP-exempt, so it loads; pointing its `importScripts` at the local asset
+ * keeps the whole thing same-origin and offline. This is the combination that
+ * works in the sandboxed Electron renderer without weakening any boundary.
+ *
+ * `INIT_TIMEOUT_MS` caps a wedged instantiate so a stuck worker surfaces as an
+ * error instead of hanging.
  */
 
 import type * as duckdb from "@duckdb/duckdb-wasm";
+
+// Local, same-origin worker + wasm assets. Vite rewrites each `?url` import to a
+// hashed asset on the app's own origin (http(s):// in dev/web, file:// when
+// packaged). selectBundle() picks the right variant from browser feature
+// detection (coi → eh → mvp), exactly as it does for the CDN bundles.
+import duckdbPthreadCoi from "@duckdb/duckdb-wasm/dist/duckdb-browser-coi.pthread.worker.js?url";
+import duckdbWorkerCoi from "@duckdb/duckdb-wasm/dist/duckdb-browser-coi.worker.js?url";
+import duckdbWorkerEh from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
+import duckdbWorkerMvp from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
+import duckdbWasmCoi from "@duckdb/duckdb-wasm/dist/duckdb-coi.wasm?url";
+import duckdbWasmEh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
+import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
+
+/**
+ * Hard cap on DuckDB instantiation. The duckdb-wasm worker handshake has no
+ * internal timeout: if the worker wedges (corrupt asset, blocked Worker
+ * construction, a wasm compile that never settles) `instantiate()` stays pending
+ * forever, which is what made the failure silent on desktop. Reject past this
+ * deadline so the caller can surface a real error state.
+ */
+const INIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Locally-bundled DuckDB asset bundles, same shape as `getJsDelivrBundles()`
+ * returns — but pointing at same-origin URLs instead of cdn.jsdelivr.net.
+ */
+function getLocalBundles(): duckdb.DuckDBBundles {
+  return {
+    mvp: {
+      mainModule: duckdbWasmMvp,
+      mainWorker: duckdbWorkerMvp,
+    },
+    eh: {
+      mainModule: duckdbWasmEh,
+      mainWorker: duckdbWorkerEh,
+    },
+    coi: {
+      mainModule: duckdbWasmCoi,
+      mainWorker: duckdbWorkerCoi,
+      pthreadWorker: duckdbPthreadCoi,
+    },
+  };
+}
 
 /**
  * Custom DuckDB logger with cleaner console output.
@@ -59,74 +123,110 @@ class DuckDBLogger implements duckdb.Logger {
   }
 }
 
-/**
- * Creates a worker from a CDN URL using blob URL workaround.
- * Bypasses CORS restrictions by creating a same-origin script
- * that uses importScripts() to load the actual worker code.
- */
-function createWorkerFromCDN(workerUrl: string): {
-  worker: Worker;
-  blobUrl: string;
-} {
-  const blobUrl = URL.createObjectURL(
-    new Blob([`importScripts("${workerUrl}");`], { type: "text/javascript" }),
-  );
-  return { worker: new Worker(blobUrl), blobUrl };
-}
-
 export interface DuckDBInstance {
   db: duckdb.AsyncDuckDB;
   connection: duckdb.AsyncDuckDBConnection;
 }
 
 /**
- * Initialize DuckDB with lazy loading.
- * Uses dynamic import to load @duckdb/duckdb-wasm only when called.
+ * Build a worker from a same-origin blob that `importScripts()` the given local
+ * asset URL. See the module header for why the blob indirection is required on
+ * `file://` under COEP. Returns the worker plus its blob URL so the caller can
+ * revoke it after the worker has loaded.
+ */
+function createBlobWorker(localAssetUrl: string): {
+  worker: Worker;
+  blobUrl: string;
+} {
+  const blobUrl = makeImportScriptsBlobUrl(localAssetUrl);
+  return { worker: new Worker(blobUrl), blobUrl };
+}
+
+/**
+ * A same-origin blob URL whose script `importScripts()` the given local asset.
+ * Used both for the main worker and as the pthread worker URL handed to
+ * AsyncDuckDB (which spawns its own pthread workers from it).
  *
- * @returns Promise that resolves to initialized DuckDB instance
- * @throws Error if initialization fails
+ * The asset URL is absolutized against the document base first: Vite's `?url`
+ * imports yield a path relative to the document origin (e.g. `/assets/x.js` in a
+ * build, `/@fs/…` in dev), but `importScripts()` inside a blob worker resolves
+ * its argument against the *blob* URL — where a root-relative path is invalid
+ * ("The URL '…' is invalid"). An absolute URL resolves correctly from any
+ * worker context.
+ */
+function makeImportScriptsBlobUrl(localAssetUrl: string): string {
+  const absoluteUrl = new URL(localAssetUrl, document.baseURI).href;
+  return URL.createObjectURL(
+    new Blob([`importScripts(${JSON.stringify(absoluteUrl)});`], {
+      type: "text/javascript",
+    }),
+  );
+}
+
+/**
+ * Initialize DuckDB with lazy loading.
+ *
+ * Loads @duckdb/duckdb-wasm and its worker + wasm assets from the app's own
+ * origin (no CDN), then instantiates under {@link INIT_TIMEOUT_MS} so a wedged
+ * worker rejects instead of hanging forever.
+ *
+ * @returns Promise that resolves to an initialized DuckDB instance
+ * @throws Error if initialization fails or exceeds the timeout
  */
 export async function initializeDuckDB(): Promise<DuckDBInstance> {
   // Dynamic import - this is where the code splitting happens
   const duckdb = await import("@duckdb/duckdb-wasm");
 
-  const blobUrls: string[] = [];
+  // selectBundle does feature detection (SIMD, exceptions, cross-origin
+  // isolation) and returns same-origin URLs from our local bundles.
+  const bundle = await duckdb.selectBundle(getLocalBundles());
 
+  if (!bundle.mainWorker) {
+    throw new Error("Selected DuckDB bundle is missing mainWorker URL");
+  }
+
+  // Blob-URL worker over the local asset (see createBlobWorker / module header).
+  // Revoked after the worker has constructed; the Worker keeps its own copy.
+  const { worker, blobUrl: mainWorkerBlobUrl } = createBlobWorker(
+    bundle.mainWorker,
+  );
+
+  // The coi (multithreaded) bundle ships a pthread worker; eh/mvp don't.
+  // AsyncDuckDB spawns pthread workers from this URL lazily, for the lifetime of
+  // the DB, so its blob URL is intentionally NOT revoked here.
+  const pthreadWorkerUrl = bundle.pthreadWorker
+    ? makeImportScriptsBlobUrl(bundle.pthreadWorker)
+    : undefined;
+
+  // Create logger and set module reference for synchronous logging
+  const logger = new DuckDBLogger();
+  logger.setModule(duckdb);
+
+  const db = new duckdb.AsyncDuckDB(logger, worker);
+
+  // The worker fetches the wasm module by URL. `?url` yields a document-relative
+  // path; the worker resolves it against its own (blob) origin, so it must be
+  // absolutized — same reasoning as the importScripts URLs above.
+  const mainModuleUrl = new URL(bundle.mainModule, document.baseURI).href;
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
-    // Select DuckDB bundle
-    const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
-    const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+    const instantiation = db.instantiate(mainModuleUrl, pthreadWorkerUrl);
 
-    // Defensive check for mainWorker URL
-    if (!bundle.mainWorker) {
-      throw new Error("Selected DuckDB bundle is missing mainWorker URL");
-    }
-
-    // Create main worker via blob URL to avoid CORS
-    const { worker, blobUrl } = createWorkerFromCDN(bundle.mainWorker);
-    blobUrls.push(blobUrl);
-
-    // Handle pthread worker if present (for SharedArrayBuffer multithreading)
-    let pthreadWorkerUrl = bundle.pthreadWorker;
-    if (bundle.pthreadWorker) {
-      const pthreadBlobUrl = URL.createObjectURL(
-        new Blob([`importScripts("${bundle.pthreadWorker}");`], {
-          type: "text/javascript",
-        }),
-      );
-      blobUrls.push(pthreadBlobUrl);
-      pthreadWorkerUrl = pthreadBlobUrl;
-    }
-
-    // Create logger and set module reference for synchronous logging
-    const logger = new DuckDBLogger();
-    logger.setModule(duckdb);
-
-    const db = new duckdb.AsyncDuckDB(logger, worker);
-    await db.instantiate(bundle.mainModule, pthreadWorkerUrl);
-
-    // Clean up blob URLs to prevent memory leaks
-    blobUrls.forEach((url) => URL.revokeObjectURL(url));
+    await Promise.race([
+      instantiation,
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `DuckDB failed to initialize within ${INIT_TIMEOUT_MS / 1000}s`,
+              ),
+            ),
+          INIT_TIMEOUT_MS,
+        );
+      }),
+    ]);
 
     // Create connection
     const connection = await db.connect();
@@ -136,8 +236,17 @@ export async function initializeDuckDB(): Promise<DuckDBInstance> {
 
     return { db, connection };
   } catch (err) {
-    // Clean up blob URLs on error
-    blobUrls.forEach((url) => URL.revokeObjectURL(url));
+    // Tear the worker down so a failed attempt doesn't leak a wedged worker.
+    try {
+      db.terminate();
+    } catch {
+      worker.terminate();
+    }
     throw err;
+  } finally {
+    // The main worker has captured its script; the blob URL can go. (The
+    // pthread blob URL is kept alive — duckdb spawns from it on demand.)
+    URL.revokeObjectURL(mainWorkerBlobUrl);
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }
 }

--- a/packages/app/src/lib/duckdb/init.ts
+++ b/packages/app/src/lib/duckdb/init.ts
@@ -212,6 +212,11 @@ export async function initializeDuckDB(): Promise<DuckDBInstance> {
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
     const instantiation = db.instantiate(mainModuleUrl, pthreadWorkerUrl);
+    // If the timeout wins the race we abandon this promise; terminating the DB
+    // below makes the worker handshake reject. Swallow that losing-side
+    // rejection so it doesn't surface as an unhandled rejection (which Electron
+    // reports as a visible error in the renderer and main process).
+    instantiation.catch(() => {});
 
     await Promise.race([
       instantiation,
@@ -237,15 +242,18 @@ export async function initializeDuckDB(): Promise<DuckDBInstance> {
     return { db, connection };
   } catch (err) {
     // Tear the worker down so a failed attempt doesn't leak a wedged worker.
-    try {
-      db.terminate();
-    } catch {
-      worker.terminate();
-    }
+    // db.terminate() is async; await it and swallow any rejection so cleanup
+    // never masks the original error.
+    await db.terminate().catch(() => {});
+    // The pthread blob URL is only kept alive for a *successful* coi init (the
+    // running DB spawns from it). On failure it's revoked here so retries don't
+    // accumulate leaked blob URLs.
+    if (pthreadWorkerUrl) URL.revokeObjectURL(pthreadWorkerUrl);
     throw err;
   } finally {
-    // The main worker has captured its script; the blob URL can go. (The
-    // pthread blob URL is kept alive — duckdb spawns from it on demand.)
+    // The main worker has captured its script; the blob URL can go. (On the
+    // success path the pthread blob URL is kept alive — duckdb spawns from it on
+    // demand; the failure path revokes it in the catch above.)
     URL.revokeObjectURL(mainWorkerBlobUrl);
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+// Vite `?url` asset imports resolve to a string URL on the app's own origin.
+// Declared locally (the package doesn't depend on `vite`, so we can't reference
+// `vite/client`) so DuckDB's local worker/wasm asset imports typecheck in any
+// consumer of @dashframe/app (desktop renderer + web) — both Vite builds.
+declare module "*?url" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Problem

DuckDB WASM never initialized in the sandboxed Electron renderer, so **all chart compute was dead on desktop** — the identical flow works on web. The failure was silent: chart cards sat behind the `!isChartViewReady` guard at 50% opacity with no surfaced error.

## Root cause (with evidence)

Instrumented the renderer over CDP in both dev (`http://localhost`) and a packaged-style `file://` load. Findings:

- **Isolation layer is healthy, not the cause.** `crossOriginIsolated === true` and `SharedArrayBuffer` is available in the renderer on *both* dev and `file://`. The existing COOP/COEP injection (`session.onHeadersReceived` in main, Vite middleware in dev) already works. (This contradicts the initial "COEP missing / crossOriginIsolated false" hypothesis — measured directly, both are present.)
- **The failing layer is worker loading.** The old init loaded duckdb-wasm's worker **and** wasm from `cdn.jsdelivr.net` at runtime via a blob `importScripts` shim. Two problems:
  1. **CDN dependency.** For a desktop app this is offline-broken and proxy/firewall-fragile. The duckdb-wasm worker handshake has **no internal timeout**, so a blocked/slow worker load leaves `instantiate()` pending forever → the silent indefinite hang.
  2. **`file://` worker block.** A worker loaded directly from a `file://` URL under COEP `require-corp` is blocked by Chromium and fails with an *empty* error event (`error in duckdb worker: undefined`), which duckdb-wasm surfaces as a hang.

## Fix (at the worker-loading layer)

- **Bundle worker + wasm assets locally** via Vite `?url` imports and feed them to `selectBundle()` (picks `coi → eh → mvp` by feature detection). No CDN: offline-correct, deterministic, supply-chain-tighter.
- **Load the worker from a same-origin blob** that `importScripts()` the local asset. The blob inherits the document origin and is COEP-exempt, so it loads on `file://` where a direct `file://` worker would not.
- **Absolutize** the worker, pthread, and wasm URLs against `document.baseURI` before crossing the worker boundary (a blob worker resolves relative paths against the blob origin, not the document — this was the subtle bug that made a naive local-bundle attempt still fail).
- **Add a 30s instantiate timeout** that rejects on a wedged worker. This makes the **existing** root-level `VisualizationSetup` error boundary actually fire — "Failed to initialize data engine" + **Retry** — instead of the indefinite silent disabled-card state. (No new UI component needed; the boundary was already there but unreachable because init never rejected.)

## Security boundary: untouched

Renderer `sandbox: true`, `contextIsolation: true`, and `nodeIntegration: false` are **unchanged**. This is a loading/origin fix, not a security relaxation.

## Verification (run-the-app, real Electron)

Built the renderer and ran the actual Electron app. Imported a CSV (`revenue.csv`), and the insight view rendered the **DuckDB-backed data preview (20 rows)** and **DuckDB-generated chart suggestions** (Comparison/Trend/Correlation/Distribution — Bar, Line, Scatter, Hexbin). `coi` (multithreaded) bundle, ~750ms init, no error state.

Engine init confirmed working on both the packaged `file://` path (`SHIPPED-INIT-OK ~750ms`, query returns correct rows) and dev (`DEV-ENGINE-OK ~800ms`).

Screenshot of the working chart flow in the real app is attached in the comment below.

## Tests

The init path is DOM/Worker/WASM glue; a unit test would require mocking `AsyncDuckDB` + `Worker` + dynamic `import()` (a mock-thicket that freezes the interface without protecting a real contract). Verification rests on the run-the-app proof plus direct engine-init checks on both `file://` and dev. `bun check` is green.

Closes #85

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent DuckDB WASM initialization failure in the sandboxed Electron renderer by replacing runtime CDN worker loading with locally-bundled assets and a blob-URL worker indirection that is COEP-exempt on `file://`. A 30 s instantiation timeout is added so a wedged worker now surfaces through the existing error boundary instead of hanging indefinitely.

- **Local asset bundling**: seven `?url` imports replace the `getJsDelivrBundles()` CDN path; `getLocalBundles()` constructs the same `DuckDBBundles` shape pointing at same-origin Vite-hashed assets, making init offline-correct and supply-chain-deterministic.
- **Blob-URL worker + URL absolutization**: `makeImportScriptsBlobUrl` creates a same-origin blob that `importScripts()` the absolutized local asset URL; this is the only combination that passes COEP under `file://`, and JSON-stringifying the URL guards against special characters.
- **Cleanup correctness**: `instantiation.catch(() => {})` silences the losing-side rejection; `db.terminate()` is properly awaited in the `catch` block; the pthread blob URL is revoked on failure to prevent accumulation across retries; `mainWorkerBlobUrl` is revoked unconditionally in `finally`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is self-contained to the DuckDB init path, the security boundary (sandbox, contextIsolation, nodeIntegration) is untouched, and all three issues flagged in prior review rounds are correctly addressed.

The blob-URL indirection, URL absolutization, timeout race, and cleanup sequencing are all handled correctly. The instantiation.catch(() => {}) silences the floating rejection, db.terminate() is properly awaited, and the pthread blob URL is revoked on failure. No logic gaps found in the changed code.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/lib/duckdb/init.ts | Core init rewrite: replaces CDN worker loading with locally-bundled assets via Vite ?url imports, uses blob-URL worker indirection for COEP/file:// compat, absolutizes URLs before crossing the blob-worker boundary, and adds a 30 s instantiation timeout. The three issues from prior review threads are all correctly addressed. |
| packages/app/src/vite-env.d.ts | New ambient module declaration for *?url imports; provides correct string type for Vite asset URL imports without requiring vite as a package dependency. |
| apps/web/vite-env.d.ts | New triple-slash reference to vite/client, ensuring the web app project picks up Vite's ambient ?url declarations when compiling shared @dashframe/app source through the @/* path alias. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initializeDuckDB] --> B[dynamic import duckdb-wasm]
    B --> C[selectBundle - getLocalBundles]
    C -->|feature detection: coi/eh/mvp| D{bundle.mainWorker?}
    D -->|no| E[throw: missing mainWorker]
    D -->|yes| F[createBlobWorker\nmakeImportScriptsBlobUrl + absolutize]
    F --> G[new Worker from blob URL]
    C -->|coi bundle| H[makeImportScriptsBlobUrl\npthreadWorker - NOT revoked on success]
    H --> I[pthreadWorkerUrl]
    F --> J[new AsyncDuckDB logger + worker]
    I --> J
    J --> K[absolutize mainModule URL]
    K --> L[db.instantiate mainModuleUrl pthreadWorkerUrl]
    L --> M{Promise.race}
    M -->|instantiation wins| N[db.connect + SELECT 1]
    M -->|30s timeout wins| O[catch: await db.terminate]
    N --> P[return db + connection]
    O --> Q[revoke pthreadWorkerUrl]
    Q --> R[throw timeout error]
    P --> S[finally: revoke mainWorkerBlobUrl + clearTimeout]
    R --> S
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/69e1ed7a4e56bd8c81b4db6615819d243f7973be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37114596)</sub>

<!-- /greptile_comment -->