### PR TITLE
feat(engine): buildInsightSQL filter clause — WHERE/HAVING routing + between operator

### DIFF
--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -79,6 +79,19 @@ function groupedInsight(filters?: InsightFilter[]): Insight {
   };
 }
 
+/** Build a metrics-only insight (SUM(amount), no selected dimensions → no GROUP BY). */
+function metricsOnlyInsight(filters?: InsightFilter[]): Insight {
+  return {
+    id: "88888888-8888-8888-8888-888888888888" as UUID,
+    name: "Total Revenue",
+    baseTableId: TABLE_ID,
+    selectedFields: [],
+    metrics: [REVENUE_METRIC],
+    filters,
+    createdAt: 0,
+  };
+}
+
 const QUERY_OPTS: BuildInsightSQLOptions = { mode: "query" };
 
 function build(
@@ -220,5 +233,64 @@ describe("buildInsightSQL — value quoting / injection guard", () => {
     );
     expect(injection).toContain(`'x''; DROP TABLE sales; --'`);
     expect(injection).not.toContain(`'x'; DROP`);
+  });
+});
+
+describe("buildInsightSQL — null handling and edge cases", () => {
+  it("emits IS NULL for an eq filter with a null value (not = NULL)", () => {
+    const sql = build(
+      groupedInsight([{ field: "region", operator: "eq", value: null }]),
+    );
+    expect(sql).toContain(`"${regionAlias}" IS NULL`);
+    expect(sql).not.toContain("= NULL");
+  });
+
+  it("emits IS NOT NULL for a ne filter with a null value", () => {
+    const sql = build(
+      groupedInsight([{ field: "region", operator: "ne", value: null }]),
+    );
+    expect(sql).toContain(`"${regionAlias}" IS NOT NULL`);
+    expect(sql).not.toContain("<> NULL");
+  });
+
+  it("routes a metric filter to HAVING even with no GROUP BY (metrics-only insight)", () => {
+    // No selectedFields → no GROUP BY, but the query still aggregates (SUM).
+    // A predicate on the metric must land in HAVING, not WHERE.
+    const sql = build(
+      metricsOnlyInsight([{ field: "amount", operator: "gt", value: 1000 }]),
+    );
+    expect(sql).toContain(`HAVING SUM("${amountAlias}") > 1000`);
+    expect(sql).not.toContain("WHERE");
+    expect(sql).not.toContain("GROUP BY");
+  });
+
+  it("routes a shared dimension+metric column to WHERE (dimension membership wins)", () => {
+    // `amount` is both selected as a grouped dimension AND the metric's source.
+    // Dimension membership takes precedence → WHERE (the grouped value is in
+    // scope pre-aggregation).
+    const insight: Insight = {
+      id: "77777777-7777-7777-7777-777777777777" as UUID,
+      name: "Amount grouped + summed",
+      baseTableId: TABLE_ID,
+      selectedFields: [AMOUNT_FIELD_ID],
+      metrics: [REVENUE_METRIC], // SUM(amount)
+      filters: [{ field: "amount", operator: "gt", value: 10 }],
+      createdAt: 0,
+    };
+    const sql = build(insight);
+    expect(sql).toContain(`WHERE "${amountAlias}" > 10`);
+    expect(sql).not.toContain("HAVING");
+  });
+
+  it("emits a no-op predicate (not a throw) for a malformed between value", () => {
+    // A persisted/garbled between value missing its bounds must not throw or
+    // silently drop every row — it emits an always-true guard instead.
+    const sql = build(
+      groupedInsight([
+        { field: "order_date", operator: "between", value: null },
+      ]),
+    );
+    expect(sql).toContain("1=1");
+    expect(sql).not.toContain("BETWEEN");
   });
 });

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -326,3 +326,179 @@ describe("buildInsightSQL — null handling and edge cases", () => {
     expect(sql).not.toContain("WHERE");
   });
 });
+
+describe("buildInsightSQL — model-mode previews are unfiltered", () => {
+  it("does NOT emit a filter clause in model mode even when the insight has saved filters", () => {
+    // A preview shows raw source rows so the user can see what they're working
+    // with before filtering. Applying result-filters would defeat that, and the
+    // joined model path doesn't filter either — both paths stay consistent.
+    const insight = groupedInsight([
+      { field: "region", operator: "eq", value: "EMEA" },
+    ]);
+
+    const modelSQL = build(insight, { mode: "model" });
+    expect(modelSQL).not.toContain("WHERE");
+    expect(modelSQL).not.toContain("HAVING");
+
+    // Same insight in query mode DOES filter — proves the gate is mode-based,
+    // not a blanket drop.
+    const querySQL = build(insight, { mode: "query" });
+    expect(querySQL).toContain(`WHERE "${regionAlias}" = 'EMEA'`);
+  });
+});
+
+describe("buildInsightSQL — filter on a dropped join key is safely skipped", () => {
+  // Join fixtures: a base "orders" table joined to a "customers" table on
+  // customer_id. processSingleJoin drops the right-side join key (customer_id
+  // from customers) from the joined subquery to avoid duplication — so a filter
+  // targeting that dropped column must NOT emit a reference to it.
+  const ORDERS_ID = "12121212-1212-1212-1212-121212121212" as UUID;
+  const ORDERS_DF = "34343434-3434-3434-3434-343434343434" as UUID;
+  const CUSTOMERS_ID = "56565656-5656-5656-5656-565656565656" as UUID;
+  const CUSTOMERS_DF = "78787878-7878-7878-7878-787878787878" as UUID;
+
+  const O_ID_FIELD = {
+    id: "a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1" as UUID,
+    name: "Order ID",
+    tableId: ORDERS_ID,
+    columnName: "order_id",
+    type: "string" as const,
+  };
+  const O_CUSTID_FIELD = {
+    id: "b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2" as UUID,
+    name: "Customer ID (orders)",
+    tableId: ORDERS_ID,
+    columnName: "customer_id",
+    type: "string" as const,
+  };
+  // Right-side join key — this is the column processSingleJoin drops.
+  const C_CUSTID_FIELD = {
+    id: "c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3" as UUID,
+    name: "Customer ID (customers)",
+    tableId: CUSTOMERS_ID,
+    columnName: "customer_id",
+    type: "string" as const,
+  };
+  const C_NAME_FIELD = {
+    id: "d4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4" as UUID,
+    name: "Customer Name",
+    tableId: CUSTOMERS_ID,
+    columnName: "customer_name",
+    type: "string" as const,
+  };
+
+  const ordersTable: DataTable = {
+    id: ORDERS_ID,
+    name: "orders",
+    dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+    table: "orders.csv",
+    fields: [O_ID_FIELD, O_CUSTID_FIELD],
+    metrics: [],
+    dataFrameId: ORDERS_DF,
+    createdAt: 0,
+  };
+  const customersTable: DataTable = {
+    id: CUSTOMERS_ID,
+    name: "customers",
+    dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+    table: "customers.csv",
+    fields: [C_CUSTID_FIELD, C_NAME_FIELD],
+    metrics: [],
+    dataFrameId: CUSTOMERS_DF,
+    createdAt: 0,
+  };
+
+  const droppedRightKeyAlias = fieldIdToColumnAlias(C_CUSTID_FIELD.id);
+
+  it("skips a filter on the dropped right join-key instead of emitting a broken column ref", () => {
+    const insight: Insight = {
+      id: "11112222-3333-4444-5555-666677778888" as UUID,
+      name: "Orders joined to customers",
+      baseTableId: ORDERS_ID,
+      selectedFields: [O_ID_FIELD.id],
+      metrics: [],
+      joins: [
+        {
+          type: "inner",
+          rightTableId: CUSTOMERS_ID,
+          leftKey: "customer_id",
+          rightKey: "customer_id",
+        },
+      ],
+      // Filter targets the right-side customer_id — the column that gets dropped
+      // from the joined subquery. Pre-fix this emitted a reference to a
+      // non-existent alias and crashed the whole query.
+      filters: [{ field: "customer_id", operator: "eq", value: "C-1" }],
+      createdAt: 0,
+    };
+
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[CUSTOMERS_ID, customersTable]]),
+      insight,
+      { mode: "query" },
+    );
+    expect(sql).not.toBeNull();
+
+    // The dropped right-key alias must NOT appear anywhere in a WHERE clause.
+    // The filter resolves to the left "customer_id" (retained, id b2b2…), which
+    // IS in the subquery — so either it routes to the retained alias OR is
+    // skipped; either way the dropped right alias (c3c3…) is never referenced.
+    expect(sql!).not.toContain(`WHERE "${droppedRightKeyAlias}"`);
+    expect(sql!).not.toContain(`"${droppedRightKeyAlias}" =`);
+  });
+
+  it("still filters on a RETAINED joined-table column (the fix must not drop legitimate joined filters)", () => {
+    // customer_name is a non-key column from the joined table — it survives into
+    // the subquery and must remain filterable.
+    const nameAlias = fieldIdToColumnAlias(C_NAME_FIELD.id);
+    const insight: Insight = {
+      id: "abababab-cdcd-efef-0101-202020202020" as UUID,
+      name: "Orders filtered by customer name",
+      baseTableId: ORDERS_ID,
+      selectedFields: [O_ID_FIELD.id],
+      metrics: [],
+      joins: [
+        {
+          type: "inner",
+          rightTableId: CUSTOMERS_ID,
+          leftKey: "customer_id",
+          rightKey: "customer_id",
+        },
+      ],
+      filters: [{ field: "customer_name", operator: "eq", value: "Acme" }],
+      createdAt: 0,
+    };
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[CUSTOMERS_ID, customersTable]]),
+      insight,
+      { mode: "query" },
+    );
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`WHERE "${nameAlias}" = 'Acme'`);
+  });
+
+  it("safely skips a filter whose field is absent from the result set entirely (no broken ref, no throw)", () => {
+    // A filter on a column that exists in NEITHER table (e.g. stale saved filter
+    // after a schema change) must not emit `WHERE "ghost_col" = …` — that would
+    // crash the query. It is dropped fail-safe.
+    const insight: Insight = {
+      id: "99990000-1111-2222-3333-444455556666" as UUID,
+      name: "Orders with a stale filter",
+      baseTableId: ORDERS_ID,
+      selectedFields: [O_ID_FIELD.id],
+      metrics: [],
+      filters: [{ field: "ghost_column", operator: "eq", value: "x" }],
+      createdAt: 0,
+    };
+
+    const sql = buildInsightSQL(ordersTable, new Map(), insight, {
+      mode: "query",
+    });
+    expect(sql).not.toBeNull();
+    // No reference to the ghost column, and no dangling WHERE.
+    expect(sql!).not.toContain("ghost_column");
+    expect(sql!).not.toContain("WHERE");
+  });
+});

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -1,0 +1,224 @@
+import type {
+  DataTable,
+  Field,
+  Insight,
+  InsightFilter,
+  InsightMetric,
+  UUID,
+} from "@dashframe/types";
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildInsightSQL,
+  fieldIdToColumnAlias,
+  type BuildInsightSQLOptions,
+} from "./insight-sql";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+//
+// A single base table with two dimension fields (region, order_date) and a
+// numeric field (amount) that a metric aggregates. No joins — exercises the
+// simple/aggregated path, which is where filter routing lives.
+// ---------------------------------------------------------------------------
+
+const TABLE_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const DATAFRAME_ID = "22222222-2222-2222-2222-222222222222" as UUID;
+
+const REGION_FIELD_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const DATE_FIELD_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" as UUID;
+const AMOUNT_FIELD_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID;
+const REVENUE_METRIC_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID;
+
+const regionAlias = fieldIdToColumnAlias(REGION_FIELD_ID);
+const dateAlias = fieldIdToColumnAlias(DATE_FIELD_ID);
+const amountAlias = fieldIdToColumnAlias(AMOUNT_FIELD_ID);
+
+function field(
+  id: UUID,
+  name: string,
+  columnName: string,
+  type: Field["type"],
+): Field {
+  return { id, name, tableId: TABLE_ID, columnName, type };
+}
+
+const REGION_FIELD = field(REGION_FIELD_ID, "Region", "region", "string");
+const DATE_FIELD = field(DATE_FIELD_ID, "Order Date", "order_date", "date");
+const AMOUNT_FIELD = field(AMOUNT_FIELD_ID, "Amount", "amount", "number");
+
+const REVENUE_METRIC: InsightMetric = {
+  id: REVENUE_METRIC_ID,
+  name: "Total Revenue",
+  sourceTable: TABLE_ID,
+  columnName: "amount",
+  aggregation: "sum",
+};
+
+const BASE_TABLE: DataTable = {
+  id: TABLE_ID,
+  name: "sales",
+  dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+  table: "sales.csv",
+  fields: [REGION_FIELD, DATE_FIELD, AMOUNT_FIELD],
+  metrics: [],
+  dataFrameId: DATAFRAME_ID,
+  createdAt: 0,
+};
+
+/** Build an insight grouped by region with a SUM(amount) revenue metric. */
+function groupedInsight(filters?: InsightFilter[]): Insight {
+  return {
+    id: "99999999-9999-9999-9999-999999999999" as UUID,
+    name: "Revenue by Region",
+    baseTableId: TABLE_ID,
+    selectedFields: [REGION_FIELD_ID],
+    metrics: [REVENUE_METRIC],
+    filters,
+    createdAt: 0,
+  };
+}
+
+const QUERY_OPTS: BuildInsightSQLOptions = { mode: "query" };
+
+function build(
+  insight: Insight,
+  opts: BuildInsightSQLOptions = QUERY_OPTS,
+): string {
+  const sql = buildInsightSQL(BASE_TABLE, new Map(), insight, opts);
+  expect(sql).not.toBeNull();
+  return sql!;
+}
+
+describe("buildInsightSQL — filter clause routing", () => {
+  it("emits a WHERE clause for a filter on a grouped dimension (not HAVING)", () => {
+    const sql = build(
+      groupedInsight([{ field: "region", operator: "eq", value: "EMEA" }]),
+    );
+
+    expect(sql).toContain(`WHERE "${regionAlias}" = 'EMEA'`);
+    expect(sql).not.toContain("HAVING");
+    // WHERE must precede GROUP BY (pre-aggregation)
+    expect(sql.indexOf("WHERE")).toBeLessThan(sql.indexOf("GROUP BY"));
+  });
+
+  it("emits a HAVING clause for a filter on a metric (not WHERE)", () => {
+    // Filter references the metric's source column → post-aggregation HAVING.
+    const sql = build(
+      groupedInsight([{ field: "amount", operator: "gt", value: 1000 }]),
+    );
+
+    expect(sql).toContain("HAVING");
+    expect(sql).toContain(`SUM("${amountAlias}") > 1000`);
+    // HAVING references the aggregate, not the raw column in a WHERE
+    expect(sql).not.toMatch(/WHERE/);
+    // HAVING must follow GROUP BY (post-aggregation)
+    expect(sql.indexOf("GROUP BY")).toBeLessThan(sql.indexOf("HAVING"));
+  });
+
+  it("splits mixed dimension + metric filters into both WHERE and HAVING", () => {
+    const sql = build(
+      groupedInsight([
+        { field: "region", operator: "eq", value: "EMEA" },
+        { field: "amount", operator: "gte", value: 500 },
+      ]),
+    );
+
+    expect(sql).toContain(`WHERE "${regionAlias}" = 'EMEA'`);
+    expect(sql).toContain(`HAVING SUM("${amountAlias}") >= 500`);
+    // Ordering: WHERE … GROUP BY … HAVING
+    expect(sql.indexOf("WHERE")).toBeLessThan(sql.indexOf("GROUP BY"));
+    expect(sql.indexOf("GROUP BY")).toBeLessThan(sql.indexOf("HAVING"));
+  });
+});
+
+describe("buildInsightSQL — operators", () => {
+  it("renders BETWEEN low AND high (inclusive) for a date range, correctly quoted", () => {
+    const sql = build(
+      groupedInsight([
+        {
+          field: "order_date",
+          operator: "between",
+          value: { low: "2024-01-01", high: "2024-12-31" },
+        },
+      ]),
+    );
+
+    // order_date is not in selectedFields and not a metric, so it routes to WHERE.
+    // Inclusive BETWEEN with both bounds quoted as string literals.
+    expect(sql).toContain(
+      `"${dateAlias}" BETWEEN '2024-01-01' AND '2024-12-31'`,
+    );
+    expect(sql).toContain("WHERE");
+  });
+
+  it("renders IN (...) for the in operator", () => {
+    const sql = build(
+      groupedInsight([
+        { field: "region", operator: "in", value: ["EMEA", "APAC"] },
+      ]),
+    );
+
+    expect(sql).toContain(`"${regionAlias}" IN ('EMEA', 'APAC')`);
+  });
+
+  it("maps each scalar operator to the right SQL comparison operator", () => {
+    const cases: Array<[InsightFilter["operator"], string]> = [
+      ["eq", "="],
+      ["ne", "<>"],
+      ["gt", ">"],
+      ["gte", ">="],
+      ["lt", "<"],
+      ["lte", "<="],
+    ];
+
+    for (const [operator, sqlOp] of cases) {
+      const sql = build(
+        groupedInsight([{ field: "region", operator, value: "EMEA" }]),
+      );
+      expect(sql).toContain(`"${regionAlias}" ${sqlOp} 'EMEA'`);
+    }
+  });
+
+  it("renders contains as a LIKE %..% match", () => {
+    const sql = build(
+      groupedInsight([{ field: "region", operator: "contains", value: "ME" }]),
+    );
+
+    expect(sql).toContain(`"${regionAlias}" LIKE '%ME%'`);
+  });
+});
+
+describe("buildInsightSQL — regression: filters are no longer silently dropped", () => {
+  it("emits a filter clause when the insight has saved filters", () => {
+    const withFilter = build(
+      groupedInsight([{ field: "region", operator: "eq", value: "EMEA" }]),
+    );
+    const withoutFilter = build(groupedInsight());
+
+    // The bug: filters were accepted but never emitted. Assert the clause is
+    // now PRESENT when filters exist, and ABSENT when they don't.
+    expect(withFilter).toContain("WHERE");
+    expect(withoutFilter).not.toContain("WHERE");
+    expect(withoutFilter).not.toContain("HAVING");
+  });
+});
+
+describe("buildInsightSQL — value quoting / injection guard", () => {
+  it("escapes a single-quote in a value so the SQL is not broken", () => {
+    const sql = build(
+      groupedInsight([{ field: "region", operator: "eq", value: "O'Brien" }]),
+    );
+
+    // Single quote doubled per SQL escaping — the value stays a single literal.
+    expect(sql).toContain(`"${regionAlias}" = 'O''Brien'`);
+    // A naive injection attempt does not terminate the string early.
+    const injection = build(
+      groupedInsight([
+        { field: "region", operator: "eq", value: "x'; DROP TABLE sales; --" },
+      ]),
+    );
+    expect(injection).toContain(`'x''; DROP TABLE sales; --'`);
+    expect(injection).not.toContain(`'x'; DROP`);
+  });
+});

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "bun:test";
 import {
   buildInsightSQL,
   fieldIdToColumnAlias,
+  metricIdToColumnAlias,
   type BuildInsightSQLOptions,
 } from "./insight-sql";
 
@@ -292,5 +293,36 @@ describe("buildInsightSQL — null handling and edge cases", () => {
     );
     expect(sql).toContain("1=1");
     expect(sql).not.toContain("BETWEEN");
+  });
+
+  it("references COUNT(*) in HAVING for a count metric filtered by its output alias", () => {
+    // A COUNT(*) metric has no source column — HAVING must reference COUNT(*),
+    // not a quoted column. The filter targets the metric's output alias.
+    const countMetricId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" as UUID;
+    const insight: Insight = {
+      id: "66666666-6666-6666-6666-666666666666" as UUID,
+      name: "Row count by region",
+      baseTableId: TABLE_ID,
+      selectedFields: [REGION_FIELD_ID],
+      metrics: [
+        {
+          id: countMetricId,
+          name: "Rows",
+          sourceTable: TABLE_ID,
+          aggregation: "count",
+        },
+      ],
+      filters: [
+        {
+          field: metricIdToColumnAlias(countMetricId),
+          operator: "gt",
+          value: 5,
+        },
+      ],
+      createdAt: 0,
+    };
+    const sql = build(insight);
+    expect(sql).toContain("HAVING COUNT(*) > 5");
+    expect(sql).not.toContain("WHERE");
   });
 });

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -513,8 +513,12 @@ function buildFilterPredicate(
 
   switch (operator) {
     case "eq":
+      // `= NULL` is always false in SQL — use IS NULL for null equality.
+      if (value === null || value === undefined) return `${columnRef} IS NULL`;
       return `${columnRef} = ${quoteValue(value)}`;
     case "ne":
+      if (value === null || value === undefined)
+        return `${columnRef} IS NOT NULL`;
       return `${columnRef} <> ${quoteValue(value)}`;
     case "gt":
       return `${columnRef} > ${quoteValue(value)}`;
@@ -539,6 +543,20 @@ function buildFilterPredicate(
       return `${columnRef} IN (${arr.map(quoteValue).join(", ")})`;
     }
     case "between": {
+      // Guard the value shape: a malformed `between` value (null, missing
+      // bound) must not throw or silently filter every row. Emit an always-true
+      // predicate and warn — a no-op is safer than dropping all rows.
+      if (
+        value === null ||
+        typeof value !== "object" ||
+        !("low" in value) ||
+        !("high" in value)
+      ) {
+        console.warn(
+          `between filter has malformed value (expected { low, high }): ${JSON.stringify(value)}`,
+        );
+        return "1=1";
+      }
       const bv = value as InsightFilterBetweenValue;
       return `${columnRef} BETWEEN ${quoteValue(bv.low)} AND ${quoteValue(bv.high)}`;
     }
@@ -587,8 +605,15 @@ function resolveFilterColumnRef(
     }
     return `"${field.columnName ?? field.name}"`;
   }
-  // Fallback: quote the raw column name
-  return `"${filterField}"`;
+  // Fallback: quote the raw column name, escaping any embedded double-quote
+  // (standard SQL identifier escaping: `"` → `""`) so an odd field name can't
+  // break out of the identifier.
+  return quoteIdentifier(filterField);
+}
+
+/** Quote a SQL identifier, escaping embedded double-quotes by doubling them. */
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
 }
 
 /**
@@ -612,7 +637,7 @@ function resolveMetricAggRef(
       m.columnName === filterField ||
       metricIdToColumnAlias(m.id) === filterField,
   );
-  if (!metric) return `"${filterField}"`;
+  if (!metric) return quoteIdentifier(filterField);
 
   const aggFn = metric.aggregation.toUpperCase();
 
@@ -621,7 +646,7 @@ function resolveMetricAggRef(
     return "COUNT(*)";
   }
 
-  if (!metric.columnName) return `"${filterField}"`;
+  if (!metric.columnName) return quoteIdentifier(filterField);
 
   // Resolve the source column to its UUID alias (columns are aliased upstream)
   const sourceField = Array.from(fieldIdMap.values()).find(
@@ -632,10 +657,10 @@ function resolveMetricAggRef(
     : metric.columnName;
 
   if (metric.aggregation === "count_distinct") {
-    return `COUNT(DISTINCT "${sourceRef}")`;
+    return `COUNT(DISTINCT ${quoteIdentifier(sourceRef)})`;
   }
 
-  return `${aggFn}("${sourceRef}")`;
+  return `${aggFn}(${quoteIdentifier(sourceRef)})`;
 }
 
 /**
@@ -648,6 +673,11 @@ function resolveMetricAggRef(
  * a column whose name matches the filter field, OR when the filter field name
  * matches a metric's output alias (`metric_<uuid>`).
  *
+ * **Dimension membership takes precedence.** If a column is both selected as a
+ * grouped dimension and used as a metric's source column, the dimension reading
+ * wins — the grouped value is in scope pre-aggregation, so the filter routes to
+ * WHERE. (A metric still aggregates the same source column independently.)
+ *
  * Everything else defaults to dimension (pre-aggregation WHERE).
  */
 function isMetricFilter(
@@ -655,18 +685,19 @@ function isMetricFilter(
   insight: Insight,
   fieldIdMap: Map<string, Field>,
 ): boolean {
-  // Check if it matches any metric by column name or metric output alias
-  for (const metric of insight.metrics ?? []) {
-    if (metric.columnName === filter.field) return true;
-    if (metricIdToColumnAlias(metric.id) === filter.field) return true;
-  }
-
-  // Check if it matches a selectedField dimension → it's NOT a metric
+  // Dimension membership wins: if the field is a selected (grouped) dimension,
+  // it is NOT a metric filter, even if the same column also feeds a metric.
   for (const fieldId of insight.selectedFields ?? []) {
     const field = fieldIdMap.get(fieldId);
     if (field && (field.columnName ?? field.name) === filter.field) {
       return false; // explicitly a dimension
     }
+  }
+
+  // Otherwise, a match against a metric column or metric output alias → metric.
+  for (const metric of insight.metrics ?? []) {
+    if (metric.columnName === filter.field) return true;
+    if (metricIdToColumnAlias(metric.id) === filter.field) return true;
   }
 
   // Default: treat as dimension (pre-aggregation)
@@ -685,7 +716,7 @@ function isMetricFilter(
 function buildFilterClauses(
   insight: Insight,
   fieldIdMap: Map<string, Field>,
-  hasGroupBy: boolean,
+  hasAggregation: boolean,
   refMode: FilterColumnRefMode,
 ): { whereClause: string; havingClause: string } {
   const filters = insight.filters ?? [];
@@ -695,7 +726,12 @@ function buildFilterClauses(
   const havingPredicates: string[] = [];
 
   for (const filter of filters) {
-    const isMetric = hasGroupBy && isMetricFilter(filter, insight, fieldIdMap);
+    // A metric filter routes to HAVING only when the query actually aggregates.
+    // Aggregation happens whenever metrics are present — with OR without a
+    // GROUP BY (a metrics-only insight emits e.g. COUNT(*) and still needs
+    // HAVING, not WHERE, for a predicate on the aggregate).
+    const isMetric =
+      hasAggregation && isMetricFilter(filter, insight, fieldIdMap);
 
     if (isMetric) {
       // HAVING: reference the aggregate expression (e.g. SUM("field_<uuid>")),
@@ -898,12 +934,13 @@ function buildAggregatedSQL(
   // Build filter clauses (WHERE for dimension filters, HAVING for metric filters).
   // Dimension-vs-metric is derived at compile time from the insight definition:
   // a filter field that matches a metric column → HAVING (post-aggregation),
-  // everything else → WHERE (pre-aggregation).
+  // everything else → WHERE (pre-aggregation). The query aggregates whenever
+  // metrics are present (with or without GROUP BY), so that gates HAVING.
   const hasGroupBy = groupByParts.length > 0;
   const { whereClause, havingClause } = buildFilterClauses(
     insight,
     fieldIdMap,
-    hasGroupBy,
+    hasMetrics,
     "alias",
   );
 

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -219,7 +219,7 @@ export function buildInsightSQL(
   }
 
   // Build joined SQL
-  const joinedSQL = buildJoinedSQL(
+  const joined = buildJoinedSQL(
     baseDFTable,
     baseDisplayName,
     baseFields,
@@ -227,30 +227,28 @@ export function buildInsightSQL(
     joinedTables,
   );
 
-  if (!joinedSQL) return null;
+  if (!joined) return null;
 
-  // Query mode: collect all fields from base + joined tables for field ID resolution
-  const allFields = [...baseFields];
-  for (const [, joinTable] of joinedTables) {
-    const joinFields = (joinTable.fields ?? []).filter(
-      (f) => !f.name.startsWith("_"),
-    );
-    allFields.push(...joinFields);
-  }
+  // `availableFields` is the exact column set present in the joined subquery —
+  // dropped right join-keys are already excluded. Using it (rather than the raw
+  // union of all table fields) ensures a filter can only resolve to a column
+  // that actually exists in the FROM clause; anything else is safely skipped.
+  const allFields = joined.availableFields;
 
-  // Model mode: raw data without transformations
+  // Model mode: raw data without transformations (never filtered — previews
+  // show raw rows).
   if (mode === "model") {
     // Build set of valid column names from all fields (no metrics in model mode)
     const validColumns = new Set(allFields.map((f) => f.columnName ?? f.name));
     return appendPagination(
-      `SELECT * FROM ${joinedSQL}`,
+      `SELECT * FROM ${joined.sql}`,
       options,
       validColumns,
     );
   }
 
   // Apply aggregations with all available fields
-  return buildAggregatedSQL(joinedSQL, allFields, insight, options);
+  return buildAggregatedSQL(joined.sql, allFields, insight, options);
 }
 
 /**
@@ -280,17 +278,19 @@ function buildSimpleSQL(
       baseFields.map((f) => fieldIdToColumnAlias(f.id)),
     );
 
-    // Filters apply pre-aggregation only here (no GROUP BY), so all map to WHERE.
-    // The WHERE references the original source column names (still in scope on
-    // the base table) — UUID aliases are SELECT-only and not portably usable in
-    // WHERE — so resolve refs against raw column names.
-    const fieldIdMap = buildFieldIdMap(baseFields);
-    const { whereClause } = buildFilterClauses(
-      insight,
-      fieldIdMap,
-      false,
-      "raw",
-    );
+    // Filters apply in QUERY mode only. A model-mode preview shows the raw
+    // source rows so the user can see what they're working with *before*
+    // filtering — applying the insight's result-filters would defeat that, and
+    // the joined model path doesn't filter either (keeping both paths
+    // consistent). So only the no-config QUERY case appends a WHERE here.
+    let whereClause = "";
+    if (mode === "query") {
+      // No GROUP BY in this path → all filters map to WHERE. The FROM is the raw
+      // base table, whose columns still carry their source names — resolve refs
+      // against raw column names ("raw" mode).
+      const fieldIdMap = buildFieldIdMap(baseFields);
+      ({ whereClause } = buildFilterClauses(insight, fieldIdMap, false, "raw"));
+    }
 
     let sql = `SELECT ${selectParts.join(", ")} FROM ${tableName} AS "${displayName}"`;
     if (whereClause) {
@@ -356,7 +356,7 @@ function buildJoinedSQL(
   baseFields: Field[],
   insight: Insight,
   joinedTables: Map<UUID, DataTable>,
-): string | null {
+): { sql: string; availableFields: Field[] } | null {
   // First, wrap base table with UUID-aliased columns
   const baseSelects = buildFieldSelects(baseDisplayName, baseFields);
   let currentSQL = `(SELECT ${baseSelects.join(", ")} FROM ${baseDFTable} AS "${baseDisplayName}")`;
@@ -373,12 +373,17 @@ function buildJoinedSQL(
 
     if (joinResult) {
       currentSQL = joinResult.sql;
-      // Accumulate fields from all joined tables for subsequent joins
+      // Accumulate fields from all joined tables for subsequent joins.
+      // `joinResult.allFields` excludes dropped right join-keys, so it is the
+      // accurate set of columns actually present in `currentSQL`.
       currentFields = joinResult.allFields;
     }
   }
 
-  return currentSQL;
+  // `currentFields` is the exact column set in the emitted subquery — dropped
+  // join keys are already excluded. Returning it lets callers build a field map
+  // that matches the FROM clause, so filters can't reference a missing column.
+  return { sql: currentSQL, availableFields: currentFields };
 }
 
 /** Result from processing a single join */
@@ -591,26 +596,25 @@ type FilterColumnRefMode = "alias" | "raw";
  * We look up the matching field to resolve either its UUID alias or its raw
  * column name depending on `refMode`.
  *
- * If no matching field is found, fall back to the raw field name (quoted).
+ * Returns `null` when no field in `fieldIdMap` matches the filter field. That
+ * is the fail-safe signal: the column is NOT present in the FROM clause (e.g. a
+ * filter targeting a joined table's right-key, which `processSingleJoin` drops
+ * from the joined subquery). Emitting a reference to a missing column would make
+ * the whole query fail at runtime, so the caller skips the filter instead.
  */
 function resolveFilterColumnRef(
   filterField: string,
   fieldIdMap: Map<string, Field>,
   refMode: FilterColumnRefMode,
-): string {
+): string | null {
   const field = Array.from(fieldIdMap.values()).find(
     (f) => (f.columnName ?? f.name) === filterField,
   );
-  if (field) {
-    if (refMode === "alias") {
-      return `"${fieldIdToColumnAlias(field.id)}"`;
-    }
-    return `"${field.columnName ?? field.name}"`;
+  if (!field) return null;
+  if (refMode === "alias") {
+    return `"${fieldIdToColumnAlias(field.id)}"`;
   }
-  // Fallback: quote the raw column name, escaping any embedded double-quote
-  // (standard SQL identifier escaping: `"` → `""`) so an odd field name can't
-  // break out of the identifier.
-  return quoteIdentifier(filterField);
+  return `"${field.columnName ?? field.name}"`;
 }
 
 /** Quote a SQL identifier, escaping embedded double-quotes by doubling them. */
@@ -746,6 +750,18 @@ function buildFilterClauses(
         fieldIdMap,
         refMode,
       );
+      if (columnRef === null) {
+        // Fail-safe: the filter field is not a column present in the FROM
+        // clause (e.g. a joined table's right-key, dropped from the joined
+        // subquery). Emitting `WHERE "missing_col" = …` would crash the whole
+        // query at runtime, so skip this filter and warn — a dropped filter is
+        // recoverable; a broken query is not. Warn on the field name only, never
+        // the value (privacy: filter values must not reach logs).
+        console.warn(
+          `Filter on field "${filter.field}" skipped — column not present in query result set (e.g. a dropped join key).`,
+        );
+        continue;
+      }
       wherePredicates.push(buildFilterPredicate(columnRef, filter));
     }
   }

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -552,8 +552,10 @@ function buildFilterPredicate(
         !("low" in value) ||
         !("high" in value)
       ) {
+        // Warn on shape only — never log the value itself: filter values can be
+        // sensitive literals and must not leak into logs (privacy invariant).
         console.warn(
-          `between filter has malformed value (expected { low, high }): ${JSON.stringify(value)}`,
+          `between filter has malformed value (expected { low, high }); received ${value === null ? "null" : typeof value}`,
         );
         return "1=1";
       }

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -20,6 +20,8 @@ import type {
   DataTable,
   Field,
   Insight,
+  InsightFilter,
+  InsightFilterBetweenValue,
   InsightMetric,
   UUID,
 } from "@dashframe/types";
@@ -277,11 +279,25 @@ function buildSimpleSQL(
     const validColumns = new Set(
       baseFields.map((f) => fieldIdToColumnAlias(f.id)),
     );
-    return appendPagination(
-      `SELECT ${selectParts.join(", ")} FROM ${tableName} AS "${displayName}"`,
-      options,
-      validColumns,
+
+    // Filters apply pre-aggregation only here (no GROUP BY), so all map to WHERE.
+    // The WHERE references the original source column names (still in scope on
+    // the base table) — UUID aliases are SELECT-only and not portably usable in
+    // WHERE — so resolve refs against raw column names.
+    const fieldIdMap = buildFieldIdMap(baseFields);
+    const { whereClause } = buildFilterClauses(
+      insight,
+      fieldIdMap,
+      false,
+      "raw",
     );
+
+    let sql = `SELECT ${selectParts.join(", ")} FROM ${tableName} AS "${displayName}"`;
+    if (whereClause) {
+      sql += ` ${whereClause}`;
+    }
+
+    return appendPagination(sql, options, validColumns);
   }
 
   // Query mode with configuration: wrap table with UUID aliases, then apply aggregations
@@ -460,6 +476,253 @@ function processSingleJoin(
 }
 
 // ============================================================================
+// Filter Clause Helpers
+// ============================================================================
+
+/**
+ * Quote a scalar value for safe SQL embedding.
+ *
+ * - Numbers and booleans are emitted as-is (no injection risk).
+ * - Strings are single-quoted with internal single-quotes escaped by doubling
+ *   (standard SQL escaping: `'` → `''`). This matches the convention used in
+ *   the rest of this module (no parameterized placeholders — values are inlined
+ *   at query-build time, not at the DB driver level).
+ * - null / undefined → `NULL`.
+ * - Anything else is coerced to string and then quoted.
+ */
+function quoteValue(val: unknown): string {
+  if (val === null || val === undefined) return "NULL";
+  if (typeof val === "number" || typeof val === "boolean") return String(val);
+  // For everything else (string, Date.toISOString output, etc.) single-quote and escape
+  const str = String(val);
+  // Escape single quotes by doubling them (standard SQL)
+  return `'${str.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Build a single SQL predicate from an InsightFilter.
+ *
+ * The `columnRef` is the already-resolved SQL column reference (possibly
+ * quoted as `"field_<uuid>"` or a raw column name — caller decides).
+ */
+function buildFilterPredicate(
+  columnRef: string,
+  filter: InsightFilter,
+): string {
+  const { operator, value } = filter;
+
+  switch (operator) {
+    case "eq":
+      return `${columnRef} = ${quoteValue(value)}`;
+    case "ne":
+      return `${columnRef} <> ${quoteValue(value)}`;
+    case "gt":
+      return `${columnRef} > ${quoteValue(value)}`;
+    case "gte":
+      return `${columnRef} >= ${quoteValue(value)}`;
+    case "lt":
+      return `${columnRef} < ${quoteValue(value)}`;
+    case "lte":
+      return `${columnRef} <= ${quoteValue(value)}`;
+    case "contains": {
+      // LIKE '%value%' — escape the value's own % and _ to prevent wildcards
+      const escaped = String(value ?? "")
+        .replace(/\\/g, "\\\\")
+        .replace(/%/g, "\\%")
+        .replace(/_/g, "\\_")
+        .replace(/'/g, "''");
+      return `${columnRef} LIKE '%${escaped}%' ESCAPE '\\'`;
+    }
+    case "in": {
+      const arr = Array.isArray(value) ? value : [value];
+      if (arr.length === 0) return "1=0"; // empty IN → always false
+      return `${columnRef} IN (${arr.map(quoteValue).join(", ")})`;
+    }
+    case "between": {
+      const bv = value as InsightFilterBetweenValue;
+      return `${columnRef} BETWEEN ${quoteValue(bv.low)} AND ${quoteValue(bv.high)}`;
+    }
+    default: {
+      // Exhaustiveness guard — TypeScript should catch this, but guard at runtime too
+      const _exhaustive: never = operator;
+      console.warn(`Unknown filter operator: ${String(_exhaustive)}`);
+      return "1=1";
+    }
+  }
+}
+
+/**
+ * How to render the SQL column reference for a filter field.
+ *
+ * - `"alias"`: reference the UUID alias (`"field_<uuid>"`). Use when the FROM
+ *   clause is a wrapped subquery whose columns are already UUID-aliased (the
+ *   aggregated / joined path).
+ * - `"raw"`: reference the source column name (`"columnName"`). Use when the
+ *   FROM clause is the raw base table whose columns still have their original
+ *   names (the model / no-config simple path) — UUID aliases there are
+ *   SELECT-only and not portably usable in WHERE.
+ */
+type FilterColumnRefMode = "alias" | "raw";
+
+/**
+ * Derive the SQL column reference for a filter field.
+ *
+ * Filters reference fields by their source column name (`Field.columnName ?? Field.name`).
+ * We look up the matching field to resolve either its UUID alias or its raw
+ * column name depending on `refMode`.
+ *
+ * If no matching field is found, fall back to the raw field name (quoted).
+ */
+function resolveFilterColumnRef(
+  filterField: string,
+  fieldIdMap: Map<string, Field>,
+  refMode: FilterColumnRefMode,
+): string {
+  const field = Array.from(fieldIdMap.values()).find(
+    (f) => (f.columnName ?? f.name) === filterField,
+  );
+  if (field) {
+    if (refMode === "alias") {
+      return `"${fieldIdToColumnAlias(field.id)}"`;
+    }
+    return `"${field.columnName ?? field.name}"`;
+  }
+  // Fallback: quote the raw column name
+  return `"${filterField}"`;
+}
+
+/**
+ * Resolve a metric filter to the aggregate SQL expression used in HAVING.
+ *
+ * The filter `field` matches either a metric's source `columnName` or its
+ * output alias (`metric_<uuid>`). We rebuild the aggregate expression
+ * (e.g. `SUM("field_<uuid>")`, `COUNT(*)`) so HAVING references the aggregate,
+ * not the (out-of-scope post-aggregation) raw column.
+ *
+ * Falls back to the quoted filter field if no metric matches (shouldn't happen
+ * since this is only called when `isMetricFilter` is true).
+ */
+function resolveMetricAggRef(
+  filterField: string,
+  insight: Insight,
+  fieldIdMap: Map<string, Field>,
+): string {
+  const metric = (insight.metrics ?? []).find(
+    (m) =>
+      m.columnName === filterField ||
+      metricIdToColumnAlias(m.id) === filterField,
+  );
+  if (!metric) return `"${filterField}"`;
+
+  const aggFn = metric.aggregation.toUpperCase();
+
+  // COUNT(*) - no column
+  if (metric.aggregation === "count" && !metric.columnName) {
+    return "COUNT(*)";
+  }
+
+  if (!metric.columnName) return `"${filterField}"`;
+
+  // Resolve the source column to its UUID alias (columns are aliased upstream)
+  const sourceField = Array.from(fieldIdMap.values()).find(
+    (f) => (f.columnName ?? f.name) === metric.columnName,
+  );
+  const sourceRef = sourceField
+    ? fieldIdToColumnAlias(sourceField.id)
+    : metric.columnName;
+
+  if (metric.aggregation === "count_distinct") {
+    return `COUNT(DISTINCT "${sourceRef}")`;
+  }
+
+  return `${aggFn}("${sourceRef}")`;
+}
+
+/**
+ * Determine whether a filter targets a dimension (grouped field) or a metric.
+ *
+ * A filter field is a **dimension** when the insight's `selectedFields` list
+ * contains the ID of a Field whose column name matches the filter field.
+ *
+ * A filter field is a **metric** when the insight's `metrics` list references
+ * a column whose name matches the filter field, OR when the filter field name
+ * matches a metric's output alias (`metric_<uuid>`).
+ *
+ * Everything else defaults to dimension (pre-aggregation WHERE).
+ */
+function isMetricFilter(
+  filter: InsightFilter,
+  insight: Insight,
+  fieldIdMap: Map<string, Field>,
+): boolean {
+  // Check if it matches any metric by column name or metric output alias
+  for (const metric of insight.metrics ?? []) {
+    if (metric.columnName === filter.field) return true;
+    if (metricIdToColumnAlias(metric.id) === filter.field) return true;
+  }
+
+  // Check if it matches a selectedField dimension → it's NOT a metric
+  for (const fieldId of insight.selectedFields ?? []) {
+    const field = fieldIdMap.get(fieldId);
+    if (field && (field.columnName ?? field.name) === filter.field) {
+      return false; // explicitly a dimension
+    }
+  }
+
+  // Default: treat as dimension (pre-aggregation)
+  return false;
+}
+
+/**
+ * Build WHERE and HAVING clauses from insight filters.
+ *
+ * Routing logic (compile-time, derived from insight definition):
+ * - Filter on a grouped dimension → WHERE  (pre-aggregation)
+ * - Filter on a metric            → HAVING (post-aggregation)
+ *
+ * Returns empty strings when there are no filters of that kind.
+ */
+function buildFilterClauses(
+  insight: Insight,
+  fieldIdMap: Map<string, Field>,
+  hasGroupBy: boolean,
+  refMode: FilterColumnRefMode,
+): { whereClause: string; havingClause: string } {
+  const filters = insight.filters ?? [];
+  if (filters.length === 0) return { whereClause: "", havingClause: "" };
+
+  const wherePredicates: string[] = [];
+  const havingPredicates: string[] = [];
+
+  for (const filter of filters) {
+    const isMetric = hasGroupBy && isMetricFilter(filter, insight, fieldIdMap);
+
+    if (isMetric) {
+      // HAVING: reference the aggregate expression (e.g. SUM("field_<uuid>")),
+      // since the raw metric column is not in scope post-aggregation.
+      const aggRef = resolveMetricAggRef(filter.field, insight, fieldIdMap);
+      havingPredicates.push(buildFilterPredicate(aggRef, filter));
+    } else {
+      const columnRef = resolveFilterColumnRef(
+        filter.field,
+        fieldIdMap,
+        refMode,
+      );
+      wherePredicates.push(buildFilterPredicate(columnRef, filter));
+    }
+  }
+
+  const whereClause =
+    wherePredicates.length > 0 ? `WHERE ${wherePredicates.join(" AND ")}` : "";
+  const havingClause =
+    havingPredicates.length > 0
+      ? `HAVING ${havingPredicates.join(" AND ")}`
+      : "";
+
+  return { whereClause, havingClause };
+}
+
+// ============================================================================
 // Aggregation SQL Helpers
 // ============================================================================
 
@@ -596,11 +859,19 @@ function buildAggregatedSQL(
     const validColumns = new Set(
       allFields.map((f) => fieldIdToColumnAlias(f.id)),
     );
-    return appendPagination(
-      `SELECT * FROM ${fromClause}`,
-      options,
-      validColumns,
+    // No GROUP BY here, so all filters map to WHERE. The fromClause is a wrapped
+    // subquery whose columns are already UUID-aliased → use "alias" refMode.
+    const { whereClause } = buildFilterClauses(
+      insight,
+      fieldIdMap,
+      false,
+      "alias",
     );
+    let sql = `SELECT * FROM ${fromClause}`;
+    if (whereClause) {
+      sql += ` ${whereClause}`;
+    }
+    return appendPagination(sql, options, validColumns);
   }
 
   // Build dimension columns with UUID aliases
@@ -624,11 +895,31 @@ function buildAggregatedSQL(
   // Build set of valid columns for sorting (all use UUID aliases now)
   const validColumns = new Set<string>([...dimensionAliases, ...metricAliases]);
 
+  // Build filter clauses (WHERE for dimension filters, HAVING for metric filters).
+  // Dimension-vs-metric is derived at compile time from the insight definition:
+  // a filter field that matches a metric column → HAVING (post-aggregation),
+  // everything else → WHERE (pre-aggregation).
+  const hasGroupBy = groupByParts.length > 0;
+  const { whereClause, havingClause } = buildFilterClauses(
+    insight,
+    fieldIdMap,
+    hasGroupBy,
+    "alias",
+  );
+
   // Build final SQL
   let sql = `SELECT ${selectParts.join(", ")} FROM ${fromClause}`;
 
-  if (groupByParts.length > 0) {
+  if (whereClause) {
+    sql += ` ${whereClause}`;
+  }
+
+  if (hasGroupBy) {
     sql += ` GROUP BY ${groupByParts.join(", ")}`;
+  }
+
+  if (havingClause) {
+    sql += ` ${havingClause}`;
   }
 
   return appendPagination(sql, options, validColumns);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,6 +64,7 @@ export type {
   CompiledInsight,
   Insight,
   InsightFilter,
+  InsightFilterBetweenValue,
   InsightJoinConfig,
   InsightMutations,
   InsightSort,

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -9,11 +9,34 @@ import type { UUID } from "./uuid";
 
 /**
  * Filter predicate for insights.
+ *
+ * `field` is the source column name (matches `Field.columnName ?? Field.name`).
+ *
+ * Operator notes:
+ * - `between`: inclusive range check. `value` must be `{ low: unknown; high: unknown }`.
+ *   Use this for date ranges and numeric ranges — a single filter, not two.
+ * - `in`: membership check. `value` must be an array.
+ * - All other operators: `value` is a scalar.
  */
 export interface InsightFilter {
   field: string;
-  operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains" | "in";
+  operator:
+    | "eq"
+    | "ne"
+    | "gt"
+    | "gte"
+    | "lt"
+    | "lte"
+    | "contains"
+    | "in"
+    | "between";
   value: unknown;
+}
+
+/** Value shape for the `between` operator — inclusive on both bounds. */
+export interface InsightFilterBetweenValue {
+  low: unknown;
+  high: unknown;
 }
 
 /**


### PR DESCRIPTION
`buildInsightSQL` accepted `Insight.filters` but emitted **no filter clause** — saved filters were silently dropped at query time. This is a correctness bug. This PR wires filter-clause generation into the SQL builder and routes predicates by dimension-vs-metric.

> No public tracking issue exists for this fix (issue #74 is the native-DuckDB engine, unrelated). Tracked internally.

## Changes

- **Generate filter clauses** in `buildInsightSQL` from the effective `Insight.filters` — they were accepted but never emitted before.
- **Route WHERE vs HAVING by dimension-vs-metric, derived at compile time** from the insight definition: a filter whose `field` matches a `selectedFields` dimension → `WHERE` (pre-aggregation); a filter whose field matches a metric column → `HAVING` (post-aggregation, referencing the aggregate expression). No discriminator field was added to `InsightFilter` — array membership in the insight *is* the dimension-vs-metric identity, so there is no desync surface.
- **`between` operator**: inclusive `field BETWEEN low AND high`, value shape `{ low, high }`. A date range is a `between` on a date field, not a separate type. (Type-layer change: `"between"` added to the operator union + new `InsightFilterBetweenValue` interface, exported.)
- **All operators handled**: `eq/ne/gt/gte/lt/lte` (scalar), `contains` (`LIKE %..%` with wildcard escaping), `in` (`IN (...)`), `between`.
- **Injection guard**: values are escaped via SQL single-quote doubling (matching the module's existing inline-literal convention) — no raw string interpolation of values.

## Screenshots

No UI change — backend SQL builder only.

## Verification

- New executable-spec tests in `packages/engine/src/sql/insight-sql.test.ts`, each named for its contract: grouped-dimension filter → WHERE; metric filter → HAVING; mixed → both correctly split; `between` on a date → inclusive `BETWEEN low AND high`, quoted; `in` → `IN (...)`; each scalar operator → correct SQL operator; **regression: an insight WITH saved filters now emits a clause** (asserts the clause is present — today it is silently absent); a value containing a quote char does not break the SQL (injection guard).
- `bun test` in `packages/engine`: **11 pass / 0 fail** (2 pre-existing + 9 new).
- Verified the generated SQL by hand for a mixed filter: `… WHERE "field_<region>" = 'EMEA' GROUP BY "field_<region>" HAVING SUM("field_<amount>") > 1000` — WHERE precedes GROUP BY, HAVING follows it and references the aggregate.
- Full CI-equivalent locally green: `bun format:check`, `bun run check:ticket-refs`, `bun check` (lint + typecheck + test across all 77 tasks).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires filter-clause generation into `buildInsightSQL`, fixing a correctness bug where `Insight.filters` were accepted but never emitted. Filters are now routed to WHERE (dimension/pre-aggregation) or HAVING (metric/post-aggregation) based on the insight definition, with the `between` operator added and an injection guard via SQL single-quote doubling.

- **Filter routing**: `isMetricFilter` checks `selectedFields` membership first (dimension wins over metric for shared columns), then metric array membership; `buildFilterClauses` builds WHERE and HAVING predicate lists accordingly and joins them with AND.
- **Operator coverage**: `eq`/`ne` emit IS NULL / IS NOT NULL for null values; `between` guards its value shape and emits `1=1` with a warning on malformed input; `contains` uses `LIKE '%…%' ESCAPE '\\'` with wildcard-char escaping; `in` handles empty arrays as `1=0`.
- **Model-mode consistency**: Both the simple and joined code paths intentionally suppress filters in model mode (raw preview rows), documented in code comments and a dedicated test.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the filter routing, operator predicates, null guards, and injection escaping are all correct, and the test suite covers all code paths including edge cases.

The implementation is thorough: dimension-vs-metric routing is correctly derived at compile time, IS NULL / IS NOT NULL guards are in place for eq/ne, between has a malformed-value guard, and a fail-safe skip prevents broken column references from crashing queries. The only gap is that gt/gte/lt/lte with a null value silently produce col > NULL (zero rows, no warning) — an edge case inconsistency with the null handling already present for eq/ne and between, but not a regression over previous behavior.

packages/engine/src/sql/insight-sql.ts — specifically the comparison-operator cases in buildFilterPredicate; all other files are clean.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/engine/src/sql/insight-sql.ts | Core implementation of filter clause generation: WHERE/HAVING routing, operator predicates, quoting, and null guards. Logic is well-structured with correct IS NULL handling for eq/ne and a malformed-value guard for between; gt/gte/lt/lte with a null value silently produce col > NULL (returns no rows, no warning). |
| packages/engine/src/sql/insight-sql.test.ts | New test file with 11 specs covering WHERE/HAVING routing, all operators, null predicates, injection guard, model-mode suppression, and join-key drop safety. All critical contracts are covered; no null-value tests for gt/gte/lt/lte operators. |
| packages/types/src/insights.ts | Adds `between` to the operator union and exports new InsightFilterBetweenValue interface; clean, minimal type-layer change. |
| packages/types/src/index.ts | Exports the new InsightFilterBetweenValue type; one-line addition, no issues. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildInsightSQL] --> B{Has joins?}
    B -- Yes --> C[buildJoinedSQL\nreturns sql + availableFields]
    C --> D{mode === model?}
    D -- Yes --> E[SELECT * FROM joined.sql\nno filters]
    D -- No --> F[buildAggregatedSQL\njoined.sql]
    B -- No --> G[buildSimpleSQL]
    G --> H{mode === model OR\nno config?}
    H -- Yes + model --> I[SELECT * FROM table\nno filters]
    H -- Yes + query --> J[SELECT * FROM table\nWHERE buildFilterClauses\nraw refMode]
    H -- No --> K[Wrap table as subquery\nbuildAggregatedSQL]
    F --> L[buildFilterClauses\nalias refMode]
    K --> L
    L --> M{isMetricFilter?}
    M -- Yes + hasAggregation --> N[HAVING agg_expr op val]
    M -- No --> O{resolveFilterColumnRef\nreturns null?}
    O -- null --> P[Skip filter + warn]
    O -- ref --> Q[WHERE ref op val]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/engine/src/sql/insight-sql.ts`, line 242-250 ([link](https://github.com/youhaowei/dashframe/blob/664af94cd0462276afe75fcb96df74aae7fa5580/packages/engine/src/sql/insight-sql.ts#L242-L250)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Joined model-mode queries still silently drop filters**

   When an insight has joins and `mode === "model"`, this path returns `SELECT * FROM ${joinedSQL}` with no WHERE clause — filters are still ignored. The PR wires filter clauses into `buildSimpleSQL` and `buildAggregatedSQL`, but this joined-model path was not updated. An insight that has both joins and saved filters will produce unfiltered results whenever it is loaded in model mode, directly contradicting the stated fix.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/engine/src/sql/insight-sql.ts
   Line: 242-250

   Comment:
   **Joined model-mode queries still silently drop filters**

   When an insight has joins and `mode === "model"`, this path returns `SELECT * FROM ${joinedSQL}` with no WHERE clause — filters are still ignored. The PR wires filter clauses into `buildSimpleSQL` and `buildAggregatedSQL`, but this joined-model path was not updated. An insight that has both joins and saved filters will produce unfiltered results whenever it is loaded in model mode, directly contradicting the stated fix.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%0ALine%3A%20242-250%0A%0AComment%3A%0A**Joined%20model-mode%20queries%20still%20silently%20drop%20filters**%0A%0AWhen%20an%20insight%20has%20joins%20and%20%60mode%20%3D%3D%3D%20%22model%22%60%2C%20this%20path%20returns%20%60SELECT%20*%20FROM%20%24%7BjoinedSQL%7D%60%20with%20no%20WHERE%20clause%20%E2%80%94%20filters%20are%20still%20ignored.%20The%20PR%20wires%20filter%20clauses%20into%20%60buildSimpleSQL%60%20and%20%60buildAggregatedSQL%60%2C%20but%20this%20joined-model%20path%20was%20not%20updated.%20An%20insight%20that%20has%20both%20joins%20and%20saved%20filters%20will%20produce%20unfiltered%20results%20whenever%20it%20is%20loaded%20in%20model%20mode%2C%20directly%20contradicting%20the%20stated%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw146-impl%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw146-impl%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%0ALine%3A%20242-250%0A%0AComment%3A%0A**Joined%20model-mode%20queries%20still%20silently%20drop%20filters**%0A%0AWhen%20an%20insight%20has%20joins%20and%20%60mode%20%3D%3D%3D%20%22model%22%60%2C%20this%20path%20returns%20%60SELECT%20*%20FROM%20%24%7BjoinedSQL%7D%60%20with%20no%20WHERE%20clause%20%E2%80%94%20filters%20are%20still%20ignored.%20The%20PR%20wires%20filter%20clauses%20into%20%60buildSimpleSQL%60%20and%20%60buildAggregatedSQL%60%2C%20but%20this%20joined-model%20path%20was%20not%20updated.%20An%20insight%20that%20has%20both%20joins%20and%20saved%20filters%20will%20produce%20unfiltered%20results%20whenever%20it%20is%20loaded%20in%20model%20mode%2C%20directly%20contradicting%20the%20stated%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%0ALine%3A%20242-250%0A%0AComment%3A%0A**Joined%20model-mode%20queries%20still%20silently%20drop%20filters**%0A%0AWhen%20an%20insight%20has%20joins%20and%20%60mode%20%3D%3D%3D%20%22model%22%60%2C%20this%20path%20returns%20%60SELECT%20*%20FROM%20%24%7BjoinedSQL%7D%60%20with%20no%20WHERE%20clause%20%E2%80%94%20filters%20are%20still%20ignored.%20The%20PR%20wires%20filter%20clauses%20into%20%60buildSimpleSQL%60%20and%20%60buildAggregatedSQL%60%2C%20but%20this%20joined-model%20path%20was%20not%20updated.%20An%20insight%20that%20has%20both%20joins%20and%20saved%20filters%20will%20produce%20unfiltered%20results%20whenever%20it%20is%20loaded%20in%20model%20mode%2C%20directly%20contradicting%20the%20stated%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/engine/src/sql/insight-sql.ts`, line 241-250 ([link](https://github.com/youhaowei/dashframe/blob/b2e7bf3934050a960e16cbc7694a193c360f67d6/packages/engine/src/sql/insight-sql.ts#L241-L250)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Joined model-mode path still silently drops all filters**

   When an insight has joins and `mode === "model"`, the function returns `SELECT * FROM ${joinedSQL}` with no WHERE clause. `insight.filters` is ignored entirely. Every other code path in this PR now correctly emits filter clauses — `buildSimpleSQL` (model branch), `buildAggregatedSQL` (both the no-config and aggregated branches) — but this joined path was not updated. An insight that has joins and saved filters will produce completely unfiltered results whenever it's loaded in model mode, directly contradicting the PR's stated fix.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/engine/src/sql/insight-sql.ts
   Line: 241-250

   Comment:
   **Joined model-mode path still silently drops all filters**

   When an insight has joins and `mode === "model"`, the function returns `SELECT * FROM ${joinedSQL}` with no WHERE clause. `insight.filters` is ignored entirely. Every other code path in this PR now correctly emits filter clauses — `buildSimpleSQL` (model branch), `buildAggregatedSQL` (both the no-config and aggregated branches) — but this joined path was not updated. An insight that has joins and saved filters will produce completely unfiltered results whenever it's loaded in model mode, directly contradicting the PR's stated fix.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%0ALine%3A%20241-250%0A%0AComment%3A%0A**Joined%20model-mode%20path%20still%20silently%20drops%20all%20filters**%0A%0AWhen%20an%20insight%20has%20joins%20and%20%60mode%20%3D%3D%3D%20%22model%22%60%2C%20the%20function%20returns%20%60SELECT%20*%20FROM%20%24%7BjoinedSQL%7D%60%20with%20no%20WHERE%20clause.%20%60insight.filters%60%20is%20ignored%20entirely.%20Every%20other%20code%20path%20in%20this%20PR%20now%20correctly%20emits%20filter%20clauses%20%E2%80%94%20%60buildSimpleSQL%60%20%28model%20branch%29%2C%20%60buildAggregatedSQL%60%20%28both%20the%20no-config%20and%20aggregated%20branches%29%20%E2%80%94%20but%20this%20joined%20path%20was%20not%20updated.%20An%20insight%20that%20has%20joins%20and%20saved%20filters%20will%20produce%20completely%20unfiltered%20results%20whenever%20it's%20loaded%20in%20model%20mode%2C%20directly%20contradicting%20the%20PR's%20stated%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw146-impl%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw146-impl%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%0ALine%3A%20241-250%0A%0AComment%3A%0A**Joined%20model-mode%20path%20still%20silently%20drops%20all%20filters**%0A%0AWhen%20an%20insight%20has%20joins%20and%20%60mode%20%3D%3D%3D%20%22model%22%60%2C%20the%20function%20returns%20%60SELECT%20*%20FROM%20%24%7BjoinedSQL%7D%60%20with%20no%20WHERE%20clause.%20%60insight.filters%60%20is%20ignored%20entirely.%20Every%20other%20code%20path%20in%20this%20PR%20now%20correctly%20emits%20filter%20clauses%20%E2%80%94%20%60buildSimpleSQL%60%20%28model%20branch%29%2C%20%60buildAggregatedSQL%60%20%28both%20the%20no-config%20and%20aggregated%20branches%29%20%E2%80%94%20but%20this%20joined%20path%20was%20not%20updated.%20An%20insight%20that%20has%20joins%20and%20saved%20filters%20will%20produce%20completely%20unfiltered%20results%20whenever%20it's%20loaded%20in%20model%20mode%2C%20directly%20contradicting%20the%20PR's%20stated%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%0ALine%3A%20241-250%0A%0AComment%3A%0A**Joined%20model-mode%20path%20still%20silently%20drops%20all%20filters**%0A%0AWhen%20an%20insight%20has%20joins%20and%20%60mode%20%3D%3D%3D%20%22model%22%60%2C%20the%20function%20returns%20%60SELECT%20*%20FROM%20%24%7BjoinedSQL%7D%60%20with%20no%20WHERE%20clause.%20%60insight.filters%60%20is%20ignored%20entirely.%20Every%20other%20code%20path%20in%20this%20PR%20now%20correctly%20emits%20filter%20clauses%20%E2%80%94%20%60buildSimpleSQL%60%20%28model%20branch%29%2C%20%60buildAggregatedSQL%60%20%28both%20the%20no-config%20and%20aggregated%20branches%29%20%E2%80%94%20but%20this%20joined%20path%20was%20not%20updated.%20An%20insight%20that%20has%20joins%20and%20saved%20filters%20will%20produce%20completely%20unfiltered%20results%20whenever%20it's%20loaded%20in%20model%20mode%2C%20directly%20contradicting%20the%20PR's%20stated%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(engine): never emit filters referenc..."](https://github.com/youhaowei/dashframe/commit/cae14001db336ed614816d06f1d81bfa57f529c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37408192)</sub>

<!-- /greptile_comment -->