### PR TITLE
test(e2e): compound-insight field/metric editing coverage

### DIFF
--- a/e2e/web/tests/compound-insight-editing.spec.ts
+++ b/e2e/web/tests/compound-insight-editing.spec.ts
@@ -64,19 +64,25 @@ test.describe("compound-insight field/metric editing", () => {
     // contain "Product" in their accessible name) that are visible in the background.
     const addFieldDialog = page.getByRole("dialog", { name: "Add field" });
 
-    // Wait for field buttons to populate inside the dialog
-    await expect(
-      addFieldDialog.getByRole("button", { name: /Product/i }),
-    ).toBeVisible({ timeout: 10_000 });
+    // Wait for field buttons to populate inside the dialog, then wait a beat for
+    // the list to finish rendering (avoids DOM-detach flake when the field list
+    // re-renders while the click is in flight).
+    const productButton = addFieldDialog.getByRole("button", {
+      name: /Product/i,
+    });
+    await expect(productButton).toBeVisible({ timeout: 10_000 });
+    await productButton.waitFor({ state: "visible" });
 
-    // Intercept the updateInsight mutation to confirm it fires and succeeds
+    // Intercept the updateInsight mutation to confirm it fires and succeeds.
+    // 20s timeout accommodates Playwright's click-retry loop if the button
+    // momentarily detaches during a list re-render.
     const updateInsightResponse = page.waitForResponse(
       (resp) =>
         resp.url().includes("/api/updateInsight") && resp.status() === 200,
-      { timeout: 10_000 },
+      { timeout: 20_000 },
     );
 
-    await addFieldDialog.getByRole("button", { name: /Product/i }).click();
+    await productButton.click();
 
     // Dialog closes after selection
     await expect(
@@ -175,16 +181,16 @@ test.describe("compound-insight field/metric editing", () => {
     });
 
     const addFieldDialog = page.getByRole("dialog", { name: "Add field" });
-    await expect(
-      addFieldDialog.getByRole("button", { name: /Product/i }),
-    ).toBeVisible({ timeout: 10_000 });
+    const productBtn = addFieldDialog.getByRole("button", { name: /Product/i });
+    await expect(productBtn).toBeVisible({ timeout: 10_000 });
+    await productBtn.waitFor({ state: "visible" });
 
     const addFieldResponse1 = page.waitForResponse(
       (resp) =>
         resp.url().includes("/api/updateInsight") && resp.status() === 200,
-      { timeout: 10_000 },
+      { timeout: 20_000 },
     );
-    await addFieldDialog.getByRole("button", { name: /Product/i }).click();
+    await productBtn.click();
     await expect(
       page.getByRole("dialog", { name: "Add field" }),
     ).not.toBeVisible({ timeout: 5_000 });

--- a/e2e/web/tests/compound-insight-editing.spec.ts
+++ b/e2e/web/tests/compound-insight-editing.spec.ts
@@ -77,8 +77,7 @@ test.describe("compound-insight field/metric editing", () => {
     // 20s timeout accommodates Playwright's click-retry loop if the button
     // momentarily detaches during a list re-render.
     const updateInsightResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 20_000 },
     );
 
@@ -89,8 +88,9 @@ test.describe("compound-insight field/metric editing", () => {
       page.getByRole("dialog", { name: "Add field" }),
     ).not.toBeVisible({ timeout: 5_000 });
 
-    // Confirm the mutation reached the server and returned 200
-    await updateInsightResponse;
+    // Confirm the mutation reached the server. Assert the status explicitly so a
+    // non-200 surfaces as a clear assertion failure instead of a waitForResponse timeout.
+    expect((await updateInsightResponse).status()).toBe(200);
 
     // Reload the page to get fresh server state — confirms server persisted correctly
     await page.reload();
@@ -106,7 +106,9 @@ test.describe("compound-insight field/metric editing", () => {
     ).toBeVisible({ timeout: 15_000 });
 
     // The empty-state message should be gone
-    await expect(page.getByText("No fields selected.")).not.toBeVisible();
+    await expect(page.getByText("No fields selected.")).not.toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -133,8 +135,7 @@ test.describe("compound-insight field/metric editing", () => {
 
     // Intercept the updateInsight mutation to confirm it fires and succeeds
     const updateInsightResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 10_000 },
     );
 
@@ -144,8 +145,9 @@ test.describe("compound-insight field/metric editing", () => {
       page.getByRole("dialog", { name: "Add metric" }),
     ).not.toBeVisible({ timeout: 5_000 });
 
-    // Confirm the mutation reached the server and returned 200
-    await updateInsightResponse;
+    // Confirm the mutation reached the server. Assert the status explicitly so a
+    // non-200 surfaces as a clear assertion failure instead of a waitForResponse timeout.
+    expect((await updateInsightResponse).status()).toBe(200);
 
     // Reload the page to get fresh server state — confirms server persisted correctly
     await page.reload();
@@ -161,7 +163,9 @@ test.describe("compound-insight field/metric editing", () => {
     });
 
     // The empty-state message should be gone
-    await expect(page.getByText("No metrics configured.")).not.toBeVisible();
+    await expect(page.getByText("No metrics configured.")).not.toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -186,15 +190,14 @@ test.describe("compound-insight field/metric editing", () => {
     await productBtn.waitFor({ state: "visible" });
 
     const addFieldResponse1 = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 20_000 },
     );
     await productBtn.click();
     await expect(
       page.getByRole("dialog", { name: "Add field" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await addFieldResponse1;
+    expect((await addFieldResponse1).status()).toBe(200);
 
     // Reload to verify field was persisted
     await page.reload();
@@ -219,15 +222,14 @@ test.describe("compound-insight field/metric editing", () => {
     ).toHaveValue("Count");
 
     const addMetricResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 10_000 },
     );
     await page.getByRole("button", { name: "Add metric" }).click();
     await expect(
       page.getByRole("dialog", { name: "Add metric" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await addMetricResponse;
+    expect((await addMetricResponse).status()).toBe(200);
 
     // Reload to verify metric was persisted
     await page.reload();
@@ -253,15 +255,14 @@ test.describe("compound-insight field/metric editing", () => {
     await nameInput.fill("Row Count");
 
     const updateMetricResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 10_000 },
     );
     await page.getByRole("button", { name: "Save" }).click();
     await expect(
       page.getByRole("dialog", { name: "Edit metric" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await updateMetricResponse;
+    expect((await updateMetricResponse).status()).toBe(200);
 
     // Reload to verify metric rename was persisted
     await page.reload();
@@ -275,7 +276,7 @@ test.describe("compound-insight field/metric editing", () => {
     ).toBeVisible({ timeout: 15_000 });
     await expect(
       page.getByRole("button", { name: "Edit Count" }),
-    ).not.toBeVisible();
+    ).not.toBeVisible({ timeout: 5_000 });
 
     // ── 4. removeField ──────────────────────────────────────────────────────
     // Cause: click Remove on "Product", confirm deletion
@@ -286,15 +287,14 @@ test.describe("compound-insight field/metric editing", () => {
     ).toBeVisible({ timeout: 10_000 });
 
     const removeFieldResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 10_000 },
     );
     await page.getByRole("button", { name: "Delete field" }).click();
     await expect(
       page.getByRole("dialog", { name: "Delete field" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await removeFieldResponse;
+    expect((await removeFieldResponse).status()).toBe(200);
 
     // Reload to verify field removal was persisted
     await page.reload();
@@ -319,15 +319,14 @@ test.describe("compound-insight field/metric editing", () => {
     ).toBeVisible({ timeout: 10_000 });
 
     const removeMetricResponse = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      (resp) => resp.url().includes("/api/updateInsight"),
       { timeout: 10_000 },
     );
     await page.getByRole("button", { name: "Delete metric" }).click();
     await expect(
       page.getByRole("dialog", { name: "Delete metric" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await removeMetricResponse;
+    expect((await removeMetricResponse).status()).toBe(200);
 
     // Reload to verify metric removal was persisted
     await page.reload();

--- a/e2e/web/tests/compound-insight-editing.spec.ts
+++ b/e2e/web/tests/compound-insight-editing.spec.ts
@@ -1,0 +1,340 @@
+/**
+ * Compound-insight field/metric editing
+ *
+ * Verifies the server-side read-modify-write on `insights.definition` (jsonb)
+ * for all five COMPOUND mutations:
+ *   addField / removeField / addMetric / updateMetric / removeMetric
+ *
+ * Contract under test: after each mutation the server persists the updated
+ * definition and the UI reflects the change. Assertions are observable
+ * cause→effect: the config panel item lists and badge counts change in
+ * lock-step with each write — not just "no error thrown".
+ *
+ * The existing csv→chart specs never exercise these mutations. Those specs
+ * create an insight and immediately navigate to a visualization; they never
+ * interact with the config panel or call updateInsight with field/metric edits.
+ *
+ * Setup mirrors the existing csv-to-chart.spec.ts: upload sales_data.csv
+ * (Date, Product, Category, Sales, Quantity) → land on the insight page.
+ * The insight is created with selectedFields=[] and metrics=[], so both
+ * panel sections start empty.
+ */
+import { expect, test } from "../lib/test-fixtures";
+
+test.describe("compound-insight field/metric editing", () => {
+  /**
+   * Upload CSV and wait for the insight page to finish loading.
+   * Each test starts with an empty insight (0 fields, 0 metrics).
+   */
+  test.beforeEach(async ({ page, homePage, uploadFile }) => {
+    await homePage();
+    await uploadFile("sales_data.csv");
+
+    // Upload redirects to the insight page
+    await expect(page).toHaveURL(/\/insights\/[a-zA-Z0-9-]+/, {
+      timeout: 15_000,
+    });
+
+    // Wait for the config panel to be rendered — "Fields" section Add button
+    // is always present once the panel loads
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // addField: definition.selectedFields grows from [] to [fieldId]
+  // ---------------------------------------------------------------------------
+  test("addField: selecting a field adds it to the Fields section", async ({
+    page,
+  }) => {
+    // Initial: Fields section shows "No fields selected."
+    await expect(page.getByText("No fields selected.")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Open the Add Field dialog (first "Add" button = Fields section)
+    await page.getByRole("button", { name: "Add" }).first().click();
+    await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Select the "Product" field from the available fields list.
+    // Scope to the dialog to avoid matching chart-suggestion buttons (which also
+    // contain "Product" in their accessible name) that are visible in the background.
+    const addFieldDialog = page.getByRole("dialog", { name: "Add field" });
+
+    // Wait for field buttons to populate inside the dialog
+    await expect(
+      addFieldDialog.getByRole("button", { name: /Product/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Intercept the updateInsight mutation to confirm it fires and succeeds
+    const updateInsightResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+
+    await addFieldDialog.getByRole("button", { name: /Product/i }).click();
+
+    // Dialog closes after selection
+    await expect(
+      page.getByRole("dialog", { name: "Add field" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+
+    // Confirm the mutation reached the server and returned 200
+    await updateInsightResponse;
+
+    // Reload the page to get fresh server state — confirms server persisted correctly
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // Observable: "Product" field item now appears in the Fields section,
+    // confirming definition.selectedFields = [<productFieldId>] was written
+    // and read back from the server
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The empty-state message should be gone
+    await expect(page.getByText("No fields selected.")).not.toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // addMetric: definition.metrics grows from [] to [{ aggregation: "count" }]
+  // ---------------------------------------------------------------------------
+  test("addMetric: adding a Count metric adds it to the Metrics section", async ({
+    page,
+  }) => {
+    // Initial: Metrics section shows "No metrics configured."
+    await expect(page.getByText("No metrics configured.")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Open the Add Metric dialog (second "Add" button = Metrics section)
+    await page.getByRole("button", { name: "Add" }).nth(1).click();
+    await expect(page.getByRole("dialog", { name: "Add metric" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Default aggregation is "Count (rows)" — name auto-fills to "Count"
+    await expect(
+      page.getByRole("textbox", { name: /metric name/i }),
+    ).toHaveValue("Count");
+
+    // Intercept the updateInsight mutation to confirm it fires and succeeds
+    const updateInsightResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+
+    // Save the metric
+    await page.getByRole("button", { name: "Add metric" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Add metric" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+
+    // Confirm the mutation reached the server and returned 200
+    await updateInsightResponse;
+
+    // Reload the page to get fresh server state — confirms server persisted correctly
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // Observable: "Count" metric item now appears in the Metrics section,
+    // confirming definition.metrics = [{ name: "Count", aggregation: "count" }]
+    // was written and read back from the server
+    await expect(page.getByRole("button", { name: "Edit Count" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The empty-state message should be gone
+    await expect(page.getByText("No metrics configured.")).not.toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Full compound path: all five mutations in sequence
+  // Proves the jsonb read-modify-write chain is correct at runtime,
+  // not just at typecheck. Each step asserts an observable state change.
+  // ---------------------------------------------------------------------------
+  test("editing an insight's fields/metrics is reflected in the computed result", async ({
+    page,
+  }) => {
+    // ── 1. addField ─────────────────────────────────────────────────────────
+    // Cause: open field picker, select "Product"
+    // Effect: "Product" appears in the Fields item list; empty-state gone
+    await page.getByRole("button", { name: "Add" }).first().click();
+    await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const addFieldDialog = page.getByRole("dialog", { name: "Add field" });
+    await expect(
+      addFieldDialog.getByRole("button", { name: /Product/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const addFieldResponse1 = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+    await addFieldDialog.getByRole("button", { name: /Product/i }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Add field" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await addFieldResponse1;
+
+    // Reload to verify field was persisted
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // ✓ field is persisted and re-rendered
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // ── 2. addMetric ────────────────────────────────────────────────────────
+    // Cause: open metric editor, save Count aggregation
+    // Effect: "Count" appears in the Metrics item list; empty-state gone
+    await page.getByRole("button", { name: "Add" }).nth(1).click();
+    await expect(page.getByRole("dialog", { name: "Add metric" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByRole("textbox", { name: /metric name/i }),
+    ).toHaveValue("Count");
+
+    const addMetricResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Add metric" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Add metric" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await addMetricResponse;
+
+    // Reload to verify metric was persisted
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // ✓ metric is persisted and re-rendered
+    await expect(page.getByRole("button", { name: "Edit Count" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // ── 3. updateMetric ─────────────────────────────────────────────────────
+    // Cause: edit "Count" metric, rename to "Row Count"
+    // Effect: "Row Count" label replaces "Count" in the Metrics list
+    await page.getByRole("button", { name: "Edit Count" }).click();
+    await expect(page.getByRole("dialog", { name: "Edit metric" })).toBeVisible(
+      { timeout: 10_000 },
+    );
+
+    const nameInput = page.getByRole("textbox", { name: /display name/i });
+    await nameInput.clear();
+    await nameInput.fill("Row Count");
+
+    const updateMetricResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Edit metric" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await updateMetricResponse;
+
+    // Reload to verify metric rename was persisted
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // ✓ updated metric name is persisted and re-rendered
+    await expect(
+      page.getByRole("button", { name: "Edit Row Count" }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole("button", { name: "Edit Count" }),
+    ).not.toBeVisible();
+
+    // ── 4. removeField ──────────────────────────────────────────────────────
+    // Cause: click Remove on "Product", confirm deletion
+    // Effect: "Product" disappears; Fields section shows empty state
+    await page.getByRole("button", { name: "Remove Product" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete field" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const removeFieldResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Delete field" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete field" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await removeFieldResponse;
+
+    // Reload to verify field removal was persisted
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // ✓ definition.selectedFields = [] is persisted and re-rendered
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("No fields selected.")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // ── 5. removeMetric ─────────────────────────────────────────────────────
+    // Cause: click Remove on "Row Count", confirm deletion
+    // Effect: "Row Count" disappears; Metrics section shows empty state
+    await page.getByRole("button", { name: "Remove Row Count" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete metric" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const removeMetricResponse = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/updateInsight") && resp.status() === 200,
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Delete metric" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete metric" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await removeMetricResponse;
+
+    // Reload to verify metric removal was persisted
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
+      { timeout: 20_000 },
+    );
+
+    // ✓ definition.metrics = [] is persisted and re-rendered
+    await expect(
+      page.getByRole("button", { name: "Remove Row Count" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("No metrics configured.")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
Adds Playwright E2E coverage for all five COMPOUND mutations on `insights.definition` (jsonb) — `addField`, `removeField`, `addMetric`, `updateMetric`, `removeMetric`. The existing csv→chart specs upload a file and navigate away to a chart; they never touch the config panel or call `updateInsight` with field/metric edits.

## Changes

- Add `e2e/web/tests/compound-insight-editing.spec.ts` with three specs mirroring `csv-to-chart.spec.ts` setup (sales_data.csv → insight page)
  - `addField: selecting a field adds it to the Fields section` — opens field picker, clicks Product, confirms "Remove Product" button appears after reload
  - `addMetric: adding a Count metric adds it to the Metrics section` — opens metric editor, saves Count, confirms "Edit Count" button appears after reload  
  - `editing an insight's fields/metrics is reflected in the computed result` — all five mutations in sequence with observable state assertions at each step

Each test intercepts the `/api/updateInsight` HTTP response (asserts 200) then reloads the page to confirm the persisted state renders correctly. The reload-based pattern is intentional: during investigation, `page.on("websocket")` captured zero WS events — the production-build CSP `connect-src` only includes `http://127.0.0.1:PORT` but not `ws://127.0.0.1:PORT`, which blocks the WyStack WS reactive channel in E2E. The HTTP mutation path is correct and this test exercises the full server-side read-modify-write contract through reload. A follow-up to add `ws://` to the CSP is warranted.

## Screenshots

No UI change.

## Verification

All 14 E2E tests pass locally (3 new + 11 existing):

```
14 passed (33.6s)
  ✓ compound-insight field/metric editing › addField: selecting a field adds it to the Fields section (2.6s)
  ✓ compound-insight field/metric editing › addMetric: adding a Count metric adds it to the Metrics section (2.6s)
  ✓ compound-insight field/metric editing › editing an insight's fields/metrics is reflected in the computed result (3.8s)
```

- Server correctly persists `selectedFields` and `metrics` arrays after each mutation (verified by reload showing updated state)
- `waitForResponse` confirms `/api/updateInsight` returns 200 for every mutation before asserting UI state
- `clearServerDB` auto-fixture (pre-existing) ensures clean server state per test

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new Playwright E2E test file covering all five `insights.definition` (jsonb) mutations for compound insights: `addField`, `removeField`, `addMetric`, `updateMetric`, and `removeMetric`. The tests follow the same CSV-upload setup as `csv-to-chart.spec.ts` and use reload-based persistence verification after each mutation.

- Three test specs are added: two standalone tests for `addField` and `addMetric`, and one sequential compound test exercising all five mutations in order, with observable state assertions and a page reload after each mutation to confirm server-side persistence.
- Each mutation intercepts `/api/updateInsight` and explicitly asserts the HTTP 200 status separately from the URL predicate, so server errors surface as clear assertion failures rather than opaque timeouts — an improvement from the pattern flagged and fixed in prior review rounds.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a test-only addition with no production code changes.

All changes are new E2E test code. The previous review findings (combined URL+status predicate, missing timeouts on not.toBeVisible) have been addressed. The remaining note about scoping selectors to the edit dialog is a robustness preference, not a correctness issue, and the tests pass locally across all 14 specs.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| e2e/web/tests/compound-insight-editing.spec.ts | New test file with three specs covering all five compound-insight mutations; previous review findings addressed, but the Save button and display-name textbox in the updateMetric step are unscoped to the dialog, unlike the Product button which is explicitly scoped to avoid background matches. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant PW as Playwright
    participant UI as App UI
    participant API as /api/updateInsight

    T->>PW: page.waitForResponse(...)
    T->>UI: click action (addField / addMetric / updateMetric / removeField / removeMetric)
    UI->>API: HTTP POST
    API-->>UI: 200 OK (persisted to DB)
    UI-->>PW: response captured
    T->>PW: "await response & assert status === 200"
    T->>UI: page.reload()
    UI->>API: fetch insight
    API-->>UI: updated definition from DB
    T->>UI: assert observable state (button/text visible or not visible)
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(e2e): surface non-200 mutation stat..."](https://github.com/youhaowei/dashframe/commit/45b67e0486df63573ebaeb087a0e83d0f3ddaff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37442947)</sub>

<!-- /greptile_comment -->