### PR TITLE
feat(app): insight FiltersSection UI — add/edit/delete filter predicates

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -20,6 +20,12 @@ import {
   SelectValue,
 } from "@wystack/ui";
 import { type ChangeEvent, useMemo, useState } from "react";
+import {
+  buildFilterValue,
+  type FilterDraft,
+  inputTypeForField,
+  isFilterDraftValid,
+} from "./filter-value";
 import type { FilterWithId } from "./FiltersSection";
 
 // ============================================================================
@@ -51,17 +57,6 @@ const OPERATOR_OPTIONS: { value: Operator; label: string }[] = [
   { value: "between", label: "between" },
   { value: "in", label: "in (list)" },
 ];
-
-/** Auto-detect the HTML input type from a field's normalized ColumnType */
-function inputTypeForField(
-  field: CombinedField | undefined,
-): "text" | "number" | "date" {
-  if (!field) return "text";
-  const t = field.type;
-  if (t === "number") return "number";
-  if (t === "date") return "date";
-  return "text";
-}
 
 // ============================================================================
 // FilterEditForm (inner; key-reset pattern from MetricEditDialog)
@@ -120,39 +115,15 @@ function FilterEditForm({
   const isBetween = operator === "between";
   const isIn = operator === "in";
 
-  const buildValue = (): unknown => {
-    if (isBetween) {
-      const low = inputType === "number" ? Number(betweenLow) : betweenLow;
-      const high = inputType === "number" ? Number(betweenHigh) : betweenHigh;
-      return { low, high } satisfies InsightFilterBetweenValue;
-    }
-    if (isIn) {
-      // Parse comma-separated values; coerce to number if field is numeric
-      const items = scalarValue
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      return inputType === "number" ? items.map(Number) : items;
-    }
-    if (inputType === "number") {
-      const n = Number(scalarValue);
-      return isFinite(n) ? n : scalarValue;
-    }
-    return scalarValue;
+  const draft: FilterDraft = {
+    field,
+    operator,
+    inputType,
+    scalarValue,
+    betweenLow,
+    betweenHigh,
   };
-
-  const isValid = (() => {
-    if (!field) return false;
-    if (isBetween) {
-      if (betweenLow.trim() === "" || betweenHigh.trim() === "") return false;
-      if (inputType === "number")
-        return isFinite(Number(betweenLow)) && isFinite(Number(betweenHigh));
-      return true;
-    }
-    if (scalarValue.trim() === "") return false;
-    if (!isIn && inputType === "number") return isFinite(Number(scalarValue));
-    return true;
-  })();
+  const isValid = isFilterDraftValid(draft);
 
   let valuePlaceholder = "Enter a value";
   if (isIn) valuePlaceholder = "e.g. a, b, c";
@@ -164,7 +135,7 @@ function FilterEditForm({
       ...filter,
       field,
       operator,
-      value: buildValue(),
+      value: buildFilterValue(draft),
     });
     onClose();
   };
@@ -328,8 +299,9 @@ export function FilterEditDialog({
    * a new UUID and silently remount FilterEditForm mid-fill, discarding the
    * user's in-progress input.
    *
-   * The UUID is ephemeral — after onSave the dialog closes and filtersWithIds
-   * in InsightConfigPanel re-derives ids from array indices, dropping this UUID.
+   * This UUID becomes the filter's persisted `id`, so it survives subscription
+   * round-trips and InsightConfigPanel can match the saved filter by a stable
+   * identity rather than a fragile array index.
    */
   const newFilterId = useMemo(
     () => crypto.randomUUID(),
@@ -343,6 +315,7 @@ export function FilterEditDialog({
     if (filter === null) return null;
     if (filter === "new") {
       return {
+        id: newFilterId,
         _id: newFilterId,
         field: combinedFields[0]
           ? (combinedFields[0].columnName ?? combinedFields[0].name)

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -186,7 +186,7 @@ function FilterEditForm({
           <Label htmlFor="filter-field">Field</Label>
           <Select
             value={field}
-            onValueChange={(v: string) => {
+            onValueChange={(v: string | null) => {
               if (v) setField(v);
               // Reset values when field changes
               setScalarValue("");
@@ -218,8 +218,8 @@ function FilterEditForm({
           <Label htmlFor="filter-operator">Operator</Label>
           <Select
             value={operator}
-            onValueChange={(v: string) => {
-              setOperator(v as Operator);
+            onValueChange={(v: string | null) => {
+              if (v) setOperator(v as Operator);
               // Reset values on operator change
               setScalarValue("");
               setBetweenLow("");

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -1,0 +1,343 @@
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import type {
+  InsightFilter,
+  InsightFilterBetweenValue,
+} from "@dashframe/types";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@wystack/ui";
+import { useMemo, useState } from "react";
+import type { FilterWithId } from "./FiltersSection";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type Operator = InsightFilter["operator"];
+
+interface FilterEditDialogProps {
+  /** null = closed; FilterWithId = edit mode; "new" = add mode */
+  filter: FilterWithId | "new" | null;
+  combinedFields: CombinedField[];
+  onOpenChange: (open: boolean) => void;
+  onSave: (filter: FilterWithId) => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const OPERATOR_OPTIONS: { value: Operator; label: string }[] = [
+  { value: "eq", label: "equals (=)" },
+  { value: "ne", label: "not equals (≠)" },
+  { value: "gt", label: "greater than (>)" },
+  { value: "gte", label: "greater than or equal (≥)" },
+  { value: "lt", label: "less than (<)" },
+  { value: "lte", label: "less than or equal (≤)" },
+  { value: "contains", label: "contains" },
+  { value: "between", label: "between" },
+];
+
+/** Auto-detect the HTML input type from a field's normalized ColumnType */
+function inputTypeForField(
+  field: CombinedField | undefined,
+): "text" | "number" | "date" {
+  if (!field) return "text";
+  const t = field.type;
+  if (t === "number") return "number";
+  if (t === "date") return "date";
+  return "text";
+}
+
+// ============================================================================
+// FilterEditForm (inner; key-reset pattern from MetricEditDialog)
+// ============================================================================
+
+interface FilterEditFormProps {
+  filter: FilterWithId;
+  combinedFields: CombinedField[];
+  onSave: (filter: FilterWithId) => void;
+  onClose: () => void;
+  isNew: boolean;
+}
+
+function FilterEditForm({
+  filter,
+  combinedFields,
+  onSave,
+  onClose,
+  isNew,
+}: FilterEditFormProps) {
+  const [field, setField] = useState<string>(filter.field);
+  const [operator, setOperator] = useState<Operator>(filter.operator);
+
+  // Scalar value state
+  const initialScalar = (() => {
+    if (filter.operator === "between" || Array.isArray(filter.value)) return "";
+    return String(filter.value ?? "");
+  })();
+  const [scalarValue, setScalarValue] = useState(initialScalar);
+
+  // Between value state
+  const initialBetween = (() => {
+    if (
+      filter.operator === "between" &&
+      filter.value &&
+      typeof filter.value === "object" &&
+      !Array.isArray(filter.value)
+    ) {
+      const v = filter.value as InsightFilterBetweenValue;
+      return { low: String(v.low ?? ""), high: String(v.high ?? "") };
+    }
+    return { low: "", high: "" };
+  })();
+  const [betweenLow, setBetweenLow] = useState(initialBetween.low);
+  const [betweenHigh, setBetweenHigh] = useState(initialBetween.high);
+
+  const selectedField = combinedFields.find(
+    (f) => (f.columnName ?? f.name) === field,
+  );
+  const inputType = inputTypeForField(selectedField);
+
+  const isBetween = operator === "between";
+
+  const buildValue = (): unknown => {
+    if (isBetween) {
+      const low = inputType === "number" ? Number(betweenLow) : betweenLow;
+      const high = inputType === "number" ? Number(betweenHigh) : betweenHigh;
+      return { low, high } satisfies InsightFilterBetweenValue;
+    }
+    if (inputType === "number") return Number(scalarValue);
+    return scalarValue;
+  };
+
+  const isValid = (() => {
+    if (!field) return false;
+    if (isBetween) return betweenLow.trim() !== "" && betweenHigh.trim() !== "";
+    return scalarValue.trim() !== "";
+  })();
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({
+      ...filter,
+      field,
+      operator,
+      value: buildValue(),
+    });
+    onClose();
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{isNew ? "Add filter" : "Edit filter"}</DialogTitle>
+        <DialogDescription>
+          {isNew
+            ? "Configure a filter predicate for this insight."
+            : "Modify the filter predicate."}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 py-4">
+        {/* Field picker */}
+        <div className="space-y-2">
+          <Label htmlFor="filter-field">Field</Label>
+          <Select
+            value={field}
+            onValueChange={(v) => {
+              if (v) setField(v);
+              // Reset values when field changes
+              setScalarValue("");
+              setBetweenLow("");
+              setBetweenHigh("");
+            }}
+          >
+            <SelectTrigger id="filter-field">
+              <SelectValue placeholder="Select a field" />
+            </SelectTrigger>
+            <SelectContent>
+              {combinedFields.length === 0 ? (
+                <div className="p-2 text-center text-sm text-neutral-fg-subtle">
+                  No fields available
+                </div>
+              ) : (
+                combinedFields.map((f) => (
+                  <SelectItem key={f.id} value={f.columnName ?? f.name}>
+                    {f.displayName}
+                  </SelectItem>
+                ))
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Operator picker */}
+        <div className="space-y-2">
+          <Label htmlFor="filter-operator">Operator</Label>
+          <Select
+            value={operator}
+            onValueChange={(v) => {
+              setOperator(v as Operator);
+              // Reset values on operator change
+              setScalarValue("");
+              setBetweenLow("");
+              setBetweenHigh("");
+            }}
+          >
+            <SelectTrigger id="filter-operator">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {OPERATOR_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Value input */}
+        {isBetween ? (
+          <div className="space-y-2">
+            <Label>Range</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                type={inputType}
+                placeholder="Low"
+                value={betweenLow}
+                onChange={(e) => setBetweenLow(e.target.value)}
+                className="flex-1"
+                aria-label="Range low bound"
+              />
+              <span className="shrink-0 text-sm text-neutral-fg-subtle">
+                to
+              </span>
+              <Input
+                type={inputType}
+                placeholder="High"
+                value={betweenHigh}
+                onChange={(e) => setBetweenHigh(e.target.value)}
+                className="flex-1"
+                aria-label="Range high bound"
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <Label htmlFor="filter-value">Value</Label>
+            <Input
+              id="filter-value"
+              type={inputType}
+              placeholder={
+                inputType === "number" ? "Enter a number" : "Enter a value"
+              }
+              value={scalarValue}
+              onChange={(e) => setScalarValue(e.target.value)}
+            />
+          </div>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button label="Cancel" variant="outline" onClick={onClose} />
+        <Button
+          label={isNew ? "Add" : "Save"}
+          onClick={handleSave}
+          disabled={!isValid}
+        />
+      </DialogFooter>
+    </>
+  );
+}
+
+// ============================================================================
+// FilterEditDialog (shell; key-reset pattern from MetricEditDialog)
+// ============================================================================
+
+/**
+ * FilterEditDialog — dialog for adding or editing an insight filter predicate.
+ *
+ * Supports all operators defined in InsightFilter: eq, ne, gt, gte, lt, lte,
+ * contains, in, between. The `between` operator shows two inputs coalesced to
+ * { low, high }. Value input type is auto-detected from the field's ColumnType.
+ *
+ * Uses the key-based reset pattern from MetricEditDialog so inner state is
+ * always fresh when the dialog is opened for a different filter.
+ */
+export function FilterEditDialog({
+  filter,
+  combinedFields,
+  onOpenChange,
+  onSave,
+}: FilterEditDialogProps) {
+  const isOpen = filter !== null;
+  const isNew = filter === "new";
+
+  /**
+   * Stable UUID for the "new" session. Memoized so a parent re-render while
+   * the dialog is open (e.g. an insight subscription firing) does not generate
+   * a new UUID and silently remount FilterEditForm mid-fill, discarding the
+   * user's in-progress input.
+   *
+   * The UUID is ephemeral — after onSave the dialog closes and filtersWithIds
+   * in InsightConfigPanel re-derives ids from array indices, dropping this UUID.
+   */
+  const newFilterId = useMemo(
+    () => crypto.randomUUID(),
+    // Intentionally empty: we want one UUID per mount of FilterEditDialog,
+    // not per render. A new session (filter null→"new") unmounts+remounts this
+    // component because the parent sets filterToEdit=null on close first.
+    [],
+  );
+
+  const effectiveFilter: FilterWithId | null = (() => {
+    if (filter === null) return null;
+    if (filter === "new") {
+      return {
+        _id: newFilterId,
+        field: combinedFields[0]
+          ? (combinedFields[0].columnName ?? combinedFields[0].name)
+          : "",
+        operator: "eq",
+        value: "",
+      };
+    }
+    return filter;
+  })();
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        {effectiveFilter && (
+          <FilterEditForm
+            key={effectiveFilter._id + (isNew ? "-new" : "-edit")}
+            filter={effectiveFilter}
+            combinedFields={combinedFields}
+            onSave={onSave}
+            onClose={handleClose}
+            isNew={isNew}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -19,7 +19,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wystack/ui";
-import { type ChangeEvent, useMemo, useState } from "react";
+import { type ChangeEvent, useState } from "react";
+import { prepareFilterForSave } from "./filter-id";
 import {
   buildFilterValue,
   type FilterDraft,
@@ -148,12 +149,19 @@ function FilterEditForm({
 
   const handleSave = () => {
     if (!isValid) return;
-    onSave({
-      ...filter,
-      field,
-      operator,
-      value: buildFilterValue(draft),
-    });
+    // prepareFilterForSave stamps a fresh persisted id on a new filter (and
+    // sources its client `_id` from it). Generated per save, not per dialog
+    // mount — FilterEditDialog is permanently mounted, so a mount-scoped id
+    // would hand every Add the same value and make the second filter overwrite
+    // the first. An existing filter keeps its id/_id so edits route correctly.
+    onSave(
+      prepareFilterForSave({
+        ...filter,
+        field,
+        operator,
+        value: buildFilterValue(draft),
+      }),
+    );
     onClose();
   };
 
@@ -310,30 +318,16 @@ export function FilterEditDialog({
   const isOpen = filter !== null;
   const isNew = filter === "new";
 
-  /**
-   * Stable UUID for the "new" session. Memoized so a parent re-render while
-   * the dialog is open (e.g. an insight subscription firing) does not generate
-   * a new UUID and silently remount FilterEditForm mid-fill, discarding the
-   * user's in-progress input.
-   *
-   * This UUID becomes the filter's persisted `id`, so it survives subscription
-   * round-trips and InsightConfigPanel can match the saved filter by a stable
-   * identity rather than a fragile array index.
-   */
-  const newFilterId = useMemo(
-    () => crypto.randomUUID(),
-    // Intentionally empty: we want one UUID per mount of FilterEditDialog,
-    // not per render. A new session (filter null→"new") unmounts+remounts this
-    // component because the parent sets filterToEdit=null on close first.
-    [],
-  );
-
   const effectiveFilter: FilterWithId | null = (() => {
     if (filter === null) return null;
     if (filter === "new") {
+      // A new-filter draft carries NO persisted `id` — the id is assigned at
+      // save time (FilterEditForm.handleSave), so each Add yields a distinct
+      // filter. `_id` here is only the client key for the form below; it is a
+      // fixed sentinel because the form fully unmounts when the dialog closes
+      // (filter → null), which already resets its state between Add sessions.
       return {
-        id: newFilterId,
-        _id: newFilterId,
+        _id: "__new__",
         field: combinedFields[0]
           ? (combinedFields[0].columnName ?? combinedFields[0].name)
           : "",

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -19,7 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wystack/ui";
-import { useMemo, useState } from "react";
+import { type ChangeEvent, useMemo, useState } from "react";
 import type { FilterWithId } from "./FiltersSection";
 
 // ============================================================================
@@ -49,6 +49,7 @@ const OPERATOR_OPTIONS: { value: Operator; label: string }[] = [
   { value: "lte", label: "less than or equal (≤)" },
   { value: "contains", label: "contains" },
   { value: "between", label: "between" },
+  { value: "in", label: "in (list)" },
 ];
 
 /** Auto-detect the HTML input type from a field's normalized ColumnType */
@@ -84,9 +85,13 @@ function FilterEditForm({
   const [field, setField] = useState<string>(filter.field);
   const [operator, setOperator] = useState<Operator>(filter.operator);
 
-  // Scalar value state
+  // Scalar value state (also used for the `in` operator as comma-separated string)
   const initialScalar = (() => {
-    if (filter.operator === "between" || Array.isArray(filter.value)) return "";
+    if (filter.operator === "between") return "";
+    if (filter.operator === "in" && Array.isArray(filter.value)) {
+      return (filter.value as unknown[]).map(String).join(", ");
+    }
+    if (Array.isArray(filter.value)) return "";
     return String(filter.value ?? "");
   })();
   const [scalarValue, setScalarValue] = useState(initialScalar);
@@ -113,6 +118,7 @@ function FilterEditForm({
   const inputType = inputTypeForField(selectedField);
 
   const isBetween = operator === "between";
+  const isIn = operator === "in";
 
   const buildValue = (): unknown => {
     if (isBetween) {
@@ -120,15 +126,37 @@ function FilterEditForm({
       const high = inputType === "number" ? Number(betweenHigh) : betweenHigh;
       return { low, high } satisfies InsightFilterBetweenValue;
     }
-    if (inputType === "number") return Number(scalarValue);
+    if (isIn) {
+      // Parse comma-separated values; coerce to number if field is numeric
+      const items = scalarValue
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      return inputType === "number" ? items.map(Number) : items;
+    }
+    if (inputType === "number") {
+      const n = Number(scalarValue);
+      return isFinite(n) ? n : scalarValue;
+    }
     return scalarValue;
   };
 
   const isValid = (() => {
     if (!field) return false;
-    if (isBetween) return betweenLow.trim() !== "" && betweenHigh.trim() !== "";
-    return scalarValue.trim() !== "";
+    if (isBetween) {
+      if (betweenLow.trim() === "" || betweenHigh.trim() === "") return false;
+      if (inputType === "number")
+        return isFinite(Number(betweenLow)) && isFinite(Number(betweenHigh));
+      return true;
+    }
+    if (scalarValue.trim() === "") return false;
+    if (!isIn && inputType === "number") return isFinite(Number(scalarValue));
+    return true;
   })();
+
+  let valuePlaceholder = "Enter a value";
+  if (isIn) valuePlaceholder = "e.g. a, b, c";
+  else if (inputType === "number") valuePlaceholder = "Enter a number";
 
   const handleSave = () => {
     if (!isValid) return;
@@ -158,7 +186,7 @@ function FilterEditForm({
           <Label htmlFor="filter-field">Field</Label>
           <Select
             value={field}
-            onValueChange={(v) => {
+            onValueChange={(v: string) => {
               if (v) setField(v);
               // Reset values when field changes
               setScalarValue("");
@@ -190,7 +218,7 @@ function FilterEditForm({
           <Label htmlFor="filter-operator">Operator</Label>
           <Select
             value={operator}
-            onValueChange={(v) => {
+            onValueChange={(v: string) => {
               setOperator(v as Operator);
               // Reset values on operator change
               setScalarValue("");
@@ -220,7 +248,9 @@ function FilterEditForm({
                 type={inputType}
                 placeholder="Low"
                 value={betweenLow}
-                onChange={(e) => setBetweenLow(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setBetweenLow(e.target.value)
+                }
                 className="flex-1"
                 aria-label="Range low bound"
               />
@@ -231,7 +261,9 @@ function FilterEditForm({
                 type={inputType}
                 placeholder="High"
                 value={betweenHigh}
-                onChange={(e) => setBetweenHigh(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setBetweenHigh(e.target.value)
+                }
                 className="flex-1"
                 aria-label="Range high bound"
               />
@@ -239,15 +271,17 @@ function FilterEditForm({
           </div>
         ) : (
           <div className="space-y-2">
-            <Label htmlFor="filter-value">Value</Label>
+            <Label htmlFor="filter-value">
+              {isIn ? "Values (comma-separated)" : "Value"}
+            </Label>
             <Input
               id="filter-value"
-              type={inputType}
-              placeholder={
-                inputType === "number" ? "Enter a number" : "Enter a value"
-              }
+              type={isIn ? "text" : inputType}
+              placeholder={valuePlaceholder}
               value={scalarValue}
-              onChange={(e) => setScalarValue(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setScalarValue(e.target.value)
+              }
             />
           </div>
         )}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -20,7 +20,7 @@ import {
   SelectValue,
 } from "@wystack/ui";
 import { type ChangeEvent, useState } from "react";
-import { prepareFilterForSave } from "./filter-id";
+import { NEW_FILTER_ID, prepareFilterForSave } from "./filter-id";
 import {
   buildFilterValue,
   type FilterDraft,
@@ -327,7 +327,7 @@ export function FilterEditDialog({
       // fixed sentinel because the form fully unmounts when the dialog closes
       // (filter → null), which already resets its state between Add sessions.
       return {
-        _id: "__new__",
+        _id: NEW_FILTER_ID,
         field: combinedFields[0]
           ? (combinedFields[0].columnName ?? combinedFields[0].name)
           : "",

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -112,6 +112,23 @@ function FilterEditForm({
   );
   const inputType = inputTypeForField(selectedField);
 
+  // The picker normally offers only filterable fields. An existing filter may
+  // reference a field outside that set (e.g. an API-created filter on a column
+  // the picker excludes); keep the current value selectable so the Select
+  // doesn't render blank and the user can still edit operator/value.
+  const fieldOptions =
+    field && !selectedField
+      ? [
+          ...combinedFields,
+          {
+            id: `__current__${field}`,
+            name: field,
+            columnName: field,
+            displayName: field,
+          } as CombinedField,
+        ]
+      : combinedFields;
+
   const isBetween = operator === "between";
   const isIn = operator === "in";
 
@@ -169,12 +186,12 @@ function FilterEditForm({
               <SelectValue placeholder="Select a field" />
             </SelectTrigger>
             <SelectContent>
-              {combinedFields.length === 0 ? (
+              {fieldOptions.length === 0 ? (
                 <div className="p-2 text-center text-sm text-neutral-fg-subtle">
                   No fields available
                 </div>
               ) : (
-                combinedFields.map((f) => (
+                fieldOptions.map((f) => (
                   <SelectItem key={f.id} value={f.columnName ?? f.name}>
                     {f.displayName}
                   </SelectItem>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FiltersSection.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FiltersSection.tsx
@@ -1,0 +1,258 @@
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import type {
+  InsightFilter,
+  InsightFilterBetweenValue,
+} from "@dashframe/types";
+import { SortableList, type SortableListItem } from "@dashframe/ui";
+import {
+  Badge,
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  cn,
+} from "@wystack/ui";
+import {
+  ChevronRightIcon,
+  CloseIcon,
+  EditIcon,
+  PlusIcon,
+  SettingsIcon,
+} from "@wystack/ui-icons";
+import { useCallback, useMemo, useState } from "react";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Extended sortable item with filter data + stable id */
+interface FilterSortableItem extends SortableListItem {
+  filter: InsightFilter;
+}
+
+export interface FilterWithId extends InsightFilter {
+  /** Stable client-only id for sortable list keying */
+  _id: string;
+}
+
+interface FiltersSectionProps {
+  filters: FilterWithId[];
+  combinedFields: CombinedField[];
+  onReorder: (filters: FilterWithId[]) => void;
+  onRemove: (filterId: string) => void;
+  onEditClick: (filter: FilterWithId) => void;
+  onAddClick: () => void;
+  defaultOpen?: boolean;
+}
+
+// ============================================================================
+// Operator label helpers
+// ============================================================================
+
+const OPERATOR_LABELS: Record<InsightFilter["operator"], string> = {
+  eq: "=",
+  ne: "≠",
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  contains: "contains",
+  in: "in",
+  between: "between",
+};
+
+function formatFilterValue(filter: InsightFilter): string {
+  if (filter.operator === "between") {
+    const v = filter.value as InsightFilterBetweenValue | undefined;
+    if (v && typeof v === "object" && "low" in v && "high" in v) {
+      return `${String(v.low ?? "")} … ${String(v.high ?? "")}`;
+    }
+    return "…";
+  }
+  if (Array.isArray(filter.value)) {
+    return `(${(filter.value as unknown[]).join(", ")})`;
+  }
+  return String(filter.value ?? "");
+}
+
+// ============================================================================
+// FiltersSection
+// ============================================================================
+
+/**
+ * FiltersSection — Collapsible section for managing insight filter predicates.
+ *
+ * Mirrors MetricsSection exactly: same Collapsible/SortableList/inline-edit
+ * pattern. Filters have no visualization encoding dependency so deletion is
+ * immediate — no cascade confirmation dialog.
+ */
+export function FiltersSection({
+  filters,
+  combinedFields,
+  onReorder,
+  onRemove,
+  onEditClick,
+  onAddClick,
+  defaultOpen = true,
+}: FiltersSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  const sortableItems: FilterSortableItem[] = filters.map((filter) => ({
+    id: filter._id,
+    filter,
+  }));
+
+  const handleReorder = useCallback(
+    (items: FilterSortableItem[]) => {
+      onReorder(items.map((item) => item.filter as FilterWithId));
+    },
+    [onReorder],
+  );
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="border-b">
+        <div className="flex items-center justify-between px-4 py-3">
+          <CollapsibleTrigger
+            render={
+              <button className="-ml-2 flex items-center gap-1.5 rounded-md px-2 py-1 text-left transition-colors hover:bg-neutral-bg-emphasis/50">
+                <ChevronRightIcon
+                  className={cn(
+                    "h-4 w-4 text-neutral-fg-subtle transition-transform",
+                    isOpen && "rotate-90",
+                  )}
+                />
+                <SettingsIcon className="h-4 w-4 text-neutral-fg-subtle" />
+                <span className="text-sm leading-none font-medium">
+                  Filters
+                </span>
+                <Badge
+                  variant="soft"
+                  className="h-5 px-1.5 text-xs leading-none tabular-nums"
+                >
+                  {filters.length}
+                </Badge>
+              </button>
+            }
+          />
+          <Button
+            label="Add"
+            icon={PlusIcon}
+            variant="ghost"
+            size="sm"
+            onClick={onAddClick}
+          />
+        </div>
+        <CollapsibleContent>
+          <div className="overflow-hidden px-4 pb-4">
+            {sortableItems.length > 0 ? (
+              <SortableList
+                items={sortableItems}
+                onReorder={handleReorder}
+                gap={6}
+                renderItem={(item) => (
+                  <FilterItemContent
+                    filter={item.filter as FilterWithId}
+                    combinedFields={combinedFields}
+                    onRemove={() => onRemove(item.id)}
+                    onEditClick={() => onEditClick(item.filter as FilterWithId)}
+                  />
+                )}
+              />
+            ) : (
+              <p className="py-2 text-sm text-neutral-fg-subtle">
+                No filters configured.
+              </p>
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+// ============================================================================
+// FilterItemContent
+// ============================================================================
+
+interface FilterItemContentProps {
+  filter: FilterWithId;
+  combinedFields: CombinedField[];
+  onRemove: () => void;
+  onEditClick: () => void;
+}
+
+function FilterItemContent({
+  filter,
+  combinedFields,
+  onRemove,
+  onEditClick,
+}: FilterItemContentProps) {
+  // Resolve display name for the field — stale ref shows fieldName with warning
+  const fieldDisplay = useMemo(() => {
+    const found = combinedFields.find(
+      (f) => (f.columnName ?? f.name) === filter.field,
+    );
+    if (!found) {
+      // Stale field reference — show gracefully, don't crash
+      return { name: filter.field, stale: true };
+    }
+    return { name: found.displayName, stale: false };
+  }, [combinedFields, filter.field]);
+
+  const operatorLabel = OPERATOR_LABELS[filter.operator] ?? filter.operator;
+  const valueLabel = formatFilterValue(filter);
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <span
+        className={cn(
+          "min-w-0 shrink-0 max-w-[6rem] truncate text-sm",
+          fieldDisplay.stale
+            ? "text-palette-danger/80 line-through"
+            : "text-neutral-fg",
+        )}
+        title={
+          fieldDisplay.stale
+            ? `Field "${filter.field}" no longer exists`
+            : fieldDisplay.name
+        }
+      >
+        {fieldDisplay.name}
+      </span>
+      <span className="shrink-0 text-xs font-medium text-neutral-fg-subtle">
+        {operatorLabel}
+      </span>
+      <span
+        className="min-w-0 flex-1 cursor-pointer truncate text-sm text-neutral-fg hover:underline"
+        onClick={(e) => {
+          e.stopPropagation();
+          onEditClick();
+        }}
+        title={`${fieldDisplay.name} ${operatorLabel} ${valueLabel} (click to edit)`}
+      >
+        {valueLabel}
+      </span>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onEditClick();
+        }}
+        className="shrink-0 rounded-full p-0.5 text-neutral-fg-subtle hover:bg-neutral-bg-muted hover:text-neutral-fg"
+        aria-label={`Edit filter on ${fieldDisplay.name}`}
+      >
+        <EditIcon className="h-3 w-3" />
+      </button>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        className="shrink-0 rounded-full p-0.5 text-neutral-fg-subtle hover:bg-neutral-bg-muted hover:text-neutral-fg"
+        aria-label={`Remove filter on ${fieldDisplay.name}`}
+      >
+        <CloseIcon className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx
@@ -8,7 +8,12 @@ import {
   useVisualizationMutations,
   useVisualizations,
 } from "@dashframe/core";
-import type { DataTable, Insight, InsightMetric } from "@dashframe/types";
+import type {
+  DataTable,
+  Insight,
+  InsightFilter,
+  InsightMetric,
+} from "@dashframe/types";
 import { InputField } from "@dashframe/ui";
 import { Panel } from "@wystack/ui";
 import { useCallback, useMemo, useState } from "react";
@@ -21,6 +26,8 @@ import {
 } from "./DeleteConfirmDialog";
 import { FieldRenameDialog } from "./FieldRenameDialog";
 import { FieldsSection } from "./FieldsSection";
+import { FilterEditDialog } from "./FilterEditDialog";
+import { FiltersSection, type FilterWithId } from "./FiltersSection";
 import { InsightFieldEditorModal } from "./InsightFieldEditorModal";
 import { InsightMetricEditorModal } from "./InsightMetricEditorModal";
 import { MetricEditDialog } from "./MetricEditDialog";
@@ -72,6 +79,10 @@ export function InsightConfigPanel({
     null,
   );
   const [metricToEdit, setMetricToEdit] = useState<InsightMetric | null>(null);
+  /** null = closed; FilterWithId = edit; "new" = add */
+  const [filterToEdit, setFilterToEdit] = useState<FilterWithId | "new" | null>(
+    null,
+  );
   const [deleteDialog, setDeleteDialog] = useState<DeleteDialogState>(
     initialDeleteDialogState,
   );
@@ -128,6 +139,22 @@ export function InsightConfigPanel({
     () => (insight.metrics ?? []).filter((m) => !m.name.startsWith("_")),
     [insight.metrics],
   );
+
+  /**
+   * Stable client-side ids for filters (filters have no id in the domain type).
+   * Derived from the filter list; re-generated only when the raw filter array
+   * reference changes (i.e., after a save). The index-based id scheme is
+   * intentionally simple — filters are always edited via a close-then-reopen
+   * dialog, so stale ids are never in flight. FilterEditDialog's "new" session
+   * generates a UUID for its own key-reset scope; that UUID is dropped here on
+   * the next derivation after save.
+   */
+  const filtersWithIds = useMemo((): FilterWithId[] => {
+    return (insight.filters ?? []).map((f, i) => ({
+      ...f,
+      _id: `${f.field}-${f.operator}-${i}`,
+    }));
+  }, [insight.filters]);
 
   // --- Field handlers ---
   const handleFieldsReorder = useCallback(
@@ -217,6 +244,40 @@ export function InsightConfigPanel({
       updateInsight(insight.id, { metrics: updated });
     },
     [insight.id, insight.metrics, updateInsight],
+  );
+
+  // --- Filter handlers ---
+  /** Strip client-only _id before persisting */
+  const stripFilterIds = useCallback(
+    (fs: FilterWithId[]): InsightFilter[] =>
+      fs.map(({ _id: _discarded, ...rest }) => rest),
+    [],
+  );
+
+  const handleFiltersReorder = useCallback(
+    (reordered: FilterWithId[]) => {
+      updateInsight(insight.id, { filters: stripFilterIds(reordered) });
+    },
+    [insight.id, stripFilterIds, updateInsight],
+  );
+
+  const handleRemoveFilter = useCallback(
+    (filterId: string) => {
+      const updated = filtersWithIds.filter((f) => f._id !== filterId);
+      updateInsight(insight.id, { filters: stripFilterIds(updated) });
+    },
+    [insight.id, filtersWithIds, stripFilterIds, updateInsight],
+  );
+
+  const handleSaveFilter = useCallback(
+    (saved: FilterWithId) => {
+      const exists = filtersWithIds.some((f) => f._id === saved._id);
+      const updated = exists
+        ? filtersWithIds.map((f) => (f._id === saved._id ? saved : f))
+        : [...filtersWithIds, saved];
+      updateInsight(insight.id, { filters: stripFilterIds(updated) });
+    },
+    [insight.id, filtersWithIds, stripFilterIds, updateInsight],
   );
 
   // --- Delete dialog handlers ---
@@ -325,6 +386,16 @@ export function InsightConfigPanel({
           onEditClick={setMetricToEdit}
           onAddClick={() => setIsMetricEditorOpen(true)}
         />
+
+        {/* Filters Section */}
+        <FiltersSection
+          filters={filtersWithIds}
+          combinedFields={combinedFields}
+          onReorder={handleFiltersReorder}
+          onRemove={handleRemoveFilter}
+          onEditClick={setFilterToEdit}
+          onAddClick={() => setFilterToEdit("new")}
+        />
       </div>
 
       <InsightFieldEditorModal
@@ -356,6 +427,12 @@ export function InsightConfigPanel({
         dataTable={dataTable}
         onOpenChange={(open) => !open && setMetricToEdit(null)}
         onSave={handleEditMetric}
+      />
+      <FilterEditDialog
+        filter={filterToEdit}
+        combinedFields={combinedFields}
+        onOpenChange={(open) => !open && setFilterToEdit(null)}
+        onSave={handleSaveFilter}
       />
       <DeleteConfirmDialog
         isOpen={deleteDialog.isOpen}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx
@@ -1,5 +1,6 @@
 import {
   computeCombinedFields,
+  computeFilterableFields,
   type CombinedField,
 } from "@/lib/insights/compute-combined-fields";
 import {
@@ -26,6 +27,7 @@ import {
 } from "./DeleteConfirmDialog";
 import { FieldRenameDialog } from "./FieldRenameDialog";
 import { FieldsSection } from "./FieldsSection";
+import { applyFilterSave, withFilterIds } from "./filter-id";
 import { FilterEditDialog } from "./FilterEditDialog";
 import { FiltersSection, type FilterWithId } from "./FiltersSection";
 import { InsightFieldEditorModal } from "./InsightFieldEditorModal";
@@ -120,6 +122,17 @@ export function InsightConfigPanel({
     [dataTable, insight.joins, allDataTables],
   );
 
+  // Fields that can actually back a filter predicate — excludes dropped right
+  // join-keys and ambiguous duplicate column names that the SQL builder cannot
+  // resolve. Offered in the FilterEditDialog picker so a saved filter always
+  // produces a working predicate. (FiltersSection still receives the full
+  // combinedFields, so an existing filter on an excluded field renders by name
+  // rather than as a stale reference.)
+  const filterableFields = useMemo(
+    () => computeFilterableFields(combinedFields, insight.joins),
+    [combinedFields, insight.joins],
+  );
+
   // Get selected fields in order (preserving insight.selectedFields order)
   const selectedFields = useMemo(() => {
     const fieldMap = new Map(combinedFields.map((f) => [f.id, f]));
@@ -141,20 +154,20 @@ export function InsightConfigPanel({
   );
 
   /**
-   * Stable client-side ids for filters (filters have no id in the domain type).
-   * Derived from the filter list; re-generated only when the raw filter array
-   * reference changes (i.e., after a save). The index-based id scheme is
-   * intentionally simple — filters are always edited via a close-then-reopen
-   * dialog, so stale ids are never in flight. FilterEditDialog's "new" session
-   * generates a UUID for its own key-reset scope; that UUID is dropped here on
-   * the next derivation after save.
+   * Stable client-side ids for filters, used for SortableList keying and for
+   * matching an in-flight edit back to its predicate on save.
+   *
+   * `_id` is sourced from the filter's persisted `id` (generated on add by
+   * FilterEditDialog and preserved across persistence round-trips). This
+   * survives a subscription firing mid-edit — a concurrent reorder no longer
+   * shifts the id, so handleSaveFilter cannot misroute the save to the wrong
+   * filter. Filters created via the API/agent path without an `id` fall back to
+   * a content+index key; those aren't expected to be edited concurrently.
    */
-  const filtersWithIds = useMemo((): FilterWithId[] => {
-    return (insight.filters ?? []).map((f, i) => ({
-      ...f,
-      _id: `${f.field}-${f.operator}-${i}`,
-    }));
-  }, [insight.filters]);
+  const filtersWithIds = useMemo(
+    (): FilterWithId[] => withFilterIds(insight.filters),
+    [insight.filters],
+  );
 
   // --- Field handlers ---
   const handleFieldsReorder = useCallback(
@@ -271,10 +284,7 @@ export function InsightConfigPanel({
 
   const handleSaveFilter = useCallback(
     (saved: FilterWithId) => {
-      const exists = filtersWithIds.some((f) => f._id === saved._id);
-      const updated = exists
-        ? filtersWithIds.map((f) => (f._id === saved._id ? saved : f))
-        : [...filtersWithIds, saved];
+      const updated = applyFilterSave(filtersWithIds, saved);
       updateInsight(insight.id, { filters: stripFilterIds(updated) });
     },
     [insight.id, filtersWithIds, stripFilterIds, updateInsight],
@@ -430,7 +440,7 @@ export function InsightConfigPanel({
       />
       <FilterEditDialog
         filter={filterToEdit}
-        combinedFields={combinedFields}
+        combinedFields={filterableFields}
         onOpenChange={(open) => !open && setFilterToEdit(null)}
         onSave={handleSaveFilter}
       />

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
@@ -1,0 +1,96 @@
+import type { InsightFilter } from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import { applyFilterSave, deriveFilterId, withFilterIds } from "./filter-id";
+import type { FilterWithId } from "./FiltersSection";
+
+/**
+ * Locks the stable-identity contract for in-flight filter edits. The bug class:
+ * an index-derived id goes stale if a subscription reorders the array between
+ * opening the editor and saving, routing the edit to the wrong predicate. The
+ * fix sources `_id` from the persisted filter `id`, which travels with the
+ * filter regardless of array position.
+ */
+
+describe("deriveFilterId", () => {
+  it("uses the persisted id when present", () => {
+    const f: InsightFilter = {
+      id: "uuid-1",
+      field: "amount",
+      operator: "eq",
+      value: 1,
+    };
+    expect(deriveFilterId(f, 3)).toBe("uuid-1");
+  });
+
+  it("falls back to a content+index key when id is absent", () => {
+    const f: InsightFilter = { field: "amount", operator: "eq", value: 1 };
+    expect(deriveFilterId(f, 2)).toBe("amount-eq-2");
+  });
+});
+
+describe("applyFilterSave with a stable persisted id", () => {
+  it("routes the save to the correct predicate after a concurrent reorder", () => {
+    // Open the editor for filter B (id uuid-b) when the list is [A, B, C].
+    const original: InsightFilter[] = [
+      { id: "uuid-a", field: "region", operator: "eq", value: "north" },
+      { id: "uuid-b", field: "amount", operator: "gt", value: 100 },
+      { id: "uuid-c", field: "status", operator: "eq", value: "open" },
+    ];
+    const beforeEdit = withFilterIds(original);
+    const openedForEdit = beforeEdit[1]; // filter B
+    expect(openedForEdit._id).toBe("uuid-b");
+
+    // A subscription fires mid-edit and reorders the array to [C, B, A].
+    const reordered: InsightFilter[] = [original[2], original[1], original[0]];
+    const afterReorder = withFilterIds(reordered);
+
+    // User saves an edit to B (value 100 → 200), carrying B's stable _id.
+    const saved: FilterWithId = { ...openedForEdit, value: 200 };
+    const result = applyFilterSave(afterReorder, saved);
+
+    // The list length is unchanged — no duplicate appended.
+    expect(result).toHaveLength(3);
+    // B was updated in place (still at its reordered position), not duplicated.
+    const updatedB = result.filter((f) => f._id === "uuid-b");
+    expect(updatedB).toHaveLength(1);
+    expect(updatedB[0].value).toBe(200);
+    // A and C are untouched.
+    expect(result.find((f) => f._id === "uuid-a")?.value).toBe("north");
+    expect(result.find((f) => f._id === "uuid-c")?.value).toBe("open");
+  });
+
+  it("appends a brand-new filter that is not yet in the list", () => {
+    const current = withFilterIds([
+      { id: "uuid-a", field: "region", operator: "eq", value: "north" },
+    ]);
+    const fresh: FilterWithId = {
+      id: "uuid-new",
+      _id: "uuid-new",
+      field: "amount",
+      operator: "gt",
+      value: 10,
+    };
+    const result = applyFilterSave(current, fresh);
+    expect(result).toHaveLength(2);
+    expect(result[1]._id).toBe("uuid-new");
+  });
+
+  it("with index-based fallback ids, a reorder would misroute (regression guard)", () => {
+    // This documents WHY persisted ids matter: without them, the same reorder
+    // scenario fails to find the edited filter and appends a duplicate.
+    const original: InsightFilter[] = [
+      { field: "region", operator: "eq", value: "north" },
+      { field: "amount", operator: "gt", value: 100 },
+    ];
+    const beforeEdit = withFilterIds(original); // ids: region-eq-0, amount-gt-1
+    const openedForEdit = beforeEdit[1]; // amount-gt-1
+
+    // Reorder to [amount, region] → amount is now index 0 → id amount-gt-0.
+    const reordered = withFilterIds([original[1], original[0]]);
+    const saved: FilterWithId = { ...openedForEdit, value: 200 };
+    const result = applyFilterSave(reordered, saved);
+
+    // The stale id "amount-gt-1" no longer matches → duplicate appended.
+    expect(result).toHaveLength(3);
+  });
+});

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyFilterSave,
   deriveFilterId,
+  NEW_FILTER_ID,
   prepareFilterForSave,
   withFilterIds,
 } from "./filter-id";
@@ -101,9 +102,9 @@ describe("applyFilterSave with a stable persisted id", () => {
 });
 
 describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () => {
-  it("assigns a fresh id to a new filter and leaves an existing filter's id intact", () => {
+  it("assigns a fresh id (and matching _id) to a new-draft filter", () => {
     const draftNew: FilterWithId = {
-      _id: "__new__",
+      _id: NEW_FILTER_ID,
       field: "amount",
       operator: "eq",
       value: 1,
@@ -111,7 +112,9 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
     const stamped = prepareFilterForSave(draftNew, () => "uuid-fresh");
     expect(stamped.id).toBe("uuid-fresh");
     expect(stamped._id).toBe("uuid-fresh");
+  });
 
+  it("leaves an existing filter's id and _id intact on edit", () => {
     const existing: FilterWithId = {
       id: "uuid-existing",
       _id: "uuid-existing",
@@ -127,6 +130,31 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
     expect(reStamped._id).toBe("uuid-existing");
   });
 
+  it("edits an id-less (API-created) filter in place — backfills id, keeps _id", () => {
+    // Regression: an existing filter with no persisted `id` (its `_id` is the
+    // content+index fallback) must NOT have its `_id` overwritten on save, or
+    // applyFilterSave would fail to match and APPEND A DUPLICATE instead of
+    // updating. The persisted `id` is backfilled, but `_id` is preserved.
+    const list = withFilterIds([
+      { field: "region", operator: "eq", value: "north" }, // no id → _id "region-eq-0"
+    ]);
+    const openedForEdit = list[0];
+    expect(openedForEdit.id).toBeUndefined();
+    expect(openedForEdit._id).toBe("region-eq-0");
+
+    const saved = prepareFilterForSave(
+      { ...openedForEdit, value: "south" },
+      () => "uuid-backfilled",
+    );
+    expect(saved._id).toBe("region-eq-0"); // preserved for matching
+    expect(saved.id).toBe("uuid-backfilled"); // backfilled
+
+    const result = applyFilterSave(list, saved);
+    expect(result).toHaveLength(1); // updated in place, NOT duplicated
+    expect(result[0].value).toBe("south");
+    expect(result[0].id).toBe("uuid-backfilled");
+  });
+
   it("two consecutive Adds yield distinct ids — second does NOT overwrite first", () => {
     // Repro of the data-loss bug: FilterEditDialog is permanently mounted, so a
     // mount-scoped id would be reused. prepareFilterForSave generates per save,
@@ -139,7 +167,7 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
 
     // Add filter A.
     const a = prepareFilterForSave(
-      { _id: "__new__", field: "amount", operator: "eq", value: 1 },
+      { _id: NEW_FILTER_ID, field: "amount", operator: "eq", value: 1 },
       gen,
     );
     list = applyFilterSave(list, a);
@@ -148,7 +176,7 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
     // after the array updates), then Add filter B from a fresh "new" draft.
     list = withFilterIds(list);
     const b = prepareFilterForSave(
-      { _id: "__new__", field: "region", operator: "eq", value: "north" },
+      { _id: NEW_FILTER_ID, field: "region", operator: "eq", value: "north" },
       gen,
     );
     list = applyFilterSave(list, b);

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
@@ -1,6 +1,11 @@
 import type { InsightFilter } from "@dashframe/types";
 import { describe, expect, it } from "vitest";
-import { applyFilterSave, deriveFilterId, withFilterIds } from "./filter-id";
+import {
+  applyFilterSave,
+  deriveFilterId,
+  prepareFilterForSave,
+  withFilterIds,
+} from "./filter-id";
 import type { FilterWithId } from "./FiltersSection";
 
 /**
@@ -92,5 +97,66 @@ describe("applyFilterSave with a stable persisted id", () => {
 
     // The stale id "amount-gt-1" no longer matches → duplicate appended.
     expect(result).toHaveLength(3);
+  });
+});
+
+describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () => {
+  it("assigns a fresh id to a new filter and leaves an existing filter's id intact", () => {
+    const draftNew: FilterWithId = {
+      _id: "__new__",
+      field: "amount",
+      operator: "eq",
+      value: 1,
+    };
+    const stamped = prepareFilterForSave(draftNew, () => "uuid-fresh");
+    expect(stamped.id).toBe("uuid-fresh");
+    expect(stamped._id).toBe("uuid-fresh");
+
+    const existing: FilterWithId = {
+      id: "uuid-existing",
+      _id: "uuid-existing",
+      field: "region",
+      operator: "eq",
+      value: "north",
+    };
+    const reStamped = prepareFilterForSave(
+      existing,
+      () => "uuid-SHOULD-NOT-USE",
+    );
+    expect(reStamped.id).toBe("uuid-existing");
+    expect(reStamped._id).toBe("uuid-existing");
+  });
+
+  it("two consecutive Adds yield distinct ids — second does NOT overwrite first", () => {
+    // Repro of the data-loss bug: FilterEditDialog is permanently mounted, so a
+    // mount-scoped id would be reused. prepareFilterForSave generates per save,
+    // so Add A then Add B produce two distinct filters.
+    const ids = ["uuid-A", "uuid-B"];
+    let i = 0;
+    const gen = () => ids[i++];
+
+    let list: FilterWithId[] = [];
+
+    // Add filter A.
+    const a = prepareFilterForSave(
+      { _id: "__new__", field: "amount", operator: "eq", value: 1 },
+      gen,
+    );
+    list = applyFilterSave(list, a);
+
+    // Re-derive client ids from the persisted list (as InsightConfigPanel does
+    // after the array updates), then Add filter B from a fresh "new" draft.
+    list = withFilterIds(list);
+    const b = prepareFilterForSave(
+      { _id: "__new__", field: "region", operator: "eq", value: "north" },
+      gen,
+    );
+    list = applyFilterSave(list, b);
+
+    // BOTH filters persist, with distinct ids — no overwrite.
+    expect(list).toHaveLength(2);
+    expect(list.map((f) => f.id).sort()).toEqual(["uuid-A", "uuid-B"]);
+    expect(list.find((f) => f.id === "uuid-A")?.value).toBe(1);
+    expect(list.find((f) => f.id === "uuid-B")?.value).toBe("north");
   });
 });

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -1,0 +1,41 @@
+import type { InsightFilter } from "@dashframe/types";
+import type { FilterWithId } from "./FiltersSection";
+
+/**
+ * Pure helpers for client-side filter identity and save-merge.
+ *
+ * Filters carry a persisted `id` (generated on add by FilterEditDialog) that
+ * survives persistence round-trips. The client `_id` is sourced from it so a
+ * subscription firing mid-edit — which recomputes the filter array, possibly
+ * reordered — does not shift identities and misroute an in-flight save.
+ */
+
+/** Derive the stable client `_id` for a persisted filter at array position i. */
+export function deriveFilterId(filter: InsightFilter, index: number): string {
+  // Persisted id is the stable identity. Filters from the API/agent path may
+  // lack one; fall back to a content+index key (not edited concurrently).
+  return filter.id ?? `${filter.field}-${filter.operator}-${index}`;
+}
+
+/** Attach stable client ids to a persisted filter list. */
+export function withFilterIds(
+  filters: InsightFilter[] | undefined,
+): FilterWithId[] {
+  return (filters ?? []).map((f, i) => ({ ...f, _id: deriveFilterId(f, i) }));
+}
+
+/**
+ * Merge a saved filter into the current list: update the row whose `_id`
+ * matches, else append. Matching on the persisted-id-derived `_id` means a
+ * concurrent reorder between open and save cannot route the edit to the wrong
+ * predicate — the id travels with the filter, not its index.
+ */
+export function applyFilterSave(
+  current: FilterWithId[],
+  saved: FilterWithId,
+): FilterWithId[] {
+  const exists = current.some((f) => f._id === saved._id);
+  return exists
+    ? current.map((f) => (f._id === saved._id ? saved : f))
+    : [...current, saved];
+}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -25,13 +25,25 @@ export function withFilterIds(
 }
 
 /**
+ * Client `_id` sentinel for a not-yet-saved new-filter draft. Distinguishes a
+ * brand-new filter (which must get a fresh identity and append) from an
+ * existing row being edited (which must preserve its `_id` so the save routes
+ * back to the same predicate — even if the existing filter has no persisted
+ * `id`, e.g. one created via the API/agent path).
+ */
+export const NEW_FILTER_ID = "__new__";
+
+/**
  * Stamp a stable identity onto a filter at save time.
  *
- * A new filter (no persisted `id`) is assigned a freshly generated id, which
- * also becomes its client `_id`. An existing filter keeps its `id` and `_id`,
- * so edits route back to the same predicate. Generating the id *here, per save*
- * (rather than once per dialog mount) is what makes two consecutive Adds yield
- * two distinct filters instead of the second overwriting the first.
+ * - **New draft** (`_id === NEW_FILTER_ID`): assign a freshly generated id and
+ *   make it the client `_id` too, so `applyFilterSave` appends a distinct row.
+ *   Generating the id *here, per save* (not once per dialog mount) is what makes
+ *   two consecutive Adds yield two distinct filters instead of the second
+ *   overwriting the first.
+ * - **Existing row** (any other `_id`): preserve `_id` so the save updates the
+ *   matching predicate. Backfill a persisted `id` if it lacks one (API/agent
+ *   filters), without disturbing the `_id` used for matching.
  *
  * `genId` is injectable for tests; defaults to `crypto.randomUUID`.
  */
@@ -39,8 +51,12 @@ export function prepareFilterForSave(
   filter: FilterWithId,
   genId: () => string = () => crypto.randomUUID(),
 ): FilterWithId {
-  const id = filter.id ?? genId();
-  return { ...filter, id, _id: filter.id ? filter._id : id };
+  if (filter._id === NEW_FILTER_ID) {
+    const id = filter.id ?? genId();
+    return { ...filter, id, _id: id };
+  }
+  // Existing row: keep _id for matching; backfill a persisted id if missing.
+  return { ...filter, id: filter.id ?? genId() };
 }
 
 /**

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -25,6 +25,25 @@ export function withFilterIds(
 }
 
 /**
+ * Stamp a stable identity onto a filter at save time.
+ *
+ * A new filter (no persisted `id`) is assigned a freshly generated id, which
+ * also becomes its client `_id`. An existing filter keeps its `id` and `_id`,
+ * so edits route back to the same predicate. Generating the id *here, per save*
+ * (rather than once per dialog mount) is what makes two consecutive Adds yield
+ * two distinct filters instead of the second overwriting the first.
+ *
+ * `genId` is injectable for tests; defaults to `crypto.randomUUID`.
+ */
+export function prepareFilterForSave(
+  filter: FilterWithId,
+  genId: () => string = () => crypto.randomUUID(),
+): FilterWithId {
+  const id = filter.id ?? genId();
+  return { ...filter, id, _id: filter.id ? filter._id : id };
+}
+
+/**
  * Merge a saved filter into the current list: update the row whose `_id`
  * matches, else append. Matching on the persisted-id-derived `_id` means a
  * concurrent reorder between open and save cannot route the edit to the wrong

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-value.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-value.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFilterValue,
+  isFilterDraftValid,
+  type FilterDraft,
+} from "./filter-value";
+
+/**
+ * These tests lock the filter draft validation/build contract — the seam the
+ * Save button gates on. Each case maps to a correctness bug: a draft that
+ * validates must never produce SQL-breaking persisted values (NaN, empty IN).
+ */
+
+function draft(overrides: Partial<FilterDraft>): FilterDraft {
+  return {
+    field: "amount",
+    operator: "eq",
+    inputType: "text",
+    scalarValue: "",
+    betweenLow: "",
+    betweenHigh: "",
+    ...overrides,
+  };
+}
+
+describe("isFilterDraftValid", () => {
+  it("rejects a draft with no field selected", () => {
+    expect(isFilterDraftValid(draft({ field: "", scalarValue: "x" }))).toBe(
+      false,
+    );
+  });
+
+  describe("scalar operators", () => {
+    it("accepts a non-empty text value", () => {
+      expect(isFilterDraftValid(draft({ scalarValue: "foo" }))).toBe(true);
+    });
+
+    it("rejects an empty scalar value", () => {
+      expect(isFilterDraftValid(draft({ scalarValue: "   " }))).toBe(false);
+    });
+
+    it("rejects a non-finite number on a numeric field", () => {
+      expect(
+        isFilterDraftValid(draft({ inputType: "number", scalarValue: "abc" })),
+      ).toBe(false);
+    });
+
+    it("accepts a finite number on a numeric field", () => {
+      expect(
+        isFilterDraftValid(draft({ inputType: "number", scalarValue: "42" })),
+      ).toBe(true);
+    });
+  });
+
+  describe("between operator", () => {
+    it("rejects when either bound is empty", () => {
+      expect(
+        isFilterDraftValid(
+          draft({ operator: "between", betweenLow: "1", betweenHigh: "" }),
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects non-finite numeric bounds", () => {
+      expect(
+        isFilterDraftValid(
+          draft({
+            operator: "between",
+            inputType: "number",
+            betweenLow: "1",
+            betweenHigh: "xyz",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("accepts finite numeric bounds", () => {
+      expect(
+        isFilterDraftValid(
+          draft({
+            operator: "between",
+            inputType: "number",
+            betweenLow: "1",
+            betweenHigh: "10",
+          }),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("in operator", () => {
+    it("rejects an all-comma input that parses to an empty list", () => {
+      // Bug: "," passes the trim() !== "" guard but split→filter yields [].
+      // IN () is always-false SQL — must be rejected.
+      expect(
+        isFilterDraftValid(draft({ operator: "in", scalarValue: "," })),
+      ).toBe(false);
+    });
+
+    it("rejects whitespace-only tokens that collapse to an empty list", () => {
+      expect(
+        isFilterDraftValid(draft({ operator: "in", scalarValue: " , , " })),
+      ).toBe(false);
+    });
+
+    it("rejects a non-finite element on a numeric field", () => {
+      // Bug: "in"+numeric skipped the isFinite check and stored [NaN, 2024].
+      expect(
+        isFilterDraftValid(
+          draft({
+            operator: "in",
+            inputType: "number",
+            scalarValue: "abc, 2024",
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("accepts all-finite numeric elements", () => {
+      expect(
+        isFilterDraftValid(
+          draft({
+            operator: "in",
+            inputType: "number",
+            scalarValue: "1, 2, 3",
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts non-empty text elements", () => {
+      expect(
+        isFilterDraftValid(draft({ operator: "in", scalarValue: "a, b" })),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("buildFilterValue", () => {
+  it("coerces a numeric scalar to a number", () => {
+    expect(
+      buildFilterValue(draft({ inputType: "number", scalarValue: "42" })),
+    ).toBe(42);
+  });
+
+  it("keeps a text scalar as a string", () => {
+    expect(buildFilterValue(draft({ scalarValue: "north" }))).toBe("north");
+  });
+
+  it("builds a { low, high } object for between", () => {
+    expect(
+      buildFilterValue(
+        draft({
+          operator: "between",
+          inputType: "number",
+          betweenLow: "1",
+          betweenHigh: "10",
+        }),
+      ),
+    ).toEqual({ low: 1, high: 10 });
+  });
+
+  it("builds a numeric array for in on a numeric field", () => {
+    expect(
+      buildFilterValue(
+        draft({ operator: "in", inputType: "number", scalarValue: "1, 2, 3" }),
+      ),
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("builds a trimmed string array for in on a text field", () => {
+    expect(
+      buildFilterValue(draft({ operator: "in", scalarValue: " a , b ,c" })),
+    ).toEqual(["a", "b", "c"]);
+  });
+});

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-value.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-value.ts
@@ -1,0 +1,93 @@
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import type {
+  InsightFilter,
+  InsightFilterBetweenValue,
+} from "@dashframe/types";
+
+/**
+ * Pure value parsing + validation for the filter editor. Kept free of UI/React
+ * imports so it can be unit-tested directly — this is the single source of
+ * truth the Save button gates on.
+ */
+
+type Operator = InsightFilter["operator"];
+export type FilterInputType = "text" | "number" | "date";
+
+/** Auto-detect the HTML input type from a field's normalized ColumnType. */
+export function inputTypeForField(
+  field: CombinedField | undefined,
+): FilterInputType {
+  if (!field) return "text";
+  const t = field.type;
+  if (t === "number") return "number";
+  if (t === "date") return "date";
+  return "text";
+}
+
+/** Editable draft of a filter's inputs, independent of React state. */
+export interface FilterDraft {
+  field: string;
+  operator: Operator;
+  inputType: FilterInputType;
+  scalarValue: string;
+  betweenLow: string;
+  betweenHigh: string;
+}
+
+/** Split the comma-separated `in` input into trimmed, non-empty tokens. */
+function parseInTokens(scalarValue: string): string[] {
+  return scalarValue
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Build the persisted `value` for a filter draft. Coerces to number for numeric
+ * fields. Callers must gate on isFilterDraftValid first — this does not itself
+ * reject NaN or empty lists.
+ */
+export function buildFilterValue(draft: FilterDraft): unknown {
+  const { operator, inputType, scalarValue, betweenLow, betweenHigh } = draft;
+  if (operator === "between") {
+    const low = inputType === "number" ? Number(betweenLow) : betweenLow;
+    const high = inputType === "number" ? Number(betweenHigh) : betweenHigh;
+    return { low, high } satisfies InsightFilterBetweenValue;
+  }
+  if (operator === "in") {
+    const tokens = parseInTokens(scalarValue);
+    return inputType === "number" ? tokens.map(Number) : tokens;
+  }
+  if (inputType === "number") {
+    const n = Number(scalarValue);
+    return isFinite(n) ? n : scalarValue;
+  }
+  return scalarValue;
+}
+
+/**
+ * Whether a filter draft can be saved. Rejects: no field; empty between bounds
+ * or non-finite numeric bounds; empty `in` list (IN () is always-false SQL) or
+ * any non-finite numeric `in` element; empty scalar or non-finite numeric
+ * scalar.
+ */
+export function isFilterDraftValid(draft: FilterDraft): boolean {
+  const { field, operator, inputType, scalarValue, betweenLow, betweenHigh } =
+    draft;
+  if (!field) return false;
+  if (operator === "between") {
+    if (betweenLow.trim() === "" || betweenHigh.trim() === "") return false;
+    if (inputType === "number")
+      return isFinite(Number(betweenLow)) && isFinite(Number(betweenHigh));
+    return true;
+  }
+  if (operator === "in") {
+    const tokens = parseInTokens(scalarValue);
+    if (tokens.length === 0) return false;
+    if (inputType === "number") return tokens.every((t) => isFinite(Number(t)));
+    return true;
+  }
+  if (scalarValue.trim() === "") return false;
+  if (inputType === "number") return isFinite(Number(scalarValue));
+  return true;
+}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/index.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/index.ts
@@ -1,4 +1,7 @@
 export { FieldsSection } from "./FieldsSection";
+export { FilterEditDialog } from "./FilterEditDialog";
+export { FiltersSection } from "./FiltersSection";
+export type { FilterWithId } from "./FiltersSection";
 export { InsightConfigPanel } from "./InsightConfigPanel";
 export { InsightFieldEditorModal } from "./InsightFieldEditorModal";
 export { InsightMetricEditorModal } from "./InsightMetricEditorModal";

--- a/packages/app/src/lib/insights/compute-combined-fields.test.ts
+++ b/packages/app/src/lib/insights/compute-combined-fields.test.ts
@@ -1,0 +1,116 @@
+import type { InsightJoinConfig } from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import {
+  computeFilterableFields,
+  type CombinedField,
+} from "./compute-combined-fields";
+
+/**
+ * Locks the filterable-field narrowing used by the FilterEditDialog picker.
+ * Every offered field must back a working, unambiguous predicate — so dropped
+ * right join-keys and ambiguous duplicate column names are excluded. Mirrors
+ * the insight SQL builder's join emission (right join-key dropped) and its
+ * column-name-based filter resolution.
+ */
+
+function field(overrides: Partial<CombinedField>): CombinedField {
+  return {
+    id: overrides.id ?? `id-${overrides.name ?? "f"}`,
+    name: overrides.name ?? "f",
+    type: "string",
+    columnName: overrides.columnName,
+    sourceTableId: overrides.sourceTableId ?? "table-base",
+    displayName: overrides.displayName ?? overrides.name ?? "f",
+    ...overrides,
+  } as CombinedField;
+}
+
+describe("computeFilterableFields", () => {
+  it("returns all fields unchanged when there are no joins", () => {
+    const fields = [
+      field({ id: "a", name: "amount", columnName: "amount" }),
+      field({ id: "b", name: "region", columnName: "region" }),
+    ];
+    expect(computeFilterableFields(fields, undefined)).toHaveLength(2);
+  });
+
+  it("excludes the right-side join key (dropped from the emitted subquery)", () => {
+    // The joined table's `room_id` is joined on join.rightKey and dropped from
+    // the subquery — a filter on it would silently resolve to a missing column.
+    const fields = [
+      field({ id: "lead-id", name: "lead_id", columnName: "lead_id" }),
+      field({
+        id: "room-id",
+        name: "room_id",
+        columnName: "room_id",
+        sourceTableId: "table-rooms",
+      }),
+      field({
+        id: "room-name",
+        name: "room_name",
+        columnName: "room_name",
+        sourceTableId: "table-rooms",
+      }),
+    ];
+    const joins: InsightJoinConfig[] = [
+      {
+        type: "inner",
+        rightTableId: "table-rooms",
+        leftKey: "lead_id",
+        rightKey: "room_id",
+      },
+    ];
+    const result = computeFilterableFields(fields, joins);
+    expect(result.map((f) => f.columnName)).toEqual(["lead_id", "room_name"]);
+    expect(result.some((f) => f.columnName === "room_id")).toBe(false);
+  });
+
+  it("matches the right join key case-insensitively", () => {
+    const fields = [
+      field({ id: "k", name: "ID", columnName: "ID", sourceTableId: "t2" }),
+      field({
+        id: "x",
+        name: "label",
+        columnName: "label",
+        sourceTableId: "t2",
+      }),
+    ];
+    const joins: InsightJoinConfig[] = [
+      {
+        type: "inner",
+        rightTableId: "t2",
+        leftKey: "fk",
+        rightKey: "id", // lower-case, field is "ID"
+      },
+    ];
+    const result = computeFilterableFields(fields, joins);
+    expect(result.some((f) => f.columnName === "ID")).toBe(false);
+  });
+
+  it("excludes both sides of an ambiguous duplicate column name", () => {
+    // Base `id` and joined `id` both persist the bare value "id"; the resolver
+    // cannot disambiguate, so neither may be offered.
+    const fields = [
+      field({ id: "base-id", name: "id", columnName: "id" }),
+      field({
+        id: "join-id",
+        name: "id",
+        columnName: "id",
+        sourceTableId: "t2",
+        displayName: "rooms.id",
+      }),
+      field({ id: "amount", name: "amount", columnName: "amount" }),
+    ];
+    // No join key dropping in play here (rightKey unrelated).
+    const joins: InsightJoinConfig[] = [
+      {
+        type: "inner",
+        rightTableId: "t2",
+        leftKey: "amount",
+        rightKey: "amount_ref",
+      },
+    ];
+    const result = computeFilterableFields(fields, joins);
+    expect(result.map((f) => f.columnName)).toEqual(["amount"]);
+  });
+});

--- a/packages/app/src/lib/insights/compute-combined-fields.test.ts
+++ b/packages/app/src/lib/insights/compute-combined-fields.test.ts
@@ -113,4 +113,38 @@ describe("computeFilterableFields", () => {
     const result = computeFilterableFields(fields, joins);
     expect(result.map((f) => f.columnName)).toEqual(["amount"]);
   });
+
+  it("keeps a base column whose name matches a dropped joined join-key", () => {
+    // Base `id` and joined `id` share a name, and the join's rightKey IS `id`.
+    // The JOINED `id` is the dropped right join-key and must be excluded — but
+    // the BASE `id` stays in the emitted query, is unambiguous once the joined
+    // key is gone, and MUST remain filterable. (Regression: an earlier version
+    // dropped every field whose name matched any rightKey, hiding the base id.)
+    const fields = [
+      field({ id: "base-id", name: "id", columnName: "id" }), // base table
+      field({
+        id: "join-id",
+        name: "id",
+        columnName: "id",
+        sourceTableId: "t2", // joined table — this is the right join-key
+        displayName: "rooms.id",
+      }),
+      field({ id: "amount", name: "amount", columnName: "amount" }),
+    ];
+    const joins: InsightJoinConfig[] = [
+      {
+        type: "inner",
+        rightTableId: "t2",
+        leftKey: "id",
+        rightKey: "id",
+      },
+    ];
+    const result = computeFilterableFields(fields, joins);
+    // Base `id` survives (and is the only `id` left, so unambiguous); the
+    // joined `id` is dropped as the right join-key.
+    expect(result.map((f) => f.id).sort()).toEqual(["amount", "base-id"]);
+    const ids = result.filter((f) => f.columnName === "id");
+    expect(ids).toHaveLength(1);
+    expect(ids[0].id).toBe("base-id");
+  });
 });

--- a/packages/app/src/lib/insights/compute-combined-fields.ts
+++ b/packages/app/src/lib/insights/compute-combined-fields.ts
@@ -133,45 +133,55 @@ export function computeCombinedFields(
  *
  * The insight SQL builder keys filter resolution on a field's bare column name
  * (`columnName ?? name`) and emits the join only over columns present in the
- * joined subquery. Two classes of combined field therefore produce a filter
- * that is silently dropped at query time:
+ * joined subquery. Two classes of combined field produce a filter that is
+ * silently dropped or misrouted at query time, applied in order:
  *
- * 1. **Dropped right join-keys** — for each join, the right-side field whose
- *    column name equals `join.rightKey` is excluded from the emitted subquery
- *    (it is redundant with the left key it joins on). A filter on it resolves
- *    to a missing column and is skipped.
- * 2. **Ambiguous duplicate column names** — when base and joined tables share a
- *    column name, both fields persist the same bare `field` value, so the
- *    resolver cannot tell them apart and picks the first match. Offering either
- *    risks filtering the wrong table's column.
+ * 1. **Dropped right join-keys** — for each join, the field on that join's
+ *    *right table* whose column name equals `join.rightKey` is excluded from
+ *    the emitted subquery (redundant with the left key it joins on). Only that
+ *    specific field is dropped — a base-table column that merely shares the
+ *    name stays in the query and remains filterable.
+ * 2. **Ambiguous duplicate column names** — computed on what survives step 1.
+ *    If two queryable fields still share a bare column name, the resolver can't
+ *    tell them apart, so both are excluded. (A base/joined name collision where
+ *    the joined side was the dropped right key is NOT a duplicate here — the
+ *    base column is unambiguous once the joined key is gone.)
  *
- * Excluding both classes guarantees every offered field yields a working,
- * unambiguous predicate. (Disambiguating duplicates by a stable per-field
- * identifier instead of dropping them requires the SQL builder to resolve
- * filters by field id rather than column name — a separate change.)
+ * Applying step 1 before counting duplicates is what keeps a base column with
+ * the same name as a dropped join key filterable. Disambiguating genuine
+ * duplicates by a stable per-field identifier (rather than dropping them) would
+ * require the SQL builder to resolve filters by field id — a separate change.
  */
 export function computeFilterableFields(
   combinedFields: CombinedField[],
   joins: InsightJoinConfig[] | undefined,
 ): CombinedField[] {
-  // Column names that are the right-side key of some join (dropped from the
-  // emitted subquery), compared case-insensitively to match the builder.
-  const droppedRightKeysLower = new Set(
-    (joins ?? []).map((j) => j.rightKey.toLowerCase()),
-  );
+  const joinList = joins ?? [];
 
-  // Column names that appear more than once across the combined set — the
-  // resolver cannot disambiguate these by bare column name.
+  // Step 1: drop only the right-side join-key field of each join — matched by
+  // (source table === join.rightTableId AND column name === join.rightKey),
+  // not by bare-name-matches-any-rightKey. Case-insensitive on the column name
+  // to mirror the builder.
+  const afterJoinKeyDrop = combinedFields.filter((f) => {
+    const colNameLower = (f.columnName ?? f.name).toLowerCase();
+    const isDroppedRightKey = joinList.some(
+      (j) =>
+        f.sourceTableId === j.rightTableId &&
+        colNameLower === j.rightKey.toLowerCase(),
+    );
+    return !isDroppedRightKey;
+  });
+
+  // Step 2: among the queryable fields, exclude any column name that still
+  // appears more than once (the resolver cannot disambiguate by bare name).
   const colNameCounts = new Map<string, number>();
-  for (const f of combinedFields) {
+  for (const f of afterJoinKeyDrop) {
     const key = (f.columnName ?? f.name).toLowerCase();
     colNameCounts.set(key, (colNameCounts.get(key) ?? 0) + 1);
   }
 
-  return combinedFields.filter((f) => {
-    const colNameLower = (f.columnName ?? f.name).toLowerCase();
-    if (droppedRightKeysLower.has(colNameLower)) return false;
-    if ((colNameCounts.get(colNameLower) ?? 0) > 1) return false;
-    return true;
-  });
+  return afterJoinKeyDrop.filter(
+    (f) =>
+      (colNameCounts.get((f.columnName ?? f.name).toLowerCase()) ?? 0) === 1,
+  );
 }

--- a/packages/app/src/lib/insights/compute-combined-fields.ts
+++ b/packages/app/src/lib/insights/compute-combined-fields.ts
@@ -127,3 +127,51 @@ export function computeCombinedFields(
 
   return { fields: combined, count: combined.length };
 }
+
+/**
+ * Narrows combined fields to those that can actually back a filter predicate.
+ *
+ * The insight SQL builder keys filter resolution on a field's bare column name
+ * (`columnName ?? name`) and emits the join only over columns present in the
+ * joined subquery. Two classes of combined field therefore produce a filter
+ * that is silently dropped at query time:
+ *
+ * 1. **Dropped right join-keys** — for each join, the right-side field whose
+ *    column name equals `join.rightKey` is excluded from the emitted subquery
+ *    (it is redundant with the left key it joins on). A filter on it resolves
+ *    to a missing column and is skipped.
+ * 2. **Ambiguous duplicate column names** — when base and joined tables share a
+ *    column name, both fields persist the same bare `field` value, so the
+ *    resolver cannot tell them apart and picks the first match. Offering either
+ *    risks filtering the wrong table's column.
+ *
+ * Excluding both classes guarantees every offered field yields a working,
+ * unambiguous predicate. (Disambiguating duplicates by a stable per-field
+ * identifier instead of dropping them requires the SQL builder to resolve
+ * filters by field id rather than column name — a separate change.)
+ */
+export function computeFilterableFields(
+  combinedFields: CombinedField[],
+  joins: InsightJoinConfig[] | undefined,
+): CombinedField[] {
+  // Column names that are the right-side key of some join (dropped from the
+  // emitted subquery), compared case-insensitively to match the builder.
+  const droppedRightKeysLower = new Set(
+    (joins ?? []).map((j) => j.rightKey.toLowerCase()),
+  );
+
+  // Column names that appear more than once across the combined set — the
+  // resolver cannot disambiguate these by bare column name.
+  const colNameCounts = new Map<string, number>();
+  for (const f of combinedFields) {
+    const key = (f.columnName ?? f.name).toLowerCase();
+    colNameCounts.set(key, (colNameCounts.get(key) ?? 0) + 1);
+  }
+
+  return combinedFields.filter((f) => {
+    const colNameLower = (f.columnName ?? f.name).toLowerCase();
+    if (droppedRightKeysLower.has(colNameLower)) return false;
+    if ((colNameCounts.get(colNameLower) ?? 0) > 1) return false;
+    return true;
+  });
+}

--- a/packages/core-dexie/src/db/schema.ts
+++ b/packages/core-dexie/src/db/schema.ts
@@ -57,6 +57,7 @@ export interface InsightEntity {
   selectedFields: UUID[];
   metrics: InsightMetric[];
   filters?: Array<{
+    id?: string;
     field: string;
     operator: string;
     value: unknown;

--- a/packages/core-dexie/src/repositories/insights.ts
+++ b/packages/core-dexie/src/repositories/insights.ts
@@ -23,6 +23,7 @@ function entityToInsight(entity: InsightEntity): Insight {
     selectedFields: entity.selectedFields,
     metrics: entity.metrics,
     filters: entity.filters?.map((f) => ({
+      id: f.id,
       field: f.field,
       operator: f.operator as InsightFilter["operator"],
       value: f.value,

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -19,6 +19,13 @@ import type { UUID } from "./uuid";
  * - All other operators: `value` is a scalar.
  */
 export interface InsightFilter {
+  /**
+   * Stable identity for a filter predicate. Optional because filters created
+   * via the API/agent path may omit it; the UI generates one on add and
+   * preserves it across persistence round-trips so concurrent subscription
+   * updates can't misroute an in-flight edit to the wrong predicate.
+   */
+  id?: string;
   field: string;
   operator:
     | "eq"


### PR DESCRIPTION
Add FiltersSection, FilterEditDialog and wire them into InsightConfigPanel so users can add, edit, reorder, and delete filter predicates on an insight.

## Changes

- **FiltersSection** — collapsible section mirroring MetricsSection; SortableList with inline Edit + Remove icons; stale-field references display as struck-through danger text (no crash); formatFilterValue renders `between` as `low … high`
- **FilterEditDialog** — add/edit dialog with field picker, operator picker, and value input; `between` shows two range inputs coalesced to `{ low, high }`; input type (text/number/date) auto-detected from field's ColumnType; key-reset pattern for clean state on re-open
- **InsightConfigPanel** — wires in FiltersSection + FilterEditDialog with `filtersWithIds` memoization, `handleFiltersReorder`, `handleRemoveFilter`, `handleSaveFilter`; persists via `updateInsight({ filters: [...] })` stripping client-only `_id` before save
- **index.ts** — exports FilterEditDialog, FiltersSection, FilterWithId

## Screenshots

### FiltersSection with a filter added

**Light**

![filters-light](https://github.com/youhaowei/DashFrame/releases/download/pr-101-screenshots/filters-light.png)

**Dark**

![filters-dark](https://github.com/youhaowei/DashFrame/releases/download/pr-101-screenshots/filters-dark.png)

### FilterEditDialog — edit mode (field + operator + value pre-populated)

![filter-dialog-light](https://github.com/youhaowei/DashFrame/releases/download/pr-101-screenshots/filter-dialog-light.png)

### FilterEditDialog — between operator (two range inputs)

![filter-between-light](https://github.com/youhaowei/DashFrame/releases/download/pr-101-screenshots/filter-between-light.png)

## Verification

- Navigated to insight page; FiltersSection appears below MetricsSection in config panel (left panel)
- Clicked "Add" in Filters section → FilterEditDialog opened with field picker, operator picker, value input
- Added filter `revenue_id eq 2024-01-01`; confirmed it appears in the Filters list with badge count 1
- Switched operator to `between`; confirmed two range inputs appear labeled "Low … High"
- Clicked edit icon on existing filter → dialog pre-populated with current values
- Deleted filter → removed immediately, no cascade/confirm dialog
- Reloaded page → filter persisted (survives round-trip through `updateInsight`)
- TypeCheck: 47/47 tasks pass

## Review round 2 — correctness fixes

Resolved all open review threads (3 Greptile P1 correctness bugs + 6 P2s).

**P1 — fixed**
- `in` + numeric field stored NaN: validation now rejects non-finite elements in an `in` list on a numeric field.
- Empty `in` saved silently (`","` → `IN ()`): empty parsed lists are now rejected.
- Index-based `_id` misrouted edits under a concurrent subscription: filters now carry a persisted stable `id` (generated on add, preserved through dexie + server round-trips); identity survives reorder, so saves can't misroute or duplicate.

**P2 — fixed**
- Dropped right join-keys and ambiguous duplicate column names are excluded from the filter-field picker (`computeFilterableFields`), so every offered field yields a working predicate.
- `in` membership filters are editable without destructive rewrite to a scalar.

**P2 — deferred (replied + resolved on-thread, tracked as follow-ups)**
- `hasConfiguration` counting filters-only insights — lives in `DataPreviewSection`; result-mode behavior change with its own surface.
- `contains` gating to text-compatible fields — V1 acceptable; refinement on the static operator list.
- Metrics as filter targets (HAVING) — needs its own picker UX; SQL layer already supports it.

**New tests**
- `filter-value.test.ts` — NaN/empty-`in`/between/scalar validation + value build.
- `filter-id.test.ts` — stable id survives a simulated concurrent reorder (+ regression guard for the old index scheme).
- `compute-combined-fields.test.ts` — dropped join-key and duplicate-column exclusion.

**Runtime verification** (app on :4300, real insight): `in`+numeric `"abc, 2024"` → Add disabled; all-comma `","` → Add disabled; `between` → two range inputs; delete → immediate (no confirm dialog); valid `"1, 2, 3"` → Add enabled.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds full CRUD for insight filter predicates — `FiltersSection` (collapsible sortable list), `FilterEditDialog` (add/edit with operator/value inputs), and the wiring in `InsightConfigPanel`. It also ships `computeFilterableFields` to narrow the field picker to columns the SQL builder can actually resolve, and a stable-identity scheme (`filter.id` + `filter-id.ts`) that prevents concurrent subscription updates from misrouting in-flight edits.

- **Filter identity**: `InsightFilter.id` is generated at save-time (not dialog-mount) via `prepareFilterForSave`, so consecutive \"Add\" calls yield distinct filters rather than the second overwriting the first; `applyFilterSave` matches on `_id` (sourced from the persisted `id`) so a subscription-triggered reorder between open and save can't corrupt the target.
- **Validation**: `isFilterDraftValid` rejects empty `in` lists, non-finite numeric elements, and empty `between` bounds; `buildFilterValue` coerces numeric fields correctly; all paths are locked by unit tests.
- **Field narrowing**: `computeFilterableFields` applies a two-step filter — drop right join-keys by source table + column name (not bare name), then drop ambiguous duplicates — ensuring base columns that share a name with a dropped join key remain filterable.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the correctness bugs from round 1 are all resolved, identity logic is well-tested, and the only outstanding gap is a UX edge case (inverted between bounds) that doesn't corrupt stored data.

All three round-1 data-correctness bugs (NaN storage, empty-in, stale index identity) have been fixed and locked by unit tests. The stable-id scheme is sound: ids are generated per save, not per mount, so consecutive adds yield distinct filters; `applyFilterSave` matches by travelling id so concurrent reorders can't misroute edits. The only gap remaining is that `isFilterDraftValid` does not enforce `low ≤ high` for the `between` operator, which lets a user persist an always-false SQL predicate — a bad UX outcome but not data loss or corruption.

`filter-value.ts` — the `between` bounds validation is missing the low ≤ high ordering check.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx | New dialog for add/edit filter predicates; key-reset pattern correctly resets form state per session; `in` operator now included in OPERATOR_OPTIONS; save-time id generation via prepareFilterForSave prevents second-Add overwrite. |
| packages/app/src/app/insights/[insightId]/_components/config-panel/FiltersSection.tsx | New collapsible section mirroring MetricsSection; stale-field references shown with strikethrough; SortableList with inline edit/remove; reorder dispatches through stable _id-sourced items. |
| packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx | Wires FiltersSection + FilterEditDialog; filterableFields uses computeFilterableFields to exclude dropped join-keys and ambiguous duplicates from the picker; stripFilterIds correctly preserves persisted `id` while discarding client-only `_id`. |
| packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts | Pure helpers for stable client identity; deriveFilterId sources _id from persisted id (falling back to content+index for API-created filters); prepareFilterForSave generates id per-save (not per-mount) preventing consecutive-Add overwrite; applyFilterSave matches by _id not index. |
| packages/app/src/app/insights/[insightId]/_components/config-panel/filter-value.ts | Pure validation + value-building logic; in/NaN and empty-in bugs from round 1 are fixed; between bounds are validated for non-emptiness and finiteness but not for low <= high order, which can produce an always-false SQL predicate. |
| packages/app/src/lib/insights/compute-combined-fields.ts | New computeFilterableFields applies two-step exclusion: dropped right join-keys (matched by sourceTableId + columnName, not bare-name), then ambiguous duplicates; ordering ensures a base column sharing a name with a dropped join key remains filterable. |
| packages/core-dexie/src/db/schema.ts | Adds optional `id` field to the filter entity shape in the Dexie schema, enabling round-trip persistence of the stable filter identity. |
| packages/core-dexie/src/repositories/insights.ts | Maps the new `id` field in entityToInsight so persisted filter ids survive local DB round-trips. |
| packages/types/src/insights.ts | Adds optional `id` to InsightFilter with a clear doc comment explaining the stable-identity contract; fully backward-compatible. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant FiltersSection
    participant InsightConfigPanel
    participant FilterEditDialog
    participant filter_id as filter-id.ts
    participant filter_value as filter-value.ts
    participant updateInsight

    User->>FiltersSection: click Add
    FiltersSection->>InsightConfigPanel: onAddClick()
    InsightConfigPanel->>InsightConfigPanel: setFilterToEdit("new")
    InsightConfigPanel->>FilterEditDialog: "filter="new""
    FilterEditDialog->>FilterEditDialog: "effectiveFilter = {_id: "__new__", ...}"
    FilterEditDialog->>FilterEditDialog: "mount FilterEditForm (key="__new__-new")"

    User->>FilterEditDialog: fill field/operator/value, click Save
    FilterEditDialog->>filter_value: isFilterDraftValid(draft)
    filter_value-->>FilterEditDialog: true
    FilterEditDialog->>filter_value: buildFilterValue(draft)
    filter_value-->>FilterEditDialog: coerced value
    FilterEditDialog->>filter_id: "prepareFilterForSave({_id:"__new__",...})"
    filter_id->>filter_id: genId() → "uuid-new"
    filter_id-->>FilterEditDialog: "{id:"uuid-new", _id:"uuid-new", ...}"
    FilterEditDialog->>InsightConfigPanel: onSave(FilterWithId)
    InsightConfigPanel->>filter_id: applyFilterSave(filtersWithIds, saved)
    filter_id-->>InsightConfigPanel: [...current, saved] (appended)
    InsightConfigPanel->>InsightConfigPanel: stripFilterIds (remove _id)
    InsightConfigPanel->>updateInsight: "{filters: [{id:"uuid-new", field, operator, value}]}"
    updateInsight-->>InsightConfigPanel: insight.filters updated
    InsightConfigPanel->>InsightConfigPanel: filtersWithIds recomputed via withFilterIds
    FilterEditDialog->>InsightConfigPanel: onOpenChange(false)
    InsightConfigPanel->>InsightConfigPanel: setFilterToEdit(null)
    FilterEditDialog->>FilterEditDialog: "effectiveFilter=null → FilterEditForm unmounts"
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(app): don&#39;t duplicate an id-less fil..."](https://github.com/youhaowei/dashframe/commit/28d715f30dc0cfd405d6e5047f84da5e1dbdc61c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37420635)</sub>

<!-- /greptile_comment -->