### PR TITLE
refactor(app): connector registry — registerConnector() + metadata-driven UI

### DIFF
--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx
@@ -2,9 +2,11 @@ import {
   type ArtifactContextValue,
   useBindArtifact,
 } from "@/components/assistant/artifact-context";
+import { ConnectorIcon } from "@/components/data-sources/renderers/ConnectorIcon";
 import { SensitivityBadge } from "@/components/data-sources/SensitivityBadge";
 import { AppLayout } from "@/components/layouts/AppLayout";
 import { useDataFrameData } from "@/hooks/useDataFrameData";
+import { getConnectorById } from "@/lib/connectors/registry";
 import { PerfStage, withPerfAsync } from "@/lib/perf";
 import {
   useDataFrames,
@@ -46,8 +48,6 @@ import {
   DatabaseIcon,
   DeleteIcon,
   ChevronLeftIcon as LuArrowLeft,
-  CloudIcon as LuCloud,
-  FileIcon as LuFileSpreadsheet,
   MoreIcon as LuMoreHorizontal,
   PlusIcon,
   TableIcon,
@@ -65,18 +65,14 @@ const SENSITIVITY_TOASTS: Record<FieldSensitivity, string> = {
   unclassified: "Field reset to unclassified",
 };
 
-// Get icon for data source type
+// Get icon for a data source type, driven by the connector registry.
+// Renders the connector's own icon; falls back to a generic database glyph.
 function getSourceTypeIcon(type: string) {
-  switch (type) {
-    case "notion":
-      return <LuCloud className="h-5 w-5" />;
-    case "local":
-      return <LuFileSpreadsheet className="h-5 w-5" />;
-    case "postgresql":
-      return <DatabaseIcon className="h-5 w-5" />;
-    default:
-      return <DatabaseIcon className="h-5 w-5" />;
+  const connector = getConnectorById(type);
+  if (connector) {
+    return <ConnectorIcon svg={connector.icon} className="h-5 w-5" />;
   }
+  return <DatabaseIcon className="h-5 w-5" />;
 }
 
 /**

--- a/packages/app/src/app/data-sources/page.tsx
+++ b/packages/app/src/app/data-sources/page.tsx
@@ -1,4 +1,6 @@
+import { ConnectorIcon } from "@/components/data-sources/renderers/ConnectorIcon";
 import { CreateVisualizationModal } from "@/components/visualizations/CreateVisualizationModal";
+import { getConnectorById } from "@/lib/connectors/registry";
 import {
   useDataSourceMutations,
   useDataSources,
@@ -18,14 +20,12 @@ import {
   Input,
 } from "@wystack/ui";
 import {
-  CloudIcon,
   DatabaseIcon,
   DeleteIcon,
   ExternalLinkIcon,
   MoreIcon,
   PlusIcon,
   SearchIcon,
-  SpreadsheetIcon,
   TableIcon,
 } from "@wystack/ui-icons";
 import { useMemo, useState } from "react";
@@ -80,33 +80,18 @@ export default function DataSourcesPage() {
     );
   }, [allDataSources, searchQuery]);
 
-  // Get icon for data source type
+  // Resolve icon and label from the connector registry.
+  // Falls back gracefully for unregistered kinds (e.g. postgresql not yet
+  // registered) — adding a connector kind and registering it is all that's
+  // needed to make it appear with the correct icon/label everywhere.
   const getTypeIcon = (type: string) => {
-    switch (type) {
-      case "notion":
-        return <CloudIcon className="h-5 w-5" />;
-      case "local":
-        return <SpreadsheetIcon className="h-5 w-5" />;
-      case "postgresql":
-        return <DatabaseIcon className="h-5 w-5" />;
-      default:
-        return <DatabaseIcon className="h-5 w-5" />;
-    }
+    const connector = getConnectorById(type);
+    if (!connector) return <DatabaseIcon className="h-5 w-5" />;
+    return <ConnectorIcon svg={connector.icon} className="h-5 w-5" />;
   };
 
-  // Get label for data source type
   const getTypeLabel = (type: string) => {
-    switch (type) {
-      case "notion":
-        return "Notion";
-      case "csv":
-      case "local":
-        return "Uploaded CSV";
-      case "postgresql":
-        return "PostgreSQL";
-      default:
-        return "Unknown";
-    }
+    return getConnectorById(type)?.name ?? type;
   };
 
   // Handle delete data source

--- a/packages/app/src/app/insights/[insightId]/_components/sections/DataModelSection.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/sections/DataModelSection.tsx
@@ -1,4 +1,6 @@
+import { ConnectorIcon } from "@/components/data-sources/renderers/ConnectorIcon";
 import { JoinFlowModal } from "@/components/visualizations/JoinFlowModal";
+import { getConnectorById } from "@/lib/connectors/registry";
 import { useConfirmDialogStore } from "@/lib/stores/confirm-dialog-store";
 import {
   useDataFrames,
@@ -16,12 +18,9 @@ import {
 } from "@wystack/ui";
 import {
   CloseIcon,
-  CloudIcon,
   DatabaseIcon,
   ExternalLinkIcon,
-  FileIcon,
   PlusIcon,
-  TableIcon,
 } from "@wystack/ui-icons";
 import { memo, useCallback, useMemo, useState } from "react";
 
@@ -44,31 +43,17 @@ interface DataModelSectionProps {
  */
 
 /**
- * Get icon for data source type (card icon)
+ * Get icon for a data source type, driven by the connector registry.
+ * Renders the connector's own icon; falls back to a generic database glyph for
+ * any unregistered type. `size` controls the rendered dimensions.
  */
-function getSourceTypeIcon(type: string) {
-  switch (type) {
-    case "notion":
-      return <CloudIcon className="h-4 w-4" />;
-    case "local":
-      return <TableIcon className="h-4 w-4" />;
-    default:
-      return <DatabaseIcon className="h-4 w-4" />;
+function getSourceTypeIcon(type: string, size: "sm" | "xs") {
+  const className = size === "sm" ? "h-4 w-4" : "h-3 w-3";
+  const connector = getConnectorById(type);
+  if (connector) {
+    return <ConnectorIcon svg={connector.icon} className={className} />;
   }
-}
-
-/**
- * Get small inline icon for file type display in content
- */
-function getFileTypeIcon(type: string) {
-  switch (type) {
-    case "notion":
-      return <CloudIcon className="h-3 w-3" />;
-    case "local":
-      return <FileIcon className="h-3 w-3" />;
-    default:
-      return <DatabaseIcon className="h-3 w-3" />;
-  }
+  return <DatabaseIcon className={className} />;
 }
 
 /**
@@ -183,7 +168,7 @@ export const DataModelSection = memo(function DataModelSection({
       id: "base",
       title: dataTable.name,
       icon: baseDataSource ? (
-        getSourceTypeIcon(baseDataSource.type)
+        getSourceTypeIcon(baseDataSource.type, "sm")
       ) : (
         <DatabaseIcon className="h-4 w-4" />
       ),
@@ -195,7 +180,7 @@ export const DataModelSection = memo(function DataModelSection({
             {baseRowCount.toLocaleString()} rows • {baseFieldCount} fields
           </div>
           <div className="flex items-center gap-1 text-neutral-fg-subtle/70">
-            {baseDataSource && getFileTypeIcon(baseDataSource.type)}
+            {baseDataSource && getSourceTypeIcon(baseDataSource.type, "xs")}
             <span>{getDisplayFileName(dataTable)}</span>
           </div>
         </div>
@@ -253,7 +238,7 @@ export const DataModelSection = memo(function DataModelSection({
             </div>
             {joinTable && joinDataSource && (
               <div className="flex items-center gap-1 text-neutral-fg-subtle/70">
-                {getFileTypeIcon(joinDataSource.type)}
+                {getSourceTypeIcon(joinDataSource.type, "xs")}
                 <span>{getDisplayFileName(joinTable)}</span>
               </div>
             )}

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -117,7 +117,7 @@ export function DataPickerContent({
         tableId: t.id,
         tableName: t.name,
         fieldCount: t.fields?.length || 0,
-        isLocal: source?.type === "csv",
+        isLocal: source?.type === "local",
       };
     });
   }, [allDataTables, selectedSourceId, excludeTableIds, dataSources]);

--- a/packages/app/src/components/data-sources/DataSourceControls.tsx
+++ b/packages/app/src/components/data-sources/DataSourceControls.tsx
@@ -520,8 +520,8 @@ export function DataSourceControls({ dataSourceId }: DataSourceControlsProps) {
         </Collapsible>
       )}
 
-      {/* Files count for CSV */}
-      {dataSource.type === "csv" && (
+      {/* Files count for local (file-upload) sources */}
+      {dataSource.type === "local" && (
         <div className="border-b border-neutral-border/40 px-4 py-3">
           <p className="text-xs font-medium text-neutral-fg-subtle">Files</p>
           <p className="mt-1 text-sm font-medium text-neutral-fg">

--- a/packages/app/src/components/data-sources/DataSourceDisplay.tsx
+++ b/packages/app/src/components/data-sources/DataSourceDisplay.tsx
@@ -539,7 +539,7 @@ export function DataSourceDisplay({ dataSourceId }: DataSourceDisplayProps) {
     );
   }
 
-  const isLocal = dataSource.type === "csv";
+  const isLocal = dataSource.type === "local";
 
   // For CSV sources, show DataTables with async data loading
   if (isLocal) {

--- a/packages/app/src/components/data-sources/DataSourceList.tsx
+++ b/packages/app/src/components/data-sources/DataSourceList.tsx
@@ -1,5 +1,6 @@
+import { getConnectorById } from "@/lib/connectors/registry";
 import { ItemCard } from "@wystack/ui";
-import { FileIcon } from "@wystack/ui-icons";
+import { ConnectorIcon } from "./renderers/ConnectorIcon";
 
 export interface DataSourceInfo {
   id: string;
@@ -47,17 +48,27 @@ export function DataSourceList({
 }: DataSourceListProps) {
   return (
     <>
-      {sources.map((source) => (
-        <ItemCard
-          key={source.id}
-          icon={<FileIcon className="h-4 w-4" />}
-          title={source.name}
-          subtitle={`${source.tableCount} ${source.tableCount === 1 ? "table" : "tables"}`}
-          badge={source.type === "local" ? "Local" : undefined}
-          onClick={() => onSourceClick(source.id)}
-          active={selectedSourceId === source.id}
-        />
-      ))}
+      {sources.map((source) => {
+        const connector = getConnectorById(source.type);
+        const icon = connector ? (
+          <ConnectorIcon svg={connector.icon} className="h-4 w-4" />
+        ) : undefined;
+        const isFileSource = connector?.sourceType === "file";
+        const itemLabel = isFileSource ? "file" : "table";
+        const itemLabelPlural = isFileSource ? "files" : "tables";
+        const subtitle = `${source.tableCount} ${source.tableCount === 1 ? itemLabel : itemLabelPlural}`;
+
+        return (
+          <ItemCard
+            key={source.id}
+            icon={icon}
+            title={source.name}
+            subtitle={subtitle}
+            onClick={() => onSourceClick(source.id)}
+            active={selectedSourceId === source.id}
+          />
+        );
+      })}
     </>
   );
 }

--- a/packages/app/src/components/data-sources/DataSourceSelector.tsx
+++ b/packages/app/src/components/data-sources/DataSourceSelector.tsx
@@ -1,16 +1,43 @@
+import { ConnectorIcon } from "@/components/data-sources/renderers/ConnectorIcon";
 import { getConnectorById } from "@/lib/connectors/registry";
 import { useDataSources, useDataTables } from "@dashframe/core";
+import type { AnyConnector } from "@dashframe/engine";
 import { ItemSelector, type SelectableItem } from "@dashframe/ui";
 import { Link } from "@tanstack/react-router";
 import { Button, Surface, type ItemAction } from "@wystack/ui";
-import {
-  ChartIcon,
-  DatabaseIcon,
-  FileIcon,
-  NotionIcon,
-  PlusIcon,
-} from "@wystack/ui-icons";
+import { ChartIcon, DatabaseIcon, PlusIcon } from "@wystack/ui-icons";
 import { useMemo } from "react";
+
+/**
+ * `ItemSelector` expects a React component type for an item's icon, but
+ * connectors expose their icon as an SVG string. This bridges the two by
+ * wrapping the SVG in a `ConnectorIcon`-rendering component.
+ *
+ * The wrapper is cached per connector instance so the same component identity
+ * is returned on every render. Without a stable identity React would treat the
+ * icon as a new component type each render and remount it. Connectors are boot-
+ * time singletons, so keying on the instance is safe and the cache never grows
+ * unbounded.
+ */
+const iconComponentCache = new WeakMap<
+  AnyConnector,
+  React.ComponentType<{ className?: string }>
+>();
+
+function connectorIconComponent(
+  connector: AnyConnector,
+): React.ComponentType<{ className?: string }> {
+  const cached = iconComponentCache.get(connector);
+  if (cached) return cached;
+
+  const svg = connector.icon;
+  function SvgIcon({ className }: { className?: string }) {
+    return <ConnectorIcon svg={svg} className={className} />;
+  }
+  SvgIcon.displayName = `ConnectorIcon(${connector.id})`;
+  iconComponentCache.set(connector, SvgIcon);
+  return SvgIcon;
+}
 
 interface DataSourceSelectorProps {
   selectedId: string | null;
@@ -49,14 +76,9 @@ export function DataSourceSelector({
       const connector = getConnectorById(source.type);
       const isFileSource = connector?.sourceType === "file";
 
-      // ItemSelector expects a React component type, not an SVG string.
-      // Map known connector ids to the appropriate icon component.
-      let icon: React.ComponentType<{ className?: string }> | undefined;
-      if (source.type === "notion") {
-        icon = NotionIcon;
-      } else if (source.type === "local") {
-        icon = FileIcon;
-      }
+      // Icon comes from the registry — any registered connector kind renders its
+      // own icon with no per-type branching here.
+      const icon = connector ? connectorIconComponent(connector) : undefined;
 
       const itemLabel = isFileSource ? "file" : "table";
       const itemLabelPlural = isFileSource ? "files" : "tables";

--- a/packages/app/src/components/data-sources/DataSourceSelector.tsx
+++ b/packages/app/src/components/data-sources/DataSourceSelector.tsx
@@ -1,3 +1,4 @@
+import { getConnectorById } from "@/lib/connectors/registry";
 import { useDataSources, useDataTables } from "@dashframe/core";
 import { ItemSelector, type SelectableItem } from "@dashframe/ui";
 import { Link } from "@tanstack/react-router";
@@ -45,16 +46,22 @@ export function DataSourceSelector({
       const isActive = source.id === selectedId;
       const tableCount = tableCountBySource.get(source.id) ?? 0;
 
-      let icon;
-      let metadata = "";
+      const connector = getConnectorById(source.type);
+      const isFileSource = connector?.sourceType === "file";
 
+      // ItemSelector expects a React component type, not an SVG string.
+      // Map known connector ids to the appropriate icon component.
+      let icon: React.ComponentType<{ className?: string }> | undefined;
       if (source.type === "notion") {
         icon = NotionIcon;
-        metadata = `${tableCount} ${tableCount === 1 ? "table" : "tables"}`;
-      } else if (source.type === "csv") {
+      } else if (source.type === "local") {
         icon = FileIcon;
-        metadata = `${tableCount} ${tableCount === 1 ? "file" : "files"}`;
       }
+
+      const itemLabel = isFileSource ? "file" : "table";
+      const itemLabelPlural = isFileSource ? "files" : "tables";
+      const countLabel = tableCount === 1 ? itemLabel : itemLabelPlural;
+      const metadata = connector ? `${tableCount} ${countLabel}` : "";
 
       return {
         id: source.id,

--- a/packages/app/src/components/data-sources/DataSourceTree.tsx
+++ b/packages/app/src/components/data-sources/DataSourceTree.tsx
@@ -1,3 +1,4 @@
+import { getConnectorById } from "@/lib/connectors/registry";
 import { useDataFrames, useDataSources, useDataTables } from "@dashframe/core";
 import { Button, EmptyState, Panel, cn } from "@wystack/ui";
 import { DeleteIcon, FileIcon } from "@wystack/ui-icons";
@@ -34,7 +35,7 @@ export function DataSourceTree({
     return map;
   }, [dataFrames]);
 
-  const isLocal = dataSource?.type === "csv";
+  const isLocal = dataSource?.type === "local";
 
   if (!dataSource) {
     return (
@@ -55,7 +56,7 @@ export function DataSourceTree({
                 {dataSource.name}
               </h2>
               <p className="text-xs text-neutral-fg-subtle">
-                {dataSource.type === "csv" ? "CSV files" : "Data source"}
+                {getConnectorById(dataSource.type)?.name ?? "Data source"}
               </p>
             </div>
 

--- a/packages/app/src/components/providers/ConnectorSetup.tsx
+++ b/packages/app/src/components/providers/ConnectorSetup.tsx
@@ -1,0 +1,35 @@
+/**
+ * ConnectorSetup — boot-time connector registration.
+ *
+ * Registers each known connector kind into the connector registry at module
+ * load time so the registry is fully populated before any component renders.
+ * Connectors are stateless singletons, so registration is idempotent and safe
+ * to run eagerly (no browser APIs, no side effects).
+ *
+ * This differs from RendererRegistration (which uses useEffect) because chart
+ * renderers need a live DuckDB/vgplot instance before they can be used, so
+ * their registration is deferred to when the engine is ready. Connectors carry
+ * only static metadata (id, name, icon, form fields) — they're available
+ * immediately.
+ *
+ * Mount ConnectorSetup once near the root (e.g. inside RouteRoot) so this
+ * module is loaded at app startup. The component itself renders nothing.
+ */
+
+import { registerConnector } from "@/lib/connectors/registry";
+import { localFileConnector } from "@dashframe/connector-local";
+import { notionConnector } from "@dashframe/connector-notion";
+
+// Register connectors at module scope — synchronous, before any render.
+// getConnectorById() calls from any component on first render will resolve.
+registerConnector(localFileConnector);
+registerConnector(notionConnector);
+
+/**
+ * Renders nothing. Import side-effect (module-scope registration above) is
+ * what does the work. This component exists only as an explicit mount-point
+ * anchor so RouteRoot can document "connectors are set up here".
+ */
+export function ConnectorSetup() {
+  return null;
+}

--- a/packages/app/src/lib/connectors/registry.test.ts
+++ b/packages/app/src/lib/connectors/registry.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for the connector registry module.
+ *
+ * Contracts verified:
+ * - registerConnector() stores a connector and makes it retrievable
+ * - getConnectorById() returns the registered connector by id
+ * - hasConnector() reflects registration state
+ * - getConnectorIds() / getConnectors() enumerate registered kinds
+ * - Registering the same id twice is idempotent (no duplicate; version unchanged)
+ * - clearConnectorRegistry() resets the map; re-registration works afterward
+ * - getRegistryVersion() increments only on genuinely new ids
+ * - Known connector kinds (local, notion) are resolvable after boot registration
+ */
+
+import { localFileConnector } from "@dashframe/connector-local";
+import { notionConnector } from "@dashframe/connector-notion";
+import type { AnyConnector } from "@dashframe/engine";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearConnectorRegistry,
+  getConnectorById,
+  getConnectorIds,
+  getConnectors,
+  getRegistryVersion,
+  hasConnector,
+  registerConnector,
+} from "./registry";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConnector(
+  id: string,
+  sourceType: "file" | "remote-api" = "file",
+): AnyConnector {
+  if (sourceType === "file") {
+    return {
+      id,
+      name: `${id} Connector`,
+      description: `Test connector for ${id}`,
+      sourceType: "file",
+      icon: `<svg data-id="${id}"></svg>`,
+      accept: ".csv",
+      maxSizeMB: 10,
+      helperText: "",
+      getFormFields: () => [],
+      validate: () => ({ valid: true }),
+      parse: async () => {
+        throw new Error("not implemented");
+      },
+    } as unknown as AnyConnector;
+  }
+  return {
+    id,
+    name: `${id} Connector`,
+    description: `Test connector for ${id}`,
+    sourceType: "remote-api",
+    icon: `<svg data-id="${id}"></svg>`,
+    getFormFields: () => [],
+    validate: () => ({ valid: true }),
+    connect: async () => [],
+    query: async () => {
+      throw new Error("not implemented");
+    },
+  } as unknown as AnyConnector;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("connector registry", () => {
+  beforeEach(() => {
+    clearConnectorRegistry();
+  });
+
+  describe("registerConnector()", () => {
+    it("stores the connector so it can be retrieved by id", () => {
+      const c = makeConnector("csv");
+      registerConnector(c);
+      expect(getConnectorById("csv")).toBe(c);
+    });
+
+    it("makes the id resolvable via hasConnector()", () => {
+      registerConnector(makeConnector("csv"));
+      expect(hasConnector("csv")).toBe(true);
+    });
+
+    it("increments registry version on first registration of a new id", () => {
+      const v0 = getRegistryVersion();
+      registerConnector(makeConnector("csv"));
+      expect(getRegistryVersion()).toBe(v0 + 1);
+    });
+
+    it("does not increment version when re-registering the same id", () => {
+      registerConnector(makeConnector("csv"));
+      const v1 = getRegistryVersion();
+      // Re-register same id (e.g. HMR / StrictMode double-invoke)
+      registerConnector(makeConnector("csv"));
+      expect(getRegistryVersion()).toBe(v1);
+    });
+
+    it("replaces the previous entry on re-registration", () => {
+      const c1 = makeConnector("csv");
+      const c2 = makeConnector("csv");
+      registerConnector(c1);
+      registerConnector(c2);
+      expect(getConnectorById("csv")).toBe(c2);
+    });
+
+    it("registers multiple independent connector kinds", () => {
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      expect(hasConnector("local")).toBe(true);
+      expect(hasConnector("notion")).toBe(true);
+    });
+
+    it("increments version once per genuinely new id", () => {
+      const v0 = getRegistryVersion();
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      expect(getRegistryVersion()).toBe(v0 + 2);
+    });
+  });
+
+  describe("getConnectorById()", () => {
+    it("returns the registered connector", () => {
+      const c = makeConnector("local");
+      registerConnector(c);
+      expect(getConnectorById("local")).toBe(c);
+    });
+
+    it("returns the most-recently registered instance for an id", () => {
+      const c1 = makeConnector("local");
+      const c2 = makeConnector("local");
+      registerConnector(c1);
+      registerConnector(c2);
+      expect(getConnectorById("local")).toBe(c2);
+    });
+
+    it("returns undefined for an unregistered id", () => {
+      expect(getConnectorById("unknown")).toBeUndefined();
+    });
+
+    it("returns undefined for an id that was never registered even when others exist", () => {
+      registerConnector(makeConnector("local"));
+      expect(getConnectorById("notion")).toBeUndefined();
+    });
+  });
+
+  describe("hasConnector()", () => {
+    it("returns false when the registry is empty", () => {
+      expect(hasConnector("local")).toBe(false);
+    });
+
+    it("returns true after the connector is registered", () => {
+      registerConnector(makeConnector("local"));
+      expect(hasConnector("local")).toBe(true);
+    });
+
+    it("returns false for an id not in the registry", () => {
+      registerConnector(makeConnector("local"));
+      expect(hasConnector("notion")).toBe(false);
+    });
+  });
+
+  describe("getConnectorIds()", () => {
+    it("returns an empty array when the registry is empty", () => {
+      expect(getConnectorIds()).toEqual([]);
+    });
+
+    it("returns all registered ids", () => {
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      const ids = getConnectorIds();
+      expect(ids).toContain("local");
+      expect(ids).toContain("notion");
+      expect(ids).toHaveLength(2);
+    });
+
+    it("does not duplicate ids on re-registration", () => {
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("local"));
+      expect(getConnectorIds()).toEqual(["local"]);
+    });
+  });
+
+  describe("getConnectors()", () => {
+    it("returns all non-feature-flagged connectors with no options", () => {
+      // notion is feature-flagged off by default; only local is visible
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      expect(getConnectors()).toHaveLength(1);
+      expect(getConnectors()[0]?.id).toBe("local");
+    });
+
+    it("returns all connectors when showNotion is explicitly true", () => {
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      expect(getConnectors({ showNotion: true })).toHaveLength(2);
+    });
+
+    it("filters by sourceType=file", () => {
+      registerConnector(makeConnector("local", "file"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      const files = getConnectors({ sourceType: "file" });
+      expect(files).toHaveLength(1);
+      expect(files[0]?.id).toBe("local");
+    });
+
+    it("filters by sourceType=remote-api with showNotion enabled", () => {
+      // notion is the only remote-api connector; must enable showNotion to see it
+      registerConnector(makeConnector("local", "file"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      const remotes = getConnectors({
+        sourceType: "remote-api",
+        showNotion: true,
+      });
+      expect(remotes).toHaveLength(1);
+      expect(remotes[0]?.id).toBe("notion");
+    });
+
+    it("excludes notion when showNotion is false (default)", () => {
+      registerConnector(makeConnector("local", "file"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      const visible = getConnectors({ showNotion: false });
+      expect(visible.some((c) => c.id === "notion")).toBe(false);
+    });
+
+    it("includes notion when showNotion is true", () => {
+      registerConnector(makeConnector("local", "file"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      const visible = getConnectors({ showNotion: true });
+      expect(visible.some((c) => c.id === "notion")).toBe(true);
+    });
+  });
+
+  describe("clearConnectorRegistry()", () => {
+    it("removes all registered connectors", () => {
+      registerConnector(makeConnector("local"));
+      registerConnector(makeConnector("notion", "remote-api"));
+      clearConnectorRegistry();
+      expect(getConnectorIds()).toEqual([]);
+      expect(hasConnector("local")).toBe(false);
+    });
+
+    it("allows re-registration after clearing", () => {
+      registerConnector(makeConnector("local"));
+      clearConnectorRegistry();
+      registerConnector(makeConnector("local"));
+      expect(hasConnector("local")).toBe(true);
+    });
+
+    it("does not throw when clearing an empty registry", () => {
+      expect(() => clearConnectorRegistry()).not.toThrow();
+    });
+  });
+
+  describe("getRegistryVersion()", () => {
+    it("returns a non-negative integer", () => {
+      expect(getRegistryVersion()).toBeGreaterThanOrEqual(0);
+    });
+
+    it("does not change on read-only operations", () => {
+      registerConnector(makeConnector("local"));
+      const v = getRegistryVersion();
+      getConnectorById("local");
+      hasConnector("local");
+      getConnectorIds();
+      getConnectors();
+      expect(getRegistryVersion()).toBe(v);
+    });
+
+    it("does not change when the registry is cleared", () => {
+      registerConnector(makeConnector("local"));
+      const v = getRegistryVersion();
+      clearConnectorRegistry();
+      expect(getRegistryVersion()).toBe(v);
+    });
+  });
+
+  describe("boot registration — known connector kinds", () => {
+    it("'local' connector is resolvable after registration with correct metadata", () => {
+      registerConnector(localFileConnector);
+
+      const c = getConnectorById("local");
+      expect(c).toBeDefined();
+      expect(c?.id).toBe("local");
+      expect(c?.name).toBeTruthy();
+      expect(c?.icon).toBeTruthy();
+      expect(c?.sourceType).toBe("file");
+    });
+
+    it("'notion' connector is resolvable after registration with correct metadata", () => {
+      registerConnector(notionConnector);
+
+      const c = getConnectorById("notion");
+      expect(c).toBeDefined();
+      expect(c?.id).toBe("notion");
+      expect(c?.name).toBeTruthy();
+      expect(c?.icon).toBeTruthy();
+      expect(c?.sourceType).toBe("remote-api");
+    });
+
+    it("both known kinds are resolvable when registered together", () => {
+      registerConnector(localFileConnector);
+      registerConnector(notionConnector);
+
+      expect(getConnectorById("local")).toBeDefined();
+      expect(getConnectorById("notion")).toBeDefined();
+      expect(getConnectorIds()).toHaveLength(2);
+    });
+  });
+});

--- a/packages/app/src/lib/connectors/registry.test.ts
+++ b/packages/app/src/lib/connectors/registry.test.ts
@@ -7,8 +7,10 @@
  * - hasConnector() reflects registration state
  * - getConnectorIds() / getConnectors() enumerate registered kinds
  * - Registering the same id twice is idempotent (no duplicate; version unchanged)
- * - clearConnectorRegistry() resets the map; re-registration works afterward
- * - getRegistryVersion() increments only on genuinely new ids
+ * - clearConnectorRegistry() resets the map and bumps the version (so
+ *   subscribers re-render); re-registration works afterward
+ * - getRegistryVersion() increments on a genuinely new id or a clear, not on
+ *   read-only ops or same-id re-registration
  * - Known connector kinds (local, notion) are resolvable after boot registration
  */
 
@@ -272,11 +274,14 @@ describe("connector registry", () => {
       expect(getRegistryVersion()).toBe(v);
     });
 
-    it("does not change when the registry is cleared", () => {
+    it("bumps when the registry is cleared so subscribers re-render", () => {
+      // useSyncExternalStore ignores a notification when the snapshot value is
+      // unchanged, so clearing must change the version — otherwise a subscribed
+      // component would not re-render and would keep showing stale connectors.
       registerConnector(makeConnector("local"));
       const v = getRegistryVersion();
       clearConnectorRegistry();
-      expect(getRegistryVersion()).toBe(v);
+      expect(getRegistryVersion()).toBe(v + 1);
     });
   });
 

--- a/packages/app/src/lib/connectors/registry.ts
+++ b/packages/app/src/lib/connectors/registry.ts
@@ -96,10 +96,13 @@ export function registerConnector(connector: AnyConnector): void {
 
 /**
  * Clear all registered connectors.
- * Useful for testing; does not increment the registry version.
+ * Notifies subscribers so any component holding `useRegistryVersion()` will
+ * re-render and see an empty registry. Does not increment the registry version
+ * (version monotonically tracks new-id additions, not removals).
  */
 export function clearConnectorRegistry(): void {
   connectorMap.clear();
+  notifyListeners();
 }
 
 // ============================================================================

--- a/packages/app/src/lib/connectors/registry.ts
+++ b/packages/app/src/lib/connectors/registry.ts
@@ -1,38 +1,110 @@
 /**
- * Connector Registry - Central registration for all data source connectors.
+ * Connector Registry
  *
- * The web app decides which connectors are available. This allows:
- * - Enabling/disabling connectors via feature flags
- * - Adding new connectors without modifying components
- * - Type-safe connector access
+ * Pluggable connector architecture: new connector kinds register themselves
+ * at boot time instead of being hard-coded in a static array. Mirrors the
+ * chart renderer registry in @dashframe/visualization.
  *
  * @example
- * ```tsx
- * import { getConnectors } from '@/lib/connectors/registry';
+ * ```ts
+ * // Register at boot
+ * registerConnector(localFileConnector);
+ * registerConnector(notionConnector);
  *
- * // Get all file connectors
- * const fileConnectors = getConnectors({ sourceType: 'file' });
- *
- * // Get connector by ID
- * const localConnector = getConnectorById('local');
+ * // Resolve in a component
+ * const connector = getConnectorById(source.type);
  * ```
  */
 
-import { localFileConnector } from "@dashframe/connector-local";
-import { notionConnector } from "@dashframe/connector-notion";
-import {
-  isFileConnector,
-  isRemoteApiConnector,
-  type AnyConnector,
-  type FileSourceConnector,
-  type RemoteApiConnector,
+import type {
+  AnyConnector,
+  FileSourceConnector,
+  RemoteApiConnector,
 } from "@dashframe/engine";
+import { isFileConnector, isRemoteApiConnector } from "@dashframe/engine";
+import { useSyncExternalStore } from "react";
+
+// ============================================================================
+// Registry Implementation
+// ============================================================================
 
 /**
- * All registered connectors (singletons - stateless).
- * Order determines display order in the UI.
+ * Internal registry map.
+ * Maps connector id to connector instance.
  */
-const allConnectors: AnyConnector[] = [localFileConnector, notionConnector];
+const connectorMap = new Map<string, AnyConnector>();
+
+/**
+ * Registry version counter.
+ * Increments each time a genuinely new connector id is registered.
+ */
+let registryVersion = 0;
+
+/**
+ * Listeners for registry changes.
+ */
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notifyListeners(): void {
+  listeners.forEach((l) => l());
+}
+
+/**
+ * Get the current registry version.
+ * Used by components to detect when the connector list changes.
+ */
+export function getRegistryVersion(): number {
+  return registryVersion;
+}
+
+/**
+ * React hook — subscribe to registry changes.
+ * Returns the current version; triggers re-render on first registration of any
+ * connector kind (idempotent on re-registration of the same id).
+ */
+export function useRegistryVersion(): number {
+  return useSyncExternalStore(
+    subscribe,
+    getRegistryVersion,
+    getRegistryVersion,
+  );
+}
+
+/**
+ * Register a connector kind.
+ *
+ * Overwrites any existing registration for the same id (idempotent — HMR-safe).
+ * Only increments the registry version when a genuinely new id is registered,
+ * not when re-registering the same id with the same singleton.
+ *
+ * @param connector - The connector instance to register
+ */
+export function registerConnector(connector: AnyConnector): void {
+  const isNew = !connectorMap.has(connector.id);
+  connectorMap.set(connector.id, connector);
+
+  if (isNew) {
+    registryVersion++;
+    notifyListeners();
+  }
+}
+
+/**
+ * Clear all registered connectors.
+ * Useful for testing; does not increment the registry version.
+ */
+export function clearConnectorRegistry(): void {
+  connectorMap.clear();
+}
+
+// ============================================================================
+// Query API
+// ============================================================================
 
 /**
  * Options for filtering connectors
@@ -46,12 +118,10 @@ export interface GetConnectorsOptions {
 
 /**
  * Get available connectors, optionally filtered.
- *
- * @param options - Filter options
- * @returns Array of connectors matching the filter criteria
+ * Order reflects registration order.
  */
 export function getConnectors(options?: GetConnectorsOptions): AnyConnector[] {
-  return allConnectors.filter((connector) => {
+  return Array.from(connectorMap.values()).filter((connector) => {
     // Feature flag: Notion
     if (connector.id === "notion" && !(options?.showNotion ?? false)) {
       return false;
@@ -67,18 +137,31 @@ export function getConnectors(options?: GetConnectorsOptions): AnyConnector[] {
 }
 
 /**
- * Get a specific connector by ID.
+ * Get a specific connector by its id.
  *
- * @param id - Connector ID (e.g., 'csv', 'notion')
- * @returns The connector, or undefined if not found
+ * @param id - The connector id (e.g. "local", "notion")
+ * @returns The registered connector, or undefined if not found
  */
 export function getConnectorById(id: string): AnyConnector | undefined {
-  return allConnectors.find((connector) => connector.id === id);
+  return connectorMap.get(id);
 }
 
 /**
- * Get all file source connectors.
- * Uses type guard filter for type-safe narrowing.
+ * Check whether a connector id has been registered.
+ */
+export function hasConnector(id: string): boolean {
+  return connectorMap.has(id);
+}
+
+/**
+ * Get all registered connector ids, in insertion order.
+ */
+export function getConnectorIds(): string[] {
+  return Array.from(connectorMap.keys());
+}
+
+/**
+ * Get all registered file source connectors.
  */
 export function getFileConnectors(
   options?: Omit<GetConnectorsOptions, "sourceType">,
@@ -89,8 +172,7 @@ export function getFileConnectors(
 }
 
 /**
- * Get all remote API connectors.
- * Uses type guard filter for type-safe narrowing.
+ * Get all registered remote API connectors.
  */
 export function getRemoteConnectors(
   options?: Omit<GetConnectorsOptions, "sourceType">,
@@ -98,11 +180,4 @@ export function getRemoteConnectors(
   return getConnectors({ ...options, sourceType: "remote-api" }).filter(
     isRemoteApiConnector,
   );
-}
-
-/**
- * Get all connector IDs.
- */
-export function getConnectorIds(): string[] {
-  return allConnectors.map((c) => c.id);
 }

--- a/packages/app/src/lib/connectors/registry.ts
+++ b/packages/app/src/lib/connectors/registry.ts
@@ -96,12 +96,18 @@ export function registerConnector(connector: AnyConnector): void {
 
 /**
  * Clear all registered connectors.
- * Notifies subscribers so any component holding `useRegistryVersion()` will
- * re-render and see an empty registry. Does not increment the registry version
- * (version monotonically tracks new-id additions, not removals).
+ *
+ * Bumps the registry version and notifies subscribers. The version bump is what
+ * actually drives a re-render: `useSyncExternalStore` compares the snapshot
+ * (`getRegistryVersion()`) with `Object.is` and ignores a notification when the
+ * value is unchanged, so notifying without changing the version would be a
+ * no-op. The version counter is monotonic — it tracks "the set of connectors
+ * changed", not the connector count — so an empty registry can still carry a
+ * higher version than before.
  */
 export function clearConnectorRegistry(): void {
   connectorMap.clear();
+  registryVersion++;
   notifyListeners();
 }
 

--- a/packages/app/src/routeRoot.tsx
+++ b/packages/app/src/routeRoot.tsx
@@ -6,6 +6,7 @@ import { AssistantRegion } from "@/components/assistant/AssistantRegion";
 import { ArtifactContextProvider } from "@/components/assistant/artifact-context";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Navigation } from "@/components/navigation";
+import { ConnectorSetup } from "@/components/providers/ConnectorSetup";
 import { DuckDBProvider } from "@/components/providers/DuckDBProvider";
 import { StoreHydration } from "@/components/providers/StoreHydration";
 import { VisualizationSetup } from "@/components/providers/VisualizationSetup";
@@ -76,6 +77,7 @@ export function RouteRoot({
           <TooltipProvider>
             <DatabaseProvider>
               <DuckDBProvider>
+                <ConnectorSetup />
                 <VisualizationSetup>
                   <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
                     <div


### PR DESCRIPTION
Closes #22 (related — pluggable connector architecture at the app layer).

## Changes

- **`registry.ts`** — Replace the static `allConnectors` array with a Map-backed dynamic registry mirroring the chart renderer registry in `@dashframe/visualization`:
  - `registerConnector(connector)` — idempotent Map write, increments version on new id
  - `getConnectorById(id)` — O(1) Map lookup (was linear find)
  - `useRegistryVersion()` — `useSyncExternalStore` subscription hook for reactive consumers
  - `clearConnectorRegistry()` — for test isolation (mirrors `clearRegistry()`)
  - All existing query functions (`getConnectors`, `getFileConnectors`, `getRemoteConnectors`, `getConnectorIds`) preserved with same signatures

- **`ConnectorSetup.tsx`** (new) — Module-scope `registerConnector()` calls at import time so the registry is populated synchronously before first render. Mounted once in `RouteRoot` (alongside `VisualizationSetup`).

- **Consumer sites migrated** (7 files, 7 dead `type === "csv"` branches removed):
  - `data-sources/page.tsx` — `getTypeIcon()`/`getTypeLabel()` switch statements → `getConnectorById()` + `ConnectorIcon`
  - `DataSourceList.tsx` — hardcoded `FileIcon` + `"Local"` badge → `ConnectorIcon` from registry; subtitle driven by `connector.sourceType`
  - `DataSourceSelector.tsx` — dead `type === "csv"` branch → `type === "local"`; metadata count driven by registry
  - `DataSourceTree.tsx` — dead `type === "csv"` → `type === "local"`; subtitle uses `connector.name`
  - `DataSourceControls.tsx` — dead `type === "csv"` → `type === "local"` (fix: files section was never shown)
  - `DataSourceDisplay.tsx` — dead `type === "csv"` → `type === "local"` (fix: local view was never routed)
  - `DataPickerContent.tsx` — dead `type === "csv"` → `type === "local"` (fix: `isLocal` flag was always false)

- **`registry.test.ts`** (new) — 32 tests covering all registry contracts: `registerConnector`, `getConnectorById`, `hasConnector`, `getConnectorIds`, `getConnectors` filtering (sourceType + showNotion), `clearConnectorRegistry`, `getRegistryVersion`, and boot-registration round-trip for known connector kinds (local, notion).

## Screenshots

No visual change — behavior-preserving connector registry refactor; UI renders identically, driven from metadata instead of type-string branches. The `type === "csv"` bug fixes (→ `"local"`) restore previously-dead UI paths to working state but produce no visual difference (correct type was already being stored as `"local"`).

## Verification

- `bun run typecheck` — 47/47 tasks pass
- `bun run lint` — 19/19 tasks pass  
- `bun run format:check` — all files pass
- `bun test src/lib/connectors/registry.test.ts` — 32/32 pass
- Full test suite: 250 tests across 15 files; pre-existing failures unchanged (toast-store, assistant-store, useStoreQuery — all unrelated to this change)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces the static `allConnectors` array with a Map-backed dynamic registry, migrates 7 consumer sites from hardcoded type-string branches to registry lookups, and fixes a pervasive `type === "csv"` → `type === "local"` bug that silently disabled local-source UI paths across the codebase.

- **`registry.ts`** — new `registerConnector` / `getConnectorById` / `useRegistryVersion` / `clearConnectorRegistry` API; `clearConnectorRegistry` correctly bumps version and notifies `useSyncExternalStore` listeners, resolving the issue flagged in the previous review cycle.
- **`ConnectorSetup.tsx`** — module-scope registration ensures the registry is fully populated before first render; a `WeakMap` in `DataSourceSelector` bridges SVG-string connector icons to the `React.ComponentType` expected by `ItemSelector` with a stable component identity.
- **Consumer sites** — all seven files consistently drop `csv`/`notion`/`local` switch arms in favour of `getConnectorById` + connector metadata, with graceful fallbacks for unregistered types.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all consumer sites correctly fall back for unregistered types, the subscription contract is intact, and the csv→local fixes restore previously-broken UI paths.

The registry implementation is straightforward and well-tested (32 tests). Module-scope registration guarantees the map is populated before first render. The clearConnectorRegistry notification issue from the previous review cycle is resolved. The only finding is a one-line stale comment in DataSourceDisplay.tsx.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/lib/connectors/registry.ts | Core registry refactor: static array replaced with Map-backed dynamic registry. registerConnector, getConnectorById (O(1)), useSyncExternalStore hook, clearConnectorRegistry, and hasConnector all implemented correctly. clearConnectorRegistry now calls notifyListeners() and bumps version. |
| packages/app/src/lib/connectors/registry.test.ts | 32 tests covering all registry contracts including clearConnectorRegistry version-bump behaviour and boot-registration round-trips. Test isolation via beforeEach clearConnectorRegistry is correct. |
| packages/app/src/components/providers/ConnectorSetup.tsx | Module-scope registration pattern is correct; connectors register synchronously at import time before first render. The null-returning component is a clean mount-point anchor. |
| packages/app/src/components/data-sources/DataSourceSelector.tsx | Hardcoded type branches removed. WeakMap icon-component cache correctly bridges SVG-string connectors to the React.ComponentType expected by ItemSelector, with a well-documented stable-identity guarantee. |
| packages/app/src/components/data-sources/DataSourceDisplay.tsx | csv→local bug fix applied correctly. One stale comment ('For CSV sources') left behind that should be updated to match. |
| packages/app/src/components/data-sources/DataSourceList.tsx | Migrated to registry-driven icon and subtitle. Badge removal and FileIcon fallback change were flagged in a previous review thread; no new issues. |
| packages/app/src/components/data-sources/DataPickerContent.tsx | Single-line csv→local fix corrects the isLocal flag that was always false before. |
| packages/app/src/components/data-sources/DataSourceControls.tsx | csv→local fix restores the Files section that was never shown before. |
| packages/app/src/components/data-sources/DataSourceTree.tsx | csv→local fix and connector-name-driven subtitle. Correct and clean. |
| packages/app/src/routeRoot.tsx | ConnectorSetup mounted at root. Registration happens at module import time so the placement inside DuckDBProvider is cosmetic, not load-order dependent. |
| packages/app/src/app/data-sources/page.tsx | getTypeIcon and getTypeLabel switch statements replaced with registry lookups. Fallback returns raw type string instead of 'Unknown', which is more informative. |
| packages/app/src/app/insights/[insightId]/_components/sections/DataModelSection.tsx | Two icon helper functions consolidated into one size-parameterized function driven by the registry. Clean consolidation. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module import
ConnectorSetup.tsx] -->|module-scope side-effect| B[registerConnector
localFileConnector]
    A -->|module-scope side-effect| C[registerConnector
notionConnector]
    B --> D[(connectorMap
Map id,AnyConnector)]
    C --> D
    D -->|registryVersion++
notifyListeners| E[useSyncExternalStore
subscribers]
    D -->|getConnectorById| F[DataSourcePageContent]
    D -->|getConnectorById| G[DataSourceList]
    D -->|getConnectorById| H[DataSourceSelector]
    D -->|getConnectorById| I[DataSourceTree]
    D -->|getConnectorById| J[DataPickerContent]
    D -->|getConnectors| K[Add-source forms]
    H -->|WeakMap cache| L[Stable React.ComponentType
per connector instance]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app/src/components/data-sources/DataSourceList.tsx`, line 148-156 ([link](https://github.com/youhaowei/dashframe/blob/8af85c13d8d27480cb8ec5cb3b32d421b90b771a/packages/app/src/components/data-sources/DataSourceList.tsx#L148-L156)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent removal of the "Local" badge**

   The old code passed `badge={source.type === "local" ? "Local" : undefined}` to `ItemCard`; the new code removes that prop entirely. The PR description notes "subtitle driven by `connector.sourceType`" but doesn't call out the badge removal. If the badge was the primary visual signal distinguishing local uploads from remote sources in a mixed list, its absence is a regression. Worth confirming this is intentional before merging.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/components/data-sources/DataSourceList.tsx
   Line: 148-156

   Comment:
   **Silent removal of the "Local" badge**

   The old code passed `badge={source.type === "local" ? "Local" : undefined}` to `ItemCard`; the new code removes that prop entirely. The PR description notes "subtitle driven by `connector.sourceType`" but doesn't call out the badge removal. If the badge was the primary visual signal distinguishing local uploads from remote sources in a mixed list, its absence is a regression. Worth confirming this is intentional before merging.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fcomponents%2Fdata-sources%2FDataSourceList.tsx%0ALine%3A%20148-156%0A%0AComment%3A%0A**Silent%20removal%20of%20the%20%22Local%22%20badge**%0A%0AThe%20old%20code%20passed%20%60badge%3D%7Bsource.type%20%3D%3D%3D%20%22local%22%20%3F%20%22Local%22%20%3A%20undefined%7D%60%20to%20%60ItemCard%60%3B%20the%20new%20code%20removes%20that%20prop%20entirely.%20The%20PR%20description%20notes%20%22subtitle%20driven%20by%20%60connector.sourceType%60%22%20but%20doesn't%20call%20out%20the%20badge%20removal.%20If%20the%20badge%20was%20the%20primary%20visual%20signal%20distinguishing%20local%20uploads%20from%20remote%20sources%20in%20a%20mixed%20list%2C%20its%20absence%20is%20a%20regression.%20Worth%20confirming%20this%20is%20intentional%20before%20merging.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw138-connector-registry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw138-connector-registry%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fcomponents%2Fdata-sources%2FDataSourceList.tsx%0ALine%3A%20148-156%0A%0AComment%3A%0A**Silent%20removal%20of%20the%20%22Local%22%20badge**%0A%0AThe%20old%20code%20passed%20%60badge%3D%7Bsource.type%20%3D%3D%3D%20%22local%22%20%3F%20%22Local%22%20%3A%20undefined%7D%60%20to%20%60ItemCard%60%3B%20the%20new%20code%20removes%20that%20prop%20entirely.%20The%20PR%20description%20notes%20%22subtitle%20driven%20by%20%60connector.sourceType%60%22%20but%20doesn't%20call%20out%20the%20badge%20removal.%20If%20the%20badge%20was%20the%20primary%20visual%20signal%20distinguishing%20local%20uploads%20from%20remote%20sources%20in%20a%20mixed%20list%2C%20its%20absence%20is%20a%20regression.%20Worth%20confirming%20this%20is%20intentional%20before%20merging.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fcomponents%2Fdata-sources%2FDataSourceList.tsx%0ALine%3A%20148-156%0A%0AComment%3A%0A**Silent%20removal%20of%20the%20%22Local%22%20badge**%0A%0AThe%20old%20code%20passed%20%60badge%3D%7Bsource.type%20%3D%3D%3D%20%22local%22%20%3F%20%22Local%22%20%3A%20undefined%7D%60%20to%20%60ItemCard%60%3B%20the%20new%20code%20removes%20that%20prop%20entirely.%20The%20PR%20description%20notes%20%22subtitle%20driven%20by%20%60connector.sourceType%60%22%20but%20doesn't%20call%20out%20the%20badge%20removal.%20If%20the%20badge%20was%20the%20primary%20visual%20signal%20distinguishing%20local%20uploads%20from%20remote%20sources%20in%20a%20mixed%20list%2C%20its%20absence%20is%20a%20regression.%20Worth%20confirming%20this%20is%20intentional%20before%20merging.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(app): clearConnectorRegistry must bu..."](https://github.com/youhaowei/dashframe/commit/1025adab788a6c70f96ae30e197adc1396a7fda7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37419385)</sub>

<!-- /greptile_comment -->