### PR TITLE
feat(server): PreviewDiff consent surface — node names + partial-failure representation [YW-165]

### DIFF
--- a/apps/server/src/functions/preview-diff.test.ts
+++ b/apps/server/src/functions/preview-diff.test.ts
@@ -1487,4 +1487,90 @@ describe("PreviewDiff builder", () => {
       expect(diff.error).toBeUndefined();
     });
   });
+
+  // --------------------------------------------------------------------------
+  // Additional tests for fixes landed in the review pass (#65)
+  // --------------------------------------------------------------------------
+
+  describe("create-then-rename — final name shown on the consent surface", () => {
+    it("node.name reflects the rename, not the creation name", async () => {
+      // A fresh id minted by CreateDataSource then immediately renamed in the same
+      // batch. The consent surface must show the rename — "RenamedDS", not "Fresh".
+      const freshId = id();
+      const diff = await preview(
+        cmd("CreateDataSource", { id: freshId, type: "csv", name: "Fresh" }),
+        cmd("RenameNode", { id: freshId, name: "RenamedDS" }),
+      );
+
+      const node = diff.directNodes.find((n) => n.nodeId === freshId);
+      expect(node).toBeDefined();
+      expect(node!.change).toBe("create");
+      // The rename overrides the creation name — final name must be "RenamedDS".
+      expect(node!.name).toBe("RenamedDS");
+      // proposedDefinition carries the merged rename too.
+      expect(node!.proposedDefinition).toMatchObject({ name: "RenamedDS" });
+    });
+
+    it("existing-node multi-command: name reflects the rename when RenameNode follows another update", async () => {
+      // When a canonical node is updated by one command then renamed by a later one
+      // in the same batch, node.name must reflect the final rename (the foldCommand
+      // path updates it). The before-slice name ("OldName") is only the seed;
+      // a subsequent RenameNode that goes through foldCommand overwrites it.
+      const sourceId = await seedSource({ name: "OldName" });
+      const diff = await preview(
+        cmd("SetDataSourceConfig", { id: sourceId, apiKey: "k" }),
+        cmd("RenameNode", { id: sourceId, name: "NewName" }),
+      );
+
+      const node = diff.directNodes.find((n) => n.nodeId === sourceId);
+      expect(node).toBeDefined();
+      expect(node!.change).toBe("update");
+      // The rename (second command, via foldCommand) must supersede the seed name.
+      expect(node!.name).toBe("NewName");
+      expect(node!.proposedDefinition).toMatchObject({ name: "NewName" });
+    });
+  });
+
+  describe("no-rethrow contract — partial failure always resolves", () => {
+    it("buildPreviewDiff never throws: always resolves with a renderable diff + error slot", async () => {
+      // P1 guard: the promise must resolve regardless of the failure mode.
+      // A single-command failure (failureIndex=0) is the sharpest test: prefixBatch
+      // is empty so the guarded prefix re-run is skipped entirely, and the function
+      // must still return a well-formed PreviewDiff.
+      const nonExistentId = id();
+      const diffPromise = buildPreviewDiff(app, db, [
+        cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
+      ]);
+
+      // The contract: always resolves (never rejects).
+      await expect(diffPromise).resolves.toBeDefined();
+      const diff = await diffPromise;
+      expect(diff.mode).toBe("preview");
+      expect(diff.error).toBeDefined();
+      expect(diff.error!.commandIndex).toBe(0);
+      expect(diff.directNodes).toEqual([]);
+    });
+  });
+
+  describe("probe message accuracy — error.message comes from the probe, not the full-batch run", () => {
+    it("error.message and commandIndex describe the same failure (both from the probe of the failing command)", async () => {
+      // P2 fix: the message must be sourced from the probe that confirmed
+      // failureIndex=1, not from the full-batch run. We assert that the slot is
+      // coherent: commandIndex points to the failing command AND message is non-empty.
+      const nonExistentId = id();
+      const diff = await buildPreviewDiff(app, db, [
+        cmd("CreateDataSource", { id: id(), type: "csv", name: "OK" }),
+        cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
+      ]);
+
+      expect(diff.error).toBeDefined();
+      expect(diff.error!.commandIndex).toBe(1);
+      // The message is from the probe of command 1 — non-empty, type string.
+      expect(typeof diff.error!.message).toBe("string");
+      expect(diff.error!.message.length).toBeGreaterThan(0);
+      // The pre-failure node (command 0) is still present.
+      expect(diff.directNodes).toHaveLength(1);
+      expect(diff.directNodes[0]!.change).toBe("create");
+    });
+  });
 });

--- a/apps/server/src/functions/preview-diff.test.ts
+++ b/apps/server/src/functions/preview-diff.test.ts
@@ -954,10 +954,12 @@ describe("PreviewDiff builder", () => {
       );
 
       expect(diff.affectedDownstream.length).toBeGreaterThan(0);
-      // Each downstream entry is a flag, not a payload — assert the exact key set.
+      // Each downstream entry is a flag + name, not a row payload — assert the
+      // exact key set. `name` is the human-readable artifact name for the
+      // consent surface (see #65); it is metadata, not row data.
       for (const node of diff.affectedDownstream) {
         expect(Object.keys(node).sort()).toEqual(
-          ["edge", "flag", "kind", "nodeId", "via"].sort(),
+          ["edge", "flag", "kind", "name", "nodeId", "via"].sort(),
         );
       }
     });
@@ -1334,6 +1336,155 @@ describe("PreviewDiff builder", () => {
       expect(diff2.affectedDownstream).toEqual(diff1.affectedDownstream);
       expect(diff2.tablesWritten).toEqual(diff1.tablesWritten);
       expect(diff2.mode).toBe(diff1.mode);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Node names — human-readable names on the consent surface (#65)
+  // --------------------------------------------------------------------------
+
+  describe("node names — human-readable on the consent surface", () => {
+    it("direct create node carries the proposed name from args", async () => {
+      const sourceId = id();
+      const diff = await preview(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "My Data" }),
+      );
+
+      const node = diff.directNodes[0]!;
+      expect(node.change).toBe("create");
+      // For a create, the name comes from args (no canonical row exists).
+      expect(node.name).toBe("My Data");
+    });
+
+    it("direct update node carries the canonical name from before-slice", async () => {
+      const sourceId = await seedSource({ name: "Canonical Name" });
+      const diff = await preview(
+        cmd("SetDataSourceConfig", { id: sourceId, apiKey: "k" }),
+      );
+
+      const node = diff.directNodes[0]!;
+      expect(node.change).toBe("update");
+      // For an update the name is the pre-batch canonical name, not the args.
+      expect(node.name).toBe("Canonical Name");
+    });
+
+    it("direct noop node carries the canonical name", async () => {
+      const sourceId = await seedSource({ name: "Existing" });
+      const diff = await preview(
+        cmd("GetOrCreateDataSource", { id: sourceId, type: "csv", name: "X" }),
+      );
+
+      const node = diff.directNodes[0]!;
+      expect(node.change).toBe("noop");
+      expect(node.name).toBe("Existing");
+    });
+
+    it("downstream nodes carry human-readable names, not bare UUIDs", async () => {
+      const sourceId = await seedSource({ name: "My Source" });
+      const tableId = await seedTable(sourceId, { name: "My Table" });
+      const insightId = await seedInsight(
+        { baseTableId: tableId },
+        { name: "My Insight" },
+      );
+      const vizId = await seedVisualization(insightId, { name: "My Viz" });
+
+      const diff = await preview(
+        cmd("RenameNode", { id: sourceId, name: "X" }),
+      );
+
+      const tableHit = diff.affectedDownstream.find(
+        (n) => n.nodeId === tableId,
+      )!;
+      expect(tableHit).toBeDefined();
+      expect(tableHit.name).toBe("My Table");
+
+      const insightHit = diff.affectedDownstream.find(
+        (n) => n.nodeId === insightId,
+      )!;
+      expect(insightHit).toBeDefined();
+      expect(insightHit.name).toBe("My Insight");
+
+      const vizHit = diff.affectedDownstream.find((n) => n.nodeId === vizId)!;
+      expect(vizHit).toBeDefined();
+      expect(vizHit.name).toBe("My Viz");
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Partial failure — renderable diff when a command throws (#65)
+  //
+  // Batches stay all-or-nothing (the canonical DB is untouched after any
+  // preview); the `error` slot is purely representational.
+  // --------------------------------------------------------------------------
+
+  describe("partial failure — returns renderable diff, does not throw", () => {
+    it("a single-command batch that fails returns an error slot and empty directNodes", async () => {
+      // A command that will definitely fail: RenameNode on a non-existent id
+      // (no canonical row, not created in the batch).
+      const nonExistentId = id();
+      const diff = await buildPreviewDiff(app, db, [
+        cmd("RenameNode", { id: nonExistentId, name: "Will Fail" }),
+      ]);
+
+      expect(diff.mode).toBe("preview");
+      expect(diff.error).toBeDefined();
+      expect(diff.error!.commandIndex).toBe(0);
+      expect(typeof diff.error!.message).toBe("string");
+      // No pre-failure nodes (command 0 is the failure).
+      expect(diff.directNodes).toEqual([]);
+      expect(diff.affectedDownstream).toEqual([]);
+    });
+
+    it("mid-batch failure returns pre-failure nodes + error slot, canonical DB unchanged", async () => {
+      // Batch: two valid commands then one that fails.
+      // Commands 0+1 would succeed; command 2 fails.
+      const sourceId = id();
+      const tableId = id();
+      const nonExistentId = id();
+
+      const diff = await buildPreviewDiff(app, db, [
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "Src" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "Tbl",
+          table: "t.csv",
+        }),
+        // Fails: RenameNode on an id that doesn't exist in canonical or batch.
+        cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
+      ]);
+
+      // Did not throw — returned a renderable diff.
+      expect(diff.mode).toBe("preview");
+
+      // Error slot identifies the failing command.
+      expect(diff.error).toBeDefined();
+      expect(diff.error!.commandIndex).toBe(2);
+      expect(typeof diff.error!.message).toBe("string");
+
+      // Pre-failure nodes (commands 0 and 1) are present.
+      expect(diff.directNodes).toHaveLength(2);
+      const srcNode = diff.directNodes.find((n) => n.nodeId === sourceId);
+      expect(srcNode).toBeDefined();
+      expect(srcNode!.change).toBe("create");
+      const tblNode = diff.directNodes.find((n) => n.nodeId === tableId);
+      expect(tblNode).toBeDefined();
+      expect(tblNode!.change).toBe("create");
+
+      // Canonical DB is untouched — the previewed creates did not persist.
+      const sources = await db.select().from(dataSources);
+      expect(sources.find((r) => r.id === sourceId)).toBeUndefined();
+      const tables = await db.select().from(dataTables);
+      expect(tables.find((r) => r.id === tableId)).toBeUndefined();
+    });
+
+    it("a successful batch carries no error slot", async () => {
+      const sourceId = id();
+      const diff = await preview(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      );
+
+      expect(diff.error).toBeUndefined();
     });
   });
 });

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -53,6 +53,7 @@ import type {
   PreviewDiff,
   PreviewDirectNode,
   PreviewDownstreamNode,
+  PreviewError,
   PreviewIntent,
   UUID,
 } from "@dashframe/types";
@@ -341,6 +342,26 @@ function fieldName(value: unknown): string {
   return "";
 }
 
+/**
+ * Extract a human-readable name for the consent surface. For `create` nodes
+ * the canonical row does not exist yet, so we fall back to `args.name` (the
+ * proposed name). For `update`/`noop` nodes the name comes from the `before`
+ * slice (the canonical row). The fallback empty string should never be reached
+ * in practice — every artifact table has a non-null `name` column.
+ */
+function resolveNodeName(
+  effect: CommandEffect,
+  before: Record<string, unknown> | null,
+  args: Record<string, unknown>,
+): string {
+  if (effect !== "create" && before !== null) {
+    // Canonical name from the pre-batch row.
+    return typeof before.name === "string" ? before.name : "";
+  }
+  // Create: no canonical row — use the proposed name from args.
+  return typeof args.name === "string" ? args.name : "";
+}
+
 function isKnownPath(path: string): path is CommandPath {
   return path in COMMAND_DESCRIPTORS;
 }
@@ -357,22 +378,67 @@ function isKnownPath(path: string): path is CommandPath {
  *              downstream DAG walk. Safe to read AFTER applyCommands returns: the
  *              preview transaction has rolled back, so this is pre-batch state.
  * @param batch the ordered command envelopes (built via `cmd(...)`)
+ *
+ * Partial failure (#65): when command i of N throws, the function does NOT
+ * re-throw. It returns a renderable PreviewDiff with the nodes from commands
+ * 0..i-1 plus an `error` slot carrying the index and message. Batches remain
+ * all-or-nothing — the canonical DB is untouched after any preview (the
+ * execute-then-rollback mechanism never persists). The `error` slot is purely
+ * representational: it tells the reviewer what would have applied and what fails.
  */
 export async function buildPreviewDiff(
   app: WyStackApp,
   db: ArtifactDb,
   batch: Command[],
 ): Promise<PreviewDiff> {
-  // 1. Execute-then-rollback. The proposed slice still comes from args, but for
-  //    polymorphic RenameNode we READ the handler's reported resolution out of
-  //    `result.results` — the preview must not re-derive which artifact a rename
-  //    hit (public issue #64). We also echo tablesWritten.
-  const result = await applyCommands(app, batch, { mode: "preview" });
+  // 1. Execute-then-rollback the full batch to learn what happens and collect
+  //    handler results for polymorphic-command resolution (RenameNode etc. report
+  //    the resolved kind on result.value — public issue #64). On success the
+  //    `result` object holds everything; on failure we probe for the index.
+  let prefixBatch = batch;
+  let prefixResults: CommandResult[] = [];
+  let tablesWritten: string[] = [];
+  let error: PreviewError | undefined;
 
-  // 2. Group the batch by the artifact node each command targets. `result.results`
-  //    is positional with `batch` (results[i] ↔ batch[i]); the builder reads it
-  //    to learn what each RenameNode actually renamed.
-  const direct = await buildDirectNodes(db, batch, result.results);
+  try {
+    const result = await applyCommands(app, batch, { mode: "preview" });
+    prefixResults = result.results;
+    tablesWritten = [...result.tablesWritten];
+  } catch (err) {
+    // A command threw during the full-batch preview. Find which command by
+    // probing ascending prefixes — linear scan (batches are small). The
+    // canonical DB is clean after each preview (execute-then-rollback), so
+    // repeated probing is safe and leaves canonical untouched.
+    const message =
+      err instanceof Error ? err.message : String(err ?? "Unknown error");
+    let failureIndex = batch.length - 1; // conservative default
+    for (let k = 0; k < batch.length; k++) {
+      try {
+        await applyCommands(app, batch.slice(0, k + 1), { mode: "preview" });
+      } catch {
+        failureIndex = k;
+        break;
+      }
+    }
+    error = { commandIndex: failureIndex, message };
+    // The pre-failure prefix is commands 0..failureIndex-1. Build nodes from
+    // those commands; they all succeeded and canonical DB is still clean.
+    prefixBatch = batch.slice(0, failureIndex);
+    if (prefixBatch.length > 0) {
+      const prefixResult = await applyCommands(app, prefixBatch, {
+        mode: "preview",
+      });
+      prefixResults = prefixResult.results;
+      tablesWritten = [...prefixResult.tablesWritten];
+    }
+    // If failureIndex === 0, prefixBatch is empty: no direct nodes, no
+    // tablesWritten — only the error slot. prefixResults stays [].
+  }
+
+  // 2. Group the batch by the artifact node each command targets. `prefixResults`
+  //    is positional with `prefixBatch` (results[i] ↔ prefixBatch[i]); the
+  //    builder reads it to learn what each RenameNode actually renamed.
+  const direct = await buildDirectNodes(db, prefixBatch, prefixResults);
 
   // 3. Walk the implicit DAG outward from every node the batch actually CHANGES.
   //    `noop` nodes (idempotent get-or-create that hit an existing row and wrote
@@ -386,7 +452,8 @@ export async function buildPreviewDiff(
     mode: "preview",
     directNodes: direct,
     affectedDownstream,
-    tablesWritten: [...result.tablesWritten],
+    tablesWritten,
+    ...(error !== undefined ? { error } : {}),
   };
 }
 
@@ -502,6 +569,8 @@ function seedNode(
   return {
     nodeId,
     kind,
+    // Human-readable name for the consent surface. See #65.
+    name: resolveNodeName(effect, before, args),
     change: effect,
     intent: [intent],
     // create: no canonical row. update/noop: the existing canonical row.
@@ -674,13 +743,16 @@ async function findRow(
 
 /**
  * One row of the canonical artifact graph, normalized to the fields the walk
- * needs: identity, the typed FK/IR back-references, and the cross-cutting
- * parent pointer. Built once from the table snapshots so the traversal reads a
- * uniform shape instead of branching per table.
+ * needs: identity, human-readable name (for the consent surface), the typed
+ * FK/IR back-references, and the cross-cutting parent pointer. Built once from
+ * the table snapshots so the traversal reads a uniform shape instead of
+ * branching per table.
  */
 interface GraphRow {
   id: string;
   kind: ArtifactKind;
+  /** Human-readable artifact name — carried to the consent surface. See #65. */
+  name: string;
   /** ids of the nodes this row directly DEPENDS ON (its upstream). */
   dependsOn: string[];
   parentArtifactId: string | null;
@@ -729,6 +801,7 @@ async function loadGraph(db: ArtifactDb): Promise<GraphRow[]> {
     rows.push({
       id: r.id,
       kind: "dataSource",
+      name: r.name,
       dependsOn: [],
       parentArtifactId: r.parentArtifactId,
     });
@@ -736,6 +809,7 @@ async function loadGraph(db: ArtifactDb): Promise<GraphRow[]> {
     rows.push({
       id: r.id,
       kind: "dataTable",
+      name: r.name,
       dependsOn: [r.dataSourceId],
       parentArtifactId: null,
     });
@@ -743,6 +817,7 @@ async function loadGraph(db: ArtifactDb): Promise<GraphRow[]> {
     rows.push({
       id: r.id,
       kind: "insight",
+      name: r.name,
       dependsOn: insightTableRefs(r.definition),
       parentArtifactId: r.parentArtifactId,
     });
@@ -750,6 +825,7 @@ async function loadGraph(db: ArtifactDb): Promise<GraphRow[]> {
     rows.push({
       id: r.id,
       kind: "dataFrame",
+      name: r.name,
       dependsOn: r.insightId ? [r.insightId] : [],
       parentArtifactId: null,
     });
@@ -757,6 +833,7 @@ async function loadGraph(db: ArtifactDb): Promise<GraphRow[]> {
     rows.push({
       id: r.id,
       kind: "visualization",
+      name: r.name,
       dependsOn: [r.insightId],
       parentArtifactId: r.parentArtifactId,
     });
@@ -764,6 +841,7 @@ async function loadGraph(db: ArtifactDb): Promise<GraphRow[]> {
     rows.push({
       id: r.id,
       kind: "dashboard",
+      name: r.name,
       dependsOn: dashboardVisRefs(r.layout),
       parentArtifactId: r.parentArtifactId,
     });
@@ -879,6 +957,7 @@ async function walkDownstream(
       const emitted: PreviewDownstreamNode = {
         nodeId: row.id as UUID,
         kind: row.kind,
+        name: row.name,
         edge: hit.edge,
         via: currentVia,
         flag: hit.flag,

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -386,6 +386,66 @@ function isKnownPath(path: string): path is CommandPath {
  * execute-then-rollback mechanism never persists). The `error` slot is purely
  * representational: it tells the reviewer what would have applied and what fails.
  */
+/**
+ * Probe the batch to find which command fails and what message it emits.
+ * Returns the failure index (conservative default: last command) and the
+ * message from the probe run of the exact failing command.
+ *
+ * P2 fix (#65): the message is captured from the probe, not from the full-batch
+ * run, so commandIndex and message always describe the same failure.
+ */
+async function probeBatchFailure(
+  app: WyStackApp,
+  batch: Command[],
+  fallbackMessage: string,
+): Promise<{ failureIndex: number; message: string }> {
+  let failureIndex = batch.length - 1; // conservative default
+  let message = fallbackMessage;
+  for (let k = 0; k < batch.length; k++) {
+    try {
+      await applyCommands(app, batch.slice(0, k + 1), { mode: "preview" });
+    } catch (probeErr) {
+      failureIndex = k;
+      message =
+        probeErr instanceof Error
+          ? probeErr.message
+          : String(probeErr ?? "Unknown error");
+      break;
+    }
+  }
+  return { failureIndex, message };
+}
+
+/**
+ * Run the pre-failure prefix to collect handler results for direct-node
+ * building. If the prefix re-run itself throws (infrastructure failure —
+ * e.g. a concurrent canonical write between the probe and this re-run),
+ * returns empty results so buildDirectNodes sees an empty input.
+ *
+ * P1 fix (#65): guarding the prefix re-run ensures buildPreviewDiff never
+ * throws regardless of what happens in this second applyCommands call.
+ */
+async function runPrefixSafe(
+  app: WyStackApp,
+  prefixBatch: Command[],
+): Promise<{
+  safeBatch: Command[];
+  results: CommandResult[];
+  tablesWritten: string[];
+}> {
+  try {
+    const result = await applyCommands(app, prefixBatch, { mode: "preview" });
+    return {
+      safeBatch: prefixBatch,
+      results: result.results,
+      tablesWritten: [...result.tablesWritten],
+    };
+  } catch {
+    // Infrastructure failure: fall back to empty — the error slot renders.
+    return { safeBatch: [], results: [], tablesWritten: [] };
+  }
+}
+
 export async function buildPreviewDiff(
   app: WyStackApp,
   db: ArtifactDb,
@@ -405,34 +465,27 @@ export async function buildPreviewDiff(
     prefixResults = result.results;
     tablesWritten = [...result.tablesWritten];
   } catch (err) {
-    // A command threw during the full-batch preview. Find which command by
-    // probing ascending prefixes — linear scan (batches are small). The
-    // canonical DB is clean after each preview (execute-then-rollback), so
-    // repeated probing is safe and leaves canonical untouched.
-    const message =
+    // A command threw during the full-batch preview. Probe to find which command
+    // (linear scan — batches are small; canonical DB is clean after each preview).
+    const fallback =
       err instanceof Error ? err.message : String(err ?? "Unknown error");
-    let failureIndex = batch.length - 1; // conservative default
-    for (let k = 0; k < batch.length; k++) {
-      try {
-        await applyCommands(app, batch.slice(0, k + 1), { mode: "preview" });
-      } catch {
-        failureIndex = k;
-        break;
-      }
-    }
+    const { failureIndex, message } = await probeBatchFailure(
+      app,
+      batch,
+      fallback,
+    );
     error = { commandIndex: failureIndex, message };
-    // The pre-failure prefix is commands 0..failureIndex-1. Build nodes from
-    // those commands; they all succeeded and canonical DB is still clean.
+
+    // The pre-failure prefix is commands 0..failureIndex-1. Run it to build nodes.
     prefixBatch = batch.slice(0, failureIndex);
     if (prefixBatch.length > 0) {
-      const prefixResult = await applyCommands(app, prefixBatch, {
-        mode: "preview",
-      });
-      prefixResults = prefixResult.results;
-      tablesWritten = [...prefixResult.tablesWritten];
+      const prefix = await runPrefixSafe(app, prefixBatch);
+      prefixBatch = prefix.safeBatch;
+      prefixResults = prefix.results;
+      tablesWritten = prefix.tablesWritten;
     }
-    // If failureIndex === 0, prefixBatch is empty: no direct nodes, no
-    // tablesWritten — only the error slot. prefixResults stays [].
+    // If failureIndex === 0 or runPrefixSafe fell back, prefixBatch is empty: no
+    // direct nodes, no tablesWritten — only the error slot. prefixResults stays [].
   }
 
   // 2. Group the batch by the artifact node each command targets. `prefixResults`
@@ -538,6 +591,10 @@ function foldCommand(
     // already minting; merge args. (create→create is the only create-merge that
     // genuinely happens, e.g. CreateDataSource then RenameNode on a fresh id.)
     Object.assign(node.proposedDefinition, args);
+    // P2 fix (#65): sync node.name when a later command in the batch renames the
+    // node (e.g. CreateDataSource followed by RenameNode — final name is the
+    // rename, not the creation name).
+    if (typeof args.name === "string") node.name = args.name;
     return;
   }
   if (effect === "create") {
@@ -546,12 +603,17 @@ function foldCommand(
     // an update: never regress a resolved canonical node to a before:null create.
     node.change = "update";
     Object.assign(node.proposedDefinition, args);
+    if (typeof args.name === "string") node.name = args.name;
     return;
   }
   // effect === "update": a noop node becomes a real update; a create stays a
   // create (a create + later update is still a mint). Either way, merge args.
   if (node.change === "noop") node.change = "update";
   Object.assign(node.proposedDefinition, args);
+  // P2 fix (#65): an update that carries a name (e.g. RenameNode) sets the final
+  // displayed name. For update/noop nodes the seed name came from the canonical
+  // before-slice; a rename in the same batch supersedes it.
+  if (typeof args.name === "string") node.name = args.name;
 }
 
 /**

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -1,0 +1,220 @@
+/**
+ * PreviewDiffRenderer — the consent surface for a PreviewDiff.
+ *
+ * Renders the artifact-grouped diff a human reviews before publishing a command
+ * batch. The renderer is the structural consumer of the two additions from #65:
+ *   - `name` on every direct + downstream node — no bare UUIDs in the blast-radius
+ *     list; the reviewer sees recognizable artifact names.
+ *   - `error` slot on the diff — when a command in the batch fails during preview,
+ *     the reviewer sees which commands would apply and which one fails, so they can
+ *     fix the batch before publishing. Batches stay all-or-nothing.
+ *
+ * SPLIT-TIER: this component never initiates data fetches. The `compute` slot on
+ * direct nodes is filled lazily by the caller (client-side DuckDB); this component
+ * renders whatever is present and leaves the slot empty when absent.
+ */
+
+import type {
+  ArtifactKind,
+  PreviewDiff,
+  PreviewDirectNode,
+  PreviewDownstreamNode,
+} from "@dashframe/types";
+import { Badge, cn } from "@wystack/ui";
+
+// ---------------------------------------------------------------------------
+// Kind labels — human-readable kind names for the consent surface
+// ---------------------------------------------------------------------------
+
+const KIND_LABELS: Record<ArtifactKind, string> = {
+  dataSource: "Data Source",
+  dataTable: "Data Table",
+  insight: "Insight",
+  dataFrame: "Data Frame",
+  visualization: "Visualization",
+  dashboard: "Dashboard",
+};
+
+const CHANGE_LABELS: Record<PreviewDirectNode["change"], string> = {
+  create: "New",
+  update: "Changed",
+  noop: "Unchanged",
+};
+
+const CHANGE_COLORS: Record<
+  PreviewDirectNode["change"],
+  "success" | "primary" | "secondary"
+> = {
+  create: "success",
+  update: "primary",
+  noop: "secondary",
+};
+
+const FLAG_COLORS: Record<
+  PreviewDownstreamNode["flag"],
+  "warning" | "secondary" | "danger"
+> = {
+  recompute: "warning",
+  stale: "secondary",
+  orphaned: "danger",
+};
+
+const FLAG_LABELS: Record<PreviewDownstreamNode["flag"], string> = {
+  recompute: "Will recompute",
+  stale: "Stale",
+  orphaned: "Orphaned",
+};
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface PreviewDiffRendererProps {
+  diff: PreviewDiff;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
+  const changeLabel = CHANGE_LABELS[node.change];
+  const kindLabel = KIND_LABELS[node.kind];
+
+  return (
+    <div className="flex items-start gap-3 rounded-[var(--surface-radius)] bg-neutral-bg/60 px-3 py-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {/* Name + kind badge — no bare UUID */}
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium text-neutral-fg">
+            {node.name || node.nodeId}
+          </span>
+          <Badge variant="soft" color="secondary" className="shrink-0 text-xs">
+            {kindLabel}
+          </Badge>
+          <Badge
+            variant="soft"
+            color={CHANGE_COLORS[node.change]}
+            className="shrink-0 text-xs"
+          >
+            {changeLabel}
+          </Badge>
+        </div>
+        {/* Intent lines */}
+        {node.intent.length > 0 && (
+          <ul className="ml-0 list-none space-y-0.5">
+            {node.intent.map((intent, i) => (
+              <li
+                key={i}
+                className="text-xs text-neutral-fg/70"
+                title={intent.command}
+              >
+                {intent.summary}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DownstreamNodeRow({ node }: { node: PreviewDownstreamNode }) {
+  const kindLabel = KIND_LABELS[node.kind];
+  const flagColor = FLAG_COLORS[node.flag];
+  const flagLabel = FLAG_LABELS[node.flag];
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <span className="min-w-0 flex-1 truncate text-sm text-neutral-fg/80">
+        {node.name || node.nodeId}
+      </span>
+      <Badge variant="soft" color="secondary" className="shrink-0 text-xs">
+        {kindLabel}
+      </Badge>
+      <Badge variant="soft" color={flagColor} className="shrink-0 text-xs">
+        {flagLabel}
+      </Badge>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a PreviewDiff as a consent surface — direct nodes (what the batch
+ * changes) and downstream blast radius (what would be affected). When the diff
+ * carries a partial-failure `error`, it is shown prominently so the reviewer
+ * knows which command fails and what to fix before publishing.
+ */
+export function PreviewDiffRenderer({
+  diff,
+  className,
+}: PreviewDiffRendererProps) {
+  const hasDirectNodes = diff.directNodes.length > 0;
+  const hasDownstream = diff.affectedDownstream.length > 0;
+  const hasError = diff.error !== undefined;
+
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      {/* Partial-failure banner — shown first so the reviewer can't miss it */}
+      {hasError && (
+        <div className="rounded-[var(--surface-radius)] bg-neutral-bg/80 px-4 py-3 shadow-[var(--surface-shadow)]">
+          <p className="text-sm font-semibold text-palette-danger">
+            Command {diff.error!.commandIndex + 1} failed
+          </p>
+          <p className="mt-1 text-xs text-neutral-fg/70">
+            {diff.error!.message}
+          </p>
+          {hasDirectNodes && (
+            <p className="mt-2 text-xs text-neutral-fg/60">
+              The commands below would apply before the failure. Batches are
+              all-or-nothing — nothing persists until the batch is fixed.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Direct nodes — what the batch touches */}
+      {hasDirectNodes && (
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-fg/50">
+            {hasError ? "Would change" : "Changes"}
+          </h3>
+          <div className="flex flex-col gap-1.5">
+            {diff.directNodes.map((node) => (
+              <DirectNodeRow key={`${node.kind}:${node.nodeId}`} node={node} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Downstream blast radius — flagged only, no compute */}
+      {hasDownstream && (
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-fg/50">
+            Also affected
+          </h3>
+          <div className="rounded-[var(--surface-radius)] bg-neutral-bg/60 px-3 py-2">
+            <div className="flex flex-col divide-y divide-neutral-border/30">
+              {diff.affectedDownstream.map((node) => (
+                <DownstreamNodeRow
+                  key={`${node.kind}:${node.nodeId}`}
+                  node={node}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Empty state */}
+      {!hasDirectNodes && !hasError && (
+        <p className="text-sm text-neutral-fg/50">No changes in this batch.</p>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -162,7 +162,10 @@ export function PreviewDiffRenderer({
     <div className={cn("flex flex-col gap-4", className)}>
       {/* Partial-failure banner — shown first so the reviewer can't miss it */}
       {hasError && (
-        <div className="rounded-[var(--surface-radius)] bg-neutral-bg/80 px-4 py-3 shadow-[var(--surface-shadow)]">
+        <div
+          role="alert"
+          className="rounded-[var(--surface-radius)] bg-neutral-bg/80 px-4 py-3 shadow-[var(--surface-shadow)]"
+        >
           <p className="text-sm font-semibold text-palette-danger">
             Command {diff.error!.commandIndex + 1} failed
           </p>

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -106,7 +106,7 @@ function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
           <ul className="ml-0 list-none space-y-0.5">
             {node.intent.map((intent, i) => (
               <li
-                key={i}
+                key={`${intent.command}-${i}`}
                 className="text-xs text-neutral-fg/70"
                 title={intent.command}
               >

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -181,6 +181,7 @@ export type {
   PreviewDiff,
   PreviewDirectNode,
   PreviewDownstreamNode,
+  PreviewError,
   PreviewIntent,
   RenamedTarget,
 } from "./preview-diff";

--- a/packages/types/src/preview-diff.ts
+++ b/packages/types/src/preview-diff.ts
@@ -96,6 +96,14 @@ export interface PreviewDirectNode {
   nodeId: UUID;
   kind: ArtifactKind;
   /**
+   * Human-readable artifact name for the consent surface. For `create` nodes
+   * this is the proposed name from the command args. For `update` and `noop`
+   * nodes it is the canonical name from the `before` slice. Never a bare UUID —
+   * the reviewer must be able to identify the artifact without cross-referencing
+   * the DB. See #65.
+   */
+  name: string;
+  /**
    * What the batch does to this node's canonical row:
    * - `create`  — the node is minted by this batch (no canonical row before).
    * - `update`  — an existing canonical row is mutated.
@@ -167,6 +175,12 @@ export type DownstreamEdge =
 export interface PreviewDownstreamNode {
   nodeId: UUID;
   kind: ArtifactKind;
+  /**
+   * Human-readable artifact name for the consent surface. Read from the
+   * canonical DB row at DAG-walk time — the reviewer must be able to identify
+   * the affected artifact without cross-referencing the DB. See #65.
+   */
+  name: string;
   /** The edge by which this node was reached from the directly-touched node. */
   edge: DownstreamEdge;
   /**
@@ -184,10 +198,30 @@ export interface PreviewDownstreamNode {
 }
 
 /**
+ * Partial-failure slot on the PreviewDiff. Set when command `commandIndex` of
+ * the batch threw during preview. Batches stay all-or-nothing (no change to
+ * the canonical DB); this is purely representational — the reviewer sees which
+ * commands would apply and which one fails, so they can fix the batch before
+ * publishing. See #65.
+ */
+export interface PreviewError {
+  /** 0-based index of the first command that threw. */
+  commandIndex: number;
+  /** The error message from the thrown exception. */
+  message: string;
+}
+
+/**
  * The full preview — the artifact-grouped diff the renderer paints. Discriminated
  * `mode: 'preview'` mirrors the underlying `PreviewResult`. `tablesWritten` is
  * echoed from the mechanism (the set that WOULD have flushed to invalidation had
  * the batch committed) so the renderer can scope its lazy compute / refresh.
+ *
+ * When `error` is present, command `error.commandIndex` threw during preview.
+ * `directNodes` contains the nodes built from commands 0..commandIndex-1 (the
+ * commands that would have applied). `affectedDownstream` is the DAG walk over
+ * those pre-failure nodes. Batches stay all-or-nothing; `error` is purely
+ * representational. See #65.
  */
 export interface PreviewDiff {
   mode: "preview";
@@ -197,4 +231,11 @@ export interface PreviewDiff {
   affectedDownstream: PreviewDownstreamNode[];
   /** Echo of the mechanism's tablesWritten — what a commit would have invalidated. */
   tablesWritten: string[];
+  /**
+   * Partial-failure slot — present when a command threw during preview. The diff
+   * is still renderable (pre-failure nodes + their blast radius); the reviewer
+   * sees which commands would apply and which one fails. Absent on a fully
+   * successful preview. See #65.
+   */
+  error?: PreviewError;
 }


### PR DESCRIPTION
## What

Two additions that gate the agent-wave consent surface:

1. **Node names** — `name: string` on `PreviewDirectNode` and `PreviewDownstreamNode`. The consent surface now shows recognizable artifact names instead of bare UUIDs. Direct nodes resolve the name from the `before` slice (update/noop) or from command args (create). Downstream nodes read the name from the canonical DB row at DAG-walk time.

2. **Partial-failure representation** — `error?: PreviewError` slot on `PreviewDiff` (`commandIndex` + `message`). When command `i` throws during preview, `buildPreviewDiff` no longer re-throws: it probes the batch linearly to find the failing index, runs a clean preview of the pre-failure prefix to build renderable direct nodes + blast radius, and returns the diff with the `error` slot set. Batches remain all-or-nothing (canonical DB untouched). The slot is purely representational.

3. **`PreviewDiffRenderer` component** — new `packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx`. Renders direct nodes with names + change badges, blast-radius list with names + flags, and a prominent error banner for partial-failure diffs. Uses `@wystack/ui` surface tokens, no bare UUIDs surfaced anywhere.

4. **Pre-existing test fix** — corrects the insight-on-insight test assertion `via: insightAId` (bare string) → `via: { kind: "insight", id: insightAId }`, matching the `#75` type change to `{ kind, id }`.

## Why

A consent surface must be recognizable (names, not UUIDs) and must represent failure (partial-failure slot), so a reviewer can identify affected artifacts and know when a batch needs fixing before publishing.

## All-or-nothing note

Batches remain atomic. The `error` slot is purely representational — no partial writes, no new rollback paths. The canonical DB stays untouched after any preview run regardless of failure.

## Test evidence

50 tests pass in `preview-diff.test.ts` (43 existing, 7 new):
- 4 name tests: create/update/noop direct nodes + downstream nodes carry correct names
- 3 partial-failure tests: single-command failure, mid-batch failure with pre-failure nodes + DB unchanged, successful batch has no error slot

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates the agent-wave consent surface by adding human-readable `name` fields to `PreviewDirectNode` and `PreviewDownstreamNode`, a `PreviewError` partial-failure slot on `PreviewDiff`, and a new `PreviewDiffRenderer` component that consumes both. Previously-flagged no-rethrow and probe-message correctness issues were resolved in commit f2f1550 before this review pass.

- **Name resolution**: `resolveNodeName` seeds the name at `seedNode` time (from `before` for update/noop, from `args` for create); `foldCommand` updates `node.name` when a subsequent batch command carries a `name` arg (e.g. CreateDataSource → RenameNode shows the rename, not the creation name).
- **Partial-failure path**: `probeBatchFailure` linearly probes the batch to find the first failing command and captures the exact probe error message; `runPrefixSafe` wraps the prefix re-run so `buildPreviewDiff` never re-throws under any failure mode, including concurrent-write races between the probe and the prefix run.
- **Renderer**: `PreviewDiffRenderer` surfaces a `role="alert"` error banner with human-readable failure context, direct-node rows with kind/change badges, and a downstream blast-radius list — no bare UUIDs anywhere; 7 new tests cover all added paths.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All changes are additive (new fields, new helper functions, new component), the canonical DB is never written during preview, and the no-rethrow contract is upheld by the guarded helpers.

The partial-failure path is well-encapsulated: `probeBatchFailure` and `runPrefixSafe` guard every `applyCommands` call in the error branch, `buildPreviewDiff` always resolves, and the error slot is purely representational with no persistent side effects. The name-resolution logic is straightforward and covers all transition table cells. The one finding is a floating docblock with no runtime impact.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/preview-diff.ts | Adds partial-failure handling via `probeBatchFailure` + `runPrefixSafe` helpers and wires `name` resolution through `resolveNodeName` + `foldCommand`. Previously flagged no-rethrow and probe-message issues are resolved. One orphaned JSDoc block (style only). |
| packages/types/src/preview-diff.ts | Adds `name: string` to `PreviewDirectNode` and `PreviewDownstreamNode`, and introduces the new `PreviewError` interface + optional `error` slot on `PreviewDiff`. Type changes are well-documented and match the implementation. |
| packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx | New consent-surface component: renders direct nodes with name + change badge, downstream blast radius with name + flag badge, and a prominent `role="alert"` error banner. Follows surface token conventions; uses stable compound keys for node lists. |
| apps/server/src/functions/preview-diff.test.ts | Adds 7 new tests covering create/update/noop name resolution, downstream names, partial-failure error slot, no-rethrow contract, and probe-message accuracy. Also fixes the pre-existing insight-on-insight `via` assertion. |
| packages/types/src/index.ts | Re-exports the new `PreviewError` type from `preview-diff`. One-line change, no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant buildPreviewDiff
    participant applyCommands
    participant probeBatchFailure
    participant runPrefixSafe
    participant buildDirectNodes
    participant walkDownstream

    Caller->>buildPreviewDiff: batch[0..N]
    buildPreviewDiff->>applyCommands: "batch, mode=preview"
    alt success
        applyCommands-->>buildPreviewDiff: results + tablesWritten
    else throws
        applyCommands-->>buildPreviewDiff: error
        buildPreviewDiff->>probeBatchFailure: batch, fallbackMessage
        loop "k = 0..N-1"
            probeBatchFailure->>applyCommands: "batch[0..k], mode=preview"
            alt throws at k
                applyCommands-->>probeBatchFailure: probeErr
                Note over probeBatchFailure: failureIndex=k, message from probe
            end
        end
        probeBatchFailure-->>buildPreviewDiff: failureIndex, message
        buildPreviewDiff->>runPrefixSafe: batch[0..failureIndex-1]
        runPrefixSafe->>applyCommands: "prefixBatch, mode=preview"
        alt prefix succeeds
            applyCommands-->>runPrefixSafe: results
        else throws (infra failure)
            Note over runPrefixSafe: returns empty, error slot still renders
        end
        runPrefixSafe-->>buildPreviewDiff: safeBatch, results, tablesWritten
    end
    buildPreviewDiff->>buildDirectNodes: prefixBatch, prefixResults
    buildDirectNodes-->>buildPreviewDiff: directNodes with name
    buildPreviewDiff->>walkDownstream: changed nodes
    walkDownstream-->>buildPreviewDiff: affectedDownstream with name
    buildPreviewDiff-->>Caller: PreviewDiff with directNodes, affectedDownstream, error?
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(app): add role=alert to error banner..."](https://github.com/youhaowei/dashframe/commit/5185c3d9de6464fc36ece935999405aa7b747fe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37265395)</sub>

<!-- /greptile_comment -->