### PR TITLE
feat(server-core): PGlite snapshot + restore-at-open recovery for broken WAL

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -159,7 +159,7 @@ app
     if (project.recovery) {
       const { restoredSnapshot, quarantinedPath } = project.recovery;
       const snapshotLine = restoredSnapshot
-        ? `Your project was restored from a snapshot taken at ${restoredSnapshot.timestamp}.`
+        ? `Your project was restored from a snapshot taken at ${new Date(restoredSnapshot.timestamp).toLocaleString()}.`
         : "No snapshot was available — a fresh empty project has been created.";
       const quarantineLine = `The damaged database has been saved to:\n${quarantinedPath}`;
       dialog.showMessageBoxSync({

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -193,6 +193,12 @@ app
         corsOrigin,
         authToken,
         arrowEngine: engine,
+        // Wire the debounced snapshot scheduler: fire touchSnapshot after every
+        // committed artifact-DB write so a crash mid-session loses at most
+        // SNAPSHOT_DEBOUNCE_MS (30 s) of changes rather than the whole session.
+        // The server owns no reference to ProjectHandle — the narrow callback
+        // is the boundary (#88).
+        onWrite: () => project?.touchSnapshot(),
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -155,6 +155,22 @@ app
 
     console.log(`[dashframe] project ready at ${project.dir}`);
 
+    // Surface recovery notice when the project was restored from a snapshot.
+    if (project.recovery) {
+      const { restoredSnapshot, quarantinedPath } = project.recovery;
+      const snapshotLine = restoredSnapshot
+        ? `Your project was restored from a snapshot taken at ${restoredSnapshot.timestamp}.`
+        : "No snapshot was available — a fresh empty project has been created.";
+      const quarantineLine = `The damaged database has been saved to:\n${quarantinedPath}`;
+      dialog.showMessageBoxSync({
+        type: "warning",
+        title: "Project recovered",
+        message: "DashFrame recovered your project after an unclean shutdown.",
+        detail: `${snapshotLine}\n\nAny changes made since the last snapshot are not recoverable.\n\n${quarantineLine}`,
+        buttons: ["Continue"],
+      });
+    }
+
     try {
       // Dev uses the Vite origin from DEV_URL. Packaged Electron loads the
       // renderer from file://, which browsers send as Origin: null; allow that

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -309,4 +309,39 @@ describe("onWrite hook", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it("should isolate an onWrite that throws — the committed mutation still succeeds", async () => {
+    // onWrite runs AFTER the DB write commits. If it throws, the client must
+    // still see success — otherwise it would retry a durable write and
+    // duplicate artifacts. The hook's failure is swallowed (logged), never
+    // propagated.
+    project = await openProject({ dir: join(root, "proj") });
+    const sourceId = crypto.randomUUID();
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => {
+        throw new Error("snapshot scheduler exploded");
+      },
+    });
+
+    const res = await postMutation(server.url, "getOrCreateDataSource", {
+      id: sourceId,
+      type: "csv",
+      name: "Resilient",
+    });
+    // The mutation committed despite the hook throwing.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { id: string } };
+    expect(body.data.id).toBe(sourceId);
+
+    // The write is durable — a follow-up get-or-create returns the same row.
+    const verify = await postMutation(server.url, "getOrCreateDataSource", {
+      id: sourceId,
+      type: "csv",
+      name: "Resilient",
+    });
+    expect(verify.status).toBe(200);
+    const verifyBody = (await verify.json()) as { data: { id: string } };
+    expect(verifyBody.data.id).toBe(sourceId);
+  });
 });

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -172,3 +172,141 @@ describe("createDashframeServer", () => {
     });
   });
 });
+
+describe("onWrite hook", () => {
+  /**
+   * Tests for the `onWrite` durability hook (see GitHub issue #88 / #90).
+   *
+   * Contracts:
+   *   - A successful artifact-DB mutation fires onWrite exactly once.
+   *   - N rapid successful mutations fire onWrite exactly N times (the
+   *     debounce lives in SnapshotScheduler.touch(), not in the server).
+   *   - A failed/invalid mutation does NOT fire onWrite.
+   *   - A read-only query does NOT fire onWrite.
+   *
+   * Testing strategy: inject a mock onWrite callback and route real HTTP
+   * mutations through the server (same path the renderer uses) — no
+   * dependency on wall-clock or real PGlite snapshots.
+   */
+  let root: string;
+  let project: ProjectHandle | null;
+  let server: DashframeServer | null;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-onwrite-"));
+    project = null;
+    server = null;
+  });
+
+  afterEach(async () => {
+    server?.stop();
+    await project?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function postMutation(
+    url: string,
+    path: string,
+    body: unknown,
+  ): Promise<Response> {
+    return fetch(`${url}/api/${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("should fire onWrite once after a successful mutation", async () => {
+    const onWriteCalls: number[] = [];
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => {
+        onWriteCalls.push(Date.now());
+      },
+    });
+
+    const res = await postMutation(server.url, "getOrCreateDataSource", {
+      id: crypto.randomUUID(),
+      type: "csv",
+      name: "My Source",
+    });
+    expect(res.status).toBe(200);
+    expect(onWriteCalls).toHaveLength(1);
+  });
+
+  it("should fire onWrite once per successful mutation (N writes → N calls, no server-level debounce)", async () => {
+    let callCount = 0;
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => {
+        callCount++;
+      },
+    });
+
+    // Three rapid creates — each is a separate committed transaction.
+    for (let i = 0; i < 3; i++) {
+      const res = await postMutation(server.url, "getOrCreateDataSource", {
+        id: crypto.randomUUID(),
+        type: "csv",
+        name: `Source ${i}`,
+      });
+      expect(res.status).toBe(200);
+    }
+    // The server fires onWrite once per committed write — debounce is the
+    // scheduler's job, not the server's. The host (SnapshotScheduler.touch)
+    // collapses rapid bursts; the server must not under-count them.
+    expect(callCount).toBe(3);
+  });
+
+  it("should NOT fire onWrite when the mutation fails (invalid args)", async () => {
+    let callCount = 0;
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => {
+        callCount++;
+      },
+    });
+
+    // Send a mutation with a missing required field — Zod validation rejects it
+    // before any DB write occurs, so no transaction commits.
+    const res = await postMutation(server.url, "getOrCreateDataSource", {
+      // Missing required `id` and `name` fields → validation error, no write.
+      type: "csv",
+    });
+    expect(res.status).toBe(400);
+    expect(callCount).toBe(0);
+  });
+
+  it("should NOT fire onWrite for a read-only query", async () => {
+    let callCount = 0;
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => {
+        callCount++;
+      },
+    });
+
+    const res = await fetch(
+      `${server.url}/api/projectInfo?args=${encodeURIComponent("{}")}`,
+    );
+    expect(res.status).toBe(200);
+    expect(callCount).toBe(0);
+  });
+
+  it("should work without onWrite (backward-compatible — omitting it changes nothing)", async () => {
+    // No onWrite configured — server should start and mutations should succeed.
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({ db: project.db });
+
+    const res = await postMutation(server.url, "getOrCreateDataSource", {
+      id: crypto.randomUUID(),
+      type: "csv",
+      name: "Compat Test",
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -40,7 +40,7 @@ import {
 } from "@dashframe/engine-server/arrow-data-path";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
-import { createRoutes, createWyStack } from "@wystack/server";
+import { createRoutes, createWyStack, type WyStackApp } from "@wystack/server";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { createHash, timingSafeEqual } from "node:crypto";
@@ -97,6 +97,18 @@ export interface DashframeServerOptions {
    * result already lives in renderer WASM, so there is no server data path.
    */
   arrowEngine?: ArrowQueryRunner;
+  /**
+   * Optional hook fired after every SUCCESSFUL artifact-DB write mutation.
+   * Called once per committed write (after the DB transaction commits, never
+   * on a failed or rolled-back write). The host owns the semantics — desktop
+   * passes `() => project?.touchSnapshot()` to drive the debounced snapshot
+   * scheduler (#88); other surfaces may omit it entirely.
+   *
+   * The server does NOT import or depend on ProjectHandle — this narrow
+   * callback is the dependency boundary (same injection pattern as
+   * `arrowEngine`).
+   */
+  onWrite?: () => void;
 }
 
 export interface DashframeServer {
@@ -122,7 +134,29 @@ export async function createDashframeServer(
     ? createTokenResolver(opts.authToken)
     : undefined;
 
-  const app = await createWyStack({ db: opts.db, functions });
+  const rawApp = await createWyStack({ db: opts.db, functions });
+
+  // Wrap the WyStack app's `call` method so `opts.onWrite` fires after any
+  // successful mutation. This is the single chokepoint: both the HTTP POST
+  // handler and the WS `call` frame path in @wystack/server route every
+  // mutation through `app.call`. Wrapping here — rather than sprinkling calls
+  // across individual handlers — means a new command or mutation added later
+  // is covered automatically. The hook fires only on success (tablesWritten
+  // is the WyStack signal that the transaction committed a write); a failed or
+  // rolled-back call never sets tablesWritten and never reaches this branch.
+  const app: WyStackApp =
+    opts.onWrite == null
+      ? rawApp
+      : {
+          ...rawApp,
+          async call(path, args, context) {
+            const result = await rawApp.call(path, args, context);
+            if (result.tablesWritten.size > 0) {
+              opts.onWrite!();
+            }
+            return result;
+          },
+        };
 
   // Mirror @wystack/server/node's serve() composition, adding CORS in front.
   const honoApp = new Hono();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -144,15 +144,28 @@ export async function createDashframeServer(
   // is covered automatically. The hook fires only on success (tablesWritten
   // is the WyStack signal that the transaction committed a write); a failed or
   // rolled-back call never sets tablesWritten and never reaches this branch.
+  //
+  // `onWrite` runs AFTER `rawApp.call` has already committed, so a throw from it
+  // must NOT fail the mutation — the client would see an error for a write that
+  // durably succeeded and might retry, duplicating artifacts. The hook is a
+  // best-effort side-channel (it only schedules a debounced snapshot), so we
+  // isolate its failure: log and swallow, never propagate. `result` is returned
+  // unchanged so the committed call's success is the sole determinant of the
+  // response.
+  const onWrite = opts.onWrite;
   const app: WyStackApp =
-    opts.onWrite == null
+    onWrite == null
       ? rawApp
       : {
           ...rawApp,
           async call(path, args, context) {
             const result = await rawApp.call(path, args, context);
             if (result.tablesWritten.size > 0) {
-              opts.onWrite!();
+              try {
+                onWrite();
+              } catch (err) {
+                console.error("[dashframe] onWrite hook threw:", err);
+              }
             }
             return result;
           },

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -250,12 +250,35 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
       DEFAULT_WEB_PROJECT_DIR,
     name: opts.name,
   });
+
+  // Headless parity with the desktop host: surface a WAL-recovery rollback to
+  // the operator. The renderer dialog is desktop-only, so without this the CLI
+  // would silently serve a project restored from an older snapshot (or a fresh
+  // one) with no signal that changes since the last snapshot were lost.
+  if (project.recovery) {
+    const { restoredSnapshot, quarantinedPath } = project.recovery;
+    console.warn(
+      "[dashframe] WARNING: recovered from an unclean shutdown (WAL corruption).",
+    );
+    console.warn(
+      restoredSnapshot
+        ? `[dashframe]   restored from snapshot taken ${restoredSnapshot.timestamp}; changes since then are lost.`
+        : "[dashframe]   no snapshot was available — started a fresh empty project.",
+    );
+    console.warn(
+      `[dashframe]   damaged database quarantined at: ${quarantinedPath}`,
+    );
+  }
+
   const server = await createDashframeServer({
     db: project.db,
     hostname: opts.hostname,
     port: opts.port,
     corsOrigin: opts.corsOrigin,
     authToken: opts.token,
+    // Drive the debounced snapshot scheduler on the headless serve path too, so
+    // `dashframe serve` gets the same crash-durability guarantee as desktop.
+    onWrite: () => project.touchSnapshot(),
   });
 
   closeOnSignal(project, server);

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -25,6 +25,8 @@ export {
   SNAPSHOTS_DIRNAME,
   SNAPSHOT_DEBOUNCE_MS,
   SNAPSHOT_KEEP_N,
+  XLOG_BLCKSZ,
+  hasCorruptWalSegment,
   listSnapshots,
   writeSnapshot,
   type SnapshotMeta,

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -19,7 +19,16 @@ export {
   type OpenProjectOptions,
   type ProjectHandle,
   type ProjectMetaRow,
+  type ProjectRecoveryNotice,
 } from "./project";
+export {
+  SNAPSHOTS_DIRNAME,
+  SNAPSHOT_DEBOUNCE_MS,
+  SNAPSHOT_KEEP_N,
+  listSnapshots,
+  writeSnapshot,
+  type SnapshotMeta,
+} from "./snapshots";
 
 export {
   DASHFRAME_HOME_DIRNAME,

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -25,6 +25,7 @@ export {
   SNAPSHOTS_DIRNAME,
   SNAPSHOT_DEBOUNCE_MS,
   SNAPSHOT_KEEP_N,
+  SNAPSHOT_MAX_WAIT_MS,
   XLOG_BLCKSZ,
   hasCorruptWalSegment,
   listSnapshots,

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -191,6 +191,21 @@ export async function openProject(
     });
   } catch (err) {
     await db.$client.close().catch(() => {});
+    // If we got here via recovery, the original datadir is already quarantined
+    // aside and the restored one just failed its metadata check (e.g. an
+    // unsupported-schema snapshot after a downgrade, or a tarball that loaded
+    // but is partially corrupt). A bare throw would leave the next startup
+    // seeing only the bad restored datadir, with the user never told where their
+    // preserved data is. Surface the quarantine path, same as the recovery
+    // catch above.
+    if (recovery) {
+      throw new Error(
+        `[dashframe] recovery restored a snapshot but it failed metadata validation. ` +
+          `Your previous data has been preserved at: ${recovery.quarantinedPath}. ` +
+          `Validation error: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
     throw err;
   }
 
@@ -201,8 +216,12 @@ export async function openProject(
   );
 
   const close = async () => {
-    // Cancel any pending debounced snapshot before writing the final one.
+    // Cancel the pending debounced timer, then await any snapshot already in
+    // flight before writing (and closing). Without the flush, a debounced/max-
+    // wait dump still running here would overlap the final dump on the same
+    // client — or worse, still be using the client when `close()` tears it down.
     scheduler.cancel();
+    await scheduler.flush();
     try {
       await writeSnapshot(db.$client, dir);
     } catch (err) {

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -12,11 +12,17 @@
  * and the current OS user as `created_by`. Subsequent opens are no-ops on the
  * metadata row.
  *
- * Recovery path: if PGlite aborts during WAL replay (RuntimeError from
- * Emscripten), the damaged datadir is quarantined with a timestamp suffix and
- * the newest snapshot is restored. If no snapshot exists a fresh project is
- * created. The returned `ProjectHandle` carries a `recovery` notice the host
- * can surface to the user. See GitHub issue #88.
+ * Recovery path: if PGlite aborts during WAL replay (RuntimeError: Aborted()
+ * from Emscripten) AND the WAL probe confirms structural corruption, the
+ * damaged datadir is quarantined with a timestamp suffix and the newest
+ * snapshot is restored. If no snapshot exists a fresh project is created. The
+ * returned `ProjectHandle` carries a `recovery` notice the host can surface to
+ * the user. See GitHub issue #88.
+ *
+ * Critically, quarantine+restore only fires on POSITIVELY CONFIRMED WAL
+ * corruption. Any error that cannot be confirmed as WAL corruption is
+ * re-thrown immediately — data is never silently discarded on an ambiguous
+ * error.
  */
 
 import fs from "node:fs/promises";
@@ -42,6 +48,7 @@ import {
   type ProjectMetaRow,
 } from "./schema";
 import {
+  hasCorruptWalSegment,
   restoreNewestSnapshot,
   SnapshotScheduler,
   writeSnapshot,
@@ -124,11 +131,14 @@ export async function openProject(
   try {
     db = await openArtifactDb({ path: dbPath });
   } catch (err) {
-    // WAL-replay aborts surface as RuntimeError from Emscripten — check for
-    // that pattern and attempt recovery, but re-throw any other error class.
-    if (!isWalCorruptionError(err)) throw err;
+    // Only recover from confirmed WAL corruption. Any other error is re-thrown
+    // immediately — never quarantine on an ambiguous error.
+    const confirmed = await isConfirmedWalCorruption(err, dbPath);
+    if (!confirmed) throw err;
 
-    // Quarantine the damaged datadir.
+    // Quarantine the damaged datadir. This MUST succeed before we proceed —
+    // if the rename fails we cannot safely overwrite the existing (possibly
+    // still-recoverable) data.
     const quarantinedPath = await quarantineDamagedDb(dbPath);
 
     // Restore from snapshot (or start fresh).
@@ -190,47 +200,113 @@ export async function openProject(
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true for the class of errors that indicate a PGlite WAL-replay
- * abort. Emscripten surfaces unrecoverable WASM errors as WebAssembly
- * RuntimeError instances thrown from `waitReady`. Observed forms:
- *   RuntimeError: Aborted()              — Emscripten ASSERTIONS build
- *   RuntimeError: Aborted(OOM)           — Emscripten ASSERTIONS build
- *   RuntimeError: unreachable            — release WASM trap
+ * Returns true when startup failure is POSITIVELY CONFIRMED WAL corruption.
  *
- * Any RuntimeError thrown during PGlite startup is an unrecoverable WASM
- * abort; there is no pg_resetwal equivalent in WASM so recovery via snapshot
- * is the only option.
+ * Affirmative detection uses two independent signals:
  *
- * We also match the string "Aborted()" for runtimes that may not preserve the
- * class name across module boundaries.
+ *   1. PRIMARY — file-level probe: the pg_wal/ directory inside `dbPath`
+ *      contains at least one WAL segment file whose size is not a multiple of
+ *      XLOG_BLCKSZ (8192), indicating a torn write.
+ *
+ *   2. CONFIRMING — error class: the thrown error is a WebAssembly
+ *      RuntimeError whose message contains "Aborted()", the specific
+ *      Emscripten abort fired when Postgres exits non-zero during WAL replay.
+ *
+ * The CONFIRMING signal alone (RuntimeError+Aborted) is sufficient to classify
+ * the failure as WAL corruption when the datadir EXISTS — Emscripten aborts
+ * during PGlite startup are always Postgres-internal (the only WASM module in
+ * scope is PGlite itself). However we still require the RuntimeError+Aborted
+ * pattern to distinguish a startup crash from an OOM or permissions error.
+ *
+ * If the PRIMARY signal fires (torn WAL) without a matching error pattern, we
+ * still return true — a structurally corrupt WAL file is definitive evidence.
+ *
+ * Any error that matches neither signal is NOT WAL corruption and MUST be
+ * re-thrown by the caller.
  */
-function isWalCorruptionError(err: unknown): boolean {
+async function isConfirmedWalCorruption(
+  err: unknown,
+  dbPath: string,
+): Promise<boolean> {
+  // The error must be from the WebAssembly/Emscripten layer.
+  // RuntimeError("Aborted()") — Emscripten ASSERTIONS build
+  // RuntimeError("Aborted(OOM)") — also from ASSERTIONS build (OOM during init)
+  // RuntimeError("unreachable") — release WASM trap
+  //
+  // We only treat the specific Aborted() family as WAL corruption — not
+  // "unreachable" (a WASM trap that can arise from bugs unrelated to WAL).
+  const isAbortedRuntimeError = isAbortedEmscriptenError(err);
+
+  // PRIMARY: probe WAL files for torn segments.
+  const tornWal = await hasCorruptWalSegment(dbPath).catch(() => false);
+
+  if (tornWal) return true;
+  if (isAbortedRuntimeError) {
+    // Confirming signal: Aborted() during startup of PGlite. Check the
+    // datadir actually exists (not a fresh project that never had a DB).
+    const dataDirExists = await fs
+      .stat(dbPath)
+      .then(() => true)
+      .catch(() => false);
+    return dataDirExists;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true for Emscripten `Aborted()` RuntimeErrors — the specific abort
+ * fired when the Postgres process exits non-zero inside the WASM sandbox.
+ *
+ * Does NOT match:
+ *   RuntimeError("unreachable")  — generic WASM trap, unrelated to WAL
+ *   Any non-RuntimeError         — permissions, I/O errors, etc.
+ */
+function isAbortedEmscriptenError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  // RuntimeError is the WebAssembly/Emscripten error class.
-  return (
-    err.constructor.name === "RuntimeError" || err.message.includes("Aborted()")
-  );
+  if (err.constructor.name !== "RuntimeError") return false;
+  // Match "Aborted()" and "Aborted(OOM)" etc. but not "unreachable".
+  return err.message.startsWith("Aborted(") || err.message === "Aborted";
 }
 
 /**
  * Rename the damaged artifacts.db aside to a timestamped quarantine path.
  * Returns the quarantine path.
  *
- * If the damaged path does not exist (shouldn't happen, but be defensive),
- * returns a synthetic path without touching the filesystem.
+ * If the rename fails for any reason other than the source not existing, an
+ * error is thrown — we cannot proceed to restore without first confirming the
+ * damaged datadir has been safely moved aside (doing so would risk overwriting
+ * data that might still be partially recoverable).
+ *
+ * If the damaged path does not exist at all (ENOENT on the source), we return
+ * the quarantine path without touching the filesystem — the DB was never
+ * created and there is nothing to move.
  */
 async function quarantineDamagedDb(dbPath: string): Promise<string> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const quarantinedPath = `${dbPath}.damaged-${timestamp}`;
   try {
     await fs.rename(dbPath, quarantinedPath);
-  } catch {
-    // Directory may not exist yet or rename may fail; log but proceed.
-    console.error(
-      `[dashframe] could not quarantine ${dbPath} → ${quarantinedPath}`,
+  } catch (err) {
+    // Source doesn't exist — nothing to quarantine; proceed to fresh init.
+    if (isEnoent(err)) return quarantinedPath;
+    // Any other rename failure (permissions, cross-device, I/O) is fatal —
+    // surface the error rather than silently proceeding to restore over a DB
+    // that was NOT successfully moved aside.
+    throw new Error(
+      `[dashframe] quarantine failed: could not rename ${dbPath} → ${quarantinedPath}: ${String(err)}`,
+      { cause: err },
     );
   }
   return quarantinedPath;
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "ENOENT"
+  );
 }
 
 async function ensureProjectMeta(

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -5,11 +5,18 @@
  *   <dir>/
  *     artifacts.db          # PGLite, tables via syncSchema
  *     data/sources/         # Parquet files, one per imported DataSource
+ *     snapshots/            # Rotating PGLite datadir tarballs (see snapshots.ts)
  *
  * On first open, `project_meta` is seeded with a freshly generated
  * `project_id`, creator version, `schema_version = ARTIFACT_DB_SCHEMA_VERSION`,
  * and the current OS user as `created_by`. Subsequent opens are no-ops on the
  * metadata row.
+ *
+ * Recovery path: if PGlite aborts during WAL replay (RuntimeError from
+ * Emscripten), the damaged datadir is quarantined with a timestamp suffix and
+ * the newest snapshot is restored. If no snapshot exists a fresh project is
+ * created. The returned `ProjectHandle` carries a `recovery` notice the host
+ * can surface to the user. See GitHub issue #88.
  */
 
 import fs from "node:fs/promises";
@@ -34,10 +41,29 @@ import {
   projectMeta,
   type ProjectMetaRow,
 } from "./schema";
+import {
+  restoreNewestSnapshot,
+  SnapshotScheduler,
+  writeSnapshot,
+  type SnapshotMeta,
+} from "./snapshots";
 import { DASHFRAME_PROJECT_VERSION } from "./version";
 
 export const ARTIFACTS_DB_FILENAME = "artifacts.db";
 export const DATA_SOURCES_DIRNAME = path.join("data", "sources");
+
+/** Set when openProject had to quarantine a damaged datadir. */
+export interface ProjectRecoveryNotice {
+  /** What happened. */
+  reason: "wal-corruption";
+  /**
+   * The snapshot that was restored, or null when no snapshot was available
+   * and the project was re-initialized as a fresh empty project.
+   */
+  restoredSnapshot: SnapshotMeta | null;
+  /** Absolute path to the quarantined damaged datadir. */
+  quarantinedPath: string;
+}
 
 export interface ProjectHandle {
   /** Resolved absolute path to the project folder. */
@@ -50,7 +76,18 @@ export interface ProjectHandle {
   db: ArtifactDb;
   /** The single `project_meta` row. */
   meta: ProjectMetaRow;
-  /** Flush pending writes and close the underlying PGlite connection. */
+  /**
+   * Set when the project was recovered from a corrupt WAL; null on a normal
+   * open. The desktop host reads this and surfaces a dialog to the user.
+   */
+  recovery: ProjectRecoveryNotice | null;
+  /**
+   * Notify the snapshot scheduler that a write just occurred.
+   * Call this after any operation that mutates the artifact DB so the
+   * debounced snapshot timer is reset.
+   */
+  touchSnapshot(): void;
+  /** Flush pending writes, write a final snapshot, and close the underlying PGlite connection. */
   close(): Promise<void>;
 }
 
@@ -63,6 +100,12 @@ export interface OpenProjectOptions extends ResolveProjectDirOptions {
   createdBy?: string;
   /** DashFrame semver that created the project. */
   version?: string;
+  /**
+   * Debounce interval in ms for the post-write snapshot timer.
+   * Exposed for tests (set low to avoid real waits).
+   * Defaults to SNAPSHOT_DEBOUNCE_MS (30 s).
+   */
+  snapshotDebounceMs?: number;
 }
 
 export async function openProject(
@@ -74,7 +117,33 @@ export async function openProject(
 
   await fs.mkdir(dataSourcesDir, { recursive: true });
 
-  const db = await openArtifactDb({ path: dbPath });
+  // --- attempt normal open ---
+  let db: ArtifactDb;
+  let recovery: ProjectRecoveryNotice | null = null;
+
+  try {
+    db = await openArtifactDb({ path: dbPath });
+  } catch (err) {
+    // WAL-replay aborts surface as RuntimeError from Emscripten — check for
+    // that pattern and attempt recovery, but re-throw any other error class.
+    if (!isWalCorruptionError(err)) throw err;
+
+    // Quarantine the damaged datadir.
+    const quarantinedPath = await quarantineDamagedDb(dbPath);
+
+    // Restore from snapshot (or start fresh).
+    const restoredSnapshot = await restoreNewestSnapshot(dir, dbPath);
+
+    // Open the restored (or fresh) datadir.
+    db = await openArtifactDb({ path: dbPath });
+
+    recovery = {
+      reason: "wal-corruption",
+      restoredSnapshot,
+      quarantinedPath,
+    };
+  }
+
   let meta: ProjectMetaRow;
   try {
     meta = await ensureProjectMeta(db, {
@@ -87,8 +156,81 @@ export async function openProject(
     throw err;
   }
 
-  const close = () => db.$client.close();
-  return { dir, dbPath, dataSourcesDir, db, meta, close };
+  const scheduler = new SnapshotScheduler(
+    db.$client,
+    dir,
+    options.snapshotDebounceMs,
+  );
+
+  const close = async () => {
+    // Cancel any pending debounced snapshot before writing the final one.
+    scheduler.cancel();
+    try {
+      await writeSnapshot(db.$client, dir);
+    } catch (err) {
+      console.error("[dashframe] close-time snapshot failed:", err);
+    }
+    await db.$client.close();
+  };
+
+  return {
+    dir,
+    dbPath,
+    dataSourcesDir,
+    db,
+    meta,
+    recovery,
+    touchSnapshot: () => scheduler.touch(),
+    close,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true for the class of errors that indicate a PGlite WAL-replay
+ * abort. Emscripten surfaces unrecoverable WASM errors as WebAssembly
+ * RuntimeError instances thrown from `waitReady`. Observed forms:
+ *   RuntimeError: Aborted()              — Emscripten ASSERTIONS build
+ *   RuntimeError: Aborted(OOM)           — Emscripten ASSERTIONS build
+ *   RuntimeError: unreachable            — release WASM trap
+ *
+ * Any RuntimeError thrown during PGlite startup is an unrecoverable WASM
+ * abort; there is no pg_resetwal equivalent in WASM so recovery via snapshot
+ * is the only option.
+ *
+ * We also match the string "Aborted()" for runtimes that may not preserve the
+ * class name across module boundaries.
+ */
+function isWalCorruptionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // RuntimeError is the WebAssembly/Emscripten error class.
+  return (
+    err.constructor.name === "RuntimeError" || err.message.includes("Aborted()")
+  );
+}
+
+/**
+ * Rename the damaged artifacts.db aside to a timestamped quarantine path.
+ * Returns the quarantine path.
+ *
+ * If the damaged path does not exist (shouldn't happen, but be defensive),
+ * returns a synthetic path without touching the filesystem.
+ */
+async function quarantineDamagedDb(dbPath: string): Promise<string> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const quarantinedPath = `${dbPath}.damaged-${timestamp}`;
+  try {
+    await fs.rename(dbPath, quarantinedPath);
+  } catch {
+    // Directory may not exist yet or rename may fail; log but proceed.
+    console.error(
+      `[dashframe] could not quarantine ${dbPath} → ${quarantinedPath}`,
+    );
+  }
+  return quarantinedPath;
 }
 
 async function ensureProjectMeta(

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -12,17 +12,19 @@
  * and the current OS user as `created_by`. Subsequent opens are no-ops on the
  * metadata row.
  *
- * Recovery path: if PGlite aborts during WAL replay (RuntimeError: Aborted()
- * from Emscripten) AND the WAL probe confirms structural corruption, the
- * damaged datadir is quarantined with a timestamp suffix and the newest
+ * Recovery path: if a startup failure is accompanied by a structurally torn WAL
+ * segment on disk (a `pg_wal/` file whose size is not a multiple of XLOG_BLCKSZ),
+ * the damaged datadir is quarantined with a timestamp suffix and the newest
  * snapshot is restored. If no snapshot exists a fresh project is created. The
  * returned `ProjectHandle` carries a `recovery` notice the host can surface to
  * the user. See GitHub issue #88.
  *
- * Critically, quarantine+restore only fires on POSITIVELY CONFIRMED WAL
- * corruption. Any error that cannot be confirmed as WAL corruption is
- * re-thrown immediately — data is never silently discarded on an ambiguous
- * error.
+ * Critically, quarantine+restore only fires on a POSITIVELY CONFIRMED torn WAL
+ * segment. An Emscripten abort alone is NOT sufficient — `RuntimeError("Aborted(OOM)")`
+ * (out of memory) and any other non-WAL abort leave the on-disk datadir intact,
+ * so recovering on them would overwrite a healthy database. Any failure that
+ * cannot be tied to a torn WAL segment is re-thrown immediately — data is never
+ * silently discarded on an ambiguous error.
  */
 
 import fs from "node:fs/promises";
@@ -113,6 +115,13 @@ export interface OpenProjectOptions extends ResolveProjectDirOptions {
    * Defaults to SNAPSHOT_DEBOUNCE_MS (30 s).
    */
   snapshotDebounceMs?: number;
+  /**
+   * Injected DB-open function. Exposed for tests so the open-time failure that
+   * drives the recovery decision can be simulated deterministically — e.g. a
+   * `RuntimeError("Aborted(OOM)")` against an intact datadir, which must NOT
+   * trigger quarantine. Defaults to {@link openArtifactDb}.
+   */
+  openDb?: (opts: { path: string }) => Promise<ArtifactDb>;
 }
 
 export async function openProject(
@@ -124,15 +133,20 @@ export async function openProject(
 
   await fs.mkdir(dataSourcesDir, { recursive: true });
 
+  // Injected DB-open seam (defaults to the real openArtifactDb). Used by tests
+  // to simulate the open-time failure that drives the recovery decision.
+  const openDb = options.openDb ?? openArtifactDb;
+
   // --- attempt normal open ---
   let db: ArtifactDb;
   let recovery: ProjectRecoveryNotice | null = null;
 
   try {
-    db = await openArtifactDb({ path: dbPath });
+    db = await openDb({ path: dbPath });
   } catch (err) {
-    // Only recover from confirmed WAL corruption. Any other error is re-thrown
-    // immediately — never quarantine on an ambiguous error.
+    // Only recover when a torn WAL segment is positively confirmed on disk. Any
+    // other failure — including an Aborted(OOM) abort whose datadir is intact —
+    // is re-thrown immediately; we never quarantine on ambiguous evidence.
     const confirmed = await isConfirmedWalCorruption(err, dbPath);
     if (!confirmed) throw err;
 
@@ -141,17 +155,31 @@ export async function openProject(
     // still-recoverable) data.
     const quarantinedPath = await quarantineDamagedDb(dbPath);
 
-    // Restore from snapshot (or start fresh).
-    const restoredSnapshot = await restoreNewestSnapshot(dir, dbPath);
+    try {
+      // Restore from snapshot (or start fresh).
+      const restoredSnapshot = await restoreNewestSnapshot(dir, dbPath);
 
-    // Open the restored (or fresh) datadir.
-    db = await openArtifactDb({ path: dbPath });
+      // Open the restored (or fresh) datadir.
+      db = await openArtifactDb({ path: dbPath });
 
-    recovery = {
-      reason: "wal-corruption",
-      restoredSnapshot,
-      quarantinedPath,
-    };
+      recovery = {
+        reason: "wal-corruption",
+        restoredSnapshot,
+        quarantinedPath,
+      };
+    } catch (recoveryErr) {
+      // The damaged DB has ALREADY been renamed aside to `quarantinedPath`, but
+      // the restore/re-open failed — so `dbPath` now has no usable database. A
+      // bare throw here would leave the operator with a missing DB and no clue
+      // where their data went. Surface the quarantine location in the error so
+      // the data is recoverable by hand, and chain the original cause.
+      throw new Error(
+        `[dashframe] recovery failed after quarantining the damaged database. ` +
+          `Your previous data has been preserved at: ${quarantinedPath}. ` +
+          `Restore/reopen error: ${recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr)}`,
+        { cause: recoveryErr },
+      );
+    }
   }
 
   let meta: ProjectMetaRow;
@@ -200,73 +228,48 @@ export async function openProject(
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true when startup failure is POSITIVELY CONFIRMED WAL corruption.
+ * Returns true ONLY when startup failure is POSITIVELY CONFIRMED WAL corruption.
  *
- * Affirmative detection uses two independent signals:
+ * Guiding rule — fail toward PRESERVING data: quarantine + restore DESTROYS the
+ * live datadir (it renames the database aside and overwrites it with an older
+ * snapshot), so it must fire only on definitive, file-level evidence of
+ * corruption. When the evidence is ambiguous the caller re-throws and surfaces
+ * the real error; it never quarantines on a signal it cannot positively tie to a
+ * structurally torn WAL.
  *
- *   1. PRIMARY — file-level probe: the pg_wal/ directory inside `dbPath`
- *      contains at least one WAL segment file whose size is not a multiple of
- *      XLOG_BLCKSZ (8192), indicating a torn write.
+ * The SOLE sufficient signal is the WAL-segment probe (`hasCorruptWalSegment`):
+ * a `pg_wal/` segment file whose byte length is not a multiple of XLOG_BLCKSZ —
+ * a torn/misaligned write, direct on-disk proof the WAL is damaged.
  *
- *   2. CONFIRMING — error class: the thrown error is a WebAssembly
- *      RuntimeError whose message contains "Aborted()", the specific
- *      Emscripten abort fired when Postgres exits non-zero during WAL replay.
+ * What is deliberately NOT trusted: the Emscripten abort signature. Earlier this
+ * helper treated any `RuntimeError("Aborted(...)")` as corruption, but that class
+ * covers unrelated failures — most importantly `Aborted(OOM)`, an out-of-memory
+ * abort that leaves the on-disk datadir perfectly intact. Recovering on an OOM
+ * would overwrite a healthy database under memory pressure: the exact data-loss
+ * mode this whole path exists to prevent. So the abort message is never an
+ * independent trigger — only a torn WAL segment authorizes recovery.
  *
- * The CONFIRMING signal alone (RuntimeError+Aborted) is sufficient to classify
- * the failure as WAL corruption when the datadir EXISTS — Emscripten aborts
- * during PGlite startup are always Postgres-internal (the only WASM module in
- * scope is PGlite itself). However we still require the RuntimeError+Aborted
- * pattern to distinguish a startup crash from an OOM or permissions error.
+ * Net rule:
+ *   torn WAL segment present  → confirmed corruption  → quarantine + restore
+ *   anything else (incl. any  → NOT confirmed         → re-throw (preserve data)
+ *   abort, OOM, EACCES probe
+ *   failure, unreachable trap)
  *
- * If the PRIMARY signal fires (torn WAL) without a matching error pattern, we
- * still return true — a structurally corrupt WAL file is definitive evidence.
- *
- * Any error that matches neither signal is NOT WAL corruption and MUST be
- * re-thrown by the caller.
+ * `err` is currently unused for the decision — recovery keys solely on the
+ * file-level probe — but is kept in the signature so a future, precisely
+ * WAL-attributable error class could become a corroborating signal alongside
+ * (never instead of) the torn-WAL probe.
  */
 async function isConfirmedWalCorruption(
-  err: unknown,
+  _err: unknown,
   dbPath: string,
 ): Promise<boolean> {
-  // The error must be from the WebAssembly/Emscripten layer.
-  // RuntimeError("Aborted()") — Emscripten ASSERTIONS build
-  // RuntimeError("Aborted(OOM)") — also from ASSERTIONS build (OOM during init)
-  // RuntimeError("unreachable") — release WASM trap
-  //
-  // We only treat the specific Aborted() family as WAL corruption — not
-  // "unreachable" (a WASM trap that can arise from bugs unrelated to WAL).
-  const isAbortedRuntimeError = isAbortedEmscriptenError(err);
-
-  // PRIMARY: probe WAL files for torn segments.
-  const tornWal = await hasCorruptWalSegment(dbPath).catch(() => false);
-
-  if (tornWal) return true;
-  if (isAbortedRuntimeError) {
-    // Confirming signal: Aborted() during startup of PGlite. Check the
-    // datadir actually exists (not a fresh project that never had a DB).
-    const dataDirExists = await fs
-      .stat(dbPath)
-      .then(() => true)
-      .catch(() => false);
-    return dataDirExists;
-  }
-
-  return false;
-}
-
-/**
- * Returns true for Emscripten `Aborted()` RuntimeErrors — the specific abort
- * fired when the Postgres process exits non-zero inside the WASM sandbox.
- *
- * Does NOT match:
- *   RuntimeError("unreachable")  — generic WASM trap, unrelated to WAL
- *   Any non-RuntimeError         — permissions, I/O errors, etc.
- */
-function isAbortedEmscriptenError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  if (err.constructor.name !== "RuntimeError") return false;
-  // Match "Aborted()" and "Aborted(OOM)" etc. but not "unreachable".
-  return err.message.startsWith("Aborted(") || err.message === "Aborted";
+  // The ONLY sufficient signal: a structurally torn WAL segment on disk. A probe
+  // failure (EACCES/EPERM/etc.) resolves to false — absence of positive evidence
+  // is never grounds to destroy the datadir. Every other startup failure
+  // (Aborted(OOM), a bare abort with an intact datadir, an `unreachable` trap, a
+  // permissions error) falls through to false and the caller re-throws.
+  return hasCorruptWalSegment(dbPath).catch(() => false);
 }
 
 /**

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -8,6 +8,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -18,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PGlite } from "@electric-sql/pglite";
 
+import { openArtifactDb } from "./db";
 import {
   ARTIFACTS_DB_FILENAME,
   openProject,
@@ -378,6 +380,88 @@ describe("openProject WAL corruption recovery", () => {
     expect(quarantined).toHaveLength(0);
   });
 
+  test("Aborted(OOM) with a STRUCTURALLY-INTACT datadir does NOT quarantine — data survives", async () => {
+    // The regression this pins (PR #90 P1): an out-of-memory abort
+    // (`RuntimeError: Aborted(OOM)`) leaves the on-disk datadir intact, so it
+    // must NEVER trigger quarantine + restore. The decision keys solely on a
+    // torn WAL segment — and here the WAL is block-aligned (healthy), so the
+    // abort must propagate and the live datadir must be preserved untouched.
+    const dir = join(root, "oom-intact");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // Build a structurally-intact datadir: a block-aligned WAL segment so
+    // hasCorruptWalSegment returns false. A sentinel file lets us prove the
+    // exact bytes survive (not silently overwritten by a fresh/restored DB).
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ * 128),
+    );
+    const sentinel = join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION");
+    writeFileSync(sentinel, "INTACT-DATADIR\n");
+
+    // Inject an open that fails with the OOM abort — the documented case the
+    // broad `startsWith("Aborted(")` match would have mis-classified as WAL
+    // corruption. WebAssembly.RuntimeError reproduces the exact shape PGlite's
+    // Emscripten layer throws (constructor.name === "RuntimeError").
+    const oomAbort = new WebAssembly.RuntimeError("Aborted(OOM)");
+    const openDb = () => Promise.reject(oomAbort);
+
+    // The OOM abort must propagate — recovery must NOT swallow it.
+    await expect(openProject({ dir, openDb })).rejects.toBe(oomAbort);
+
+    // The live datadir is preserved: not quarantined, bytes untouched.
+    expect(existsSync(dbPath)).toBe(true);
+    const parentDir = await readdir(dir);
+    expect(parentDir.filter((f) => f.includes(".damaged-"))).toHaveLength(0);
+    expect(readFileSync(sentinel, "utf8")).toBe("INTACT-DATADIR\n");
+  });
+
+  test("Aborted(OOM) paired with a TORN WAL segment DOES quarantine — the probe, not the message, decides", async () => {
+    // The contrast case: the same OOM-shaped abort, but now the datadir has a
+    // torn (misaligned) WAL segment — positive, on-disk corruption evidence.
+    // Recovery keys on the probe, so this DOES quarantine + restore despite the
+    // abort message being identical to the intact-datadir case above.
+    const dir = join(root, "oom-torn-wal");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // 1. Seed a healthy project + snapshot so there is something to restore to.
+    const h1 = await openProject({ dir, name: "TornWalOOM" });
+    openHandles.splice(0);
+    await h1.close();
+    expect((await listSnapshots(dir)).length).toBeGreaterThan(0);
+
+    // 2. Corrupt the datadir with a TORN WAL segment (not block-aligned).
+    rmSync(dbPath, { recursive: true, force: true });
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ - 1),
+    );
+    writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+
+    // 3. Open with the OOM-shaped abort on the FIRST open attempt. The recovery
+    // path's second open uses the real openArtifactDb (restored datadir).
+    let firstOpen = true;
+    const openDb = (opts: { path: string }) => {
+      if (firstOpen) {
+        firstOpen = false;
+        return Promise.reject(new WebAssembly.RuntimeError("Aborted(OOM)"));
+      }
+      return openArtifactDb(opts);
+    };
+
+    const handle = await openProject({ dir, openDb });
+    openHandles.push(handle);
+
+    // The torn WAL drove recovery: quarantined + restored, despite the OOM message.
+    expect(handle.recovery).not.toBeNull();
+    expect(handle.recovery!.reason).toBe("wal-corruption");
+    expect(handle.recovery!.quarantinedPath).toMatch(/\.damaged-/);
+    expect(existsSync(handle.recovery!.quarantinedPath)).toBe(true);
+    expect(handle.meta.name).toBe("TornWalOOM");
+  });
+
   test("restoreNewestSnapshot falls back to older snapshot when newest is missing", async () => {
     const dir = join(root, "fallback-snap");
     const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
@@ -422,5 +506,50 @@ describe("openProject WAL corruption recovery", () => {
     // Should have fallen back to the second-newest snapshot.
     expect(h2.recovery!.restoredSnapshot!.absPath).toBe(secondNewest.absPath);
     expect(h2.meta.name).toBe("FallbackTest");
+  });
+
+  test("rejects a readable-but-empty newest snapshot and falls back to a valid older one", async () => {
+    // PR #90 P2: PGlite does NOT throw on a truncated/garbage tarball — it
+    // silently loads a FRESH EMPTY datadir. So a "successful" load is not proof
+    // the data survived. restoreNewestSnapshot must validate (project_meta
+    // present) and reject the empty restore, falling back to a valid older
+    // snapshot rather than accepting an empty DB as recovered.
+    const dir = join(root, "empty-newest-snap");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // 1. Healthy project → a real (valid) snapshot on close.
+    const h1 = await openProject({ dir, name: "ValidOlder" });
+    openHandles.splice(0);
+    await h1.close();
+
+    const snaps = await listSnapshots(dir);
+    expect(snaps.length).toBeGreaterThanOrEqual(1);
+    const validOlder = snaps[snaps.length - 1]!;
+
+    // 2. Plant a NEWER snapshot file that is a readable but garbage .tar.gz.
+    // Its filename sorts last (newer timestamp), so it is tried first. PGlite
+    // will load it as an empty datadir — which validation must reject.
+    const newerName = `${SNAPSHOT_PREFIX}2999-01-01T00-00-00-000Z${SNAPSHOT_EXT}`;
+    const newerPath = join(resolveSnapshotsDir(dir), newerName);
+    writeFileSync(newerPath, Buffer.from("not a real gzip tarball"));
+
+    // 3. Corrupt the datadir (torn WAL) so recovery triggers.
+    rmSync(dbPath, { recursive: true, force: true });
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ - 1),
+    );
+    writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+
+    // 4. Recovery must SKIP the empty newest and restore the valid older one.
+    const h2 = await openProject({ dir });
+    openHandles.push(h2);
+
+    expect(h2.recovery).not.toBeNull();
+    expect(h2.recovery!.restoredSnapshot).not.toBeNull();
+    expect(h2.recovery!.restoredSnapshot!.absPath).toBe(validOlder.absPath);
+    // The restored project carries the real data, not an empty fresh DB.
+    expect(h2.meta.name).toBe("ValidOlder");
   });
 });

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -32,6 +32,7 @@ import {
   SNAPSHOT_EXT,
   SNAPSHOT_KEEP_N,
   SNAPSHOT_PREFIX,
+  SnapshotScheduler,
   writeSnapshot,
   XLOG_BLCKSZ,
 } from "./snapshots";
@@ -142,6 +143,154 @@ describe("writeSnapshot + listSnapshots", () => {
     } finally {
       await pg.close();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SnapshotScheduler — debounce + max-wait cap
+// ---------------------------------------------------------------------------
+
+describe("SnapshotScheduler", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempDir();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // A fake PGlite whose dumpDataDir records each call (a fired snapshot) and
+  // resolves to a tiny blob. It captures the in-flight writeSnapshot promise so
+  // teardown can await it — otherwise the real fs rename inside writeSnapshot
+  // could race the afterEach rmSync and emit a stray ENOENT. The fire counter
+  // increments synchronously at the start of each snapshot, so `fires()` is
+  // accurate the moment a snapshot is triggered.
+  function fakeClient(): {
+    client: PGlite;
+    fires: () => number;
+    settle: () => Promise<void>;
+  } {
+    let count = 0;
+    let inFlight: Promise<unknown> = Promise.resolve();
+    const client = {
+      dumpDataDir: () => {
+        count += 1;
+        // Defer one microtask so the synchronous fireNow() returns first, then
+        // the fs work runs; capture it so the test can await completion.
+        const p = Promise.resolve(new Blob([Buffer.from("snap")]));
+        inFlight = p;
+        return p;
+      },
+    } as unknown as PGlite;
+    return {
+      client,
+      fires: () => count,
+      // Await any in-flight snapshot fs work before teardown.
+      settle: async () => {
+        await inFlight;
+        await new Promise((r) => setTimeout(r, 20));
+      },
+    };
+  }
+
+  // Let the snapshot's dumpDataDir + fs microtasks settle.
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  test("N rapid touches within the debounce window fire exactly ONE snapshot", async () => {
+    const projectDir = join(root, "debounce-once");
+    mkdirSync(projectDir, { recursive: true });
+    const { client, fires, settle } = fakeClient();
+
+    let now = 0;
+    const sched = new SnapshotScheduler(
+      client,
+      projectDir,
+      1000, // debounceMs
+      100_000, // maxWaitMs (far away; debounce wins here)
+      () => now,
+    );
+
+    // 5 touches, each 10ms apart — all inside the 1000ms debounce, max-wait far.
+    for (let i = 0; i < 5; i++) {
+      now = i * 10;
+      sched.touch();
+    }
+    expect(fires()).toBe(0); // nothing fired yet — still debouncing
+
+    // Quiet gap → the single debounced timer fires.
+    await new Promise((r) => setTimeout(r, 1100));
+    await flush();
+    expect(fires()).toBe(1);
+
+    sched.cancel();
+    await settle();
+  });
+
+  test("a continuous touch stream still snapshots once max-wait is exceeded (no infinite deferral)", async () => {
+    const projectDir = join(root, "maxwait-cap");
+    mkdirSync(projectDir, { recursive: true });
+    const { client, fires, settle } = fakeClient();
+
+    let now = 0;
+    const debounceMs = 1000;
+    const maxWaitMs = 5000;
+    const sched = new SnapshotScheduler(
+      client,
+      projectDir,
+      debounceMs,
+      maxWaitMs,
+      () => now,
+    );
+
+    // Writes arrive every 500ms — faster than the 1000ms debounce, so a pure
+    // debounce would NEVER fire. With the cap, once writes have been pending
+    // maxWaitMs (5000ms) the next touch fires immediately.
+    // First write at t=0 anchors the burst.
+    sched.touch();
+    for (let t = 500; t < 5000; t += 500) {
+      now = t;
+      sched.touch();
+      expect(fires()).toBe(0); // still under the cap — keeps deferring
+    }
+
+    // At t=5000 the burst has been pending exactly maxWaitMs → fire now.
+    now = 5000;
+    sched.touch();
+    await flush();
+    expect(fires()).toBe(1);
+
+    // The burst tracker reset: subsequent fast touches defer again until the
+    // next cap window, so we don't snapshot on every write after the first cap.
+    now = 5200;
+    sched.touch();
+    expect(fires()).toBe(1);
+
+    sched.cancel();
+    await settle();
+  });
+
+  test("cancel() clears a pending debounced snapshot and resets the burst anchor", async () => {
+    const projectDir = join(root, "cancel");
+    mkdirSync(projectDir, { recursive: true });
+    const { client, fires } = fakeClient();
+
+    const now = 0;
+    const sched = new SnapshotScheduler(
+      client,
+      projectDir,
+      1000,
+      100_000,
+      () => now,
+    );
+    sched.touch();
+    sched.cancel();
+
+    // The debounce timer was cleared — even after the window elapses, no fire.
+    await new Promise((r) => setTimeout(r, 1100));
+    await flush();
+    expect(fires()).toBe(0);
   });
 });
 

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -19,12 +19,13 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PGlite } from "@electric-sql/pglite";
 
-import { openArtifactDb } from "./db";
+import { ARTIFACT_DB_SCHEMA_VERSION, openArtifactDb } from "./db";
 import {
   ARTIFACTS_DB_FILENAME,
   openProject,
   type ProjectHandle,
 } from "./project";
+import { projectMeta } from "./schema";
 import {
   hasCorruptWalSegment,
   listSnapshots,
@@ -291,6 +292,55 @@ describe("SnapshotScheduler", () => {
     await new Promise((r) => setTimeout(r, 1100));
     await flush();
     expect(fires()).toBe(0);
+  });
+
+  test("serializes overlapping snapshot writes — dumps never run concurrently", async () => {
+    const projectDir = join(root, "serialize");
+    mkdirSync(projectDir, { recursive: true });
+
+    // A client whose dumpDataDir is slow and records peak concurrency. If two
+    // snapshots ran in parallel, `active` would exceed 1 at some point.
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    const client = {
+      dumpDataDir: async () => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 30));
+        active -= 1;
+        return new Blob([Buffer.from("snap")]);
+      },
+    } as unknown as PGlite;
+
+    let now = 0;
+    const maxWaitMs = 1000;
+    const sched = new SnapshotScheduler(
+      client,
+      projectDir,
+      500, // debounceMs
+      maxWaitMs,
+      () => now,
+    );
+
+    // Force two immediate max-wait fires back-to-back: anchor at t=0, then jump
+    // past the cap twice so fireNow runs twice without the first dump finishing.
+    sched.touch(); // anchor at t=0
+    now = 1000;
+    sched.touch(); // cap reached → fire #1 (dump in flight, ~30ms)
+    sched.touch(); // anchor resets to t=1000
+    now = 2000;
+    sched.touch(); // cap reached again → fire #2, chained behind #1
+
+    // Await the serialized chain.
+    await sched.flush();
+
+    expect(calls).toBe(2);
+    // The contract: the two dumps were serialized, never concurrent.
+    expect(maxActive).toBe(1);
+
+    sched.cancel();
   });
 });
 
@@ -700,5 +750,44 @@ describe("openProject WAL corruption recovery", () => {
     expect(h2.recovery!.restoredSnapshot!.absPath).toBe(validOlder.absPath);
     // The restored project carries the real data, not an empty fresh DB.
     expect(h2.meta.name).toBe("ValidOlder");
+  });
+
+  test("metadata failure on a restored snapshot still surfaces the quarantine path", async () => {
+    // PR #90 P2: if recovery restores a snapshot that opens but then fails
+    // ensureProjectMeta (e.g. an unsupported-schema snapshot after a downgrade),
+    // the error must still tell the operator where their preserved data is —
+    // the original datadir has already been renamed aside.
+    const dir = join(root, "meta-fail-recovery");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // 1. Healthy project, then poison project_meta with an unsupported schema
+    // version and snapshot that poisoned state.
+    const h1 = await openProject({ dir, name: "PoisonedSchema" });
+    openHandles.splice(0);
+    await h1.db
+      .update(projectMeta)
+      .set({ schemaVersion: ARTIFACT_DB_SCHEMA_VERSION + 99 });
+    await writeSnapshot(h1.db.$client, dir);
+    await h1.db.$client.close();
+
+    // 2. Corrupt the live datadir (torn WAL) so recovery triggers.
+    rmSync(dbPath, { recursive: true, force: true });
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ - 1),
+    );
+    writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+
+    // 3. Recovery restores the poisoned snapshot; ensureProjectMeta then rejects
+    // the unsupported schema. The thrown error must carry the quarantine path so
+    // the user can recover their preserved data.
+    await expect(openProject({ dir })).rejects.toThrow(
+      /preserved at:.*\.damaged-/,
+    );
+
+    // The quarantined original must exist on disk.
+    const parentDir = await readdir(dir);
+    expect(parentDir.filter((f) => f.includes(".damaged-")).length).toBe(1);
   });
 });

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for the PGlite snapshot layer (see GitHub issue #88).
+ *
+ * All tests use temp dirs — never touch ~/.DashFrame.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { PGlite } from "@electric-sql/pglite";
+
+import {
+  ARTIFACTS_DB_FILENAME,
+  openProject,
+  type ProjectHandle,
+} from "./project";
+import {
+  listSnapshots,
+  resolveSnapshotsDir,
+  SNAPSHOT_EXT,
+  SNAPSHOT_KEEP_N,
+  SNAPSHOT_PREFIX,
+  writeSnapshot,
+} from "./snapshots";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), "dashframe-snap-"));
+}
+
+async function openFreshPGlite(dbPath: string): Promise<PGlite> {
+  mkdirSync(dbPath, { recursive: true });
+  const pg = new PGlite(dbPath);
+  await pg.waitReady;
+  return pg;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot write / list / rotate
+// ---------------------------------------------------------------------------
+
+describe("writeSnapshot + listSnapshots", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempDir();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("writes a .tar.gz file under <project>/snapshots/ and lists it", async () => {
+    const projectDir = join(root, "proj");
+    const dbPath = join(projectDir, "artifacts.db");
+    mkdirSync(projectDir, { recursive: true });
+
+    const pg = await openFreshPGlite(dbPath);
+    try {
+      const snapPath = await writeSnapshot(pg, projectDir);
+
+      expect(snapPath).toMatch(/\.tar\.gz$/);
+      expect(existsSync(snapPath)).toBe(true);
+
+      const snaps = await listSnapshots(projectDir);
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0]!.absPath).toBe(snapPath);
+      expect(snaps[0]!.filename).toMatch(
+        new RegExp(`^${SNAPSHOT_PREFIX}.*${SNAPSHOT_EXT.replace(".", "\\.")}$`),
+      );
+    } finally {
+      await pg.close();
+    }
+  });
+
+  test("prunes old snapshots, keeping only SNAPSHOT_KEEP_N most recent", async () => {
+    const projectDir = join(root, "rotate");
+    const dbPath = join(projectDir, "artifacts.db");
+    mkdirSync(projectDir, { recursive: true });
+
+    const pg = await openFreshPGlite(dbPath);
+    try {
+      // Write KEEP_N + 2 snapshots with a small delay so filenames differ.
+      const written: string[] = [];
+      for (let i = 0; i < SNAPSHOT_KEEP_N + 2; i++) {
+        // Ensure timestamps differ by manipulating Date (vitest fake timers).
+        vi.setSystemTime(new Date(2024, 0, 1, 0, 0, i));
+        const p = await writeSnapshot(pg, projectDir);
+        written.push(p);
+      }
+      vi.useRealTimers();
+
+      const snaps = await listSnapshots(projectDir);
+      expect(snaps).toHaveLength(SNAPSHOT_KEEP_N);
+
+      // The oldest N snapshots should have been pruned.
+      const kept = new Set(snaps.map((s) => s.absPath));
+      const pruned = written.slice(0, written.length - SNAPSHOT_KEEP_N);
+      for (const p of pruned) {
+        expect(kept.has(p)).toBe(false);
+        expect(existsSync(p)).toBe(false);
+      }
+    } finally {
+      vi.useRealTimers();
+      await pg.close();
+    }
+  });
+
+  test("listSnapshots returns empty array when no snapshots dir exists", async () => {
+    const snaps = await listSnapshots(join(root, "nonexistent"));
+    expect(snaps).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openProject — snapshot on close
+// ---------------------------------------------------------------------------
+
+describe("openProject snapshot on close", () => {
+  let root: string;
+  let openHandles: ProjectHandle[];
+
+  beforeEach(() => {
+    root = tempDir();
+    openHandles = [];
+  });
+
+  afterEach(async () => {
+    await Promise.allSettled(openHandles.map((h) => h.close()));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  async function openTestProject(dir: string) {
+    const handle = await openProject({ dir });
+    openHandles.push(handle);
+    return handle;
+  }
+
+  test("writes a snapshot to <project>/snapshots/ on clean close", async () => {
+    const dir = join(root, "closesnap");
+    const handle = await openTestProject(dir);
+
+    // Remove from openHandles since we close manually.
+    openHandles.splice(openHandles.indexOf(handle), 1);
+    await handle.close();
+
+    const snapsDir = resolveSnapshotsDir(dir);
+    expect(existsSync(snapsDir)).toBe(true);
+
+    const files = await readdir(snapsDir);
+    const snapFiles = files.filter(
+      (f) => f.startsWith(SNAPSHOT_PREFIX) && f.endsWith(SNAPSHOT_EXT),
+    );
+    expect(snapFiles.length).toBeGreaterThan(0);
+  });
+
+  test("second open after close finds the snapshot and lists it", async () => {
+    const dir = join(root, "reopen");
+    const h1 = await openTestProject(dir);
+    openHandles.splice(openHandles.indexOf(h1), 1);
+    await h1.close();
+
+    const snapsBefore = await listSnapshots(dir);
+    expect(snapsBefore.length).toBeGreaterThan(0);
+
+    // Re-open (healthy path) — should not produce a recovery notice.
+    const h2 = await openProject({ dir });
+    openHandles.push(h2);
+    expect(h2.recovery).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openProject — WAL corruption recovery
+// ---------------------------------------------------------------------------
+
+describe("openProject WAL corruption recovery", () => {
+  let root: string;
+  let openHandles: ProjectHandle[];
+
+  beforeEach(() => {
+    root = tempDir();
+    openHandles = [];
+  });
+
+  afterEach(async () => {
+    await Promise.allSettled(openHandles.map((h) => h.close()));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("corrupted datadir with snapshot → quarantine + restore + notice", async () => {
+    const dir = join(root, "corrupt-with-snap");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // 1. Create a healthy project and write a snapshot.
+    const h1 = await openProject({ dir, name: "BeforeCorruption" });
+    openHandles.splice(0); // Will be closed manually
+    await h1.close(); // writes snapshot
+
+    const snapsBefore = await listSnapshots(dir);
+    expect(snapsBefore.length).toBeGreaterThan(0);
+
+    // 2. Corrupt the datadir by replacing it with garbage.
+    rmSync(dbPath, { recursive: true, force: true });
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME), { recursive: true });
+    // Write garbage into the expected pg_wal directory so PGlite sees corrupt layout.
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"),
+      "THIS IS GARBAGE\n",
+    );
+
+    // 3. Open — should trigger recovery.
+    const h2 = await openProject({ dir });
+    openHandles.push(h2);
+
+    expect(h2.recovery).not.toBeNull();
+    expect(h2.recovery!.reason).toBe("wal-corruption");
+    expect(h2.recovery!.restoredSnapshot).not.toBeNull();
+    expect(h2.recovery!.restoredSnapshot!.absPath).toBe(
+      snapsBefore[snapsBefore.length - 1]!.absPath,
+    );
+
+    // Quarantine path must exist and be outside the live dbPath.
+    expect(h2.recovery!.quarantinedPath).toMatch(/\.damaged-/);
+    expect(existsSync(h2.recovery!.quarantinedPath)).toBe(true);
+
+    // The live project is usable — project_meta is accessible.
+    expect(h2.meta.name).toBe("BeforeCorruption");
+  });
+
+  test("corrupted datadir with NO snapshot → fresh project + notice with null restoredSnapshot", async () => {
+    const dir = join(root, "corrupt-no-snap");
+
+    // Create a corrupt artifacts.db (directory with garbage) without any
+    // prior snapshot.
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+
+    const handle = await openProject({ dir });
+    openHandles.push(handle);
+
+    expect(handle.recovery).not.toBeNull();
+    expect(handle.recovery!.reason).toBe("wal-corruption");
+    expect(handle.recovery!.restoredSnapshot).toBeNull();
+
+    // Fresh project should be openable and seeded correctly.
+    expect(handle.meta.name).toBe(dir.split("/").at(-1));
+  });
+});

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -163,46 +163,25 @@ describe("SnapshotScheduler", () => {
   });
 
   // A fake PGlite whose dumpDataDir records each call (a fired snapshot) and
-  // resolves to a tiny blob. It captures the in-flight writeSnapshot promise so
-  // teardown can await it — otherwise the real fs rename inside writeSnapshot
-  // could race the afterEach rmSync and emit a stray ENOENT. The fire counter
-  // increments synchronously at the start of each snapshot, so `fires()` is
-  // accurate the moment a snapshot is triggered.
-  function fakeClient(): {
-    client: PGlite;
-    fires: () => number;
-    settle: () => Promise<void>;
-  } {
+  // resolves to a tiny blob. The fire counter increments synchronously at the
+  // start of each dump. Tests await `sched.flush()` to drain the scheduler's
+  // serialization chain — which covers both the dump AND the real writeSnapshot
+  // fs work — so no stray fs rename races the afterEach rmSync (ENOENT).
+  function fakeClient(): { client: PGlite; fires: () => number } {
     let count = 0;
-    let inFlight: Promise<unknown> = Promise.resolve();
     const client = {
-      dumpDataDir: () => {
+      dumpDataDir: async () => {
         count += 1;
-        // Defer one microtask so the synchronous fireNow() returns first, then
-        // the fs work runs; capture it so the test can await completion.
-        const p = Promise.resolve(new Blob([Buffer.from("snap")]));
-        inFlight = p;
-        return p;
+        return new Blob([Buffer.from("snap")]);
       },
     } as unknown as PGlite;
-    return {
-      client,
-      fires: () => count,
-      // Await any in-flight snapshot fs work before teardown.
-      settle: async () => {
-        await inFlight;
-        await new Promise((r) => setTimeout(r, 20));
-      },
-    };
+    return { client, fires: () => count };
   }
-
-  // Let the snapshot's dumpDataDir + fs microtasks settle.
-  const flush = () => new Promise((r) => setTimeout(r, 0));
 
   test("N rapid touches within the debounce window fire exactly ONE snapshot", async () => {
     const projectDir = join(root, "debounce-once");
     mkdirSync(projectDir, { recursive: true });
-    const { client, fires, settle } = fakeClient();
+    const { client, fires } = fakeClient();
 
     let now = 0;
     const sched = new SnapshotScheduler(
@@ -220,19 +199,20 @@ describe("SnapshotScheduler", () => {
     }
     expect(fires()).toBe(0); // nothing fired yet — still debouncing
 
-    // Quiet gap → the single debounced timer fires.
+    // Quiet gap lets the single debounced real-timer fire fireNow(); then await
+    // the scheduler's in-flight chain so the chained dump + fs write completed.
     await new Promise((r) => setTimeout(r, 1100));
-    await flush();
+    await sched.flush();
     expect(fires()).toBe(1);
 
     sched.cancel();
-    await settle();
+    await sched.flush();
   });
 
   test("a continuous touch stream still snapshots once max-wait is exceeded (no infinite deferral)", async () => {
     const projectDir = join(root, "maxwait-cap");
     mkdirSync(projectDir, { recursive: true });
-    const { client, fires, settle } = fakeClient();
+    const { client, fires } = fakeClient();
 
     let now = 0;
     const debounceMs = 1000;
@@ -257,9 +237,12 @@ describe("SnapshotScheduler", () => {
     }
 
     // At t=5000 the burst has been pending exactly maxWaitMs → fire now.
+    // Await the scheduler's own in-flight chain (not a bare tick): fireNow now
+    // chains the dump through the serialization tail, so the counter increments
+    // a couple of microtasks later — `sched.flush()` resolves once it has run.
     now = 5000;
     sched.touch();
-    await flush();
+    await sched.flush();
     expect(fires()).toBe(1);
 
     // The burst tracker reset: subsequent fast touches defer again until the
@@ -269,7 +252,7 @@ describe("SnapshotScheduler", () => {
     expect(fires()).toBe(1);
 
     sched.cancel();
-    await settle();
+    await sched.flush();
   });
 
   test("cancel() clears a pending debounced snapshot and resets the burst anchor", async () => {
@@ -290,7 +273,7 @@ describe("SnapshotScheduler", () => {
 
     // The debounce timer was cleared — even after the window elapses, no fire.
     await new Promise((r) => setTimeout(r, 1100));
-    await flush();
+    await sched.flush();
     expect(fires()).toBe(0);
   });
 

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -14,7 +14,7 @@ import {
 import { readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PGlite } from "@electric-sql/pglite";
 
@@ -92,15 +92,15 @@ describe("writeSnapshot + listSnapshots", () => {
 
     const pg = await openFreshPGlite(dbPath);
     try {
-      // Write KEEP_N + 2 snapshots with a small delay so filenames differ.
+      // Write KEEP_N + 2 snapshots with deterministic, distinct timestamps.
+      // We inject a nowMs function so filenames are guaranteed unique without
+      // fake timers — vi.useFakeTimers() breaks PGlite's WASM async I/O.
+      const BASE_MS = new Date(2024, 0, 1).getTime();
       const written: string[] = [];
       for (let i = 0; i < SNAPSHOT_KEEP_N + 2; i++) {
-        // Ensure timestamps differ by manipulating Date (vitest fake timers).
-        vi.setSystemTime(new Date(2024, 0, 1, 0, 0, i));
-        const p = await writeSnapshot(pg, projectDir);
+        const p = await writeSnapshot(pg, projectDir, () => BASE_MS + i * 1000);
         written.push(p);
       }
-      vi.useRealTimers();
 
       const snaps = await listSnapshots(projectDir);
       expect(snaps).toHaveLength(SNAPSHOT_KEEP_N);
@@ -113,7 +113,6 @@ describe("writeSnapshot + listSnapshots", () => {
         expect(existsSync(p)).toBe(false);
       }
     } finally {
-      vi.useRealTimers();
       await pg.close();
     }
   });

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -13,7 +13,7 @@ import {
 } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PGlite } from "@electric-sql/pglite";
@@ -24,12 +24,14 @@ import {
   type ProjectHandle,
 } from "./project";
 import {
+  hasCorruptWalSegment,
   listSnapshots,
   resolveSnapshotsDir,
   SNAPSHOT_EXT,
   SNAPSHOT_KEEP_N,
   SNAPSHOT_PREFIX,
   writeSnapshot,
+  XLOG_BLCKSZ,
 } from "./snapshots";
 
 // ---------------------------------------------------------------------------
@@ -120,6 +122,83 @@ describe("writeSnapshot + listSnapshots", () => {
   test("listSnapshots returns empty array when no snapshots dir exists", async () => {
     const snaps = await listSnapshots(join(root, "nonexistent"));
     expect(snaps).toEqual([]);
+  });
+
+  test("writeSnapshot is atomic: no .tmp- file left on disk after write", async () => {
+    const projectDir = join(root, "atomic");
+    const dbPath = join(projectDir, "artifacts.db");
+    mkdirSync(projectDir, { recursive: true });
+
+    const pg = await openFreshPGlite(dbPath);
+    try {
+      await writeSnapshot(pg, projectDir);
+
+      const snapsDir = resolveSnapshotsDir(projectDir);
+      const files = await readdir(snapsDir);
+      const tmpFiles = files.filter((f) => f.startsWith(".tmp-"));
+      expect(tmpFiles).toHaveLength(0);
+    } finally {
+      await pg.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WAL probe
+// ---------------------------------------------------------------------------
+
+describe("hasCorruptWalSegment", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tempDir();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("returns false for a healthy PGlite datadir", async () => {
+    const dbPath = join(root, "healthy.db");
+    const pg = await openFreshPGlite(dbPath);
+    await pg.close();
+
+    const corrupt = await hasCorruptWalSegment(dbPath);
+    expect(corrupt).toBe(false);
+  });
+
+  test("returns false when pg_wal does not exist", async () => {
+    const corrupt = await hasCorruptWalSegment(join(root, "nonexistent"));
+    expect(corrupt).toBe(false);
+  });
+
+  test("returns true when a WAL segment has a torn size", async () => {
+    const dbPath = join(root, "torn.db");
+    const walDir = join(dbPath, "pg_wal");
+    mkdirSync(walDir, { recursive: true });
+    // Write a 24-hex-char WAL segment file with a non-block-aligned size.
+    const tornSize = XLOG_BLCKSZ - 1; // deliberately not a multiple of 8192
+    writeFileSync(
+      join(walDir, "000000010000000000000001"),
+      Buffer.alloc(tornSize),
+    );
+
+    const corrupt = await hasCorruptWalSegment(dbPath);
+    expect(corrupt).toBe(true);
+  });
+
+  test("returns false when WAL segment is correctly block-aligned", async () => {
+    const dbPath = join(root, "clean.db");
+    const walDir = join(dbPath, "pg_wal");
+    mkdirSync(walDir, { recursive: true });
+    // Write a 24-hex-char WAL segment file with a block-aligned size.
+    writeFileSync(
+      join(walDir, "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ * 128), // 1 MB — canonical PGlite segment size
+    );
+
+    const corrupt = await hasCorruptWalSegment(dbPath);
+    expect(corrupt).toBe(false);
   });
 });
 
@@ -220,6 +299,11 @@ describe("openProject WAL corruption recovery", () => {
       join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"),
       "THIS IS GARBAGE\n",
     );
+    // Write a torn WAL segment (not block-aligned) for affirmative WAL detection.
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ - 1),
+    );
 
     // 3. Open — should trigger recovery.
     const h2 = await openProject({ dir });
@@ -247,6 +331,11 @@ describe("openProject WAL corruption recovery", () => {
     // prior snapshot.
     mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
     writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+    // Torn WAL segment for affirmative detection.
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ - 1),
+    );
 
     const handle = await openProject({ dir });
     openHandles.push(handle);
@@ -256,6 +345,82 @@ describe("openProject WAL corruption recovery", () => {
     expect(handle.recovery!.restoredSnapshot).toBeNull();
 
     // Fresh project should be openable and seeded correctly.
-    expect(handle.meta.name).toBe(dir.split("/").at(-1));
+    // Use path.basename() instead of split("/").at(-1) for cross-platform safety.
+    expect(handle.meta.name).toBe(basename(dir));
+  });
+
+  test("non-WAL RuntimeError does NOT trigger quarantine — data is preserved", async () => {
+    // Verify that the openProject catch path only fires for confirmed WAL
+    // corruption. An unrelated Error (e.g. permissions, schema mismatch) must
+    // bubble up unchanged and must NOT move the datadir aside.
+    const dir = join(root, "non-wal-error");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // Create a valid-looking datadir with a properly-sized WAL segment so
+    // hasCorruptWalSegment returns false. The directory layout is otherwise
+    // garbage (not a real PGlite DB) but the WAL probe must pass.
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    // Block-aligned WAL segment → hasCorruptWalSegment returns false.
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ * 128),
+    );
+    writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+
+    // The open should throw (garbage datadir, no corruption signal).
+    await expect(openProject({ dir })).rejects.toThrow();
+
+    // The original datadir must NOT have been quarantined.
+    expect(existsSync(dbPath)).toBe(true);
+    // No .damaged- quarantine path should have been created.
+    const parentDir = await readdir(dir);
+    const quarantined = parentDir.filter((f) => f.includes(".damaged-"));
+    expect(quarantined).toHaveLength(0);
+  });
+
+  test("restoreNewestSnapshot falls back to older snapshot when newest is missing", async () => {
+    const dir = join(root, "fallback-snap");
+    const dbPath = join(dir, ARTIFACTS_DB_FILENAME);
+
+    // 1. Create a healthy project and write two snapshots.
+    const h1 = await openProject({ dir, name: "FallbackTest" });
+    openHandles.splice(0);
+
+    const BASE_MS = new Date(2024, 0, 1).getTime();
+    // Write first (older) snapshot via the public writeSnapshot.
+    await writeSnapshot(h1.db.$client, dir, () => BASE_MS);
+    // Write second (newer) snapshot.
+    await writeSnapshot(h1.db.$client, dir, () => BASE_MS + 1000);
+    await h1.close(); // writes a third snapshot
+
+    const snaps = await listSnapshots(dir);
+    expect(snaps.length).toBeGreaterThanOrEqual(2);
+
+    // 2. Delete the newest snapshot so fs.readFile throws ENOENT.
+    // NOTE: PGlite silently ignores a corrupt/truncated tarball (it just
+    // creates a fresh DB), so to test the fallback path we need readFile to
+    // throw, which only happens if the file is missing or unreadable.
+    const newest = snaps[snaps.length - 1]!;
+    const secondNewest = snaps[snaps.length - 2]!;
+    rmSync(newest.absPath);
+
+    // 3. Corrupt the datadir with a torn WAL segment so recovery triggers.
+    rmSync(dbPath, { recursive: true, force: true });
+    mkdirSync(join(dir, ARTIFACTS_DB_FILENAME, "pg_wal"), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACTS_DB_FILENAME, "pg_wal", "000000010000000000000001"),
+      Buffer.alloc(XLOG_BLCKSZ - 1),
+    );
+    writeFileSync(join(dir, ARTIFACTS_DB_FILENAME, "PG_VERSION"), "GARBAGE\n");
+
+    // 4. Open should recover using the second-newest snapshot.
+    const h2 = await openProject({ dir });
+    openHandles.push(h2);
+
+    expect(h2.recovery).not.toBeNull();
+    expect(h2.recovery!.restoredSnapshot).not.toBeNull();
+    // Should have fallen back to the second-newest snapshot.
+    expect(h2.recovery!.restoredSnapshot!.absPath).toBe(secondNewest.absPath);
+    expect(h2.meta.name).toBe("FallbackTest");
   });
 });

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -200,13 +200,21 @@ async function pruneSnapshots(snapshotsDir: string): Promise<void> {
 /**
  * Restore the newest snapshot into the given target directory.
  *
- * Attempts snapshots from newest to oldest. If the newest snapshot fails to
- * restore (e.g. the tarball itself is corrupt), the next-oldest is tried, and
- * so on. A partial targetDataDir created by a failed attempt is cleaned up
+ * Attempts snapshots from newest to oldest. A snapshot is ACCEPTED only when it
+ * both loads AND validates — see {@link snapshotLooksRestorable}. This matters
+ * because PGlite does NOT throw on a truncated/corrupt `loadDataDir` blob: it
+ * silently initializes a fresh empty datadir. Without validation,
+ * `restoreNewestSnapshot` would return that empty DB as a "successful" restore,
+ * and `openProject` would seed a brand-new project over the user's data while
+ * reporting recovery succeeded. So after load we positively confirm the
+ * project's singleton `project_meta` row survived; if it did not (empty/corrupt
+ * tarball), we reject this snapshot and fall through to the next-oldest.
+ *
+ * A partial targetDataDir created by a failed or rejected attempt is cleaned up
  * before retrying.
  *
  * Returns the snapshot metadata that was restored, or null if no snapshot
- * exists or all failed (caller should create a fresh project).
+ * exists or none restored to a valid datadir (caller creates a fresh project).
  */
 export async function restoreNewestSnapshot(
   projectDir: string,
@@ -225,7 +233,21 @@ export async function restoreNewestSnapshot(
       await fs.mkdir(targetDataDir, { recursive: true });
       const restored = new PGlite(targetDataDir, { loadDataDir: blob });
       await restored.waitReady;
+      // Validate BEFORE accepting: a truncated/corrupt tarball loads as a fresh
+      // empty datadir (PGlite does not throw), so a successful waitReady is not
+      // proof the data survived. Confirm the project_meta singleton is present.
+      const valid = await snapshotLooksRestorable(restored);
       await restored.close();
+
+      if (!valid) {
+        console.error(
+          `[dashframe] snapshot ${snap.filename} restored to an empty/invalid datadir (missing project_meta); trying older snapshot`,
+        );
+        await fs
+          .rm(targetDataDir, { recursive: true, force: true })
+          .catch(() => {});
+        continue;
+      }
 
       return snap;
     } catch (err) {
@@ -240,8 +262,31 @@ export async function restoreNewestSnapshot(
     }
   }
 
-  // All snapshots failed.
+  // No snapshot restored to a valid datadir.
   return null;
+}
+
+/**
+ * Confirm a freshly-restored PGlite datadir actually carries project data —
+ * the singleton `project_meta` row. PGlite silently creates a fresh empty
+ * datadir when `loadDataDir` is given a truncated/corrupt blob, so this is the
+ * positive check that distinguishes a real restore from a phantom one.
+ *
+ * Returns false on any failure (missing table, query error, zero rows) — i.e.
+ * fail closed: an unverifiable restore is treated as not-restorable so the
+ * caller falls back rather than seeding over live data with an empty DB.
+ */
+async function snapshotLooksRestorable(client: PGlite): Promise<boolean> {
+  try {
+    const res = await client.query<{ count: number }>(
+      "SELECT COUNT(*)::int AS count FROM project_meta",
+    );
+    const count = res.rows[0]?.count ?? 0;
+    return count > 0;
+  } catch {
+    // Table missing or query failed → not a valid project datadir.
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -23,6 +23,23 @@ import path from "node:path";
 
 import { PGlite } from "@electric-sql/pglite";
 
+/**
+ * WAL block size used by PGlite's embedded Postgres. Every WAL page (and
+ * therefore every WAL file) must be a multiple of this value; a file whose
+ * byte count is not a multiple indicates a torn write and therefore WAL
+ * corruption.
+ *
+ * PGlite ships with a 1 MB WAL segment size (128 × XLOG_BLCKSZ) rather than
+ * the standard 16 MB, but the page granularity is the same.
+ */
+export const XLOG_BLCKSZ = 8192;
+
+/**
+ * Pattern that matches a standard PostgreSQL WAL segment filename (24 hex
+ * characters, no extension). These live under <dataDir>/pg_wal/.
+ */
+const WAL_SEGMENT_FILENAME_RE = /^[0-9A-F]{24}$/i;
+
 export const SNAPSHOTS_DIRNAME = "snapshots";
 export const SNAPSHOT_PREFIX = "snap-";
 export const SNAPSHOT_EXT = ".tar.gz";
@@ -44,7 +61,46 @@ export function resolveSnapshotsDir(projectDir: string): string {
 }
 
 /**
+ * Probe the WAL directory of a PGlite datadir for structurally corrupt
+ * (torn/truncated) segments.
+ *
+ * Returns true when the datadir exists, has a `pg_wal/` subdirectory, and at
+ * least one WAL segment file has a byte length that is not a multiple of
+ * XLOG_BLCKSZ. A healthy database may also have no WAL files yet (right after
+ * initdb), so an empty pg_wal is not considered corrupt.
+ *
+ * This is the PRIMARY affirmative-detection signal for WAL corruption. It runs
+ * BEFORE attempting to open PGlite so the caller can distinguish corruption
+ * from completely unrelated startup failures.
+ */
+export async function hasCorruptWalSegment(dataDir: string): Promise<boolean> {
+  const walDir = path.join(dataDir, "pg_wal");
+  let entries: string[];
+  try {
+    entries = await fs.readdir(walDir);
+  } catch {
+    // pg_wal doesn't exist → can't be WAL corruption; fresh DB or wrong path.
+    return false;
+  }
+
+  const segmentFiles = entries.filter((f) => WAL_SEGMENT_FILENAME_RE.test(f));
+  if (segmentFiles.length === 0) return false;
+
+  for (const seg of segmentFiles) {
+    const stat = await fs.stat(path.join(walDir, seg)).catch(() => null);
+    if (stat && stat.size % XLOG_BLCKSZ !== 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Write a snapshot of the current datadir to disk.
+ *
+ * The write is atomic: the tarball is first flushed to a temporary file in the
+ * same directory, then renamed over the destination. A crash mid-write cannot
+ * leave a partial .tar.gz visible to restoreNewestSnapshot.
  *
  * The caller MUST only call this on a healthy, fully-open PGlite instance.
  * Returns the absolute path of the written snapshot file.
@@ -61,10 +117,20 @@ export async function writeSnapshot(
   const timestamp = new Date(nowMs()).toISOString().replace(/[:.]/g, "-");
   const filename = `${SNAPSHOT_PREFIX}${timestamp}${SNAPSHOT_EXT}`;
   const destPath = path.join(snapshotsDir, filename);
+  const tempPath = path.join(snapshotsDir, `.tmp-${filename}`);
 
   const blob = await pgliteClient.dumpDataDir("gzip");
   const buffer = Buffer.from(await blob.arrayBuffer());
-  await fs.writeFile(destPath, buffer);
+
+  // Write to a temp file first; rename to final path atomically.
+  try {
+    await fs.writeFile(tempPath, buffer);
+    await fs.rename(tempPath, destPath);
+  } catch (err) {
+    // Clean up temp file on any error so it doesn't accumulate.
+    await fs.unlink(tempPath).catch(() => {});
+    throw err;
+  }
 
   await pruneSnapshots(snapshotsDir);
   return destPath;
@@ -72,6 +138,9 @@ export async function writeSnapshot(
 
 /**
  * List all snapshots for a project, sorted oldest-first.
+ *
+ * Returns an empty array only when the snapshots directory does not exist yet
+ * (ENOENT). All other readdir failures are propagated as thrown errors.
  */
 export async function listSnapshots(
   projectDir: string,
@@ -80,8 +149,11 @@ export async function listSnapshots(
   let entries: string[];
   try {
     entries = await fs.readdir(snapshotsDir);
-  } catch {
-    return [];
+  } catch (err) {
+    // Only swallow "directory doesn't exist yet"; propagate all other errors
+    // (permission denied, I/O error, …) so callers know something is wrong.
+    if (isEnoent(err)) return [];
+    throw err;
   }
 
   const snaps: SnapshotMeta[] = entries
@@ -128,12 +200,13 @@ async function pruneSnapshots(snapshotsDir: string): Promise<void> {
 /**
  * Restore the newest snapshot into the given target directory.
  *
- * Opens a temporary PGlite instance with `loadDataDir` (a constructor option
- * that imports a previously dumped tarball) pointing to `targetDataDir`, then
- * closes it so the datadir is materialized on disk.
+ * Attempts snapshots from newest to oldest. If the newest snapshot fails to
+ * restore (e.g. the tarball itself is corrupt), the next-oldest is tried, and
+ * so on. A partial targetDataDir created by a failed attempt is cleaned up
+ * before retrying.
  *
  * Returns the snapshot metadata that was restored, or null if no snapshot
- * exists (caller should create a fresh project).
+ * exists or all failed (caller should create a fresh project).
  */
 export async function restoreNewestSnapshot(
   projectDir: string,
@@ -142,16 +215,45 @@ export async function restoreNewestSnapshot(
   const snaps = await listSnapshots(projectDir);
   if (snaps.length === 0) return null;
 
-  const newest = snaps[snaps.length - 1]!;
-  const rawBuffer = await fs.readFile(newest.absPath);
-  const blob = new Blob([rawBuffer]);
+  // Iterate newest-first.
+  for (let i = snaps.length - 1; i >= 0; i--) {
+    const snap = snaps[i]!;
+    try {
+      const rawBuffer = await fs.readFile(snap.absPath);
+      const blob = new Blob([rawBuffer]);
 
-  await fs.mkdir(targetDataDir, { recursive: true });
-  const restored = new PGlite(targetDataDir, { loadDataDir: blob });
-  await restored.waitReady;
-  await restored.close();
+      await fs.mkdir(targetDataDir, { recursive: true });
+      const restored = new PGlite(targetDataDir, { loadDataDir: blob });
+      await restored.waitReady;
+      await restored.close();
 
-  return newest;
+      return snap;
+    } catch (err) {
+      console.error(
+        `[dashframe] snapshot restore failed for ${snap.filename}:`,
+        err,
+      );
+      // Clean up any partial targetDataDir before trying the next snapshot.
+      await fs
+        .rm(targetDataDir, { recursive: true, force: true })
+        .catch(() => {});
+    }
+  }
+
+  // All snapshots failed.
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isEnoent(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "ENOENT"
+  );
 }
 
 /**

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -52,11 +52,13 @@ export function resolveSnapshotsDir(projectDir: string): string {
 export async function writeSnapshot(
   pgliteClient: PGlite,
   projectDir: string,
+  /** Injected for testing — returns the timestamp to embed in the filename. */
+  nowMs: () => number = Date.now,
 ): Promise<string> {
   const snapshotsDir = resolveSnapshotsDir(projectDir);
   await fs.mkdir(snapshotsDir, { recursive: true });
 
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const timestamp = new Date(nowMs()).toISOString().replace(/[:.]/g, "-");
   const filename = `${SNAPSHOT_PREFIX}${timestamp}${SNAPSHOT_EXT}`;
   const destPath = path.join(snapshotsDir, filename);
 

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -48,6 +48,17 @@ export const SNAPSHOT_KEEP_N = 3;
 /** Milliseconds of inactivity after a write before a debounced snapshot fires. */
 export const SNAPSHOT_DEBOUNCE_MS = 30_000;
 
+/**
+ * Maximum milliseconds a snapshot may be deferred by a continuous write stream.
+ * The pure debounce resets on every write, so a session that writes faster than
+ * SNAPSHOT_DEBOUNCE_MS would NEVER snapshot until it goes quiet — an unclean
+ * shutdown mid-burst would then fall back to the last clean-close snapshot and
+ * lose the whole active session. This cap forces a snapshot once writes have
+ * been pending this long, so a long burst still produces periodic snapshots and
+ * the crash window stays bounded. Default 5 min (10× the debounce).
+ */
+export const SNAPSHOT_MAX_WAIT_MS = 300_000;
+
 export interface SnapshotMeta {
   filename: string;
   absPath: string;
@@ -302,7 +313,18 @@ function isEnoent(err: unknown): boolean {
 }
 
 /**
- * Manages the debounced post-write snapshot schedule.
+ * Manages the debounced post-write snapshot schedule, with a max-wait cap so a
+ * sustained write stream still produces periodic snapshots.
+ *
+ * Debounce: each `touch()` resets a `debounceMs` timer, so a quiet gap after a
+ * burst triggers one snapshot rather than one-per-write.
+ *
+ * Max-wait: a pure debounce would never fire while writes keep arriving faster
+ * than `debounceMs`. So the scheduler also remembers when the FIRST
+ * un-snapshotted write of the current burst arrived; once writes have been
+ * pending `maxWaitMs`, the next `touch()` snapshots immediately instead of
+ * deferring again. This bounds the crash window during a long active session
+ * (import/autosave) to at most `maxWaitMs`, not "until the session goes quiet".
  *
  * Usage:
  *   const scheduler = new SnapshotScheduler(pgliteClient, projectDir);
@@ -312,24 +334,54 @@ function isEnoent(err: unknown): boolean {
 export class SnapshotScheduler {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private readonly debounceMs: number;
+  private readonly maxWaitMs: number;
+  /**
+   * Timestamp (ms) of the first write since the last snapshot/cancel — the
+   * anchor the max-wait is measured from. null when no write is pending.
+   */
+  private firstPendingAt: number | null = null;
 
   constructor(
     private readonly pgliteClient: PGlite,
     private readonly projectDir: string,
     debounceMs: number = SNAPSHOT_DEBOUNCE_MS,
+    maxWaitMs: number = SNAPSHOT_MAX_WAIT_MS,
+    /** Injected for tests; the clock the max-wait is measured against. */
+    private readonly nowMs: () => number = Date.now,
   ) {
     this.debounceMs = debounceMs;
+    // The cap must be at least the debounce, otherwise it would fire before a
+    // normal quiet-gap debounce ever could. Clamp defensively.
+    this.maxWaitMs = Math.max(maxWaitMs, debounceMs);
   }
 
   /** Notify the scheduler that a write just happened. */
   touch(): void {
+    const now = this.nowMs();
+    if (this.firstPendingAt === null) this.firstPendingAt = now;
+
+    // Max-wait reached: writes have been pending at least maxWaitMs and the
+    // debounce keeps resetting. Snapshot now instead of deferring again, so a
+    // continuous burst still produces periodic snapshots.
+    if (now - this.firstPendingAt >= this.maxWaitMs) {
+      this.fireNow();
+      return;
+    }
+
     if (this.timer !== null) clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
+    this.timer = setTimeout(() => this.fireNow(), this.debounceMs);
+  }
+
+  /** Write a snapshot now and reset the pending-burst tracking. */
+  private fireNow(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
       this.timer = null;
-      writeSnapshot(this.pgliteClient, this.projectDir).catch((err) => {
-        console.error("[dashframe] debounced snapshot failed:", err);
-      });
-    }, this.debounceMs);
+    }
+    this.firstPendingAt = null;
+    writeSnapshot(this.pgliteClient, this.projectDir).catch((err) => {
+      console.error("[dashframe] debounced snapshot failed:", err);
+    });
   }
 
   /** Cancel any pending debounced snapshot (call before close). */
@@ -338,5 +390,6 @@ export class SnapshotScheduler {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    this.firstPendingAt = null;
   }
 }

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -1,0 +1,193 @@
+/**
+ * PGlite snapshot layer for DashFrame projects.
+ *
+ * Rotating snapshots guard against unrecoverable WAL corruption caused by
+ * unclean shutdown (RuntimeError: Aborted() from Emscripten during WAL
+ * replay). See GitHub issue #88.
+ *
+ * Layout under <projectDir>/snapshots/:
+ *   snap-<ISO-timestamp>.tar.gz   — gzipped PGlite datadir tarballs
+ *
+ * N=3 snapshots are kept; the oldest is pruned after each write.
+ * Snapshots are written:
+ *   - on clean project close (via writeSnapshot)
+ *   - debounced after write bursts (the caller drives the debounce via
+ *     SnapshotScheduler)
+ *
+ * Snapshots are NEVER written to a damaged handle — callers must only call
+ * writeSnapshot on a healthy, open PGlite client.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { PGlite } from "@electric-sql/pglite";
+
+export const SNAPSHOTS_DIRNAME = "snapshots";
+export const SNAPSHOT_PREFIX = "snap-";
+export const SNAPSHOT_EXT = ".tar.gz";
+export const SNAPSHOT_KEEP_N = 3;
+
+/** Milliseconds of inactivity after a write before a debounced snapshot fires. */
+export const SNAPSHOT_DEBOUNCE_MS = 30_000;
+
+export interface SnapshotMeta {
+  filename: string;
+  absPath: string;
+  /** Human-readable ISO timestamp decoded from the filename. */
+  timestamp: string;
+}
+
+/** Resolve the snapshots directory for a project dir. */
+export function resolveSnapshotsDir(projectDir: string): string {
+  return path.join(projectDir, SNAPSHOTS_DIRNAME);
+}
+
+/**
+ * Write a snapshot of the current datadir to disk.
+ *
+ * The caller MUST only call this on a healthy, fully-open PGlite instance.
+ * Returns the absolute path of the written snapshot file.
+ */
+export async function writeSnapshot(
+  pgliteClient: PGlite,
+  projectDir: string,
+): Promise<string> {
+  const snapshotsDir = resolveSnapshotsDir(projectDir);
+  await fs.mkdir(snapshotsDir, { recursive: true });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${SNAPSHOT_PREFIX}${timestamp}${SNAPSHOT_EXT}`;
+  const destPath = path.join(snapshotsDir, filename);
+
+  const blob = await pgliteClient.dumpDataDir("gzip");
+  const buffer = Buffer.from(await blob.arrayBuffer());
+  await fs.writeFile(destPath, buffer);
+
+  await pruneSnapshots(snapshotsDir);
+  return destPath;
+}
+
+/**
+ * List all snapshots for a project, sorted oldest-first.
+ */
+export async function listSnapshots(
+  projectDir: string,
+): Promise<SnapshotMeta[]> {
+  const snapshotsDir = resolveSnapshotsDir(projectDir);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(snapshotsDir);
+  } catch {
+    return [];
+  }
+
+  const snaps: SnapshotMeta[] = entries
+    .filter((f) => f.startsWith(SNAPSHOT_PREFIX) && f.endsWith(SNAPSHOT_EXT))
+    .map((f) => ({
+      filename: f,
+      absPath: path.join(snapshotsDir, f),
+      // Decode the filename timestamp back to an ISO string.
+      // Encoding replaces ":" and "." with "-"; we reverse the last three
+      // substitutions in the time part (HH-mm-ss-mmmZ → HH:mm:ss.mmmZ).
+      timestamp: f
+        .slice(SNAPSHOT_PREFIX.length, -SNAPSHOT_EXT.length)
+        .replace(
+          /^(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+          "$1:$2:$3.$4Z",
+        ),
+    }))
+    .sort((a, b) => a.filename.localeCompare(b.filename));
+
+  return snaps;
+}
+
+/**
+ * Prune snapshots, keeping only the N most recent.
+ */
+async function pruneSnapshots(snapshotsDir: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(snapshotsDir);
+  } catch {
+    return;
+  }
+
+  const snaps = entries
+    .filter((f) => f.startsWith(SNAPSHOT_PREFIX) && f.endsWith(SNAPSHOT_EXT))
+    .sort(); // lexicographic = chronological given ISO timestamp prefix
+
+  const toDelete = snaps.slice(0, Math.max(0, snaps.length - SNAPSHOT_KEEP_N));
+  await Promise.all(
+    toDelete.map((f) => fs.unlink(path.join(snapshotsDir, f)).catch(() => {})),
+  );
+}
+
+/**
+ * Restore the newest snapshot into the given target directory.
+ *
+ * Opens a temporary PGlite instance with `loadDataDir` (a constructor option
+ * that imports a previously dumped tarball) pointing to `targetDataDir`, then
+ * closes it so the datadir is materialized on disk.
+ *
+ * Returns the snapshot metadata that was restored, or null if no snapshot
+ * exists (caller should create a fresh project).
+ */
+export async function restoreNewestSnapshot(
+  projectDir: string,
+  targetDataDir: string,
+): Promise<SnapshotMeta | null> {
+  const snaps = await listSnapshots(projectDir);
+  if (snaps.length === 0) return null;
+
+  const newest = snaps[snaps.length - 1]!;
+  const rawBuffer = await fs.readFile(newest.absPath);
+  const blob = new Blob([rawBuffer]);
+
+  await fs.mkdir(targetDataDir, { recursive: true });
+  const restored = new PGlite(targetDataDir, { loadDataDir: blob });
+  await restored.waitReady;
+  await restored.close();
+
+  return newest;
+}
+
+/**
+ * Manages the debounced post-write snapshot schedule.
+ *
+ * Usage:
+ *   const scheduler = new SnapshotScheduler(pgliteClient, projectDir);
+ *   scheduler.touch();   // call after any write; schedules/resets the timer
+ *   scheduler.cancel();  // call on close (before writing the final snapshot)
+ */
+export class SnapshotScheduler {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly debounceMs: number;
+
+  constructor(
+    private readonly pgliteClient: PGlite,
+    private readonly projectDir: string,
+    debounceMs: number = SNAPSHOT_DEBOUNCE_MS,
+  ) {
+    this.debounceMs = debounceMs;
+  }
+
+  /** Notify the scheduler that a write just happened. */
+  touch(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      writeSnapshot(this.pgliteClient, this.projectDir).catch((err) => {
+        console.error("[dashframe] debounced snapshot failed:", err);
+      });
+    }, this.debounceMs);
+  }
+
+  /** Cancel any pending debounced snapshot (call before close). */
+  cancel(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -340,6 +340,17 @@ export class SnapshotScheduler {
    * anchor the max-wait is measured from. null when no write is pending.
    */
   private firstPendingAt: number | null = null;
+  /**
+   * Serializes snapshot writes. `writeSnapshot` reads the live PGlite client
+   * (dumpDataDir) and writes a temp file + rename, all async. Two overlapping
+   * writes would race the same client and the same temp/destination paths — and
+   * worse, `ProjectHandle.close()` could start its final snapshot (and close the
+   * client) while a debounced/max-wait dump is still mid-flight, turning the
+   * clean-close snapshot into a logged failure. Every snapshot chains onto this
+   * tail so they run strictly one-at-a-time; `flush()` lets `close()` await the
+   * in-flight write before its own.
+   */
+  private inFlight: Promise<unknown> = Promise.resolve();
 
   constructor(
     private readonly pgliteClient: PGlite,
@@ -379,9 +390,25 @@ export class SnapshotScheduler {
       this.timer = null;
     }
     this.firstPendingAt = null;
-    writeSnapshot(this.pgliteClient, this.projectDir).catch((err) => {
-      console.error("[dashframe] debounced snapshot failed:", err);
-    });
+    // Chain onto the in-flight tail so writes never overlap on the shared
+    // client. A failed write is logged and swallowed so it doesn't poison the
+    // chain for the next snapshot.
+    this.inFlight = this.inFlight
+      .catch(() => {})
+      .then(() =>
+        writeSnapshot(this.pgliteClient, this.projectDir).catch((err) => {
+          console.error("[dashframe] debounced snapshot failed:", err);
+        }),
+      );
+  }
+
+  /**
+   * Await any in-flight snapshot write. `ProjectHandle.close()` calls this
+   * before its own final `writeSnapshot` so the final dump never overlaps (or
+   * outlives, into a closed client) a debounced/max-wait dump still in flight.
+   */
+  async flush(): Promise<void> {
+    await this.inFlight.catch(() => {});
   }
 
   /** Cancel any pending debounced snapshot (call before close). */

--- a/packages/server-core/vitest.config.ts
+++ b/packages/server-core/vitest.config.ts
@@ -4,7 +4,13 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    testTimeout: 30_000,
+    // These suites are PGlite(WASM)-bound integration tests: snapshot
+    // dump/restore and WAL-recovery each spin up real Postgres-in-WASM. On a
+    // loaded CI runner a single dumpDataDir can take many seconds, and the
+    // recovery tests open multiple instances serially. 30s was too tight there
+    // (the prune test, ~2.5s locally, timed out under CI contention). 60s
+    // tolerates a slow runner without masking a genuine hang.
+    testTimeout: 60_000,
     include: ["**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## What

Adds a rotating snapshot layer and WAL-corruption recovery path to `@dashframe/server-core`, plus a user-facing recovery dialog in the desktop host.

### Snapshot layer (`snapshots.ts`)

- `writeSnapshot(pgliteClient, projectDir)` — calls `dumpDataDir("gzip")` on a healthy open handle and writes a gzipped tarball to `<project>/snapshots/snap-<timestamp>.tar.gz`. Prunes to keep the N=3 most recent after each write.
- `listSnapshots(projectDir)` — returns all snapshots sorted oldest-first.
- `SnapshotScheduler` — debounced timer (default 30 s) that fires `writeSnapshot` after write bursts. The `ProjectHandle` exposes `touchSnapshot()` for callers to notify after mutations.
- A final snapshot is written on every clean `close()`.

### Recovery path in `openProject()`

1. `openArtifactDb` is called normally. If it throws a `RuntimeError` (the class Emscripten/WASM uses for all abort traps — `"Aborted()"` in debug builds, `"unreachable"` in release), WAL corruption is assumed and recovery begins.
2. Damaged `artifacts.db` is renamed to `artifacts.db.damaged-<timestamp>` (quarantined).
3. Newest snapshot is restored via `loadDataDir` (a PGlite constructor option that imports a previously dumped tarball) into a fresh `artifacts.db`.
4. If no snapshot exists, a fresh empty project is created.
5. The returned `ProjectHandle` carries a `recovery: ProjectRecoveryNotice | null` field the host can inspect.

### Desktop host (`apps/desktop/src/main.ts`)

Shows a `showMessageBoxSync` dialog on recovery — snapshot timestamp, data-loss scope, quarantine path. No raw Emscripten/WASM text is ever shown to the user.

## Upstream investigation (PGlite 0.3.16 → 0.5.2)

- No WAL-durability, fsync, or NODEFS crash-safety fix shipped in any release between 0.3.16 and 0.5.2 (confirmed via GitHub releases page).
- PR #994 ("Recover PGlite data dirs with corrupt WAL") was the only upstream attempt; it was closed on 2026-05-25 — collaborators wanted it as a standalone tool, not an in-process retry.
- The WAL-replay `RuntimeError` is reproducible: writing a garbage `PG_VERSION` + `pg_wal/` structure causes `RuntimeError: unreachable` (release WASM trap), while debug builds produce `RuntimeError: Aborted()`. Both forms are caught by the same `err.constructor.name === "RuntimeError"` check.
- Bumping PGlite is not warranted for this fix; the snapshot layer is the correct defense regardless of upstream version.

## Test coverage

`packages/server-core/src/snapshots.test.ts` — 9 new tests across 3 describe blocks:

- **writeSnapshot + listSnapshots**: snapshot file created, listed, and rotated (KEEP_N=3 enforced by pruning).
- **openProject snapshot on close**: clean close writes a snapshot; re-open on healthy datadir returns `recovery: null`.
- **openProject WAL corruption recovery**: real PGlite corruption (garbage `PG_VERSION`) → quarantine + restore + `recovery` notice with correct snapshot ref; no-snapshot path → fresh project + `recovery.restoredSnapshot === null`.

All 40 tests pass (`4 test files`).

## Files changed

- `packages/server-core/src/snapshots.ts` — new snapshot layer
- `packages/server-core/src/snapshots.test.ts` — new tests
- `packages/server-core/src/project.ts` — recovery path, `ProjectHandle.recovery`, `touchSnapshot`, snapshot-on-close
- `packages/server-core/src/index.ts` — export new types + snapshot utilities
- `apps/desktop/src/main.ts` — recovery dialog

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a rotating PGlite snapshot layer and WAL-corruption recovery path to `@dashframe/server-core`, wiring it into both the desktop Electron host and the headless CLI server. Recovery triggers exclusively on positive, file-level evidence of a torn WAL segment (non-block-aligned `pg_wal/` file), ensuring OOM aborts and other non-corruption failures never quarantine a healthy database.

- **`snapshots.ts`**: new `writeSnapshot` (atomic temp→rename), `listSnapshots`, pruning to KEEP_N=3, `hasCorruptWalSegment` probe, `restoreNewestSnapshot` with validation to reject silent empty-DB loads from corrupt tarballs, and `SnapshotScheduler` with debounce + max-wait cap and a serialized `inFlight` chain preventing concurrent PGlite dumps.
- **`project.ts`**: torn-WAL-only recovery gate via `isConfirmedWalCorruption`, quarantine-path surfaced in both failure branches, `SnapshotScheduler` integration, and close-time snapshot with cancel→flush→write→close ordering.
- **Tests**: 9 new snapshot/recovery tests and 6 new `onWrite` hook contract tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The recovery gate keys exclusively on a torn WAL segment probe, so healthy databases are never quarantined; all three issues from the previous review round have been fully addressed with tests pinning each fix.

All previously identified issues — quarantine-path surfacing on restore failure, OOM false-positive recovery, and partial-datadir cleanup on failed restore — are fixed and each regression is pinned by a dedicated test. The new snapshot layer uses atomic writes, validated restores, and a serialized scheduler. No new defects found.

No files require special attention. The core logic in project.ts and snapshots.ts is well-tested end-to-end.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server-core/src/snapshots.ts | New snapshot layer: atomic write-temp-then-rename, KEEP_N=3 pruning, WAL-segment probe, restore-with-validation loop, and SnapshotScheduler with debounce+max-wait cap and serialized inFlight chain. |
| packages/server-core/src/project.ts | Adds torn-WAL-only recovery gate, quarantine+restore path with quarantine-path surfaced in both failure branches, SnapshotScheduler integration, and close-time snapshot with proper cancel+flush ordering. |
| packages/server-core/src/snapshots.test.ts | 9 tests covering snapshot write/list/prune, SnapshotScheduler debounce and max-wait, WAL probe, and recovery paths including OOM-intact-datadir regression, fallback-to-older-snapshot, and garbage-tarball-rejection. |
| apps/desktop/src/main.ts | Adds recovery dialog with snapshot timestamp and quarantine path, and wires onWrite to touchSnapshot to drive the debounced scheduler. |
| apps/server/src/app.ts | Adds optional onWrite hook via a thin WyStackApp wrapper; errors from the hook are caught and logged so a failing scheduler never propagates to the client. |
| apps/server/src/app.test.ts | Adds 6 onWrite contract tests: fires-once, N-mutations→N-calls, no-fire on failure, no-fire on reads, backward-compat, and hook-throw isolation. |
| apps/server/src/index.ts | Headless serve path logs WAL recovery notices and wires onWrite for crash-durability parity with the desktop host. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[openProject called] --> B[openDb]
    B -->|success| C[ensureProjectMeta]
    B -->|throws| D{isConfirmedWalCorruption}
    D -->|false| E[re-throw original error]
    D -->|true: torn WAL segment| F[quarantineDamagedDb]
    F -->|rename error| H[throw with quarantine path in message]
    F --> I[restoreNewestSnapshot newest to oldest]
    I --> J{snapshot found?}
    J -->|yes| K[snapshotLooksRestorable validation]
    K -->|invalid| L[rm partial dir, try older]
    K -->|valid| M[return SnapshotMeta]
    J -->|none valid| N[return null - fresh DB]
    M --> O[openArtifactDb]
    N --> O
    O --> C
    C -->|throws + recovery active| Q[throw with quarantine path]
    C -->|success| S[SnapshotScheduler + ProjectHandle with recovery notice]
```
</details>

<sub>Reviews (10): Last reviewed commit: ["test(server-core): await scheduler.flush..."](https://github.com/youhaowei/dashframe/commit/8db6e20a3f98741eda2df15f9e7457e0be1afef1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37264298)</sub>

<!-- /greptile_comment -->