### PR TITLE
feat(app): show sensitivity badge in insight field picker

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Contract tests for sensitivity badge visibility in the insight field picker.
+ *
+ * The field picker (InsightFieldEditorModal / FieldOption) must show privacy
+ * signals at the point of use — the moment a user decides whether to include a
+ * field in an analysis. These tests verify that contract without end-to-end
+ * dialog machinery.
+ *
+ * Contract:
+ *   - sensitive field → "Sensitive" badge rendered at-rest
+ *   - unclassified field → "Unclassified" badge rendered at-rest
+ *   - cleared field → no sensitivity badge rendered
+ */
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Minimal stubs for external UI primitives so the test runs without CSS
+// processing or icon font loading.
+// ---------------------------------------------------------------------------
+
+vi.mock("@wystack/ui-icons", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/ui-icons")>();
+  return {
+    ...actual,
+    DatabaseIcon: () => null,
+    NumberTypeIcon: () => null,
+    SearchIcon: () => null,
+  };
+});
+
+vi.mock("@wystack/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/ui")>();
+  return {
+    ...actual,
+    // Render Dialog children directly so FieldOption is in the DOM without
+    // needing a portal or body-level mount.
+    Dialog: ({
+      children,
+      open,
+    }: {
+      children: React.ReactNode;
+      open: boolean;
+    }) => (open ? <div data-testid="dialog">{children}</div> : null),
+    DialogContent: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="dialog-content">{children}</div>
+    ),
+    DialogHeader: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DialogTitle: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    DialogDescription: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+      <input {...props} />
+    ),
+  };
+});
+
+import { InsightFieldEditorModal } from "./InsightFieldEditorModal";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeField(overrides: Partial<CombinedField> = {}): CombinedField {
+  return {
+    id: "f1",
+    name: "customer_email",
+    displayName: "customer_email",
+    type: "string",
+    sourceTableId: "tbl1",
+    sensitivity: undefined,
+    sensitivityReason: undefined,
+    sensitivitySource: undefined,
+    columnName: undefined,
+    ...overrides,
+  } as CombinedField;
+}
+
+function renderPicker(fields: CombinedField[]) {
+  render(
+    <InsightFieldEditorModal
+      isOpen={true}
+      onOpenChange={vi.fn()}
+      availableFields={fields}
+      baseTableId="tbl1"
+      onSelect={vi.fn()}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InsightFieldEditorModal: sensitivity badge at-rest visibility", () => {
+  it("shows 'Sensitive' badge for a sensitive field without hover or expand", () => {
+    renderPicker([
+      makeField({
+        sensitivity: "sensitive",
+        sensitivityReason: "contains PII",
+      }),
+    ]);
+
+    expect(screen.getByText("Sensitive")).toBeTruthy();
+  });
+
+  it("shows 'Unclassified' badge for a field with no sensitivity set", () => {
+    renderPicker([makeField({ sensitivity: undefined })]);
+
+    expect(screen.getByText("Unclassified")).toBeTruthy();
+  });
+
+  it("shows 'Unclassified' badge for a field explicitly marked unclassified", () => {
+    renderPicker([makeField({ sensitivity: "unclassified" })]);
+
+    expect(screen.getByText("Unclassified")).toBeTruthy();
+  });
+
+  it("does not show any sensitivity badge for a cleared field", () => {
+    renderPicker([makeField({ sensitivity: "cleared" })]);
+
+    expect(screen.queryByText("Sensitive")).toBeNull();
+    expect(screen.queryByText("Unclassified")).toBeNull();
+    expect(screen.queryByText("Likely sensitive")).toBeNull();
+  });
+});

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
@@ -127,6 +127,8 @@ describe("InsightFieldEditorModal: sensitivity badge at-rest visibility", () => 
 
     expect(screen.queryByText("Sensitive")).toBeNull();
     expect(screen.queryByText("Unclassified")).toBeNull();
-    expect(screen.queryByText("Likely sensitive")).toBeNull();
+    // "Likely sensitive" is never rendered in the picker: FieldOption always
+    // passes suggestedReasons={[]} to SensitivityBadge, disabling the
+    // classifier-suggestion affordance at the component level.
   });
 });

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx
@@ -1,3 +1,4 @@
+import { SensitivityBadge } from "@/components/data-sources/SensitivityBadge";
 import type { CombinedField } from "@/lib/insights/compute-combined-fields";
 import {
   Badge,
@@ -163,6 +164,11 @@ function FieldOption({ field, isJoined, onClick }: FieldOptionProps) {
         )}
       </div>
       <div className="flex shrink-0 items-center gap-2">
+        <SensitivityBadge
+          field={field}
+          suggestedReasons={[]}
+          onConfirmSuggestion={() => {}}
+        />
         <Badge variant="outline" className="text-[10px]">
           {field.type}
         </Badge>


### PR DESCRIPTION
Closes #81

`SensitivityBadge` was rendered on the data-source detail page but absent from `InsightFieldEditorModal` — the dialog where a user decides to add a field to an insight. A user selecting `customer_email` saw no privacy signal at the point of use.

## Changes

- Reuse `SensitivityBadge` (from `packages/app/src/components/data-sources/SensitivityBadge.tsx`) in the `FieldOption` component inside `InsightFieldEditorModal`, adjacent to the field name, at-rest (no hover/expand required).
- Same badge component + prop pattern as the data-source detail page: `suggestedReasons={[]}` (no classifier confirm flow in a picker context) and no-op `onConfirmSuggestion`. Renders: `sensitive` → soft-danger "Sensitive" badge; `unclassified` → outline "Unclassified" badge; `cleared` → nothing.
- Added 4 component-level tests verifying the at-rest badge contract for all three sensitivity states.

## Screenshots

Screenshots captured via Playwright from a minimal component harness rendering `InsightFieldEditorModal` open with a mix of sensitive / unclassified / cleared fields. Identical component tree to production — same `SensitivityBadge` import, same `FieldOption` logic.

**After — light mode** (`customer_email` → Sensitive badge; `phone_number` → Unclassified badge; `region`/`revenue` (cleared / no sensitivity) → no badge):

> field picker showing: `customer_email` [🔴 Sensitive] [string], `phone_number` [Unclassified] [string], `region` [string], `revenue` [number]
>
> Before this change: all four rows showed only the type badge — no sensitivity signal.

**After — dark mode** (same badge visibility, dark surface tokens):

> Same field picker in dark mode: `customer_email` [🔴 Sensitive] [string], `phone_number` [Unclassified] [string], `region` [string]

_Full-stack app screenshots require the loopback DuckDB server. The harness renders the identical component and the Playwright screenshots confirm badge rendering in both modes._

## Verification

- `bun run --cwd packages/app test`: **326 passed** (4 new sensitivity badge contract tests)
- `bun run --cwd packages/app lint`: clean
- `bun format:check`: clean
- `bun run check:ticket-refs`: OK
- Badge component reused: `packages/app/src/components/data-sources/SensitivityBadge.tsx`
- Routed surface confirmed: `InsightFieldEditorModal` used by `InsightConfigPanel` at `packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx` — the live routed insight surface, **not** the dead `DataSourcesWorkbench` UI

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces `SensitivityBadge` inside the `FieldOption` component of `InsightFieldEditorModal`, closing the gap where a user selecting a field for an insight had no privacy signal at the point of choice. The badge is wired identically to the data-source detail page — `suggestedReasons={[]}` intentionally suppresses the classifier-confirm affordance since that flow doesn't apply in a picker context.

- **`InsightFieldEditorModal.tsx`**: One-line import + four-line `SensitivityBadge` usage added to `FieldOption`; `CombinedField` extends `Field` so the prop type is structurally compatible without any casting.
- **`InsightFieldEditorModal.test.tsx`**: Four new contract tests covering all three sensitivity states (sensitive → "Sensitive" badge, unclassified/undefined → "Unclassified" badge, cleared → no badge); Dialog/UI primitives are stubbed so only badge rendering is exercised.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, additive reuse of an existing component with no mutations or side effects.

The only changed logic is wiring SensitivityBadge into FieldOption; CombinedField extends Field makes the type assignment structurally sound, suggestedReasons=[] correctly suppresses the confirm flow, and 4 new tests cover all badge states. No new data paths, API calls, or state changes are introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx | Adds SensitivityBadge to FieldOption with suggestedReasons=[] and a no-op onConfirmSuggestion; CombinedField extends Field so the prop type is compatible. No issues found. |
| packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx | New test file with 4 contract tests covering sensitive, unclassified (implicit + explicit), and cleared states; mocks Dialog components to avoid portal issues. Comment on line 130-132 correctly explains why 'Likely sensitive' is suppressed at the component level. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FieldOption renders] --> B[SensitivityBadge\nsuggestedReasons empty\nonConfirmSuggestion no-op]
    B --> C{getFieldSensitivity}
    C -->|cleared| D[return null - no badge]
    C -->|sensitive| E[Badge soft danger - Sensitive\nwith sensitivityReason title]
    C -->|unclassified or undefined| F{suggestedReasons length > 0?}
    F -->|yes - never reached| G[Clickable Likely sensitive badge]
    F -->|no - always taken| H[Badge outline secondary - Unclassified]
    E --> I[Field row continues]
    H --> I
    D --> I
    I --> J[Type badge]
    J --> K[Optional joined badge]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(app): remove vacuous &#39;Likely sensiti..."](https://github.com/youhaowei/dashframe/commit/4f27a81079c9ee35d16adfa09f75414e722a40b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37408444)</sub>

<!-- /greptile_comment -->