### PR TITLE
fix(server): correct preview-diff via assertion to {kind, id}

### DIFF
--- a/apps/server/src/functions/preview-diff.test.ts
+++ b/apps/server/src/functions/preview-diff.test.ts
@@ -659,7 +659,7 @@ describe("PreviewDiff builder", () => {
       expect(insB).toMatchObject({
         kind: "insight",
         edge: "insight->insight",
-        via: insightAId,
+        via: { kind: "insight", id: insightAId },
       });
       // Transitive fan-out continues past B to B's own visualization.
       const vizB = diff.affectedDownstream.find((n) => n.nodeId === vizBId);


### PR DESCRIPTION
## Problem

`apps/server` test suite is red on `main`. `preview-diff.test.ts:659` (the `insight->insight` case) asserts `via: insightAId` (a bare UUID), but `via` is `{ kind, id }`.

## Root cause — semantic merge race

- **#75** changed `PreviewDownstreamNode.via` from `UUID` to `{ kind, id }` and updated all then-existing assertions. Green when merged.
- **#56** added a *new* test case with the old `via: UUID` shape. It branched **before** #75 merged, so its branch never saw the new shape — green on its own branch, stale once combined.
- #56 merged after #75 without rebasing → `main` went red. No textual conflict, so nothing flagged it.

## Fix

One line: bring the `insight->insight` case in line with the `{ kind, id }` shape every other `via:` assertion in the file already uses.

## Verification
`vitest run preview-diff.test.ts` → 43/43 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a broken test assertion in `preview-diff.test.ts` caused by a semantic merge race between two PRs. PR #75 changed `PreviewDownstreamNode.via` from a bare UUID to `{ kind, id }`, and PR #56 added a new test case using the old shape — when #56 merged after #75 without rebasing, `main` went red.

- Updates the `insight->insight` test assertion at line 659 from `via: insightAId` to `via: { kind: "insight", id: insightAId }`, matching the shape used by all other `via:` assertions in the file.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line test assertion fix with no production code touched.

The fix correctly aligns the one stale assertion with the { kind, id } shape that every other via: check in the file already uses. No logic, schema, or runtime behavior is changed — only a broken test expectation is corrected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/preview-diff.test.ts | Single-line test assertion fix: aligns `via` shape in `insight->insight` case with the `{ kind, id }` object used by every other `via:` assertion in the file. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PR75 as PR #75 (via shape change)
    participant PR56 as PR #56 (new test case)
    participant Main as main branch

    PR75->>Main: "Merges: via changed from UUID to {kind, id}"
    Note over PR56: Branched before #75 merged<br/>uses old via: UUID shape
    PR56->>Main: Merges without rebasing → test red
    Note over Main: preview-diff.test.ts:659 fails<br/>via: insightAId (UUID) ≠ {kind, id}
    Main->>Main: "This PR fixes via to { kind: "insight", id: insightAId }"
    Note over Main: 43/43 tests pass
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): update preview-diff test vi..."](https://github.com/youhaowei/dashframe/commit/d62a5e499803f0f87cb06b26f9e820fcd53bae24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37367849)</sub>

<!-- /greptile_comment -->