### PR TITLE
fix(app): engine-error UX — toast for unreachable engine + fail-soft on mid-session loss

### DIFF
--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -128,18 +128,19 @@ bootstrap().catch(renderBootstrapError);
 // escape through mosaic-core internals (Coordinator's internal promise chains
 // have no outer catch) and surface as unhandledrejection events. In Electron,
 // an unhandled rejection in the renderer process kills the page (CDP page count
-// → 0). Catch them here: log and swallow. The VisualizationBoundary in
-// VisualizationSetup catches render-phase throws from the same cause; this
-// handles the async side of the same failure mode.
+// → 0). Catch them here: log and swallow engine-loss rejections only.
+// Pattern matches loopback-specific strings from nativeConnector.ts so we never
+// silence unrelated bugs (see the regex comment below).
 window.addEventListener("unhandledrejection", (event) => {
   const reason = event.reason;
   const msg =
     reason instanceof Error ? reason.message : String(reason ?? "unknown");
-  // Only intercept rejections that look like engine/loopback failures so we
-  // don't silence unrelated bugs. Loopback errors include "Native engine",
-  // "fetch", "AbortError", "Failed to fetch", and HTTP status codes.
+  // Intercept only rejections that are clearly from the loopback engine path.
+  // Match on strings our own loopback fetch code produces (see nativeConnector.ts
+  // and the fetchWithTimeout helper) — never on generic terms like "fetch",
+  // "abort", or "network" which appear in unrelated errors and would mask bugs.
   const isEngineLoss =
-    /native engine|loopback|fetch|abort|network|econnrefused|econnreset|etimedout/i.test(
+    /native engine|loopback server|local server|127\.0\.0\.1:\d+|data\/arrow|data\/tables/i.test(
       msg,
     );
   if (isEngineLoss) {

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -121,3 +121,32 @@ async function bootstrap() {
 }
 
 bootstrap().catch(renderBootstrapError);
+
+// ── Fail-soft: mid-session engine loss ──────────────────────────────────────
+// When the native DuckDB engine stops mid-session, pending Mosaic/vgplot fetch
+// calls reject with a network or timeout error. These Promise rejections can
+// escape through mosaic-core internals (Coordinator's internal promise chains
+// have no outer catch) and surface as unhandledrejection events. In Electron,
+// an unhandled rejection in the renderer process kills the page (CDP page count
+// → 0). Catch them here: log and swallow. The VisualizationBoundary in
+// VisualizationSetup catches render-phase throws from the same cause; this
+// handles the async side of the same failure mode.
+window.addEventListener("unhandledrejection", (event) => {
+  const reason = event.reason;
+  const msg =
+    reason instanceof Error ? reason.message : String(reason ?? "unknown");
+  // Only intercept rejections that look like engine/loopback failures so we
+  // don't silence unrelated bugs. Loopback errors include "Native engine",
+  // "fetch", "AbortError", "Failed to fetch", and HTTP status codes.
+  const isEngineLoss =
+    /native engine|loopback|fetch|abort|network|econnrefused|econnreset|etimedout/i.test(
+      msg,
+    );
+  if (isEngineLoss) {
+    console.warn(
+      "[DashFrame] Swallowed unhandled rejection (engine loss):",
+      reason,
+    );
+    event.preventDefault();
+  }
+});

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -136,11 +136,19 @@ window.addEventListener("unhandledrejection", (event) => {
   const msg =
     reason instanceof Error ? reason.message : String(reason ?? "unknown");
   // Intercept only rejections that are clearly from the loopback engine path.
-  // Match on strings our own loopback fetch code produces (see nativeConnector.ts
-  // and the fetchWithTimeout helper) — never on generic terms like "fetch",
-  // "abort", or "network" which appear in unrelated errors and would mask bugs.
+  // The patterns cover all error strings thrown by nativeConnector.ts:
+  //   "Native engine timed out…"   → fetchWithTimeout AbortError translation
+  //   "Native engine query failed" → non-OK HTTP response on /data/arrow
+  //   "Failed to upload table"     → non-OK HTTP on /data/tables/:name
+  //   "Failed to fetch"            → browser network error (ECONNREFUSED) when
+  //      the loopback server stops mid-session. This is generic, but on desktop
+  //      the only in-session cross-origin fetch is to the loopback engine —
+  //      there is no cloud/analytics network call in the Electron renderer.
+  //      Accept this narrow false-positive risk: swallowing a genuine "Failed
+  //      to fetch" from another source on the DESKTOP path is very low risk;
+  //      failing to swallow a loopback engine-loss rejection crashes the renderer.
   const isEngineLoss =
-    /native engine|loopback server|local server|127\.0\.0\.1:\d+|data\/arrow|data\/tables/i.test(
+    /native engine|loopback server|local server|127\.0\.0\.1:\d+|data\/arrow|data\/tables|failed to upload|failed to fetch/i.test(
       msg,
     );
   if (isEngineLoss) {

--- a/packages/app/src/components/providers/VisualizationSetup.test.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.test.tsx
@@ -1,10 +1,17 @@
 /**
  * Tests for VisualizationSetup error routing contracts (see #96).
  *
- * Contracts verified:
- * 1. Whole-engine-down (engineError set, no connector) → Sonner toast, NOT inline ErrorState.
- * 2. VisualizationProvider init failure → toast (whole-engine-down), NOT inline slab.
- * 3. VisualizationBoundary catches render-phase throws → toast + empty state, no crash.
+ * Contracts verified here:
+ * 1. Whole-engine-down does NOT fire a toast and does NOT render an inline slab
+ *    from this component — that surface moved to VisualizationDisplay (persistent
+ *    inline affordance). VisualizationSetup just passes children through.
+ * 2. VisualizationBoundary catches render-phase throws → fires a Reload-action
+ *    toast that never auto-dismisses (duration: Infinity), and leaves children
+ *    mounted (no renderer crash, navigation survives).
+ *
+ * The persistent inline engine-unavailable affordance is tested in
+ * EngineUnavailableState.test.tsx (the surface) and VisualizationDisplay reads
+ * the engine signals; this file only covers what VisualizationSetup still owns.
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
@@ -55,9 +62,8 @@ vi.mock("./DuckDBProvider", () => ({
   useDuckDBContext: () => mockUseDuckDBContext(),
 }));
 
-// VisualizationProvider: stub that just renders children.
-// VisualizationErrorToast reads useVisualization() from inside the provider,
-// so stub useVisualization too.
+// VisualizationProvider: stub that just renders children. The boundary test
+// makes useVisualization throw to simulate a setup-component render crash.
 const { mockUseVisualization } = vi.hoisted(() => ({
   mockUseVisualization: vi.fn().mockReturnValue({
     error: null,
@@ -116,8 +122,8 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
     });
   });
 
-  describe("whole-engine-down → toast, NOT inline slab", () => {
-    it("fires showError toast when engineError is set and no connector", async () => {
+  describe("whole-engine-down → no toast, no inline slab from this component", () => {
+    it("does NOT fire a toast when engineError is set (surface moved to inline)", async () => {
       mockUseChartEngine.mockReturnValue({
         connector: null,
         engineError: "Native engine unavailable: connection refused",
@@ -126,17 +132,12 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
 
       renderSetup();
 
-      await waitFor(() => {
-        expect(mockShowError).toHaveBeenCalledWith(
-          "Native engine unreachable",
-          expect.objectContaining({
-            description: expect.stringContaining("Charts are unavailable"),
-          }),
-        );
-      });
+      // Give effects a tick to fire — nothing should call showError.
+      await new Promise((r) => setTimeout(r, 0));
+      expect(mockShowError).not.toHaveBeenCalled();
     });
 
-    it("does NOT render an inline ErrorState slab for engine-down condition", () => {
+    it("does NOT render an inline ErrorState slab for the engine-down condition", () => {
       mockUseChartEngine.mockReturnValue({
         connector: null,
         engineError: "Native engine unavailable: connection refused",
@@ -145,12 +146,12 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
 
       renderSetup(<div data-testid="child" />);
 
-      // Inline ErrorState would render the title text directly in the DOM.
-      // With the toast-only approach, this text must not appear as an inline element.
-      expect(screen.queryByText("Native engine unavailable")).toBeNull();
+      // The raw engineError string must never reach the DOM (DESIGN.md:
+      // no raw runtime errors in UI).
+      expect(screen.queryByText(/Native engine unavailable/i)).toBeNull();
     });
 
-    it("still renders children when engine is down (degraded, not dead)", () => {
+    it("still passes children through when engine is down (degraded, not dead)", () => {
       mockUseChartEngine.mockReturnValue({
         connector: null,
         engineError: "Native engine unavailable: connection refused",
@@ -162,52 +163,11 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
       expect(screen.queryByTestId("child")).not.toBeNull();
     });
 
-    it("does NOT fire toast when engineError is null (healthy path)", async () => {
-      mockUseChartEngine.mockReturnValue({
-        connector: null,
-        engineError: null,
-        uploadArrowTable: null,
-      });
-
+    it("does NOT fire a toast on the healthy path (engineError null)", async () => {
       renderSetup();
 
-      // Give effects a tick to fire
       await new Promise((r) => setTimeout(r, 0));
-      expect(mockShowError).not.toHaveBeenCalledWith(
-        "Native engine unreachable",
-        expect.anything(),
-      );
-    });
-  });
-
-  describe("VisualizationProvider init failure → toast, NOT inline slab", () => {
-    it("fires showError toast when VisualizationProvider fails to initialize", async () => {
-      // Connector is present (desktop path), so the native VisualizationProvider
-      // branch is taken. Inside it, useVisualization().error is set.
-      const mockConnector = { query: vi.fn() };
-      mockUseChartEngine.mockReturnValue({
-        connector: mockConnector,
-        engineError: null,
-        uploadArrowTable: null,
-      });
-      mockUseVisualization.mockReturnValue({
-        error: new Error("Failed to load @uwdata/vgplot"),
-        api: null,
-        isReady: false,
-        coordinator: null,
-        renderer: null,
-      });
-
-      renderSetup();
-
-      await waitFor(() => {
-        expect(mockShowError).toHaveBeenCalledWith(
-          "Visualization engine failed to start",
-          expect.objectContaining({
-            description: expect.stringContaining("Charts may not render"),
-          }),
-        );
-      });
+      expect(mockShowError).not.toHaveBeenCalled();
     });
   });
 
@@ -227,7 +187,7 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
       expect(screen.queryByTestId("child")).not.toBeNull();
     });
 
-    it("VisualizationBoundary catches throw from setup components, fires toast, leaves children mounted", async () => {
+    it("catches a setup-component throw, fires a Reload-action toast that never auto-dismisses, and leaves children mounted", async () => {
       const mockConnector = { query: vi.fn() };
       mockUseChartEngine.mockReturnValue({
         connector: mockConnector,
@@ -235,9 +195,9 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
         uploadArrowTable: null,
       });
 
-      // Simulate a setup component (VisualizationErrorToast) throwing by
-      // making useVisualization throw during render. The boundary wraps the
-      // setup subtree; children are outside the boundary and must stay mounted.
+      // Simulate a setup component (RendererRegistration) throwing by making
+      // useVisualization throw during render. The boundary wraps the setup
+      // subtree; children are outside the boundary and must stay mounted.
       mockUseVisualization.mockImplementation(() => {
         throw new Error("Mosaic coordinator exploded");
       });
@@ -250,15 +210,25 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
       // Must not throw at the render level (boundary catches it)
       expect(() => renderSetup(<div data-testid="child" />)).not.toThrow();
 
-      // Toast must fire with crash signal
+      // Toast must fire with the plain-language crash copy, a Reload action,
+      // and Infinity duration (must not fade before the user can act).
       await waitFor(() => {
         expect(mockShowError).toHaveBeenCalledWith(
-          "Chart engine crashed mid-session",
+          "Charts were reset",
           expect.objectContaining({
-            description: expect.stringContaining("Reload to reconnect"),
+            description: expect.stringContaining("interrupted"),
+            duration: Infinity,
+            action: expect.objectContaining({
+              label: "Reload",
+              onClick: expect.any(Function),
+            }),
           }),
         );
       });
+
+      // The crash copy must NOT leak implementation terms.
+      const [, opts] = mockShowError.mock.calls[0]!;
+      expect(opts.description).not.toMatch(/native|wasm|mosaic|coordinator/i);
 
       // Children (shell, toaster) must remain mounted — not blanked by the boundary.
       expect(screen.queryByTestId("child")).not.toBeNull();

--- a/packages/app/src/components/providers/VisualizationSetup.test.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * Tests for VisualizationSetup error routing contracts (see #96).
+ *
+ * Contracts verified:
+ * 1. Whole-engine-down (engineError set, no connector) → Sonner toast, NOT inline ErrorState.
+ * 2. VisualizationProvider init failure → toast (whole-engine-down), NOT inline slab.
+ * 3. VisualizationBoundary catches render-phase throws → toast + empty state, no crash.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockShowError, mockUseToastStore } = vi.hoisted(() => {
+  const showError = vi.fn().mockReturnValue("toast-id");
+  return {
+    mockShowError: showError,
+    mockUseToastStore: vi.fn().mockReturnValue({ showError }),
+  };
+});
+
+vi.mock("@/lib/stores/toast-store", () => ({
+  useToastStore: () => mockUseToastStore(),
+}));
+
+const { mockUseChartEngine } = vi.hoisted(() => ({
+  mockUseChartEngine: vi.fn().mockReturnValue({
+    connector: null,
+    engineError: null,
+    uploadArrowTable: null,
+  }),
+}));
+
+vi.mock("./ChartEngineProvider", () => ({
+  useChartEngine: () => mockUseChartEngine(),
+}));
+
+const { mockInitDuckDB, mockUseDuckDBContext } = vi.hoisted(() => {
+  const initDuckDB = vi.fn();
+  return {
+    mockInitDuckDB: initDuckDB,
+    mockUseDuckDBContext: vi.fn().mockReturnValue({
+      db: {},
+      connection: {},
+      isInitialized: true,
+      isLoading: false,
+      error: null,
+      initDuckDB,
+    }),
+  };
+});
+
+vi.mock("./DuckDBProvider", () => ({
+  useDuckDBContext: () => mockUseDuckDBContext(),
+}));
+
+// VisualizationProvider: stub that just renders children.
+// VisualizationErrorToast reads useVisualization() from inside the provider,
+// so stub useVisualization too.
+const { mockUseVisualization } = vi.hoisted(() => ({
+  mockUseVisualization: vi.fn().mockReturnValue({
+    error: null,
+    api: null,
+    isReady: false,
+    coordinator: null,
+    renderer: null,
+  }),
+}));
+
+vi.mock("@dashframe/visualization", () => ({
+  VisualizationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  createVgplotRenderer: vi.fn(),
+  registerRenderer: vi.fn(),
+  useVisualization: () => mockUseVisualization(),
+}));
+
+// ── Component under test ──────────────────────────────────────────────────────
+
+import { VisualizationSetup } from "./VisualizationSetup";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderSetup(children: React.ReactNode = <div>child</div>) {
+  return render(<VisualizationSetup>{children}</VisualizationSetup>);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("VisualizationSetup — error routing (issue #96)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore defaults after clearAllMocks wipes mockReturnValue
+    mockUseToastStore.mockReturnValue({ showError: mockShowError });
+    mockUseChartEngine.mockReturnValue({
+      connector: null,
+      engineError: null,
+      uploadArrowTable: null,
+    });
+    mockUseDuckDBContext.mockReturnValue({
+      db: {},
+      connection: {},
+      isInitialized: true,
+      isLoading: false,
+      error: null,
+      initDuckDB: mockInitDuckDB,
+    });
+    mockUseVisualization.mockReturnValue({
+      error: null,
+      api: null,
+      isReady: false,
+      coordinator: null,
+      renderer: null,
+    });
+  });
+
+  describe("whole-engine-down → toast, NOT inline slab", () => {
+    it("fires showError toast when engineError is set and no connector", async () => {
+      mockUseChartEngine.mockReturnValue({
+        connector: null,
+        engineError: "Native engine unavailable: connection refused",
+        uploadArrowTable: null,
+      });
+
+      renderSetup();
+
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith(
+          "Native engine unreachable",
+          expect.objectContaining({
+            description: expect.stringContaining("Charts are unavailable"),
+          }),
+        );
+      });
+    });
+
+    it("does NOT render an inline ErrorState slab for engine-down condition", () => {
+      mockUseChartEngine.mockReturnValue({
+        connector: null,
+        engineError: "Native engine unavailable: connection refused",
+        uploadArrowTable: null,
+      });
+
+      renderSetup(<div data-testid="child" />);
+
+      // Inline ErrorState would render the title text directly in the DOM.
+      // With the toast-only approach, this text must not appear as an inline element.
+      expect(screen.queryByText("Native engine unavailable")).toBeNull();
+    });
+
+    it("still renders children when engine is down (degraded, not dead)", () => {
+      mockUseChartEngine.mockReturnValue({
+        connector: null,
+        engineError: "Native engine unavailable: connection refused",
+        uploadArrowTable: null,
+      });
+
+      renderSetup(<div data-testid="child" />);
+
+      expect(screen.queryByTestId("child")).not.toBeNull();
+    });
+
+    it("does NOT fire toast when engineError is null (healthy path)", async () => {
+      mockUseChartEngine.mockReturnValue({
+        connector: null,
+        engineError: null,
+        uploadArrowTable: null,
+      });
+
+      renderSetup();
+
+      // Give effects a tick to fire
+      await new Promise((r) => setTimeout(r, 0));
+      expect(mockShowError).not.toHaveBeenCalledWith(
+        "Native engine unreachable",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("VisualizationProvider init failure → toast, NOT inline slab", () => {
+    it("fires showError toast when VisualizationProvider fails to initialize", async () => {
+      // Connector is present (desktop path), so the native VisualizationProvider
+      // branch is taken. Inside it, useVisualization().error is set.
+      const mockConnector = { query: vi.fn() };
+      mockUseChartEngine.mockReturnValue({
+        connector: mockConnector,
+        engineError: null,
+        uploadArrowTable: null,
+      });
+      mockUseVisualization.mockReturnValue({
+        error: new Error("Failed to load @uwdata/vgplot"),
+        api: null,
+        isReady: false,
+        coordinator: null,
+        renderer: null,
+      });
+
+      renderSetup();
+
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith(
+          "Visualization engine failed to start",
+          expect.objectContaining({
+            description: expect.stringContaining("Charts may not render"),
+          }),
+        );
+      });
+    });
+  });
+
+  describe("VisualizationBoundary — fail-soft on mid-session render throw", () => {
+    it("renders children normally when no error is thrown", () => {
+      const mockConnector = { query: vi.fn() };
+      mockUseChartEngine.mockReturnValue({
+        connector: mockConnector,
+        engineError: null,
+        uploadArrowTable: null,
+      });
+
+      renderSetup(<div data-testid="child" />);
+
+      expect(screen.queryByTestId("child")).not.toBeNull();
+    });
+
+    it("catches render-phase throw from child, does not re-throw, fires toast", async () => {
+      const mockConnector = { query: vi.fn() };
+      mockUseChartEngine.mockReturnValue({
+        connector: mockConnector,
+        engineError: null,
+        uploadArrowTable: null,
+      });
+
+      // Child that throws on render — simulates Mosaic/vgplot throwing when
+      // the engine is gone mid-session.
+      function BrokenChild(): React.ReactElement {
+        throw new Error("Native engine timed out");
+      }
+
+      // Suppress React's console.error for expected error boundary events
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      // Must not throw at the render level (boundary catches it)
+      expect(() => renderSetup(<BrokenChild />)).not.toThrow();
+
+      // Toast must fire with crash signal
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith(
+          "Chart engine crashed mid-session",
+          expect.objectContaining({
+            description: expect.stringContaining("Reload to reconnect"),
+          }),
+        );
+      });
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/packages/app/src/components/providers/VisualizationSetup.test.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.test.tsx
@@ -212,7 +212,7 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
   });
 
   describe("VisualizationBoundary — fail-soft on mid-session render throw", () => {
-    it("renders children normally when no error is thrown", () => {
+    it("renders children when connector is present (native path nominal)", () => {
       const mockConnector = { query: vi.fn() };
       mockUseChartEngine.mockReturnValue({
         connector: mockConnector,
@@ -220,12 +220,14 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
         uploadArrowTable: null,
       });
 
+      // Children are inside VisualizationProvider but OUTSIDE the boundary,
+      // so they are always visible and never blanked by a boundary trip.
       renderSetup(<div data-testid="child" />);
 
       expect(screen.queryByTestId("child")).not.toBeNull();
     });
 
-    it("catches render-phase throw from child, does not re-throw, fires toast", async () => {
+    it("VisualizationBoundary catches throw from setup components, fires toast, leaves children mounted", async () => {
       const mockConnector = { query: vi.fn() };
       mockUseChartEngine.mockReturnValue({
         connector: mockConnector,
@@ -233,11 +235,12 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
         uploadArrowTable: null,
       });
 
-      // Child that throws on render — simulates Mosaic/vgplot throwing when
-      // the engine is gone mid-session.
-      function BrokenChild(): React.ReactElement {
-        throw new Error("Native engine timed out");
-      }
+      // Simulate a setup component (VisualizationErrorToast) throwing by
+      // making useVisualization throw during render. The boundary wraps the
+      // setup subtree; children are outside the boundary and must stay mounted.
+      mockUseVisualization.mockImplementation(() => {
+        throw new Error("Mosaic coordinator exploded");
+      });
 
       // Suppress React's console.error for expected error boundary events
       const consoleSpy = vi
@@ -245,7 +248,7 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
         .mockImplementation(() => {});
 
       // Must not throw at the render level (boundary catches it)
-      expect(() => renderSetup(<BrokenChild />)).not.toThrow();
+      expect(() => renderSetup(<div data-testid="child" />)).not.toThrow();
 
       // Toast must fire with crash signal
       await waitFor(() => {
@@ -256,6 +259,9 @@ describe("VisualizationSetup — error routing (issue #96)", () => {
           }),
         );
       });
+
+      // Children (shell, toaster) must remain mounted — not blanked by the boundary.
+      expect(screen.queryByTestId("child")).not.toBeNull();
 
       consoleSpy.mockRestore();
     });

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -36,29 +36,6 @@ function RendererRegistration() {
   return null;
 }
 
-/**
- * Fires a Sonner error toast when the VisualizationProvider fails to
- * initialize its Mosaic coordinator (e.g. vgplot import failure, connector
- * rejected). This is a whole-engine-init failure, not a per-chart failure,
- * so it surfaces as a toast rather than an inline slab. Children continue
- * to render — the failure is transient/recoverable and the user can retry
- * by reloading.
- */
-function VisualizationErrorToast() {
-  const { error } = useVisualization();
-  const { showError } = useToastStore();
-
-  useEffect(() => {
-    if (!error) return;
-    showError("Visualization engine failed to start", {
-      description: "Charts may not render. Reload to retry.",
-      duration: 8000,
-    });
-  }, [error, showError]);
-
-  return null;
-}
-
 // ============================================================================
 // Error Boundary
 // ============================================================================
@@ -111,26 +88,6 @@ class VisualizationBoundary extends Component<
   }
 }
 
-/**
- * Hook that fires a toast for a whole-engine-down condition, then returns
- * nothing. Separated so the toast logic can consume hooks (useToastStore)
- * while the boundary above it is a class component.
- */
-function EngineErrorToast({ engineError }: { engineError: string }) {
-  const { showError } = useToastStore();
-
-  useEffect(() => {
-    showError("Native engine unreachable", {
-      description:
-        "Charts are unavailable. Reload to reconnect to the local engine.",
-      duration: 10000,
-    });
-    // Only fire once per engineError value change.
-  }, [engineError, showError]);
-
-  return null;
-}
-
 // VisualizationBoundary fallback: null. Nothing visible — the toast fired
 // by onError is the user-facing signal. Children (Shell, Toaster, routes)
 // are outside the boundary and stay alive; only the provider's setup
@@ -158,23 +115,27 @@ interface VisualizationSetupProps {
  *
  * ## Error surfaces
  *
- * - Native bootstrap failure (connector=null, engineError set): shown as a
- *   Sonner toast (whole-engine-down condition); WASM path used as fallback for
- *   non-chart content.
+ * - Whole engine unreachable (native bootstrap failure OR provider init
+ *   failure): shown as a PERSISTENT inline affordance where the chart would
+ *   render, with a Reload button (EngineUnavailableState in VisualizationDisplay).
+ *   It's a persistent condition — charts stay broken until reload — so a fading
+ *   toast is the wrong surface. This component still passes children through so
+ *   non-chart content (nav, routes) stays usable.
  * - Native connector healthy but WASM failed: WASM error shown as an inline
  *   ErrorState inside the native provider (chart queries still route to native;
  *   data-viewer paths that need WASM see the banner).
  * - WASM-only path failure: standard ErrorState with retry.
  * - Mid-session render throw (engine dies while rendering): caught by
- *   VisualizationBoundary → toast + empty state, never crashes the renderer.
+ *   VisualizationBoundary → toast WITH a Reload action (a momentary event, so a
+ *   toast is right), never crashes the renderer.
  *
  * ## Error routing
  *
  * | Condition                               | Surface          |
  * |-----------------------------------------|------------------|
- * | Whole engine unreachable (engineError)  | Sonner toast     |
- * | VisualizationProvider init failure      | Sonner toast     |
- * | Mid-session render-phase throw          | Boundary + toast |
+ * | Whole engine unreachable (engineError)  | Persistent inline + Reload (VisualizationDisplay) |
+ * | VisualizationProvider init failure      | Persistent inline + Reload (VisualizationDisplay) |
+ * | Mid-session render-phase throw          | Boundary → toast + Reload action |
  * | Per-chart compute failure (insightView) | Inline ErrorState (in VisualizationDisplay) |
  *
  * ## Provider Hierarchy
@@ -200,7 +161,7 @@ interface VisualizationSetupProps {
  * ```
  */
 export function VisualizationSetup({ children }: VisualizationSetupProps) {
-  const { connector, engineError } = useChartEngine();
+  const { connector } = useChartEngine();
   const { db, connection, isInitialized, isLoading, error, initDuckDB } =
     useDuckDBContext();
   const { showError } = useToastStore();
@@ -209,13 +170,20 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
     initDuckDB();
   }, [initDuckDB]);
 
-  // Callback fired by VisualizationBoundary on a render-phase throw. Shows a
-  // toast so the user knows something degraded without crashing the renderer.
+  // Callback fired by VisualizationBoundary on a render-phase throw. A
+  // mid-session crash is a momentary event (the renderer survived; charts got
+  // reset) — so a toast is the right surface, but it carries a Reload action so
+  // the user can act, and never auto-dismisses (duration: Infinity) so it can't
+  // fade before they do. Copy stays plain-language: no "engine"/"Mosaic" terms.
   const handleBoundaryError = useCallback(
     (_err: Error) => {
-      showError("Chart engine crashed mid-session", {
-        description: "Charts have been reset. Reload to reconnect.",
-        duration: 10000,
+      showError("Charts were reset", {
+        description: "Something interrupted the data engine.",
+        duration: Infinity,
+        action: {
+          label: "Reload",
+          onClick: () => window.location.reload(),
+        },
       });
     },
     [showError],
@@ -239,12 +207,17 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
       ) : null;
 
     // VisualizationBoundary wraps the provider's setup components (renderer
-    // registration, error toast, WASM banner) but NOT {children}. Children
-    // include the full Shell — navigation, the <Toaster>, route outlets — all
-    // of which must stay alive if the visualization setup crashes. Children are
-    // still inside VisualizationProvider (needed for useVisualization() context)
-    // but sit outside the boundary so a provider-internal throw doesn't blank
-    // the UI or swallow the toast that fires via onError.
+    // registration, WASM banner) but NOT {children}. Children include the full
+    // Shell — navigation, the <Toaster>, route outlets — all of which must stay
+    // alive if the visualization setup crashes. Children are still inside
+    // VisualizationProvider (needed for useVisualization() context) but sit
+    // outside the boundary so a provider-internal throw doesn't blank the UI or
+    // swallow the toast that fires via onError.
+    //
+    // Provider init failure (useVisualization().error) and engine-unreachable
+    // both surface as a persistent inline affordance in VisualizationDisplay,
+    // not here — that's where the chart would render, and it carries the Reload
+    // action. The boundary's onError handles the mid-session crash toast.
     //
     // If a Chart component inside {children} throws during render (uncommon —
     // Mosaic's Coordinator callbacks are async, not synchronous render calls),
@@ -255,7 +228,6 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
       <VisualizationProvider connector={connector}>
         <VisualizationBoundary fallback={null} onError={handleBoundaryError}>
           <RendererRegistration />
-          <VisualizationErrorToast />
           {wasmErrorBanner}
         </VisualizationBoundary>
         {children}
@@ -265,15 +237,15 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
 
   // ── WASM path (web tier default) OR native bootstrap failure ─────────────
   // When the Electron IPC call fails or returns missing server info, `main.tsx`
-  // sets engineError with connector=null. Fire a toast for the whole-engine-down
-  // condition (never an inline slab — see error routing table above), then fall
-  // through to the WASM path so non-chart content still renders.
+  // sets engineError with connector=null. The whole-engine-down condition is
+  // surfaced as a persistent inline affordance in VisualizationDisplay (where
+  // the chart would render), not here — so this path just falls through to the
+  // WASM path so non-chart content still renders.
   //
   // Show error state if DuckDB WASM initialization failed
   if (error) {
     return (
       <>
-        {engineError && <EngineErrorToast engineError={engineError} />}
         <ErrorState
           title="Failed to initialize data engine"
           description={error.message}
@@ -287,22 +259,13 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
 
   // Pass through children during loading - components handle their own loading states
   if (isLoading || !isInitialized || !db || !connection) {
-    return (
-      <>
-        {engineError && <EngineErrorToast engineError={engineError} />}
-        {children}
-      </>
-    );
+    return <>{children}</>;
   }
 
   return (
-    <>
-      {engineError && <EngineErrorToast engineError={engineError} />}
-      <VisualizationProvider db={db} connection={connection}>
-        <RendererRegistration />
-        <VisualizationErrorToast />
-        {children}
-      </VisualizationProvider>
-    </>
+    <VisualizationProvider db={db} connection={connection}>
+      <RendererRegistration />
+      {children}
+    </VisualizationProvider>
   );
 }

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -1,3 +1,4 @@
+import { useToastStore } from "@/lib/stores/toast-store";
 import {
   VisualizationProvider,
   createVgplotRenderer,
@@ -5,7 +6,7 @@ import {
   useVisualization,
 } from "@dashframe/visualization";
 import { ErrorState } from "@wystack/ui";
-import { useCallback, useEffect, type ReactNode } from "react";
+import { Component, useCallback, useEffect, type ReactNode } from "react";
 import { useChartEngine } from "./ChartEngineProvider";
 import { useDuckDBContext } from "./DuckDBProvider";
 
@@ -36,29 +37,109 @@ function RendererRegistration() {
 }
 
 /**
- * Surfaces post-mount VisualizationProvider failures as a visible ErrorState.
- *
- * VisualizationProvider may throw AFTER mount (e.g. vgplot import failure,
- * wasmConnector/databaseConnector throw). Without this component the error
- * lives only in `useVisualization().error` and nothing renders — a silent
- * failure. Mounted inside each VisualizationProvider branch, this component
- * reads the provider's error and shows ErrorState so the user always sees
- * something actionable.
- *
- * A separate ticket tracks moving engine-unreachable errors to a toast. This
- * component only ensures the post-mount failure path is VISIBLE — matching the
- * existing ErrorState pattern — without changing the UX for the common case.
+ * Fires a Sonner error toast when the VisualizationProvider fails to
+ * initialize its Mosaic coordinator (e.g. vgplot import failure, connector
+ * rejected). This is a whole-engine-init failure, not a per-chart failure,
+ * so it surfaces as a toast rather than an inline slab. Children continue
+ * to render — the failure is transient/recoverable and the user can retry
+ * by reloading.
  */
-function VisualizationErrorBanner() {
+function VisualizationErrorToast() {
   const { error } = useVisualization();
-  if (!error) return null;
-  return (
-    <ErrorState
-      title="Visualization engine error"
-      description={error.message}
-      className="min-h-[200px]"
-    />
-  );
+  const { showError } = useToastStore();
+
+  useEffect(() => {
+    if (!error) return;
+    showError("Visualization engine failed to start", {
+      description: "Charts may not render. Reload to retry.",
+      duration: 8000,
+    });
+  }, [error, showError]);
+
+  return null;
+}
+
+// ============================================================================
+// Error Boundary
+// ============================================================================
+
+/**
+ * Catches render-phase throws from the visualization subtree.
+ *
+ * When the engine dies mid-session, pending Mosaic/vgplot updates can throw
+ * synchronously during a render (e.g. a coordinator callback that runs after
+ * the connector is gone). Without a boundary these throws propagate to React's
+ * root and kill the renderer process. The boundary catches them, shows the
+ * `fallback` (empty state + toast via `onError`), and prevents a renderer crash.
+ *
+ * This is the "fail-soft" layer: an unhandled throw that would otherwise take
+ * the renderer down degrades to a visible empty state instead.
+ */
+interface VisualizationBoundaryState {
+  hasError: boolean;
+}
+
+interface VisualizationBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode;
+  onError?: (err: Error) => void;
+}
+
+class VisualizationBoundary extends Component<
+  VisualizationBoundaryProps,
+  VisualizationBoundaryState
+> {
+  constructor(props: VisualizationBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): VisualizationBoundaryState {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(err: Error, info: React.ErrorInfo) {
+    console.error("[VisualizationBoundary] caught render error:", err, info);
+    this.props.onError?.(err);
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Hook that fires a toast for a whole-engine-down condition, then returns
+ * nothing. Separated so the toast logic can consume hooks (useToastStore)
+ * while the boundary above it is a class component.
+ */
+function EngineErrorToast({ engineError }: { engineError: string }) {
+  const { showError } = useToastStore();
+
+  useEffect(() => {
+    showError("Native engine unreachable", {
+      description:
+        "Charts are unavailable. Reload to reconnect to the local engine.",
+      duration: 10000,
+    });
+    // Only fire once per engineError value change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engineError]);
+
+  return null;
+}
+
+/**
+ * Fallback shown inside the VisualizationBoundary when a mid-session engine
+ * crash causes a render-phase throw. Renders nothing visible — the toast (fired
+ * by the onError callback) is the user-facing signal. Children outside the
+ * visualization subtree (navigation, data sources, etc.) are unaffected.
+ */
+function VisualizationCrashedFallback() {
+  return null;
 }
 
 // ============================================================================
@@ -84,11 +165,23 @@ interface VisualizationSetupProps {
  * ## Error surfaces
  *
  * - Native bootstrap failure (connector=null, engineError set): shown as a
- *   banner above children; WASM path used as fallback for non-chart content.
- * - Native connector healthy but WASM failed: WASM error shown inside the
- *   native provider (chart queries still route to native; data-viewer paths
- *   that need WASM see the banner).
+ *   Sonner toast (whole-engine-down condition); WASM path used as fallback for
+ *   non-chart content.
+ * - Native connector healthy but WASM failed: WASM error shown as an inline
+ *   ErrorState inside the native provider (chart queries still route to native;
+ *   data-viewer paths that need WASM see the banner).
  * - WASM-only path failure: standard ErrorState with retry.
+ * - Mid-session render throw (engine dies while rendering): caught by
+ *   VisualizationBoundary → toast + empty state, never crashes the renderer.
+ *
+ * ## Error routing
+ *
+ * | Condition                               | Surface          |
+ * |-----------------------------------------|------------------|
+ * | Whole engine unreachable (engineError)  | Sonner toast     |
+ * | VisualizationProvider init failure      | Sonner toast     |
+ * | Mid-session render-phase throw          | Boundary + toast |
+ * | Per-chart compute failure (insightView) | Inline ErrorState (in VisualizationDisplay) |
  *
  * ## Provider Hierarchy
  *
@@ -116,10 +209,23 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
   const { connector, engineError } = useChartEngine();
   const { db, connection, isInitialized, isLoading, error, initDuckDB } =
     useDuckDBContext();
+  const { showError } = useToastStore();
 
   const handleRetry = useCallback(() => {
     initDuckDB();
   }, [initDuckDB]);
+
+  // Callback fired by VisualizationBoundary on a render-phase throw. Shows a
+  // toast so the user knows something degraded without crashing the renderer.
+  const handleBoundaryError = useCallback(
+    (_err: Error) => {
+      showError("Chart engine crashed mid-session", {
+        description: "Charts have been reset. Reload to reconnect.",
+        duration: 10000,
+      });
+    },
+    [showError],
+  );
 
   // ── Native engine path (desktop host supplied a connector) ──────────────
   if (connector) {
@@ -139,33 +245,31 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
       ) : null;
 
     return (
-      <VisualizationProvider connector={connector}>
-        <RendererRegistration />
-        <VisualizationErrorBanner />
-        {wasmErrorBanner}
-        {children}
-      </VisualizationProvider>
+      <VisualizationBoundary
+        fallback={<VisualizationCrashedFallback />}
+        onError={handleBoundaryError}
+      >
+        <VisualizationProvider connector={connector}>
+          <RendererRegistration />
+          <VisualizationErrorToast />
+          {wasmErrorBanner}
+          {children}
+        </VisualizationProvider>
+      </VisualizationBoundary>
     );
   }
 
   // ── WASM path (web tier default) OR native bootstrap failure ─────────────
   // When the Electron IPC call fails or returns missing server info, `main.tsx`
-  // sets engineError with connector=null. Show the native-engine error banner
-  // above children, then fall through to the WASM path so non-chart content
-  // still renders. Never surface raw engine strings (DESIGN.md anti-pattern).
-  const nativeErrorBanner = engineError ? (
-    <ErrorState
-      title="Native engine unavailable"
-      description={engineError}
-      className="min-h-[200px]"
-    />
-  ) : null;
-
+  // sets engineError with connector=null. Fire a toast for the whole-engine-down
+  // condition (never an inline slab — see error routing table above), then fall
+  // through to the WASM path so non-chart content still renders.
+  //
   // Show error state if DuckDB WASM initialization failed
   if (error) {
     return (
       <>
-        {nativeErrorBanner}
+        {engineError && <EngineErrorToast engineError={engineError} />}
         <ErrorState
           title="Failed to initialize data engine"
           description={error.message}
@@ -181,7 +285,7 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
   if (isLoading || !isInitialized || !db || !connection) {
     return (
       <>
-        {nativeErrorBanner}
+        {engineError && <EngineErrorToast engineError={engineError} />}
         {children}
       </>
     );
@@ -189,10 +293,10 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
 
   return (
     <>
-      {nativeErrorBanner}
+      {engineError && <EngineErrorToast engineError={engineError} />}
       <VisualizationProvider db={db} connection={connection}>
         <RendererRegistration />
-        <VisualizationErrorBanner />
+        <VisualizationErrorToast />
         {children}
       </VisualizationProvider>
     </>

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -126,8 +126,7 @@ function EngineErrorToast({ engineError }: { engineError: string }) {
       duration: 10000,
     });
     // Only fire once per engineError value change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [engineError]);
+  }, [engineError, showError]);
 
   return null;
 }

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -244,18 +244,31 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
         />
       ) : null;
 
+    // VisualizationBoundary wraps the provider's setup components (renderer
+    // registration, error toast, WASM banner) but NOT {children}. Children
+    // include the full Shell — navigation, the <Toaster>, route outlets — all
+    // of which must stay alive if the visualization setup crashes. Children are
+    // still inside VisualizationProvider (needed for useVisualization() context)
+    // but sit outside the boundary so a provider-internal throw doesn't blank
+    // the UI or swallow the toast that fires via onError.
+    //
+    // If a Chart component inside {children} throws during render (uncommon —
+    // Mosaic's Coordinator callbacks are async, not synchronous render calls),
+    // that error propagates to the nearest ancestor boundary above this tree.
+    // The primary guard for async engine-loss rejections is the
+    // unhandledrejection handler in the renderer's main.tsx.
     return (
-      <VisualizationBoundary
-        fallback={<VisualizationCrashedFallback />}
-        onError={handleBoundaryError}
-      >
-        <VisualizationProvider connector={connector}>
+      <VisualizationProvider connector={connector}>
+        <VisualizationBoundary
+          fallback={<VisualizationCrashedFallback />}
+          onError={handleBoundaryError}
+        >
           <RendererRegistration />
           <VisualizationErrorToast />
           {wasmErrorBanner}
-          {children}
-        </VisualizationProvider>
-      </VisualizationBoundary>
+        </VisualizationBoundary>
+        {children}
+      </VisualizationProvider>
     );
   }
 

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -132,15 +132,10 @@ function EngineErrorToast({ engineError }: { engineError: string }) {
   return null;
 }
 
-/**
- * Fallback shown inside the VisualizationBoundary when a mid-session engine
- * crash causes a render-phase throw. Renders nothing visible — the toast (fired
- * by the onError callback) is the user-facing signal. Children outside the
- * visualization subtree (navigation, data sources, etc.) are unaffected.
- */
-function VisualizationCrashedFallback() {
-  return null;
-}
+// VisualizationBoundary fallback: null. Nothing visible — the toast fired
+// by onError is the user-facing signal. Children (Shell, Toaster, routes)
+// are outside the boundary and stay alive; only the provider's setup
+// components go blank.
 
 // ============================================================================
 // Provider Wrapper
@@ -259,10 +254,7 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
     // unhandledrejection handler in the renderer's main.tsx.
     return (
       <VisualizationProvider connector={connector}>
-        <VisualizationBoundary
-          fallback={<VisualizationCrashedFallback />}
-          onError={handleBoundaryError}
-        >
+        <VisualizationBoundary fallback={null} onError={handleBoundaryError}>
           <RendererRegistration />
           <VisualizationErrorToast />
           {wasmErrorBanner}

--- a/packages/app/src/components/visualizations/EngineUnavailableState.test.tsx
+++ b/packages/app/src/components/visualizations/EngineUnavailableState.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for EngineUnavailableState — the persistent inline affordance shown
+ * where a chart would render when the data engine can't be reached (see #96).
+ *
+ * Contracts verified:
+ * 1. Persistent inline surface (not a toast): renders a visible title + body in
+ *    the DOM, present immediately on mount and not auto-dismissing.
+ * 2. Actionable: renders a real "Reload" button.
+ * 3. The Reload button triggers the renderer's reload path.
+ * 4. Copy is plain-language: no implementation terms (native/WASM/Mosaic/engine
+ *    jargon beyond the allowed "data engine"), and the exact decided strings.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EngineUnavailableState } from "./EngineUnavailableState";
+
+describe("EngineUnavailableState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a persistent inline title and body (not a toast)", () => {
+    render(<EngineUnavailableState />);
+
+    // Title and body are visible in the DOM right away — this is the persistent
+    // affordance, not an ephemeral notification.
+    expect(screen.getByText("Charts can't load right now")).not.toBeNull();
+    expect(
+      screen.getByText(
+        "The data engine isn't responding. Reload to reconnect.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("renders a Reload button (the action, not instruction-as-homework)", () => {
+    render(<EngineUnavailableState />);
+
+    expect(screen.getByRole("button", { name: /reload/i })).not.toBeNull();
+  });
+
+  it("triggers the renderer reload path when Reload is clicked", () => {
+    const reload = vi.fn();
+    // window.location.reload is non-writable in jsdom; redefine for the test.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    render(<EngineUnavailableState />);
+    fireEvent.click(screen.getByRole("button", { name: /reload/i }));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses plain language — no implementation terms leak into copy", () => {
+    const { container } = render(<EngineUnavailableState />);
+    const text = container.textContent ?? "";
+
+    // "data engine" is the allowed plain-language term; the forbidden ones are
+    // implementation leaks the user has no mental model for.
+    expect(text).not.toMatch(/native/i);
+    expect(text).not.toMatch(/\bWASM\b/i);
+    expect(text).not.toMatch(/mosaic/i);
+    expect(text).not.toMatch(/loopback|127\.0\.0\.1/i);
+  });
+});

--- a/packages/app/src/components/visualizations/EngineUnavailableState.tsx
+++ b/packages/app/src/components/visualizations/EngineUnavailableState.tsx
@@ -1,0 +1,39 @@
+import { ErrorState } from "@wystack/ui";
+import { useCallback } from "react";
+
+/**
+ * EngineUnavailableState — persistent inline affordance shown where a chart
+ * would render when the data engine can't be reached.
+ *
+ * Engine-unreachable is a PERSISTENT condition: charts stay broken until the
+ * user reloads to reconnect. A fading toast is the wrong surface for a state
+ * that doesn't resolve on its own — this stays visible and carries the action
+ * (Reload) that actually fixes it.
+ *
+ * Two conditions fold into this one surface because they look identical to the
+ * user — there are no charts, and reloading is the fix:
+ *   - native engine unreachable (connector=null, engineError set), and
+ *   - the visualization provider failing to initialize.
+ *
+ * Copy is plain-language by intent: users have a CHARTS mental model, not an
+ * "engine" one. No implementation terms ("native", "WASM", "Mosaic"), no raw
+ * runtime strings (DESIGN.md — "Raw runtime errors in user-facing UI").
+ *
+ * Reload runs the renderer's reload path (window.location.reload), which
+ * re-runs bootstrap() in main.tsx and re-establishes the loopback connection.
+ */
+export function EngineUnavailableState({ className }: { className?: string }) {
+  const handleReload = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  return (
+    <ErrorState
+      size="sm"
+      title="Charts can't load right now"
+      description="The data engine isn't responding. Reload to reconnect."
+      retryAction={{ label: "Reload", onClick: handleReload }}
+      className={className}
+    />
+  );
+}

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -1,3 +1,4 @@
+import { useChartEngine } from "@/components/providers/ChartEngineProvider";
 import { useDuckDBContext } from "@/components/providers/DuckDBProvider";
 import { useInsightPagination } from "@/hooks/useInsightPagination";
 import { useInsightView } from "@/hooks/useInsightView";
@@ -6,7 +7,11 @@ import { getMetricDisplayLabel, resolveEncodingToSql } from "@dashframe/engine";
 import type { ChartEncoding, Insight, Visualization } from "@dashframe/types";
 import { parseEncoding } from "@dashframe/types";
 import { VirtualTable, type VirtualTableColumnConfig } from "@dashframe/ui";
-import { Chart, VisualizationProvider } from "@dashframe/visualization";
+import {
+  Chart,
+  VisualizationProvider,
+  useVisualization,
+} from "@dashframe/visualization";
 import { ErrorState, Spinner, Surface, Toggle } from "@wystack/ui";
 import { ChartIcon, LayersIcon, TableIcon } from "@wystack/ui-icons";
 import {
@@ -17,6 +22,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { EngineUnavailableState } from "./EngineUnavailableState";
 
 /**
  * Wraps `children` in a WASM-backed VisualizationProvider when `nativeCapable`
@@ -58,6 +64,14 @@ export function VisualizationDisplay({
 }: {
   visualizationId?: string;
 }) {
+  // Whole-engine-down signals. `engineError` is the native bootstrap failure
+  // (connector never came up); `visualizationError` is the provider failing to
+  // initialize its Mosaic coordinator. Both mean the same thing to the user —
+  // charts can't load — and reloading is the fix, so they share one surface.
+  const { engineError } = useChartEngine();
+  const { error: visualizationError } = useVisualization();
+  const engineUnavailable = Boolean(engineError) || Boolean(visualizationError);
+
   // Use effect to detect mounting (avoids hydration mismatch)
   const [isMounted, setIsMounted] = useState(false);
   const [visibleRows, setVisibleRows] = useState<number>(10);
@@ -322,6 +336,19 @@ export function VisualizationDisplay({
 
     previousCanShowBothRef.current = canShowBoth;
   }, [canShowBoth, activeTab]);
+
+  // Whole-engine-down: show the persistent inline affordance where the chart
+  // would render. This takes precedence over loading/per-chart states — when
+  // the engine is unreachable there's nothing to load and no chart to compute,
+  // so spinning or surfacing a per-chart error would be misleading. The user
+  // gets a Reload button (the actual fix) instead of instruction-as-homework.
+  if (isMounted && engineUnavailable) {
+    return (
+      <div className="flex h-full w-full items-center justify-center px-6">
+        <EngineUnavailableState className="w-full max-w-lg" />
+      </div>
+    );
+  }
 
   // Surface a post-bootstrap insight-view failure instead of spinning forever.
   // When the native upload fails at runtime (loopback server stopped, auth


### PR DESCRIPTION
Fixes #96.

The first round swapped the 200px inline slab for a fading toast. Review found the toast was the wrong surface for a **persistent** condition (charts stay broken until reload) and that the copy leaked implementation terms. This revision fixes the error *surface*: persistent inline affordance for engine-down, real Reload buttons everywhere, plain-language copy. The verified fail-soft crash mechanism (boundary + `unhandledrejection`) is unchanged.

## Changes

- **`EngineUnavailableState.tsx`** (new): a slim, dedicated presentational component composed from the `@wystack/ui` `ErrorState` primitive (`size="sm"`, danger icon, title, body, real **Reload** button). Not the 200px slab; not the insight-creation `EmptyState`. Tokenized — adapts light/dark.

- **`VisualizationDisplay.tsx`**: whole-engine-down (`engineError` from `useChartEngine()` **or** `visualizationError` from provider init) renders `EngineUnavailableState` **where the chart would render** — a persistent inline affordance with a Reload button, not a toast. The two conditions fold into one surface because they're identical to the user (no charts, reload is the fix). Per-chart compute failures (`insightViewError`) stay inline `ErrorState` — unchanged.

- **`VisualizationSetup.tsx`**: removed the engine-down/provider-init toasts (surface moved to the inline affordance). The mid-session **crash** toast (boundary `onError`) now carries a **Reload action button** and `duration: Infinity` so it can't fade before the user can act. The `VisualizationBoundary` (class `ErrorBoundary`) and its scope — wrapping only the setup subtree, never `{children}` — are unchanged and verified.

- **`apps/renderer/src/main.tsx`**: unchanged in this revision. The `unhandledrejection` engine-loss handler (verified: renderer survives engine kill + reload, page count stays 1) stays as-is.

**Copy** — one user concept (charts + "data engine"), no implementation leaks ("native"/"local"/"Visualization engine"/"WASM"/"Mosaic"). Honors DESIGN.md "no raw runtime errors in user-facing UI".

**Error routing table:**

| Condition | Surface |
|---|---|
| Whole engine unreachable (`engineError` set at bootstrap) | **Persistent inline `EngineUnavailableState` + Reload** (in `VisualizationDisplay`) |
| `VisualizationProvider` init failure (`visualizationError`) | **Persistent inline `EngineUnavailableState` + Reload** (same surface) |
| Mid-session render-phase throw (engine dies while rendering) | `VisualizationBoundary` → toast **+ Reload action**, `duration: Infinity` |
| Per-chart compute failure (`insightViewError`) | Inline `ErrorState` (unchanged) |

**Copy strings:**
- Engine unreachable (inline): **"Charts can't load right now"** / **"The data engine isn't responding. Reload to reconnect."** / **[Reload]**
- Mid-session crash (toast): **"Charts were reset"** / **"Something interrupted the data engine."** / **[Reload]**

## Screenshots

Captured from the running Electron desktop app via CDP (port 9222; Vite on a non-5173 port). The real `EngineUnavailableState` component, mounted through the live app's theme.

**Engine-unreachable — light:**

`EngineUnavailableState` rendered light mode — warm `bg-surface-base` canvas, danger `AlertCircleIcon`, "Charts can't load right now" / "The data engine isn't responding. Reload to reconnect." + an outlined **Reload** button with refresh icon. Slim and centered (`size="sm"`), no 200px slab.

**Engine-unreachable — dark:**

Same surface, dark mode — dark canvas, lighter-tuned danger icon, white title, muted body, bordered Reload button. AA contrast holds across themes; tokens adapt with no off-token color.

**Runtime verification (CDP):**
- Reload button click → real page reload fired (URL returned to `/visualizations`), **page count stayed 1** — renderer survived (fail-soft intact).
- No raw runtime string on screen; copy is plain-language.

> Note: image attachments aren't uploadable via the GitHub CLI from this environment. Screenshots were captured and reviewed during QA; the states above describe exactly what renders. The four `EngineUnavailableState` contracts + the boundary contract lock the behavior in the test suite.

## Verification

- `bun run typecheck` — clean (47/47 tasks)
- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run check:ticket-refs` — clean
- `bun run test` in `packages/app` — **332/332 pass**
- New / updated test contracts:
  - `EngineUnavailableState.test.tsx` (4): persistent inline title/body renders; Reload button present; Reload click fires `window.location.reload`; copy has no implementation-term leaks.
  - `VisualizationSetup.test.tsx` (6): engine-down fires **no** toast and renders no inline slab from this component; children pass through when engine down; boundary catches a setup throw → fires a **Reload-action** toast with `duration: Infinity` and plain-language copy, leaving children mounted.
- Runtime QA (Electron CDP): engine-unreachable surface renders light + dark with a working Reload; renderer survives reload (page count 1).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines the engine-error UX introduced for issue #96, replacing an earlier toast-based approach with a persistent inline `EngineUnavailableState` component for whole-engine-down conditions, while keeping a non-dismissing toast (with Reload action) for mid-session render-phase crashes caught by the new `VisualizationBoundary`.

- **`EngineUnavailableState`** is a new slim presentational component that renders where a chart would appear when the data engine is unreachable, with plain-language copy and a real Reload button — replacing the 200px inline slab and the earlier transient toast.
- **`VisualizationDisplay`** now reads both `engineError` (native bootstrap failure) and `visualizationError` (provider init failure) and folds them into one persistent inline surface; `VisualizationSetup` gains a class-based `VisualizationBoundary` that catches render-phase throws and fires a `duration: Infinity` toast with a Reload action without blanking the shell or navigation.
- **`main.tsx`** adds a scoped `unhandledrejection` handler that swallows only loopback-engine-specific rejections to prevent mid-session engine loss from killing the Electron renderer process.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changed paths are covered by the 332-passing test suite and the error routing contracts are clearly enforced.

The three new files are focused and well-scoped: EngineUnavailableState is purely presentational, VisualizationDisplay's early-return is guarded by isMounted, and VisualizationBoundary is correctly placed to catch setup throws without blanking the shell. The key correctness assumption — that useVisualization() is safe to call outside a provider — is verified: VisualizationContext carries a default value of {error: null} so no throw occurs during the WASM-loading phase. No logic gaps found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/components/visualizations/EngineUnavailableState.tsx | New presentational component; slim, correctly tokenised, uses approved copy, and window.location.reload path is appropriate for the Electron renderer context. |
| packages/app/src/components/visualizations/VisualizationDisplay.tsx | Adds engine-unavailable early return using both engineError and visualizationError; safe because VisualizationContext has a default value of {error: null} so useVisualization() is safe to call outside a provider during the WASM-loading phase. |
| packages/app/src/components/providers/VisualizationSetup.tsx | Replaces VisualizationErrorBanner with a class VisualizationBoundary; correctly scopes the boundary to the setup subtree, leaving {children} outside so navigation/shell survive a boundary trip. |
| apps/renderer/src/main.tsx | Adds a scoped unhandledrejection handler; accepted false-positive risk for 'failed to fetch' is well-reasoned and documented inline. |
| packages/app/src/components/visualizations/EngineUnavailableState.test.tsx | 4 targeted tests cover: persistent inline rendering, Reload button presence, reload click behaviour, and implementation-term leakage. |
| packages/app/src/components/providers/VisualizationSetup.test.tsx | 6 tests lock the error-routing contracts: no toast on engine-down, no raw error string in DOM, children pass-through, boundary crash fires Infinity-duration Reload toast, implementation terms excluded from copy. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Engine Error Occurs] --> B{Error Type}
    B -->|Native bootstrap failure| C[VisualizationSetup falls through to WASM path]
    B -->|VisualizationProvider init failure| D[Provider context: error set]
    B -->|Mid-session render throw| E[VisualizationBoundary catches]
    B -->|Per-chart compute failure| F[insightViewError set]
    C --> G[VisualizationDisplay reads engineError]
    D --> H[VisualizationDisplay reads visualizationError]
    G --> I{isMounted && engineUnavailable?}
    H --> I
    I -->|true| J[EngineUnavailableState - Persistent inline + Reload]
    I -->|false| K[Normal chart render path]
    E --> L[fallback: null, onError fires toast]
    L --> M[showError: Charts were reset, duration: Infinity, Reload action]
    F --> N[ErrorState inline]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;main&#39; into yw228-engine-er..."](https://github.com/youhaowei/dashframe/commit/5997b5347d8e6ca9f75ec07bee9cf7976f36c13b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37408217)</sub>

<!-- /greptile_comment -->