### PR TITLE
test(server): fix stale preview-diff via assertion (main CI red)

### DIFF
--- a/apps/server/src/functions/preview-diff.test.ts
+++ b/apps/server/src/functions/preview-diff.test.ts
@@ -659,7 +659,7 @@ describe("PreviewDiff builder", () => {
       expect(insB).toMatchObject({
         kind: "insight",
         edge: "insight->insight",
-        via: insightAId,
+        via: { kind: "insight", id: insightAId },
       });
       // Transitive fan-out continues past B to B's own visualization.
       const vizB = diff.affectedDownstream.find((n) => n.nodeId === vizBId);


### PR DESCRIPTION
After PR #75 changed `PreviewDiff` downstream provenance so that `via` carries `{ id, kind }` instead of a bare UUID string, one test assertion in the Insight-on-Insight fan-out case was not updated and continued to assert `via: insightAId` (a raw string). This caused the preview-diff suite to fail on main. The fix updates the single stale assertion to the shipped `{ kind: "insight", id: insightAId }` shape, consistent with how all other `via` assertions in the file were already written post-#75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a single stale test assertion in the `preview-diff` suite that was left behind when PR #75 changed the `via` field from a bare UUID string to a `{ kind, id }` object. The broken assertion was causing CI failures on main.

- Updates `via: insightAId` → `via: { kind: \"insight\", id: insightAId }` in the Insight-on-Insight fan-out test case, matching the shape all other `via` assertions in the file already used post-#75.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line test assertion fix with no production code touched.

Only a single test assertion is changed, updating it to match the shape the production code already returns. Every other `via` assertion in the file already used the `{ kind, id }` form, confirming this is the correct shape. No production logic, no schema, no data path is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/preview-diff.test.ts | Single stale `via: insightAId` assertion updated to `via: { kind: "insight", id: insightAId }`, aligning with all other `via` assertions in the file and with the shape shipped by PR #75. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test(server): update stale via assertion..."](https://github.com/youhaowei/dashframe/commit/f62e5ce6bbfa92f10b773c36dfa5167ba6d958ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37266756)</sub>

<!-- /greptile_comment -->