### PR TITLE
fix(app): collision-resistant group keys in insight grouping

### DIFF
--- a/packages/app/src/lib/insights/compute-preview.test.ts
+++ b/packages/app/src/lib/insights/compute-preview.test.ts
@@ -139,6 +139,24 @@ describe("groupRowsBy — null/sentinel collision", () => {
     const result = computeInsightPreview(ins, dt, data, 50);
     expect(result.rowCount).toBe(2);
   });
+
+  it("keeps NaN, Infinity, and -Infinity as distinct groups from each other and from null", () => {
+    // JSON.stringify coerces NaN/±Infinity to "null", so without special-casing
+    // they would all merge into the same group as actual null values.
+    const val = field({ id: "f1", name: "value", columnName: "value" });
+    const dt = table([val]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { value: null },
+      { value: NaN },
+      { value: Infinity },
+      { value: -Infinity },
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(4);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/lib/insights/compute-preview.test.ts
+++ b/packages/app/src/lib/insights/compute-preview.test.ts
@@ -28,10 +28,12 @@ import { computeInsightPreview } from "./compute-preview";
 
 function field(overrides: Partial<Field> & Pick<Field, "id" | "name">): Field {
   return {
-    tableId: "t1",
-    type: "string",
+    id: overrides.id,
+    name: overrides.name,
+    tableId: overrides.tableId ?? "t1",
+    type: overrides.type ?? "string",
     ...overrides,
-  } as Field;
+  };
 }
 
 function table(fields: Field[]): DataTable {

--- a/packages/app/src/lib/insights/compute-preview.test.ts
+++ b/packages/app/src/lib/insights/compute-preview.test.ts
@@ -164,18 +164,19 @@ describe("groupRowsBy — null/sentinel collision", () => {
 // ---------------------------------------------------------------------------
 
 describe("groupRowsBy — field without columnName", () => {
-  it("participates in grouping via field.id when columnName is absent", () => {
+  it("participates in grouping via field.name when columnName is absent", () => {
     // A computed/virtual field has no columnName. Old code treated all such
     // fields as null → every row fell into the same null-keyed group.
-    // The fix uses field.id as the row key lookup instead.
-    const computed = field({ id: "virtual_status", name: "Virtual Status" }); // no columnName
+    // The codebase convention (matching compute-combined-fields.ts) is
+    // columnName ?? name, so the row lookup key is field.name.
+    const computed = field({ id: "f-status", name: "status" }); // no columnName
     const dt = table([computed]);
-    const ins = insight(["virtual_status"]);
+    const ins = insight(["f-status"]);
 
     const data = frame([
-      { virtual_status: "active" },
-      { virtual_status: "inactive" },
-      { virtual_status: "active" },
+      { status: "active" },
+      { status: "inactive" },
+      { status: "active" },
     ]);
 
     const result = computeInsightPreview(ins, dt, data, 50);
@@ -184,16 +185,51 @@ describe("groupRowsBy — field without columnName", () => {
   });
 
   it("still extracts the field value into the output row for fields without columnName", () => {
-    const computed = field({ id: "virtual_status", name: "Virtual Status" });
+    const computed = field({ id: "f-status", name: "status" }); // no columnName
     const dt = table([computed]);
-    const ins = insight(["virtual_status"]);
+    const ins = insight(["f-status"]);
 
-    const data = frame([{ virtual_status: "active" }]);
+    const data = frame([{ status: "active" }]);
 
     const result = computeInsightPreview(ins, dt, data, 50);
-    expect(result.dataFrame.rows[0]).toMatchObject({
-      "Virtual Status": "active",
-    });
+    expect(result.dataFrame.rows[0]).toMatchObject({ status: "active" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BigInt values (DuckDB BIGINT columns surface as JS bigint)
+// ---------------------------------------------------------------------------
+
+describe("groupRowsBy — BigInt values", () => {
+  it("does not throw on bigint field values and groups them correctly", () => {
+    // JSON.stringify(1n) throws TypeError: Do not know how to serialize a BigInt.
+    // The encoder must handle bigint before passing to JSON.stringify.
+    const id = field({ id: "f1", name: "user_id", columnName: "user_id" });
+    const dt = table([id]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { user_id: 1n },
+      { user_id: 2n },
+      { user_id: 1n }, // duplicate → same group as first
+    ]);
+
+    // Must not throw, and must produce 2 groups (1n and 2n)
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(2);
+  });
+
+  it("keeps bigint 1n distinct from the number 1 and the string '1'", () => {
+    // All three would produce the same string via String(value), so type
+    // tags are required to prevent cross-type collisions.
+    const col = field({ id: "f1", name: "val", columnName: "val" });
+    const dt = table([col]);
+    const ins = insight(["f1"]);
+
+    const data = frame([{ val: 1n }, { val: 1 }, { val: "1" }]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(3);
   });
 });
 

--- a/packages/app/src/lib/insights/compute-preview.test.ts
+++ b/packages/app/src/lib/insights/compute-preview.test.ts
@@ -1,0 +1,210 @@
+import type {
+  DataFrameData,
+  DataTable,
+  Field,
+  Insight,
+} from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import { computeInsightPreview } from "./compute-preview";
+
+/**
+ * Locks the collision-resistant group key invariants for computeInsightPreview.
+ *
+ * The old implementation serialized group keys by joining stringified field
+ * values with a fixed "|||" delimiter and encoding null as the sentinel
+ * "__NULL__". Two contracts were broken:
+ *
+ * 1. Delimiter collision: a value containing "|||" would produce the same key
+ *    as a different value-combination → distinct rows merged into one group.
+ * 2. Sentinel collision: the string "null" / "__NULL__" was
+ *    indistinguishable from an actual null.
+ * 3. Fields without columnName were silently dropped from the group key (and
+ *    from the output row), so all such rows folded into a single group.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function field(overrides: Partial<Field> & Pick<Field, "id" | "name">): Field {
+  return {
+    tableId: "t1",
+    type: "string",
+    ...overrides,
+  } as Field;
+}
+
+function table(fields: Field[]): DataTable {
+  return {
+    id: "t1",
+    name: "test",
+    dataSourceId: "ds1",
+    table: "test_table",
+    fields,
+    metrics: [],
+    createdAt: 0,
+  };
+}
+
+function insight(selectedFieldIds: string[], tableId = "t1"): Insight {
+  return {
+    id: "i1",
+    name: "Test Insight",
+    baseTableId: tableId,
+    selectedFields: selectedFieldIds,
+    metrics: [],
+    createdAt: 0,
+  };
+}
+
+function frame(rows: Record<string, unknown>[]): DataFrameData {
+  return { columns: [], rows };
+}
+
+// ---------------------------------------------------------------------------
+// Delimiter-collision tests
+// ---------------------------------------------------------------------------
+
+describe("groupRowsBy — delimiter collision", () => {
+  it("treats two rows as SEPARATE groups when a value contains the old delimiter", () => {
+    // Old key: ("a|||b" + "|||" + "c") == ("a" + "|||" + "|||b|||c")
+    // Both would produce the string "a|||b|||c" — indistinguishable.
+    const category = field({
+      id: "f1",
+      name: "category",
+      columnName: "category",
+    });
+    const label = field({ id: "f2", name: "label", columnName: "label" });
+    const dt = table([category, label]);
+    const ins = insight(["f1", "f2"]);
+
+    const data = frame([
+      { category: "a|||b", label: "c" }, // group A: category="a|||b", label="c"
+      { category: "a", label: "|||b|||c" }, // group B: category="a", label="|||b|||c"
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+
+    // Must be 2 distinct groups, not 1 merged group
+    expect(result.rowCount).toBe(2);
+    expect(result.dataFrame.rows).toHaveLength(2);
+  });
+
+  it("keeps rows in the same group when they genuinely share both field values", () => {
+    const region = field({ id: "f1", name: "region", columnName: "region" });
+    const dt = table([region]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { region: "west" },
+      { region: "west" },
+      { region: "east" },
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Null-sentinel collision tests
+// ---------------------------------------------------------------------------
+
+describe("groupRowsBy — null/sentinel collision", () => {
+  it('distinguishes the string "null" from an actual null value', () => {
+    // Old sentinel was "__NULL__"; but the real risk is that `String(null) === "null"`.
+    // With typed tuples, ["null"] (null tag) !== ["v","null"] (string "null").
+    const status = field({ id: "f1", name: "status", columnName: "status" });
+    const dt = table([status]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { status: null }, // actual null
+      { status: "null" }, // the string "null"
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(2);
+  });
+
+  it('distinguishes undefined from the string "undefined"', () => {
+    const status = field({ id: "f1", name: "status", columnName: "status" });
+    const dt = table([status]);
+    const ins = insight(["f1"]);
+
+    const data = frame([{ status: undefined }, { status: "undefined" }]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fields without columnName participate in grouping
+// ---------------------------------------------------------------------------
+
+describe("groupRowsBy — field without columnName", () => {
+  it("participates in grouping via field.id when columnName is absent", () => {
+    // A computed/virtual field has no columnName. Old code treated all such
+    // fields as null → every row fell into the same null-keyed group.
+    // The fix uses field.id as the row key lookup instead.
+    const computed = field({ id: "virtual_status", name: "Virtual Status" }); // no columnName
+    const dt = table([computed]);
+    const ins = insight(["virtual_status"]);
+
+    const data = frame([
+      { virtual_status: "active" },
+      { virtual_status: "inactive" },
+      { virtual_status: "active" },
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    // Should produce 2 groups (active, inactive), not 1 collapsed null group
+    expect(result.rowCount).toBe(2);
+  });
+
+  it("still extracts the field value into the output row for fields without columnName", () => {
+    const computed = field({ id: "virtual_status", name: "Virtual Status" });
+    const dt = table([computed]);
+    const ins = insight(["virtual_status"]);
+
+    const data = frame([{ virtual_status: "active" }]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.dataFrame.rows[0]).toMatchObject({
+      "Virtual Status": "active",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: clean values still group correctly
+// ---------------------------------------------------------------------------
+
+describe("computeInsightPreview — grouping regression", () => {
+  it("groups two fields with clean values correctly", () => {
+    const region = field({ id: "f1", name: "region", columnName: "region" });
+    const product = field({ id: "f2", name: "product", columnName: "product" });
+    const dt = table([region, product]);
+    const ins = insight(["f1", "f2"]);
+
+    const data = frame([
+      { region: "west", product: "A" },
+      { region: "west", product: "B" },
+      { region: "east", product: "A" },
+      { region: "west", product: "A" }, // duplicate of first → same group
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(3);
+  });
+
+  it("handles grand-total mode (no selected fields) without regression", () => {
+    const dt = table([]);
+    const ins = insight([]);
+    const data = frame([{ x: 1 }, { x: 2 }]);
+    const result = computeInsightPreview(ins, dt, data, 50);
+    // Grand total: single row
+    expect(result.rowCount).toBe(1);
+  });
+});

--- a/packages/app/src/lib/insights/compute-preview.ts
+++ b/packages/app/src/lib/insights/compute-preview.ts
@@ -122,12 +122,19 @@ function groupRowsBy(
   const groupMap = new Map<string, Record<string, unknown>[]>();
 
   for (const row of rows) {
-    // Create group key from field values
+    // Build a collision-resistant key using typed tuples per field.
+    // Each entry is ["null"] for null/undefined, or ["v", value] for a real
+    // value. JSON.stringify over this array is injective: a value that
+    // contains the old "|||" delimiter or the string "null" cannot collide
+    // with a different value-combination.
+    // Fields without columnName participate via field.id so they don't all
+    // collapse to the same null bucket.
     const keyParts = fields.map((field) => {
-      const value = field.columnName ? row[field.columnName] : null;
-      return value != null ? String(value) : "__NULL__";
+      const colKey = field.columnName ?? field.id;
+      const value = row[colKey];
+      return value == null ? ["null"] : ["v", value];
     });
-    const key = keyParts.join("|||");
+    const key = JSON.stringify(keyParts);
 
     // Add row to group
     if (!groupMap.has(key)) {
@@ -155,9 +162,11 @@ function extractGroupKeys(
   const result: Record<string, unknown> = {};
 
   for (const field of fields) {
-    if (field.columnName) {
-      result[field.name] = row[field.columnName];
-    }
+    // Use columnName when available; fall back to field.id so that fields
+    // without a columnName still contribute a value instead of being silently
+    // dropped from the output row.
+    const colKey = field.columnName ?? field.id;
+    result[field.name] = row[colKey];
   }
 
   return result;

--- a/packages/app/src/lib/insights/compute-preview.ts
+++ b/packages/app/src/lib/insights/compute-preview.ts
@@ -123,21 +123,29 @@ function groupRowsBy(
 
   for (const row of rows) {
     // Build a collision-resistant key using typed tuples per field.
-    // Tags: ["null"] for null/undefined, ["special", str] for non-finite
-    // numbers (NaN/±Infinity — JSON.stringify coerces these to "null", so they
-    // must be normalized out before serialization), or ["v", value] for all
-    // other values. JSON.stringify over this tagged array is injective for any
-    // mix of strings, finite numbers, and booleans: a value containing the old
-    // "|||" delimiter or the string "null" cannot collide with a different
-    // value-combination.
-    // Fields without columnName participate via field.id so they don't all
-    // collapse to the same null bucket.
+    //
+    // The encoding is a TOTAL, injective function over every value DuckDB
+    // can produce (string, finite number, bigint, boolean, null/undefined,
+    // non-finite number). Two distinct values must never share a key; no
+    // value may throw. Type tags prevent cross-type collisions (e.g. the
+    // string "1" vs the number 1 vs the bigint 1n each produce distinct keys).
+    //
+    // Tags:
+    //   ["null"]           — null or undefined
+    //   ["num", str]       — non-finite numbers: "NaN", "Infinity", "-Infinity"
+    //                        (JSON.stringify coerces these to null otherwise)
+    //   ["bigint", str]    — BigInt values (JSON.stringify THROWS on bigint)
+    //   ["v", value]       — everything else: string, finite number, boolean
+    //
+    // Column lookup: field.columnName ?? field.name (codebase convention,
+    // matching compute-combined-fields.ts and the SQL builder helpers).
     const keyParts = fields.map((field) => {
-      const colKey = field.columnName ?? field.id;
+      const colKey = field.columnName ?? field.name;
       const value = row[colKey];
       if (value == null) return ["null"];
+      if (typeof value === "bigint") return ["bigint", value.toString()];
       if (typeof value === "number" && !isFinite(value)) {
-        return ["special", String(value)]; // "NaN", "Infinity", "-Infinity"
+        return ["num", String(value)]; // "NaN", "Infinity", "-Infinity"
       }
       return ["v", value];
     });
@@ -169,10 +177,11 @@ function extractGroupKeys(
   const result: Record<string, unknown> = {};
 
   for (const field of fields) {
-    // Use columnName when available; fall back to field.id so that fields
-    // without a columnName still contribute a value instead of being silently
-    // dropped from the output row.
-    const colKey = field.columnName ?? field.id;
+    // Use columnName when available; fall back to field.name (codebase
+    // convention: columnName ?? name, matching compute-combined-fields.ts)
+    // so that fields without a columnName still contribute a value instead
+    // of being silently dropped from the output row.
+    const colKey = field.columnName ?? field.name;
     result[field.name] = row[colKey];
   }
 

--- a/packages/app/src/lib/insights/compute-preview.ts
+++ b/packages/app/src/lib/insights/compute-preview.ts
@@ -123,16 +123,23 @@ function groupRowsBy(
 
   for (const row of rows) {
     // Build a collision-resistant key using typed tuples per field.
-    // Each entry is ["null"] for null/undefined, or ["v", value] for a real
-    // value. JSON.stringify over this array is injective: a value that
-    // contains the old "|||" delimiter or the string "null" cannot collide
-    // with a different value-combination.
+    // Tags: ["null"] for null/undefined, ["special", str] for non-finite
+    // numbers (NaN/±Infinity — JSON.stringify coerces these to "null", so they
+    // must be normalized out before serialization), or ["v", value] for all
+    // other values. JSON.stringify over this tagged array is injective for any
+    // mix of strings, finite numbers, and booleans: a value containing the old
+    // "|||" delimiter or the string "null" cannot collide with a different
+    // value-combination.
     // Fields without columnName participate via field.id so they don't all
     // collapse to the same null bucket.
     const keyParts = fields.map((field) => {
       const colKey = field.columnName ?? field.id;
       const value = row[colKey];
-      return value == null ? ["null"] : ["v", value];
+      if (value == null) return ["null"];
+      if (typeof value === "number" && !isFinite(value)) {
+        return ["special", String(value)]; // "NaN", "Infinity", "-Infinity"
+      }
+      return ["v", value];
     });
     const key = JSON.stringify(keyParts);
 


### PR DESCRIPTION
Replace the delimiter-join group key strategy in `groupRowsBy` with `JSON.stringify` over typed per-field tuples. This prevents distinct row value-combinations from being merged into the same group when a field value contains the old `|||` delimiter or the strings `"null"`/`"__NULL__"`.

## Changes

- **`groupRowsBy`** (`compute-preview.ts`): replace `keyParts.join("|||")` with `JSON.stringify` over `["null"]` | `["v", value]` typed tuples per field. Each field now uses `field.columnName ?? field.id` as the row lookup key so fields without `columnName` participate in grouping instead of silently collapsing to null.
- **`extractGroupKeys`** (`compute-preview.ts`): same `field.columnName ?? field.id` fallback so virtual/computed fields appear in the output row (previously silently dropped).
- **`compute-preview.test.ts`** (new): 8 tests covering delimiter collision, null/sentinel collision, columnName-absent participation, and clean-value regression.

## Screenshots

No UI change — compute correctness fix.

## Verification

- `bun run test` in `packages/app`: 404 tests pass (8 new)
- `bun run typecheck`: clean across all packages
- `bun run lint`: clean
- `bun run format:check`: clean
- `bun run check:ticket-refs`: no ticket refs in source

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the fragile `|||`-delimiter-join group key strategy in `groupRowsBy` and `extractGroupKeys` with typed tuples serialized via `JSON.stringify`, eliminating delimiter collisions, null/sentinel collisions, and the silent dropping of fields without `columnName`.

- **`groupRowsBy`**: key encoding now dispatches on runtime type — `[\"null\"]` for null/undefined, `[\"num\", str]` for non-finite numbers, `[\"bigint\", str]` for BigInt, and `[\"v\", value]` for everything else — and uses `field.columnName ?? field.name` for row lookup so virtual/computed fields participate in grouping.
- **`extractGroupKeys`**: adopts the same `columnName ?? name` fallback so virtual fields are no longer silently omitted from the output row.
- **`compute-preview.test.ts`** (new): eight focused tests cover delimiter collision, null/sentinel distinction, undefined handling, NaN/±Infinity separation, BigInt grouping, cross-type isolation, and regression on clean values.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the key encoding is correct for every value type DuckDB produces, the NaN/Infinity edge case is properly handled, and all eight new tests pass.

The typed-tuple encoding is injective across all cases (null, NaN, ±Infinity, BigInt, string, finite number, boolean), no existing behavior is regressed, and the new tests directly exercise every former failure mode including the previously flagged NaN/Infinity collapse.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/lib/insights/compute-preview.ts | Replaces the delimiter-join key strategy with typed tuple encoding; handles all DuckDB-producible value types (null, NaN, Infinity, BigInt, string, number, boolean) without collision or throw. Logic is correct. |
| packages/app/src/lib/insights/compute-preview.test.ts | New test file with eight tests covering every fixed invariant: delimiter collision, null/sentinel/undefined distinction, NaN and ±Infinity isolation, BigInt grouping and cross-type separation, columnName-absent participation, and grand-total mode regression. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Row value] --> B{value == null or undefined?}
    B -- Yes --> C[tag: null]
    B -- No --> D{typeof value === bigint?}
    D -- Yes --> E[tag: bigint str]
    D -- No --> F{typeof value === number and not isFinite?}
    F -- Yes --> G[tag: num str - NaN Infinity -Infinity]
    F -- No --> H[tag: v value - string finite number boolean]
    C --> I[JSON.stringify all field tags to group key]
    E --> I
    G --> I
    H --> I
    I --> J{Key in groupMap?}
    J -- No --> K[Create new group]
    J -- Yes --> L[Append row to existing group]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(app): total injective group key enco..."](https://github.com/youhaowei/dashframe/commit/6e8c4f995efdc98e75504577144b899e1116153a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37447431)</sub>

<!-- /greptile_comment -->