### PR TITLE
refactor(app): CSV ingest via CreateDataTable command (replace legacy addDataTable)

### DIFF
--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2560,4 +2560,86 @@ describe("command vocabulary", () => {
       expect(rows[0]?.name).toBe("New");
     });
   });
+
+  describe("CSV ingest via CreateDataTable — default Count metric preserved", () => {
+    /**
+     * No-regression contract: CSV ingest that migrated from the legacy
+     * `addDataTable` mutation (which auto-injected Count via
+     * `withDefaultCountMetric`) to the `CreateDataTable` command (a
+     * PRIMITIVE — no auto-inject) must produce the same row shape.
+     * The caller is now responsible for passing the Count metric explicitly.
+     *
+     * This test asserts the contract: a DataTable created via CreateDataTable
+     * with an explicit default Count metric has exactly one Count metric and
+     * the metric matches the expected shape.
+     */
+    it("should produce a DataTable with the default Count metric when the caller passes it explicitly", async () => {
+      const sourceId = id();
+      const tableId = id();
+      const metricId = id();
+
+      await commit(
+        cmd("GetOrCreateDataSource", {
+          id: sourceId,
+          type: "local",
+          name: "Local Files",
+        }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "sales",
+          table: "sales.csv",
+          metrics: [
+            {
+              id: metricId,
+              name: "Count",
+              tableId,
+              columnName: undefined,
+              aggregation: "count",
+            },
+          ],
+        }),
+      );
+
+      const [row] = await tablesById(tableId);
+      const metrics = (row?.metrics ?? []) as {
+        id: string;
+        name: string;
+        tableId: string;
+        columnName: unknown;
+        aggregation: string;
+      }[];
+
+      // Exactly one metric — the default Count metric the caller supplied.
+      expect(metrics).toHaveLength(1);
+      expect(metrics[0]?.id).toBe(metricId);
+      expect(metrics[0]?.name).toBe("Count");
+      expect(metrics[0]?.tableId).toBe(tableId);
+      expect(metrics[0]?.columnName).toBeUndefined();
+      expect(metrics[0]?.aggregation).toBe("count");
+    });
+
+    it("should NOT auto-inject a Count metric — CreateDataTable is a primitive (caller owns metrics)", async () => {
+      // Verifies the command's PRIMITIVE contract: unlike the legacy
+      // `addDataTable` mutation, CreateDataTable stores exactly what the caller
+      // passes. If the caller omits metrics, the row has no metrics — no
+      // silent injection.
+      const sourceId = id();
+      const tableId = id();
+
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+        cmd("CreateDataTable", {
+          id: tableId,
+          dataSourceId: sourceId,
+          name: "T",
+          table: "t.csv",
+          // No metrics supplied — CreateDataTable stores an empty array.
+        }),
+      );
+
+      const [row] = await tablesById(tableId);
+      expect(row?.metrics).toEqual([]);
+    });
+  });
 });

--- a/packages/app-data/src/data-tables.ts
+++ b/packages/app-data/src/data-tables.ts
@@ -164,6 +164,34 @@ export async function addDataTable(
   return id;
 }
 
+/**
+ * Create a DataTable via the `CreateDataTable` command vocabulary — the
+ * PRIMITIVE that does NOT auto-inject metrics. Callers are responsible for
+ * passing explicit metrics (e.g. the default Count metric for file ingests).
+ *
+ * Use this instead of `addDataTable` when you want full control over the
+ * metrics list — the legacy `addDataTable` mutation silently prepends a Count
+ * metric via `withDefaultCountMetric`, which makes the caller's intent
+ * invisible. The command vocabulary path puts the metric explicitly in the
+ * caller, matching the spec's traceability rule.
+ */
+export async function createDataTable(args: {
+  id: UUID;
+  dataSourceId: UUID;
+  name: string;
+  table: string;
+  sourceSchema?: SourceSchema;
+  fields?: Field[];
+  metrics?: Metric[];
+  dataFrameId?: UUID;
+}): Promise<UUID> {
+  const { id } = await getWyStackClient().mutate(
+    api.createDataTable,
+    loose(args),
+  );
+  return id as UUID;
+}
+
 export async function updateDataTable(
   id: UUID,
   updates: Partial<Omit<DataTable, "id" | "createdAt" | "dataSourceId">>,

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -44,6 +44,7 @@ export {
 
 export {
   addDataTable,
+  createDataTable,
   getAllDataTables,
   getDataTable,
   getDataTablesBySource,

--- a/packages/app/src/lib/local-csv-handler.ts
+++ b/packages/app/src/lib/local-csv-handler.ts
@@ -1,6 +1,6 @@
 import {
   addDataFrameEntry,
-  addDataTable,
+  createDataTable,
   getDataTable,
   getOrCreateDataSourceByType,
   replaceDataFrame,
@@ -10,6 +10,24 @@ import { csvToDataFrame } from "@dashframe/csv";
 import type { FileParseResult } from "@dashframe/engine";
 import type { BrowserDataFrame } from "@dashframe/engine-browser";
 import type { Metric } from "@dashframe/types";
+
+/**
+ * Build the default Count metric for a new DataTable.
+ *
+ * `CreateDataTable` is a PRIMITIVE — it does not auto-inject metrics.
+ * Callers that want the default Count metric must pass it explicitly.
+ * This helper produces the same shape that `withDefaultCountMetric` in
+ * `app-artifacts.ts` used to inject, preserving the row-shape contract.
+ */
+function makeDefaultCountMetric(tableId: string): Metric {
+  return {
+    id: crypto.randomUUID(),
+    name: "Count",
+    tableId,
+    columnName: undefined,
+    aggregation: "count",
+  };
+}
 
 const ensureCountMetric = (
   existing: Metric[] = [],
@@ -21,16 +39,7 @@ const ensureCountMetric = (
 
   if (hasCount) return existing;
 
-  return [
-    {
-      id: crypto.randomUUID(),
-      name: "Count",
-      tableId,
-      columnName: undefined,
-      aggregation: "count",
-    },
-    ...existing,
-  ];
+  return [makeDefaultCountMetric(tableId), ...existing];
 };
 
 /**
@@ -110,22 +119,18 @@ export async function handleLocalCSVUpload(
     // Ensure the DataTable points to the updated DataFrame
     await updateDataTable(dataTableId, { dataFrameId });
   } else {
-    // 3b. Add DataTable
-    const defaultMetrics: Metric[] = [
-      {
-        id: crypto.randomUUID(),
-        name: "Count",
-        tableId: dataTableId,
-        columnName: undefined,
-        aggregation: "count",
-      },
-    ];
-
-    await addDataTable(dataSource.id, tableName, file.name, {
+    // 3b. Create DataTable via the CreateDataTable command — PRIMITIVE path.
+    // CreateDataTable does NOT auto-inject metrics, so we pass the default
+    // Count metric explicitly here. This mirrors the shape that the legacy
+    // `addDataTable` mutation produced via `withDefaultCountMetric`.
+    await createDataTable({
       id: dataTableId,
+      dataSourceId: dataSource.id,
+      name: tableName,
+      table: file.name,
       sourceSchema,
       fields,
-      metrics: defaultMetrics,
+      metrics: [makeDefaultCountMetric(dataTableId)],
     });
 
     // 4. Create DataFrame entry
@@ -208,22 +213,18 @@ export async function handleFileConnectorResult(
 
     await updateDataTable(dataTableId, { dataFrameId });
   } else {
-    // Add new DataTable
-    const defaultMetrics: Metric[] = [
-      {
-        id: crypto.randomUUID(),
-        name: "Count",
-        tableId: dataTableId,
-        columnName: undefined,
-        aggregation: "count",
-      },
-    ];
-
-    await addDataTable(dataSource.id, tableName, fileName, {
+    // Create DataTable via the CreateDataTable command — PRIMITIVE path.
+    // CreateDataTable does NOT auto-inject metrics, so we pass the default
+    // Count metric explicitly here. This mirrors the shape that the legacy
+    // `addDataTable` mutation produced via `withDefaultCountMetric`.
+    await createDataTable({
       id: dataTableId,
+      dataSourceId: dataSource.id,
+      name: tableName,
+      table: fileName,
       sourceSchema,
       fields,
-      metrics: defaultMetrics,
+      metrics: [makeDefaultCountMetric(dataTableId)],
     });
 
     // Create DataFrame entry


### PR DESCRIPTION
Migrate CSV file ingest off the legacy `addDataTable` coarse mutation onto the `CreateDataTable` command vocabulary. Closes the only source caller gap identified in issue #66.

## Changes

- `packages/app/src/lib/local-csv-handler.ts` — `handleLocalCSVUpload` and `handleFileConnectorResult` now call `createDataTable` instead of `addDataTable` for new-table creates. Default Count metric is passed **explicitly** via a new `makeDefaultCountMetric` helper (same shape as `withDefaultCountMetric` in `app-artifacts.ts` — preserves row-shape contract). Override path (`overrideTable`) is unchanged.
- `packages/app-data/src/data-tables.ts` — adds `createDataTable` imperative helper that routes to `api.createDataTable` (command vocabulary handler) instead of `api.addDataTable`. Uses `loose()` for the same optionality-gap workaround as other callers.
- `packages/app-data/src/index.ts` — exports `createDataTable` (re-exported through `@dashframe/core`).
- `addDataTable` is **kept** — still referenced by `useDataTableMutations` hook.
- `apps/server/src/functions/commands.test.ts` — two new contract tests: (1) explicit Count metric is stored with the correct shape when passed to `CreateDataTable`; (2) `CreateDataTable` does NOT auto-inject when metrics are omitted (primitive contract).

## Screenshots

No visual change — ingest command migration; DataTable row-shape preserved incl. default Count metric.

## Verification

- `bun run typecheck` — 47/47 tasks pass.
- `bun run lint` — clean (pre-existing UI warning unrelated).
- `bun run format` — no changes after auto-format.
- `bun run check:ticket-refs` — OK.
- `bun run test` — 165 server tests pass (incl. 2 new), 396 app tests pass; 40/40 total.
- Count metric preservation verified via the new `commands.test.ts` contract: `CreateDataTable` with explicit `[{ aggregation: "count", columnName: undefined, ... }]` stores exactly that metric — `toHaveLength(1)`, all five fields asserted. Primitive-contract test confirms no auto-inject when metrics omitted.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates CSV file ingest from the legacy `addDataTable` mutation (which server-side auto-injected a Count metric via `withDefaultCountMetric`) to the new `CreateDataTable` command primitive (no auto-injection), making the caller responsible for passing metrics explicitly. A `makeDefaultCountMetric` helper is added in `local-csv-handler.ts` and called at both `handleLocalCSVUpload` and `handleFileConnectorResult` new-table code paths.

- **`packages/app-data/src/data-tables.ts`** — adds the `createDataTable` imperative helper routing to `api.createDataTable` via `loose()`, consistent with other callers.
- **`packages/app/src/lib/local-csv-handler.ts`** — replaces both `addDataTable` call sites with `createDataTable` plus an explicit `makeDefaultCountMetric(dataTableId)` metric; the `ensureCountMetric` override path is refactored to reuse the same helper.
- **`apps/server/src/functions/commands.test.ts`** — two new contract tests verify (1) an explicit Count metric is stored with the correct five-field shape, and (2) `CreateDataTable` stores an empty array when metrics are omitted.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The migration is a straightforward caller-side responsibility shift: two call sites updated symmetrically, the Count metric shape is identical to what the legacy mutation produced, and the override path is untouched.

All changed call sites are symmetric and tested; loose() is a runtime identity so metrics pass through unmodified; the server CreateDataTable handler stores exactly what the caller provides; no behavioral regressions were introduced in the override path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/lib/local-csv-handler.ts | Both new-table code paths migrated to `createDataTable` with explicit Count metric; `ensureCountMetric` refactored to reuse the new `makeDefaultCountMetric` helper. Logic is correct and consistent. |
| packages/app-data/src/data-tables.ts | New `createDataTable` helper correctly routes to `api.createDataTable` via `loose()`; `addDataTable` is preserved for the `useDataTableMutations` hook. The `id as UUID` cast is present because the command handler declares `Promise<{ id: string }>` rather than a UUID-typed return. |
| packages/app-data/src/index.ts | Trivial re-export of the new `createDataTable` helper; no issues. |
| apps/server/src/functions/commands.test.ts | Two new contract tests cleanly cover the explicit-metric shape and the no-auto-inject primitive contract; test structure is consistent with the surrounding suite. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CSV as local-csv-handler
    participant CD as createDataTable (app-data)
    participant API as api.createDataTable
    participant SRV as CreateDataTable (server command)
    participant DB as dataTables DB

    CSV->>CSV: makeDefaultCountMetric(dataTableId)
    CSV->>CD: "createDataTable({ id, dataSourceId, name, table, fields, sourceSchema, metrics:[CountMetric] })"
    CD->>API: mutate(api.createDataTable, loose(args))
    API->>SRV: handler(ctx, args)
    SRV->>DB: "INSERT { metrics: args.metrics ?? [] }"
    DB-->>SRV: "{ id }"
    SRV-->>API: "{ id: string }"
    API-->>CD: "{ id }"
    CD-->>CSV: id as UUID
    CSV->>API: addDataFrameEntry(dataFrame, ...)
    CSV->>API: "updateDataTable(dataTableId, { dataFrameId })"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(app): CSV ingest via CreateData..."](https://github.com/youhaowei/dashframe/commit/59bc38d0def02a215dfba753a2fba42b2301cbc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37441427)</sub>

<!-- /greptile_comment -->