### PR TITLE
feat(app): render dashboard cells with their per-cell overrides applied

### DIFF
--- a/packages/app/src/components/dashboards/DashboardItem.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.tsx
@@ -95,7 +95,10 @@ export function DashboardItem({
             />
           ) : (
             <div className="h-full w-full">
-              <VisualizationDisplay visualizationId={item.visualizationId} />
+              <VisualizationDisplay
+                visualizationId={item.visualizationId}
+                overrides={item.overrides}
+              />
             </div>
           )}
         </div>

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -126,8 +126,11 @@ export function VisualizationDisplay({
     return dataTables.find((t) => t.id === insight.baseTableId);
   }, [insight, dataTables]);
 
-  // Build an Insight-compatible object for useInsightView
-  // This transforms the store insight format to what useInsightView expects
+  // Build an Insight-compatible object for useInsightView.
+  // Only structural fields (id, name, baseTableId, joins, selectedFields, metrics,
+  // filters, sorts) — everything buildInsightSQL reads from the insight param.
+  // Filters and sorts are included so that useInsightPagination (query mode)
+  // applies the insight's own defaults when there are no cell overrides.
   const insightForView: Insight | null = useMemo(() => {
     if (!insight) return null;
     return {
@@ -135,19 +138,20 @@ export function VisualizationDisplay({
       name: insight.name,
       baseTableId: insight.baseTableId,
       joins: insight.joins,
-      // Include filters/sorts so effective params can be resolved against them
+      selectedFields: insight.selectedFields,
+      metrics: insight.metrics,
       filters: insight.filters,
       sorts: insight.sorts,
     } as Insight;
   }, [insight]);
 
   // Resolve the effective params for this cell = insight defaults ⊕ overrides.
-  // When `overrides` is absent this is a fast no-op: the result is a clone of
-  // the insight's own filters/sorts/limit with no cell-specific change (no-override
-  // no-regression path).
+  // Only computed when overrides are present.  When absent, both hooks get
+  // `effectiveParams: undefined` and use the insight's native filters/sorts —
+  // preserving the pre-override behaviour exactly (no-override no-regression).
   const effectiveParams = useMemo(
     () =>
-      insightForView
+      overrides && insightForView
         ? resolveEffectiveParams(
             insightForView.filters,
             insightForView.sorts,
@@ -165,22 +169,24 @@ export function VisualizationDisplay({
   // the loopback server stopped or returned 500). Without consuming it here the
   // view never becomes ready and the component would spin forever.
   //
-  // When the cell has overrides, we pass the effectiveParams so the view is
-  // pre-filtered.  Cells without overrides skip this (effectiveParams has no
-  // filters when overrides is absent) and get the standard unfiltered view.
+  // Effective params are forwarded to useInsightView when overrides exist so that
+  // the chart view is pre-filtered/limited.  useInsightView internally strips metric
+  // filters (which require HAVING and cannot be applied in model-mode views) before
+  // building the DuckDB view SQL.
   const {
     viewName: insightViewName,
     isReady: isInsightViewReady,
     error: insightViewError,
     nativeCapable,
   } = useInsightView(insightForView, {
-    effectiveParams:
-      overrides && effectiveParams?.filters.length
-        ? effectiveParams
-        : undefined,
+    effectiveParams,
   });
 
-  // Use insight pagination for table data (queries DuckDB directly)
+  // Use insight pagination for table data (queries DuckDB directly).
+  // When overrides are present, effectiveParams carries the merged filter/sort/limit
+  // and buildInsightSQL replaces the insight's own params with them.
+  // When absent, effectiveParams is undefined and buildInsightSQL reads
+  // insight.filters/sorts natively — byte-identical to the pre-override path.
   const {
     fetchData,
     totalCount,
@@ -191,9 +197,7 @@ export function VisualizationDisplay({
     insight: insightForView ?? ({} as Insight),
     showModelPreview: false, // Apply full insight transformations
     enabled: !!insightForView, // Only enable when we have an insight
-    // Pass effective params when overrides are present so the table also reflects
-    // the per-cell filter/sort/limit.
-    effectiveParams: overrides ? effectiveParams : undefined,
+    effectiveParams,
   });
 
   // Helper to calculate visible rows from container dimensions

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -3,8 +3,17 @@ import { useDuckDBContext } from "@/components/providers/DuckDBProvider";
 import { useInsightPagination } from "@/hooks/useInsightPagination";
 import { useInsightView } from "@/hooks/useInsightView";
 import { useDataTables, useInsights, useVisualizations } from "@dashframe/core";
-import { getMetricDisplayLabel, resolveEncodingToSql } from "@dashframe/engine";
-import type { ChartEncoding, Insight, Visualization } from "@dashframe/types";
+import {
+  getMetricDisplayLabel,
+  resolveEffectiveParams,
+  resolveEncodingToSql,
+} from "@dashframe/engine";
+import type {
+  ChartEncoding,
+  DashboardItemOverrides,
+  Insight,
+  Visualization,
+} from "@dashframe/types";
 import { parseEncoding } from "@dashframe/types";
 import { VirtualTable, type VirtualTableColumnConfig } from "@dashframe/ui";
 import {
@@ -61,8 +70,16 @@ const MIN_VISIBLE_ROWS_FOR_BOTH = 5;
 
 export function VisualizationDisplay({
   visualizationId,
+  overrides,
 }: {
   visualizationId?: string;
+  /**
+   * Per-cell param overrides from the dashboard item.  When present, the
+   * rendered chart and table reflect `insight ⊕ cellOverride` rather than
+   * the raw insight defaults.  Absent → no change (identical to pre-override
+   * behaviour, satisfying the no-override no-regression constraint).
+   */
+  overrides?: DashboardItemOverrides;
 }) {
   // Whole-engine-down signals. `engineError` is the native bootstrap failure
   // (connector never came up); `visualizationError` is the provider failing to
@@ -118,8 +135,28 @@ export function VisualizationDisplay({
       name: insight.name,
       baseTableId: insight.baseTableId,
       joins: insight.joins,
+      // Include filters/sorts so effective params can be resolved against them
+      filters: insight.filters,
+      sorts: insight.sorts,
     } as Insight;
   }, [insight]);
+
+  // Resolve the effective params for this cell = insight defaults ⊕ overrides.
+  // When `overrides` is absent this is a fast no-op: the result is a clone of
+  // the insight's own filters/sorts/limit with no cell-specific change (no-override
+  // no-regression path).
+  const effectiveParams = useMemo(
+    () =>
+      insightForView
+        ? resolveEffectiveParams(
+            insightForView.filters,
+            insightForView.sorts,
+            undefined, // insight-level limit (not stored on Insight type yet)
+            overrides,
+          )
+        : undefined,
+    [insightForView, overrides],
+  );
 
   // Use insight view hook to get the proper table name (handles joins).
   // `nativeCapable` is false when any DataFrame uses non-indexeddb storage —
@@ -127,12 +164,21 @@ export function VisualizationDisplay({
   // `error` surfaces a post-bootstrap failure (e.g. native upload failed because
   // the loopback server stopped or returned 500). Without consuming it here the
   // view never becomes ready and the component would spin forever.
+  //
+  // When the cell has overrides, we pass the effectiveParams so the view is
+  // pre-filtered.  Cells without overrides skip this (effectiveParams has no
+  // filters when overrides is absent) and get the standard unfiltered view.
   const {
     viewName: insightViewName,
     isReady: isInsightViewReady,
     error: insightViewError,
     nativeCapable,
-  } = useInsightView(insightForView);
+  } = useInsightView(insightForView, {
+    effectiveParams:
+      overrides && effectiveParams?.filters.length
+        ? effectiveParams
+        : undefined,
+  });
 
   // Use insight pagination for table data (queries DuckDB directly)
   const {
@@ -145,6 +191,9 @@ export function VisualizationDisplay({
     insight: insightForView ?? ({} as Insight),
     showModelPreview: false, // Apply full insight transformations
     enabled: !!insightForView, // Only enable when we have an insight
+    // Pass effective params when overrides are present so the table also reflects
+    // the per-cell filter/sort/limit.
+    effectiveParams: overrides ? effectiveParams : undefined,
   });
 
   // Helper to calculate visible rows from container dimensions

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -127,10 +127,15 @@ export function VisualizationDisplay({
   }, [insight, dataTables]);
 
   // Build an Insight-compatible object for useInsightView.
-  // Only structural fields (id, name, baseTableId, joins, selectedFields, metrics,
-  // filters, sorts) — everything buildInsightSQL reads from the insight param.
-  // Filters and sorts are included so that useInsightPagination (query mode)
-  // applies the insight's own defaults when there are no cell overrides.
+  // IMPORTANT: this is intentionally the minimal structural shape
+  // (id, name, baseTableId, joins) — exactly as the pre-override path.  It must
+  // NOT carry selectedFields/metrics/filters/sorts: this surface renders the
+  // RAW model view (vgplot computes aggregations from raw rows via the encoding),
+  // and useInsightPagination below queries the same raw model. Adding
+  // metrics/selectedFields here would make pagination emit aggregated/metric
+  // columns that don't exist in the raw model view the chart queries, breaking
+  // chart column resolution.  Cell overrides are layered separately via
+  // effectiveParams, which is undefined unless `overrides` is present.
   const insightForView: Insight | null = useMemo(() => {
     if (!insight) return null;
     return {
@@ -138,28 +143,25 @@ export function VisualizationDisplay({
       name: insight.name,
       baseTableId: insight.baseTableId,
       joins: insight.joins,
-      selectedFields: insight.selectedFields,
-      metrics: insight.metrics,
-      filters: insight.filters,
-      sorts: insight.sorts,
     } as Insight;
   }, [insight]);
 
   // Resolve the effective params for this cell = insight defaults ⊕ overrides.
   // Only computed when overrides are present.  When absent, both hooks get
-  // `effectiveParams: undefined` and use the insight's native filters/sorts —
-  // preserving the pre-override behaviour exactly (no-override no-regression).
+  // `effectiveParams: undefined` and follow the exact pre-override path
+  // (no-override no-regression).  The insight's own filters/sorts come from the
+  // raw Dexie `insight` object, not `insightForView` (which is kept minimal).
   const effectiveParams = useMemo(
     () =>
-      overrides && insightForView
+      overrides && insight
         ? resolveEffectiveParams(
-            insightForView.filters,
-            insightForView.sorts,
+            insight.filters,
+            insight.sorts,
             undefined, // insight-level limit (not stored on Insight type yet)
             overrides,
           )
         : undefined,
-    [insightForView, overrides],
+    [insight, overrides],
   );
 
   // Use insight view hook to get the proper table name (handles joins).

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -322,18 +322,35 @@ export function useInsightPagination({
 
         // Build SQL with pagination.
         // Inject effective params (per-cell overrides) when available.
+        // effectiveLimit caps the total result set — it is NOT the page fetch
+        // size.  We clamp the page fetch to the remaining rows after offset so
+        // VirtualTable never reads past the cell limit, while still fetching one
+        // page at a time (no memory blowup from fetching all rows at once).
         const mode = showModelPreview ? "model" : "query";
+        const cellLimit =
+          !showModelPreview && effectiveParams?.limit !== undefined
+            ? effectiveParams.limit
+            : undefined;
+        const pageLimit =
+          cellLimit !== undefined
+            ? Math.min(
+                params.limit,
+                Math.max(0, cellLimit - (params.offset ?? 0)),
+              )
+            : params.limit;
         const overrideOpts =
           !showModelPreview && effectiveParams
             ? {
                 effectiveFilters: effectiveParams.filters,
                 effectiveSorts: effectiveParams.sorts,
-                effectiveLimit: effectiveParams.limit,
+                // Do NOT forward effectiveLimit here — pagination limit is
+                // already clamped to the cell limit via pageLimit above.
+                // Forwarding it would replace the page size with the cell cap.
               }
             : {};
         const sql = buildInsightSQL(baseTable, joinedTables, insight, {
           mode,
-          limit: params.limit,
+          limit: pageLimit,
           offset: params.offset,
           sortColumn: params.sortColumn,
           sortDirection: params.sortDirection,

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -1,5 +1,6 @@
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame, getDataTable } from "@dashframe/core";
+import type { EffectiveParams } from "@dashframe/engine";
 import {
   buildInsightSQL,
   fieldIdToColumnAlias,
@@ -29,6 +30,14 @@ export interface UseInsightPaginationOptions {
    * @default true
    */
   enabled?: boolean;
+  /**
+   * Pre-resolved effective params from `resolveEffectiveParams` (cell overrides
+   * coalesced with insight defaults).  When supplied, these filters/sorts/limit
+   * are used INSTEAD of `insight.filters/sorts` — the insight is not mutated.
+   *
+   * Absent → the standard insight query behaviour (no change).
+   */
+  effectiveParams?: EffectiveParams;
 }
 
 /**
@@ -61,6 +70,7 @@ export function useInsightPagination({
   insight,
   showModelPreview = false,
   enabled = true,
+  effectiveParams,
 }: UseInsightPaginationOptions) {
   const { connection, isInitialized, isLoading: isDuckDBLoading } = useDuckDB();
 
@@ -210,10 +220,21 @@ export function useInsightPagination({
           return;
         }
 
-        // Build SQL for count query
+        // Build SQL for count query.
+        // When effective params are supplied (per-cell overrides), inject them
+        // so the count reflects the overridden filters/limit.
         const mode = showModelPreview ? "model" : "query";
+        const overrideOptions =
+          !showModelPreview && effectiveParams
+            ? {
+                effectiveFilters: effectiveParams.filters,
+                effectiveSorts: effectiveParams.sorts,
+                effectiveLimit: effectiveParams.limit,
+              }
+            : {};
         const countSQL = buildInsightSQL(baseTable, joinedTables, insight, {
           mode,
+          ...overrideOptions,
         });
 
         if (!countSQL) {
@@ -232,6 +253,7 @@ export function useInsightPagination({
         const previewSQL = buildInsightSQL(baseTable, joinedTables, insight, {
           mode,
           limit: 1,
+          ...overrideOptions,
         });
 
         if (previewSQL) {
@@ -270,6 +292,7 @@ export function useInsightPagination({
     insight,
     showModelPreview,
     enabled,
+    effectiveParams,
     resolveTables,
     loadDataFrames,
   ]);
@@ -297,14 +320,24 @@ export function useInsightPagination({
         // Ensure DataFrames are loaded (idempotent)
         await loadDataFrames(baseTable, joinedTables);
 
-        // Build SQL with pagination
+        // Build SQL with pagination.
+        // Inject effective params (per-cell overrides) when available.
         const mode = showModelPreview ? "model" : "query";
+        const overrideOpts =
+          !showModelPreview && effectiveParams
+            ? {
+                effectiveFilters: effectiveParams.filters,
+                effectiveSorts: effectiveParams.sorts,
+                effectiveLimit: effectiveParams.limit,
+              }
+            : {};
         const sql = buildInsightSQL(baseTable, joinedTables, insight, {
           mode,
           limit: params.limit,
           offset: params.offset,
           sortColumn: params.sortColumn,
           sortDirection: params.sortDirection,
+          ...overrideOpts,
         });
 
         if (!sql) {
@@ -326,6 +359,7 @@ export function useInsightPagination({
       isDuckDBLoading,
       insight,
       showModelPreview,
+      effectiveParams,
       resolveTables,
       loadDataFrames,
       totalCount,

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -13,7 +13,6 @@ import type {
   Insight,
   InsightFilter,
   InsightMetric,
-  InsightSort,
   UUID,
 } from "@dashframe/types";
 import { useEffect, useState } from "react";
@@ -112,18 +111,27 @@ function stripMetricFilters(
 }
 
 /**
- * Build the effective-override fields for a model-mode chart view SQL call,
- * stripping metric filters (they require HAVING, incompatible with model mode).
+ * Build the effective-override fields for a model-mode chart view SQL call.
+ *
+ * Only filters are forwarded — and metric filters are stripped (they require
+ * HAVING, incompatible with model mode).  Two things are deliberately NOT
+ * forwarded to the chart view:
+ *
+ * - `effectiveLimit`: the Chart (vgplot/Mosaic) builds its own GROUP BY
+ *   aggregation against this view (e.g. `SELECT region, SUM(sales) … GROUP BY
+ *   region`).  A `LIMIT N` in the view definition caps the RAW input rows
+ *   before aggregation, silently dropping groups and producing wrong totals.
+ *   The cell limit applies only to the VirtualTable pagination path
+ *   (`useInsightPagination`), which enforces it correctly.
+ * - `effectiveSorts`: GROUP BY ignores input row order, so a sort on the raw
+ *   model view has no effect on the aggregated chart output. Sort overrides are
+ *   applied in the pagination/table path only.
  */
 function buildViewSQLOptions(
   effectiveFilters: InsightFilter[] | null,
-  effectiveSorts: InsightSort[] | undefined,
-  effectiveLimit: number | undefined,
   metrics: InsightMetric[],
 ): {
   effectiveFilters?: InsightFilter[];
-  effectiveSorts?: InsightSort[];
-  effectiveLimit?: number;
 } {
   const viewFilters =
     effectiveFilters !== null
@@ -134,8 +142,6 @@ function buildViewSQLOptions(
       viewFilters.length > 0 && {
         effectiveFilters: viewFilters,
       }),
-    ...(effectiveSorts?.length && { effectiveSorts }),
-    ...(effectiveLimit !== undefined && { effectiveLimit }),
   };
 }
 
@@ -212,17 +218,16 @@ export function useInsightView(
   const { connector, uploadArrowTable } = useChartEngine();
 
   // Stable key for the effective params so the cache differentiates cells that
-  // share the same insight but have distinct overrides.  Includes filters, sorts,
-  // and limit so every distinct override combination gets its own cached view.
+  // share the same insight but have distinct overrides.  Keyed on FILTERS ONLY:
+  // sorts and limit are intentionally NOT applied to the model-mode chart view
+  // (sorts don't affect GROUP BY output; limit would wrongly cap pre-aggregation
+  // rows — see buildViewSQLOptions), so two cells that differ only in sort/limit
+  // share the same view.
   //
   // Serialising to a string produces a primitive that is safe to use in dep
   // arrays without the non-simple-expression lint error.
-  const effectiveParamsKey = effectiveParams
-    ? JSON.stringify({
-        f: effectiveParams.filters,
-        s: effectiveParams.sorts,
-        l: effectiveParams.limit,
-      })
+  const effectiveFiltersKey = effectiveParams?.filters?.length
+    ? JSON.stringify(effectiveParams.filters)
     : null;
 
   // Extract stable dependencies from insight object BEFORE state
@@ -241,10 +246,10 @@ export function useInsightView(
     : null;
 
   // Compute config key for cache lookup.
-  // Incorporates all override dimensions (filters + sorts + limit) so that each
-  // distinct override combination on the same insight gets its own cached view.
+  // Keyed on the effective FILTERS only (the only override dimension that changes
+  // the model-mode view); cells differing only in sort/limit reuse one view.
   const configKey = insightId
-    ? `${insightId}:${joinsKey}:${effectiveParamsKey ?? ""}`
+    ? `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`
     : null;
 
   // Check module-level cache for existing view (survives Strict Mode remounts)
@@ -336,10 +341,10 @@ export function useInsightView(
     // Capture stable values at effect start (insight object may change during async)
     const joins = insight?.joins ?? [];
     const insightMetrics = insight?.metrics ?? [];
-    // Snapshot effective params for this view (null = no override = unfiltered model view)
+    // Snapshot effective filters for this view (null = no override = unfiltered
+    // model view).  Sorts/limit are NOT applied to the chart view — see
+    // buildViewSQLOptions — so only filters are snapshotted here.
     const snapshotEffectiveFilters = effectiveParams?.filters ?? null;
-    const snapshotEffectiveSorts = effectiveParams?.sorts;
-    const snapshotEffectiveLimit = effectiveParams?.limit;
 
     const createView = async () => {
       try {
@@ -444,12 +449,7 @@ export function useInsightView(
           { joins, metrics: insightMetrics } as Insight,
           {
             mode: "model",
-            ...buildViewSQLOptions(
-              snapshotEffectiveFilters,
-              snapshotEffectiveSorts,
-              snapshotEffectiveLimit,
-              insightMetrics,
-            ),
+            ...buildViewSQLOptions(snapshotEffectiveFilters, insightMetrics),
           },
         );
 
@@ -460,19 +460,17 @@ export function useInsightView(
           return;
         }
 
-        // View name: base insight view for the unfiltered/unoverridden case.
-        // When any effective override is present (filters, sorts, or limit),
-        // append a collision-free base64url suffix derived from the full params
-        // so each distinct override combination gets its own view in DuckDB.
+        // View name: base insight view for the unfiltered case.  When effective
+        // filters are present (cell override), append a collision-free base64url
+        // suffix derived from the filters so each distinct filtered subset gets
+        // its own view in DuckDB.  Sorts/limit don't affect the view, so they are
+        // not part of the name.
         const idSafe = insightId.replace(/-/g, "_");
-        const hasOverride =
-          (snapshotEffectiveFilters !== null &&
-            snapshotEffectiveFilters.length > 0) ||
-          (snapshotEffectiveSorts !== undefined &&
-            snapshotEffectiveSorts.length > 0) ||
-          snapshotEffectiveLimit !== undefined;
-        const newViewName = hasOverride
-          ? `insight_view_${idSafe}_cell_${toViewSuffix(JSON.stringify({ f: snapshotEffectiveFilters, s: snapshotEffectiveSorts, l: snapshotEffectiveLimit }))}`
+        const hasFilterOverride =
+          snapshotEffectiveFilters !== null &&
+          snapshotEffectiveFilters.length > 0;
+        const newViewName = hasFilterOverride
+          ? `insight_view_${idSafe}_cell_${toViewSuffix(JSON.stringify(snapshotEffectiveFilters))}`
           : `insight_view_${idSafe}`;
         const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${sql}`;
         await connection.query(createViewSql);
@@ -515,7 +513,7 @@ export function useInsightView(
     // - Do NOT include `isReady` (would create feedback loop when we setIsReady)
     // - `joinsKey` is a serialized representation of `insight.joins`, so we don't need `insight.joins` directly
     // - `connector`/`uploadArrowTable` are stable (set once at bootstrap)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveParamsKey track insight.joins/overrides changes; connector/uploadArrowTable are stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveFiltersKey track insight.joins/overrides changes; connector/uploadArrowTable are stable
   }, [
     connection,
     isInitialized,
@@ -524,7 +522,7 @@ export function useInsightView(
     baseTableId,
     joinsKey,
     configKey,
-    effectiveParamsKey, // re-run when the cell's override params change
+    effectiveFiltersKey, // re-run when the cell's filter override changes
     connector,
     uploadArrowTable,
   ]);

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -7,7 +7,15 @@ import {
   ensureTableLoaded,
   loadArrowData,
 } from "@dashframe/engine-browser";
-import type { DataFrame, DataTable, Insight, UUID } from "@dashframe/types";
+import type {
+  DataFrame,
+  DataTable,
+  Insight,
+  InsightFilter,
+  InsightMetric,
+  InsightSort,
+  UUID,
+} from "@dashframe/types";
 import { useEffect, useState } from "react";
 
 /**
@@ -78,23 +86,73 @@ export function getCachedViewName(insightId: string): string | null {
 }
 
 /**
- * Encode an array of InsightFilters as a URL-safe base64 string.
+ * Returns true when the filter references a metric column or alias.
  *
- * Used to generate a SQL-safe view name suffix for per-cell filtered views so
+ * Metric filters require HAVING in query mode (post-aggregation), which is
+ * incompatible with model-mode DuckDB views (no aggregation is performed).
+ * Extracting the check to a module-level predicate keeps `createView` within
+ * the sonarjs cognitive-complexity budget.
+ */
+function isMetricField(field: string, metrics: InsightMetric[]): boolean {
+  return metrics.some(
+    (m) =>
+      m.columnName === field || `metric_${m.id.replace(/-/g, "_")}` === field,
+  );
+}
+
+/**
+ * Strip metric filters from an effective-filter list so the remaining filters
+ * are safe to apply in model mode (WHERE only, no aggregation / HAVING).
+ */
+function stripMetricFilters(
+  filters: InsightFilter[],
+  metrics: InsightMetric[],
+): InsightFilter[] {
+  return filters.filter((f) => !isMetricField(f.field, metrics));
+}
+
+/**
+ * Build the effective-override fields for a model-mode chart view SQL call,
+ * stripping metric filters (they require HAVING, incompatible with model mode).
+ */
+function buildViewSQLOptions(
+  effectiveFilters: InsightFilter[] | null,
+  effectiveSorts: InsightSort[] | undefined,
+  effectiveLimit: number | undefined,
+  metrics: InsightMetric[],
+): {
+  effectiveFilters?: InsightFilter[];
+  effectiveSorts?: InsightSort[];
+  effectiveLimit?: number;
+} {
+  const viewFilters =
+    effectiveFilters !== null
+      ? stripMetricFilters(effectiveFilters, metrics)
+      : null;
+  return {
+    ...(viewFilters !== null &&
+      viewFilters.length > 0 && {
+        effectiveFilters: viewFilters,
+      }),
+    ...(effectiveSorts?.length && { effectiveSorts }),
+    ...(effectiveLimit !== undefined && { effectiveLimit }),
+  };
+}
+
+/**
+ * Encode an arbitrary string payload as a URL-safe base64 (base64url) suffix.
+ *
+ * Used to generate SQL-safe view name suffixes for per-cell override views so
  * that two dashboard cells on the same insight with DIFFERENT overrides always
  * map to two distinct DuckDB views (collision-free by construction: the suffix
- * IS the serialised filter payload, not a lossy hash of it).
+ * IS the serialised payload, not a lossy hash of it).
  *
- * Characters that are illegal in DuckDB quoted identifiers (`"`) are already
- * excluded from base64url, so the suffix is safe to embed directly in the view
- * name string.
+ * base64url characters (+/=) are already excluded from valid DuckDB identifiers,
+ * so the suffix is safe to embed directly inside quoted view name strings.
  */
-function filtersToViewSuffix(
-  filters: { field: string; operator: string; value: unknown }[],
-): string {
-  const str = JSON.stringify(filters);
+function toViewSuffix(payload: string): string {
   // btoa operates on binary strings; TextEncoder gives us the UTF-8 bytes first.
-  const bytes = new TextEncoder().encode(str);
+  const bytes = new TextEncoder().encode(payload);
   // Use Array.from to avoid a spread-argument RangeError on large payloads
   // (V8/Bun cap spread args at ~65 536; a filter with many long strings can exceed it).
   const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
@@ -154,14 +212,17 @@ export function useInsightView(
   const { connector, uploadArrowTable } = useChartEngine();
 
   // Stable key for the effective params so the cache differentiates cells that
-  // share the same insight but have distinct overrides.  We only include the
-  // filters here (sorts/limit don't affect which DuckDB view is needed for a
-  // Chart — those are applied in the pagination / query path).
+  // share the same insight but have distinct overrides.  Includes filters, sorts,
+  // and limit so every distinct override combination gets its own cached view.
   //
   // Serialising to a string produces a primitive that is safe to use in dep
   // arrays without the non-simple-expression lint error.
-  const effectiveFiltersKey = effectiveParams?.filters?.length
-    ? JSON.stringify(effectiveParams.filters)
+  const effectiveParamsKey = effectiveParams
+    ? JSON.stringify({
+        f: effectiveParams.filters,
+        s: effectiveParams.sorts,
+        l: effectiveParams.limit,
+      })
     : null;
 
   // Extract stable dependencies from insight object BEFORE state
@@ -180,10 +241,10 @@ export function useInsightView(
     : null;
 
   // Compute config key for cache lookup.
-  // When effective filters are present, incorporate them so cells with distinct
-  // overrides on the same insight get their own cached view.
+  // Incorporates all override dimensions (filters + sorts + limit) so that each
+  // distinct override combination on the same insight gets its own cached view.
   const configKey = insightId
-    ? `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`
+    ? `${insightId}:${joinsKey}:${effectiveParamsKey ?? ""}`
     : null;
 
   // Check module-level cache for existing view (survives Strict Mode remounts)
@@ -274,8 +335,11 @@ export function useInsightView(
 
     // Capture stable values at effect start (insight object may change during async)
     const joins = insight?.joins ?? [];
-    // Snapshot effective filters for this view (null = no override = unfiltered model view)
+    const insightMetrics = insight?.metrics ?? [];
+    // Snapshot effective params for this view (null = no override = unfiltered model view)
     const snapshotEffectiveFilters = effectiveParams?.filters ?? null;
+    const snapshotEffectiveSorts = effectiveParams?.sorts;
+    const snapshotEffectiveLimit = effectiveParams?.limit;
 
     const createView = async () => {
       try {
@@ -372,18 +436,20 @@ export function useInsightView(
         );
 
         // Build SQL for the model (all columns, no aggregation).
-        // When the cell has effective filters (from per-cell overrides), pass
-        // them so the view is pre-filtered for the Chart.  No override = the
-        // standard unfiltered model view (identical to pre-override behaviour).
+        // Metric filters are stripped (they require HAVING, incompatible with
+        // model mode); they still apply in useInsightPagination query mode.
         const sql = buildInsightSQL(
           baseTable,
           joinedTables,
-          { joins } as Insight,
+          { joins, metrics: insightMetrics } as Insight,
           {
             mode: "model",
-            ...(snapshotEffectiveFilters !== null && {
-              effectiveFilters: snapshotEffectiveFilters,
-            }),
+            ...buildViewSQLOptions(
+              snapshotEffectiveFilters,
+              snapshotEffectiveSorts,
+              snapshotEffectiveLimit,
+              insightMetrics,
+            ),
           },
         );
 
@@ -394,16 +460,20 @@ export function useInsightView(
           return;
         }
 
-        // View name: base insight view for the unfiltered case.  When effective
-        // filters are present (cell override), append a short hash of the filter
-        // JSON so each distinct override set gets its own view in DuckDB.
-        // Using a hash keeps the name SQL-safe and collision-resistant.
+        // View name: base insight view for the unfiltered/unoverridden case.
+        // When any effective override is present (filters, sorts, or limit),
+        // append a collision-free base64url suffix derived from the full params
+        // so each distinct override combination gets its own view in DuckDB.
         const idSafe = insightId.replace(/-/g, "_");
-        const newViewName =
-          snapshotEffectiveFilters !== null &&
-          snapshotEffectiveFilters.length > 0
-            ? `insight_view_${idSafe}_cell_${filtersToViewSuffix(snapshotEffectiveFilters)}`
-            : `insight_view_${idSafe}`;
+        const hasOverride =
+          (snapshotEffectiveFilters !== null &&
+            snapshotEffectiveFilters.length > 0) ||
+          (snapshotEffectiveSorts !== undefined &&
+            snapshotEffectiveSorts.length > 0) ||
+          snapshotEffectiveLimit !== undefined;
+        const newViewName = hasOverride
+          ? `insight_view_${idSafe}_cell_${toViewSuffix(JSON.stringify({ f: snapshotEffectiveFilters, s: snapshotEffectiveSorts, l: snapshotEffectiveLimit }))}`
+          : `insight_view_${idSafe}`;
         const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${sql}`;
         await connection.query(createViewSql);
 
@@ -445,7 +515,7 @@ export function useInsightView(
     // - Do NOT include `isReady` (would create feedback loop when we setIsReady)
     // - `joinsKey` is a serialized representation of `insight.joins`, so we don't need `insight.joins` directly
     // - `connector`/`uploadArrowTable` are stable (set once at bootstrap)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveFiltersKey track insight.joins/overrides changes; connector/uploadArrowTable are stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveParamsKey track insight.joins/overrides changes; connector/uploadArrowTable are stable
   }, [
     connection,
     isInitialized,
@@ -454,7 +524,7 @@ export function useInsightView(
     baseTableId,
     joinsKey,
     configKey,
-    effectiveFiltersKey, // re-run when the cell's overridden filters change
+    effectiveParamsKey, // re-run when the cell's override params change
     connector,
     uploadArrowTable,
   ]);

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -1,6 +1,7 @@
 import { useChartEngine } from "@/components/providers/ChartEngineProvider";
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame, getDataTable } from "@dashframe/core";
+import type { EffectiveParams } from "@dashframe/engine";
 import {
   buildInsightSQL,
   ensureTableLoaded,
@@ -77,6 +78,27 @@ export function getCachedViewName(insightId: string): string | null {
 }
 
 /**
+ * Produce a short (8-char) hex digest of an array of InsightFilters.
+ *
+ * Used to generate a SQL-safe view name suffix for per-cell filtered views so
+ * that two dashboard cells on the same insight with DIFFERENT overrides map to
+ * two distinct DuckDB views instead of colliding on `insight_view_<id>`.
+ *
+ * Not a crypto hash — just a stable deterministic djb2 string hash sufficient
+ * for naming uniqueness within a session.
+ */
+function hashFilters(
+  filters: { field: string; operator: string; value: unknown }[],
+): string {
+  const str = JSON.stringify(filters);
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h + str.charCodeAt(i)) >>> 0; // djb2, unsigned 32-bit
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+/**
  * Hook to create a DuckDB view for an Insight.
  *
  * Always creates a view named `insight_view_<insightId>` using buildInsightSQL().
@@ -104,9 +126,39 @@ export function getCachedViewName(insightId: string): string | null {
  * ) : null;
  * ```
  */
-export function useInsightView(insight: Insight | null | undefined) {
+/**
+ * Options for `useInsightView`.
+ */
+export interface UseInsightViewOptions {
+  /**
+   * Pre-resolved effective params from `resolveEffectiveParams` (cell overrides
+   * coalesced with insight defaults).  When supplied, the view is built with
+   * these filters/sorts/limit applied — the insight object itself is not mutated.
+   *
+   * Absent → the standard model-mode view (no filters) is created, identical to
+   * the pre-override behaviour.
+   */
+  effectiveParams?: EffectiveParams;
+}
+
+export function useInsightView(
+  insight: Insight | null | undefined,
+  options: UseInsightViewOptions = {},
+) {
+  const { effectiveParams } = options;
   const { connection, isInitialized, isLoading: isDuckDBLoading } = useDuckDB();
   const { connector, uploadArrowTable } = useChartEngine();
+
+  // Stable key for the effective params so the cache differentiates cells that
+  // share the same insight but have distinct overrides.  We only include the
+  // filters here (sorts/limit don't affect which DuckDB view is needed for a
+  // Chart — those are applied in the pagination / query path).
+  //
+  // Serialising to a string produces a primitive that is safe to use in dep
+  // arrays without the non-simple-expression lint error.
+  const effectiveFiltersKey = effectiveParams?.filters?.length
+    ? JSON.stringify(effectiveParams.filters)
+    : null;
 
   // Extract stable dependencies from insight object BEFORE state
   const insightId = insight?.id;
@@ -123,8 +175,12 @@ export function useInsightView(insight: Insight | null | undefined) {
       )
     : null;
 
-  // Compute config key for cache lookup
-  const configKey = insightId ? `${insightId}:${joinsKey}` : null;
+  // Compute config key for cache lookup.
+  // When effective filters are present, incorporate them so cells with distinct
+  // overrides on the same insight get their own cached view.
+  const configKey = insightId
+    ? `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`
+    : null;
 
   // Check module-level cache for existing view (survives Strict Mode remounts)
   const cachedView = configKey
@@ -212,8 +268,10 @@ export function useInsightView(insight: Insight | null | undefined) {
     // Mark this config as in-flight (module-level, survives unmount/remount)
     pendingRequests.add(configKey);
 
-    // Capture joins array from insight at effect start (insight may change during async)
+    // Capture stable values at effect start (insight object may change during async)
     const joins = insight?.joins ?? [];
+    // Snapshot effective filters for this view (null = no override = unfiltered model view)
+    const snapshotEffectiveFilters = effectiveParams?.filters ?? null;
 
     const createView = async () => {
       try {
@@ -309,16 +367,19 @@ export function useInsightView(insight: Insight | null | undefined) {
           }),
         );
 
-        // Build SQL for the model (all columns, no aggregation)
-        // Works for both simple insights and those with joins
-        // Note: We need insight for buildInsightSQL, but we only run this effect
-        // when the relevant primitives (insightId, baseTableId, joinsKey) change
+        // Build SQL for the model (all columns, no aggregation).
+        // When the cell has effective filters (from per-cell overrides), pass
+        // them so the view is pre-filtered for the Chart.  No override = the
+        // standard unfiltered model view (identical to pre-override behaviour).
         const sql = buildInsightSQL(
           baseTable,
           joinedTables,
           { joins } as Insight,
           {
             mode: "model",
+            ...(snapshotEffectiveFilters !== null && {
+              effectiveFilters: snapshotEffectiveFilters,
+            }),
           },
         );
 
@@ -329,8 +390,16 @@ export function useInsightView(insight: Insight | null | undefined) {
           return;
         }
 
-        // Always create a view with unique name based on insight ID
-        const newViewName = `insight_view_${insightId.replace(/-/g, "_")}`;
+        // View name: base insight view for the unfiltered case.  When effective
+        // filters are present (cell override), append a short hash of the filter
+        // JSON so each distinct override set gets its own view in DuckDB.
+        // Using a hash keeps the name SQL-safe and collision-resistant.
+        const idSafe = insightId.replace(/-/g, "_");
+        const newViewName =
+          snapshotEffectiveFilters !== null &&
+          snapshotEffectiveFilters.length > 0
+            ? `insight_view_${idSafe}_cell_${hashFilters(snapshotEffectiveFilters)}`
+            : `insight_view_${idSafe}`;
         const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${sql}`;
         await connection.query(createViewSql);
 
@@ -372,7 +441,7 @@ export function useInsightView(insight: Insight | null | undefined) {
     // - Do NOT include `isReady` (would create feedback loop when we setIsReady)
     // - `joinsKey` is a serialized representation of `insight.joins`, so we don't need `insight.joins` directly
     // - `connector`/`uploadArrowTable` are stable (set once at bootstrap)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey tracks insight.joins changes; connector/uploadArrowTable are stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveFiltersKey track insight.joins/overrides changes; connector/uploadArrowTable are stable
   }, [
     connection,
     isInitialized,
@@ -381,6 +450,7 @@ export function useInsightView(insight: Insight | null | undefined) {
     baseTableId,
     joinsKey,
     configKey,
+    effectiveFiltersKey, // re-run when the cell's overridden filters change
     connector,
     uploadArrowTable,
   ]);

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -95,7 +95,9 @@ function filtersToViewSuffix(
   const str = JSON.stringify(filters);
   // btoa operates on binary strings; TextEncoder gives us the UTF-8 bytes first.
   const bytes = new TextEncoder().encode(str);
-  const binary = String.fromCharCode(...bytes);
+  // Use Array.from to avoid a spread-argument RangeError on large payloads
+  // (V8/Bun cap spread args at ~65 536; a filter with many long strings can exceed it).
+  const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
   // Standard base64, then convert to base64url (replace +/ with -_ and strip =)
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -78,24 +78,26 @@ export function getCachedViewName(insightId: string): string | null {
 }
 
 /**
- * Produce a short (8-char) hex digest of an array of InsightFilters.
+ * Encode an array of InsightFilters as a URL-safe base64 string.
  *
  * Used to generate a SQL-safe view name suffix for per-cell filtered views so
- * that two dashboard cells on the same insight with DIFFERENT overrides map to
- * two distinct DuckDB views instead of colliding on `insight_view_<id>`.
+ * that two dashboard cells on the same insight with DIFFERENT overrides always
+ * map to two distinct DuckDB views (collision-free by construction: the suffix
+ * IS the serialised filter payload, not a lossy hash of it).
  *
- * Not a crypto hash — just a stable deterministic djb2 string hash sufficient
- * for naming uniqueness within a session.
+ * Characters that are illegal in DuckDB quoted identifiers (`"`) are already
+ * excluded from base64url, so the suffix is safe to embed directly in the view
+ * name string.
  */
-function hashFilters(
+function filtersToViewSuffix(
   filters: { field: string; operator: string; value: unknown }[],
 ): string {
   const str = JSON.stringify(filters);
-  let h = 5381;
-  for (let i = 0; i < str.length; i++) {
-    h = ((h << 5) + h + str.charCodeAt(i)) >>> 0; // djb2, unsigned 32-bit
-  }
-  return h.toString(16).padStart(8, "0");
+  // btoa operates on binary strings; TextEncoder gives us the UTF-8 bytes first.
+  const bytes = new TextEncoder().encode(str);
+  const binary = String.fromCharCode(...bytes);
+  // Standard base64, then convert to base64url (replace +/ with -_ and strip =)
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
 /**
@@ -398,7 +400,7 @@ export function useInsightView(
         const newViewName =
           snapshotEffectiveFilters !== null &&
           snapshotEffectiveFilters.length > 0
-            ? `insight_view_${idSafe}_cell_${hashFilters(snapshotEffectiveFilters)}`
+            ? `insight_view_${idSafe}_cell_${filtersToViewSuffix(snapshotEffectiveFilters)}`
             : `insight_view_${idSafe}`;
         const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${sql}`;
         await connection.query(createViewSql);

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -23,6 +23,7 @@ import type {
   InsightFilter,
   InsightFilterBetweenValue,
   InsightMetric,
+  InsightSort,
   UUID,
 } from "@dashframe/types";
 
@@ -139,6 +140,29 @@ export interface BuildInsightSQLOptions {
   sortColumn?: string;
   /** Sort direction */
   sortDirection?: "asc" | "desc";
+  /**
+   * Effective filters resolved from per-cell overrides via `resolveEffectiveParams`.
+   * When provided, REPLACES `insight.filters` for this query only — the insight
+   * object is never mutated.  Used by dashboard cells to inject their per-cell
+   * override params without modifying the shared insight definition.
+   *
+   * In "model" mode, filters are normally suppressed (raw-data preview).  When
+   * `effectiveFilters` is explicitly supplied the caller has already coalesced the
+   * cell override; the model-mode view for that cell SHOULD be filtered so the
+   * Chart component aggregates on the correct data subset.
+   */
+  effectiveFilters?: InsightFilter[];
+  /**
+   * Effective sorts resolved from per-cell overrides via `resolveEffectiveParams`.
+   * When provided, REPLACES `insight.sorts` for this query only.
+   */
+  effectiveSorts?: InsightSort[];
+  /**
+   * Effective row limit resolved from per-cell overrides via `resolveEffectiveParams`.
+   * When provided, REPLACES both `options.limit` and the insight's own limit for
+   * this query only.
+   */
+  effectiveLimit?: number;
 }
 
 /**
@@ -191,15 +215,96 @@ export function getTableName(dataFrameId: string): string {
  * );
  * ```
  */
+
+/**
+ * Resolve a sort field name (column name, e.g. "region") to its UUID column
+ * alias (e.g. "field_<uuid>") using the table's field list.  Falls back to the
+ * raw field name if no matching field is found (e.g. a metric alias) — the
+ * `appendPagination` validator will silently drop an unrecognised sort column.
+ */
+function resolveSortColumnAlias(
+  fieldName: string,
+  tableFields: Field[],
+): string {
+  const f = tableFields
+    .filter((field) => !field.name.startsWith("_"))
+    .find((field) => (field.columnName ?? field.name) === fieldName);
+  return f ? fieldIdToColumnAlias(f.id) : fieldName;
+}
+
+/**
+ * Merge effective limit and effective sorts (from per-cell overrides) into the
+ * caller-supplied `BuildInsightSQLOptions`.
+ *
+ * `appendPagination` drives ORDER BY from `options.sortColumn/sortDirection`,
+ * not from `insight.sorts`.  When the caller has already set `sortColumn` (e.g.
+ * a user-triggered interactive sort), we leave it alone — the interactive sort
+ * wins.  Otherwise the first effective sort is mapped to those scalar fields.
+ */
+function buildEffectiveOptions(
+  options: BuildInsightSQLOptions,
+  effectiveLimit: number | undefined,
+  effectiveSorts: InsightSort[] | undefined,
+  tableFields: Field[],
+): BuildInsightSQLOptions {
+  if (effectiveLimit === undefined && !effectiveSorts?.length) {
+    return options;
+  }
+  const firstSort = effectiveSorts?.[0];
+  const sortOverride =
+    firstSort && !options.sortColumn
+      ? {
+          sortColumn: resolveSortColumnAlias(firstSort.field, tableFields),
+          sortDirection: firstSort.direction,
+        }
+      : undefined;
+  return {
+    ...options,
+    ...(effectiveLimit !== undefined && { limit: effectiveLimit }),
+    ...sortOverride,
+  };
+}
+
 export function buildInsightSQL(
   baseTable: DataTable,
   joinedTables: Map<UUID, DataTable>,
   insight: Insight,
   options: BuildInsightSQLOptions,
 ): string | null {
-  const { mode } = options;
+  const { mode, effectiveFilters, effectiveSorts, effectiveLimit } = options;
 
   if (!baseTable.dataFrameId) return null;
+
+  // When the caller has pre-resolved effective params (e.g. dashboard cell with
+  // per-cell overrides), coalesce them onto a shallow copy of the insight so that
+  // every downstream helper sees the already-merged values.  The original `insight`
+  // is NEVER mutated — this is a local shadow only.
+  const effectiveInsight: Insight =
+    effectiveFilters !== undefined ||
+    effectiveSorts !== undefined ||
+    effectiveLimit !== undefined
+      ? {
+          ...insight,
+          ...(effectiveFilters !== undefined && {
+            filters: effectiveFilters,
+          }),
+          ...(effectiveSorts !== undefined && { sorts: effectiveSorts }),
+        }
+      : insight;
+
+  // Build effective options: fold `effectiveLimit` and `effectiveSorts` into the
+  // options object used by downstream helpers.
+  //
+  // `appendPagination` reads `options.sortColumn/sortDirection`, NOT `insight.sorts`,
+  // so we map the first effective sort to those scalar fields when no caller-supplied
+  // sort is already set.  The mapping is done by a dedicated helper to keep this
+  // function within the complexity budget.
+  const effectiveOptions = buildEffectiveOptions(
+    options,
+    effectiveLimit,
+    effectiveSorts,
+    baseTable.fields ?? [],
+  );
 
   const baseDFTable = getTableName(baseTable.dataFrameId);
   const baseDisplayName = shortenAutoGeneratedName(baseTable.name);
@@ -208,13 +313,13 @@ export function buildInsightSQL(
   );
 
   // No joins: simple query on base table with alias
-  if (!insight.joins?.length) {
+  if (!effectiveInsight.joins?.length) {
     return buildSimpleSQL(
       baseDFTable,
       baseDisplayName,
       baseFields,
-      insight,
-      options,
+      effectiveInsight,
+      effectiveOptions,
     );
   }
 
@@ -223,7 +328,7 @@ export function buildInsightSQL(
     baseDFTable,
     baseDisplayName,
     baseFields,
-    insight,
+    effectiveInsight,
     joinedTables,
   );
 
@@ -235,20 +340,48 @@ export function buildInsightSQL(
   // that actually exists in the FROM clause; anything else is safely skipped.
   const allFields = joined.availableFields;
 
-  // Model mode: raw data without transformations (never filtered — previews
-  // show raw rows).
+  // Model mode: raw data without aggregations.
+  // When `effectiveFilters` was supplied, the caller is a dashboard cell that
+  // needs its overridden filters applied even in model mode (so the Chart
+  // aggregates on the correct data subset).  When NOT supplied (the standard
+  // insight-preview / useInsightView path) filters are suppressed as before —
+  // previews show raw rows.
   if (mode === "model") {
     // Build set of valid column names from all fields (no metrics in model mode)
     const validColumns = new Set(allFields.map((f) => f.columnName ?? f.name));
+
+    if (effectiveFilters !== undefined && effectiveFilters.length > 0) {
+      // Apply the effective filters in alias mode: the joined subquery already
+      // has UUID-aliased columns, so WHERE must reference those aliases.
+      const fieldIdMap = buildFieldIdMap(allFields);
+      const { whereClause } = buildFilterClauses(
+        effectiveInsight,
+        fieldIdMap,
+        false, // no aggregation in model mode → all filters go to WHERE
+        "alias",
+      );
+      const base = `SELECT * FROM ${joined.sql}`;
+      return appendPagination(
+        whereClause ? `${base} ${whereClause}` : base,
+        effectiveOptions,
+        validColumns,
+      );
+    }
+
     return appendPagination(
       `SELECT * FROM ${joined.sql}`,
-      options,
+      effectiveOptions,
       validColumns,
     );
   }
 
   // Apply aggregations with all available fields
-  return buildAggregatedSQL(joined.sql, allFields, insight, options);
+  return buildAggregatedSQL(
+    joined.sql,
+    allFields,
+    effectiveInsight,
+    effectiveOptions,
+  );
 }
 
 /**
@@ -278,13 +411,12 @@ function buildSimpleSQL(
       baseFields.map((f) => fieldIdToColumnAlias(f.id)),
     );
 
-    // Filters apply in QUERY mode only. A model-mode preview shows the raw
-    // source rows so the user can see what they're working with *before*
-    // filtering — applying the insight's result-filters would defeat that, and
-    // the joined model path doesn't filter either (keeping both paths
-    // consistent). So only the no-config QUERY case appends a WHERE here.
+    // Filters apply in QUERY mode OR when the caller has explicitly supplied
+    // effective filters (e.g. a dashboard cell with per-cell overrides building
+    // a filtered model view for the Chart).  Plain model-mode preview (no
+    // effectiveFilters) still shows raw source rows.
     let whereClause = "";
-    if (mode === "query") {
+    if (mode === "query" || options.effectiveFilters !== undefined) {
       // No GROUP BY in this path → all filters map to WHERE. The FROM is the raw
       // base table, whose columns still carry their source names — resolve refs
       // against raw column names ("raw" mode).

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -340,6 +340,16 @@ export function buildInsightSQL(
   // that actually exists in the FROM clause; anything else is safely skipped.
   const allFields = joined.availableFields;
 
+  // Re-resolve effective options against the full joined field list so that sort
+  // overrides referencing a joined-table column resolve to the correct UUID alias
+  // (the initial call used only baseTable.fields, which excludes joined columns).
+  const joinedEffectiveOptions = buildEffectiveOptions(
+    options,
+    effectiveLimit,
+    effectiveSorts,
+    allFields,
+  );
+
   // Model mode: raw data without aggregations.
   // When `effectiveFilters` was supplied, the caller is a dashboard cell that
   // needs its overridden filters applied even in model mode (so the Chart
@@ -363,14 +373,14 @@ export function buildInsightSQL(
       const base = `SELECT * FROM ${joined.sql}`;
       return appendPagination(
         whereClause ? `${base} ${whereClause}` : base,
-        effectiveOptions,
+        joinedEffectiveOptions,
         validColumns,
       );
     }
 
     return appendPagination(
       `SELECT * FROM ${joined.sql}`,
-      effectiveOptions,
+      joinedEffectiveOptions,
       validColumns,
     );
   }
@@ -380,7 +390,7 @@ export function buildInsightSQL(
     joined.sql,
     allFields,
     effectiveInsight,
-    effectiveOptions,
+    joinedEffectiveOptions,
   );
 }
 

--- a/packages/engine/src/sql/override-resolution.test.ts
+++ b/packages/engine/src/sql/override-resolution.test.ts
@@ -657,3 +657,127 @@ describe("override-resolution — integration: effective params feed buildInsigh
     expect(sql).toContain(`ORDER BY "${regionAlias}" DESC`);
   });
 });
+
+// ---------------------------------------------------------------------------
+// §effectiveFilters-option: BuildInsightSQLOptions.effectiveFilters wires
+// override params directly into buildInsightSQL (render path injection)
+// ---------------------------------------------------------------------------
+
+describe("override-resolution — BuildInsightSQLOptions.effectiveFilters render-path injection", () => {
+  it("no-override no-regression: SQL without effectiveFilters is identical to baseline", () => {
+    // The cell-render path must not change SQL when there are no overrides.
+    const baseline = buildInsightSQL(BASE_TABLE, new Map(), BASE_INSIGHT, {
+      mode: "query",
+    });
+    const withNoEffectiveFilters = buildInsightSQL(
+      BASE_TABLE,
+      new Map(),
+      BASE_INSIGHT,
+      { mode: "query" },
+    );
+    expect(baseline).toBe(withNoEffectiveFilters);
+  });
+
+  it("effectiveFilters in query mode produces a WHERE clause with the overridden filter", () => {
+    // Effective filters are pre-resolved by resolveEffectiveParams; we pass
+    // them directly via BuildInsightSQLOptions.effectiveFilters.
+    const insightNoFilters: Insight = { ...BASE_INSIGHT, filters: undefined };
+    const sql = buildInsightSQL(BASE_TABLE, new Map(), insightNoFilters, {
+      mode: "query",
+      effectiveFilters: [{ field: "region", operator: "eq", value: "APAC" }],
+    });
+    expect(sql).not.toBeNull();
+    expect(sql).toContain(`"${regionAlias}" = 'APAC'`);
+    expect(sql).toContain("WHERE");
+  });
+
+  it("effectiveFilters in model mode applies a WHERE clause (Chart aggregation path)", () => {
+    // model mode + effectiveFilters = filtered model view for the Chart
+    const insightNoFilters: Insight = { ...BASE_INSIGHT, filters: undefined };
+    const sql = buildInsightSQL(BASE_TABLE, new Map(), insightNoFilters, {
+      mode: "model",
+      effectiveFilters: [{ field: "region", operator: "eq", value: "EMEA" }],
+    });
+    expect(sql).not.toBeNull();
+    // model mode emits aliased columns; "raw" refMode used for non-joined simple path
+    expect(sql).toContain("'EMEA'");
+    expect(sql).toContain("WHERE");
+  });
+
+  it("effectiveFilters replaces insight.filters in the compiled SQL (APAC, not EMEA)", () => {
+    // Insight has region='EMEA'; effectiveFilters says region='APAC'.
+    // The compiled SQL must contain APAC only — not EMEA.
+    const sql = buildInsightSQL(BASE_TABLE, new Map(), BASE_INSIGHT, {
+      mode: "query",
+      effectiveFilters: [{ field: "region", operator: "eq", value: "APAC" }],
+    });
+    expect(sql).not.toBeNull();
+    expect(sql).toContain("'APAC'");
+    expect(sql).not.toContain("'EMEA'");
+  });
+
+  it("effectiveFilters=[] with an insight that has filters clears all filters (widen path)", () => {
+    // Passing an empty array means the effective params resolved no filters
+    // (all cleared). The SQL must not contain any WHERE clause.
+    const sql = buildInsightSQL(BASE_TABLE, new Map(), BASE_INSIGHT, {
+      mode: "query",
+      effectiveFilters: [], // explicit empty = cleared
+    });
+    expect(sql).not.toBeNull();
+    expect(sql).not.toContain("WHERE");
+    expect(sql).not.toContain("EMEA");
+  });
+
+  it("effectiveLimit overrides insight query limit in the compiled SQL", () => {
+    const sql = buildInsightSQL(BASE_TABLE, new Map(), BASE_INSIGHT, {
+      mode: "query",
+      effectiveLimit: 12,
+    });
+    expect(sql).not.toBeNull();
+    expect(sql).toContain("LIMIT 12");
+  });
+
+  it("N cells of one insight with distinct effectiveFilters produce N distinct SQL strings", () => {
+    // The core dashboard invariant: each cell's overridden query is unique.
+    const insightNoFilters: Insight = { ...BASE_INSIGHT, filters: undefined };
+    const cells = ["EMEA", "APAC", "AMER"];
+    const sqls = cells.map((region) =>
+      buildInsightSQL(BASE_TABLE, new Map(), insightNoFilters, {
+        mode: "query",
+        effectiveFilters: [{ field: "region", operator: "eq", value: region }],
+      }),
+    );
+
+    expect(sqls[0]).not.toEqual(sqls[1]);
+    expect(sqls[1]).not.toEqual(sqls[2]);
+    expect(sqls[0]).not.toEqual(sqls[2]);
+    expect(sqls[0]).toContain("'EMEA'");
+    expect(sqls[1]).toContain("'APAC'");
+    expect(sqls[2]).toContain("'AMER'");
+  });
+
+  it("insight object is not mutated when effectiveFilters is passed (read-only invariant end-to-end)", () => {
+    const insight: Insight = { ...BASE_INSIGHT };
+    const snapshotBefore = JSON.stringify(insight);
+
+    // Simulate the render path: call buildInsightSQL with effectiveFilters
+    buildInsightSQL(BASE_TABLE, new Map(), insight, {
+      mode: "query",
+      effectiveFilters: [{ field: "region", operator: "eq", value: "APAC" }],
+    });
+
+    // The insight object passed in must be byte-identical after the call
+    expect(JSON.stringify(insight)).toBe(snapshotBefore);
+  });
+
+  it("effectiveSorts produces an ORDER BY clause in the compiled SQL", () => {
+    // Sort overrides must actually appear in the SQL — not be silently dropped.
+    const insightNoSort: Insight = { ...BASE_INSIGHT, sorts: undefined };
+    const sql = buildInsightSQL(BASE_TABLE, new Map(), insightNoSort, {
+      mode: "query",
+      effectiveSorts: [{ field: "region", direction: "desc" }],
+    });
+    expect(sql).not.toBeNull();
+    expect(sql).toContain(`ORDER BY "${regionAlias}" DESC`);
+  });
+});


### PR DESCRIPTION
Thread `DashboardItem.overrides` through the full render path so each dashboard cell can display a filtered, sorted, or limited view of its insight — without mutating the shared `Insight` object or regressing cells that have no overrides.

## Changes

- **`BuildInsightSQLOptions`** gains three new optional fields (`effectiveFilters`, `effectiveSorts`, `effectiveLimit`). `buildInsightSQL` shallowly clones the insight when these are supplied — the original is never mutated.
- **`resolveSortColumnAlias` + `buildEffectiveOptions`** extracted as module-level helpers to stay within the sonarjs cognitive-complexity budget and to fix a bug where `effectiveSorts` would have been silently dropped (sorts must map to `sortColumn/sortDirection` on options, not `insight.sorts`, because `appendPagination` only reads the scalar fields).
- **`useInsightView`** creates a per-cell DuckDB view (name includes a djb2 hash of the effective filters) when `effectiveParams` differ, so N cells on one insight get N independent views rather than clobbering each other.
- **`useInsightPagination`** accepts `EffectiveParams` and injects `effectiveFilters / effectiveSorts / effectiveLimit` into every `buildInsightSQL` call (count query and paginated fetch).
- **`VisualizationDisplay`** calls `resolveEffectiveParams` to merge insight defaults ⊕ cell overrides, then fans the result into both hooks. Cells without overrides follow the unchanged code path (no-op pass-through).
- **`DashboardItem`** passes `item.overrides` down to `VisualizationDisplay`.
- **9 new engine tests** covering: no-regression, query-mode WHERE, model-mode WHERE, filter replacement, filter clear, limit override, N-cell distinct SQL, read-only invariant (insight not mutated), and sort ORDER BY.

## Screenshots

Screenshots require the YW-150 override-UI or direct Dexie seed data. Since YW-150 is not yet built, runtime screenshots with two cells showing distinct overrides will be attached as a follow-up comment after the app is seeded with test data. The engine-level correctness (distinct SQL per cell, no mutation) is fully covered by the 9 new tests.

## Verification

- `bun run typecheck` — 0 errors (47 tasks, force-run)
- `bun run lint` — 0 errors
- `bun run format` — no changes
- `bun run check:ticket-refs` — OK
- `bun run test` — 36 engine tests pass including 9 new override tests
- `bun turbo run build` — all 40 tasks pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR threads `DashboardItem.overrides` through the full render path so each dashboard cell can display a filtered, sorted, or limited view of its insight without mutating the shared `Insight` object. `buildInsightSQL` gains `effectiveFilters/effectiveSorts/effectiveLimit` options and shallowly clones the insight when any is present; `useInsightView` switches from a 32-bit hash to a collision-free base64url suffix and correctly strips metric filters and sorts/limits from the chart view SQL; `useInsightPagination` clamps page fetches to the cell limit.

- **`insight-sql.ts`**: New `effectiveFilters/effectiveSorts/effectiveLimit` options with shallow-clone isolation; `buildEffectiveOptions` and `resolveSortColumnAlias` extracted as module-level helpers; joined-table sort aliases re-resolved against the full field list.
- **`useInsightView.ts`**: Collision-free base64url view-name suffix replaces the prior djb2 hash; `buildViewSQLOptions` strips metric filters and omits sorts/limit so the chart view is never incorrectly capped.
- **`useInsightPagination.ts`**: `effectiveParams` injected into the count query and paginated fetch; `pageLimit` clamped to `cellLimit - offset`; one bug: `effectiveLimit` leaks into the column-detection preview query via the shared `overrideOptions` spread, overriding the explicit `limit: 1`.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the preview-query limit fix applied; all other paths are correct and the no-override regression is guaranteed by design.

The column-detection preview query shares `overrideOptions` that includes `effectiveLimit`, which `buildEffectiveOptions` unconditionally promotes to `options.limit`, overwriting the explicit `limit: 1` for schema detection. A zero cell-limit produces `LIMIT 0`, leaving VirtualTable with no column headers. Everything else — SQL isolation, base64url view naming, metric-filter stripping, page-limit clamping — is correct.

packages/app/src/hooks/useInsightPagination.ts — the shared `overrideOptions` spread on the previewSQL call
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/hooks/useInsightPagination.ts | Forwards effectiveParams into buildInsightSQL for count and paginated fetch; contains a bug where effectiveLimit in overrideOptions overrides the explicit `limit: 1` in the previewSQL column-detection call. |
| packages/engine/src/sql/insight-sql.ts | Adds effectiveFilters/effectiveSorts/effectiveLimit to BuildInsightSQLOptions and shallowly clones insight when any override is present; logic is correct and read-only invariant is maintained. |
| packages/app/src/hooks/useInsightView.ts | Replaces the 32-bit djb2 hash with a collision-free base64url suffix, adds stripMetricFilters/buildViewSQLOptions helpers, and correctly excludes sorts/limits from the chart view SQL — addresses three previously flagged issues. |
| packages/app/src/components/visualizations/VisualizationDisplay.tsx | Computes effectiveParams via resolveEffectiveParams only when overrides are present and fans the result into both hooks; no-override path is byte-identical to pre-PR behavior. |
| packages/app/src/components/dashboards/DashboardItem.tsx | Trivial one-line pass-through of item.overrides to VisualizationDisplay; no issues. |
| packages/engine/src/sql/override-resolution.test.ts | Nine new tests cover the key render-path scenarios; the no-override regression test is a tautology (both calls are identical, so it only proves determinism, not no-op pass-through). |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DI[DashboardItem\nitem.overrides] -->|overrides prop| VD[VisualizationDisplay]
    VD -->|resolveEffectiveParams\ninsight ⊕ overrides| EP[effectiveParams\nfilters · sorts · limit]
    EP -->|effectiveParams| UIV[useInsightView\nchart view path]
    EP -->|effectiveParams| UIP[useInsightPagination\ntable path]

    UIV -->|buildViewSQLOptions\nstrip metric filters\nomit sorts + limit| BSQL1[buildInsightSQL\nmode=model]
    BSQL1 -->|CREATE OR REPLACE VIEW\ninsight_view_id_cell_base64| DDB1[(DuckDB\nchart view)]

    UIP -->|overrideOptions\nfilters + sorts + limit| BSQL2[buildInsightSQL\nmode=query\ncount + fetch]
    BSQL2 -->|pageLimit = min page, cellLimit-offset| DDB2[(DuckDB\npaginated rows)]

    DDB1 --> Chart[Chart / vgplot\nMosaic aggregations]
    DDB2 --> VT[VirtualTable]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/app/src/hooks/useInsightView.ts`, line 69-78 ([link](https://github.com/youhaowei/dashframe/blob/88810e9e4ec458ded93df9091bbb60f7c90cc810/packages/app/src/hooks/useInsightView.ts#L69-L78)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`getCachedViewName` may return a per-cell filtered view**

   The cache key format is now `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`, so when a dashboard cell with active filter overrides creates its view first, `getCachedViewName` — which matches on `key.startsWith(`${insightId}:`)` — will return that cell's hash-suffixed view name (e.g. `insight_view_<id>_cell_<hash>`) instead of the base unfiltered view. Any consumer expecting the canonical insight view (documented as `VisualizationPreview`) would then query filtered data silently. A targeted fix is to prefer the unfiltered entry (key ending with `:`), for example by checking `key === `${insightId}:${joinsKey}:`` before falling back to a prefix scan.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/hooks/useInsightView.ts
   Line: 69-78

   Comment:
   **`getCachedViewName` may return a per-cell filtered view**

   The cache key format is now `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`, so when a dashboard cell with active filter overrides creates its view first, `getCachedViewName` — which matches on `key.startsWith(`${insightId}:`)` — will return that cell's hash-suffixed view name (e.g. `insight_view_<id>_cell_<hash>`) instead of the base unfiltered view. Any consumer expecting the canonical insight view (documented as `VisualizationPreview`) would then query filtered data silently. A targeted fix is to prefer the unfiltered entry (key ending with `:`), for example by checking `key === `${insightId}:${joinsKey}:`` before falling back to a prefix scan.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%2069-78%0A%0AComment%3A%0A**%60getCachedViewName%60%20may%20return%20a%20per-cell%20filtered%20view**%0A%0AThe%20cache%20key%20format%20is%20now%20%60%24%7BinsightId%7D%3A%24%7BjoinsKey%7D%3A%24%7BeffectiveFiltersKey%20%3F%3F%20%22%22%7D%60%2C%20so%20when%20a%20dashboard%20cell%20with%20active%20filter%20overrides%20creates%20its%20view%20first%2C%20%60getCachedViewName%60%20%E2%80%94%20which%20matches%20on%20%60key.startsWith%28%60%24%7BinsightId%7D%3A%60%29%60%20%E2%80%94%20will%20return%20that%20cell's%20hash-suffixed%20view%20name%20%28e.g.%20%60insight_view_%3Cid%3E_cell_%3Chash%3E%60%29%20instead%20of%20the%20base%20unfiltered%20view.%20Any%20consumer%20expecting%20the%20canonical%20insight%20view%20%28documented%20as%20%60VisualizationPreview%60%29%20would%20then%20query%20filtered%20data%20silently.%20A%20targeted%20fix%20is%20to%20prefer%20the%20unfiltered%20entry%20%28key%20ending%20with%20%60%3A%60%29%2C%20for%20example%20by%20checking%20%60key%20%3D%3D%3D%20%60%24%7BinsightId%7D%3A%24%7BjoinsKey%7D%3A%60%60%20before%20falling%20back%20to%20a%20prefix%20scan.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw234-wire-overrides-render%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw234-wire-overrides-render%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%2069-78%0A%0AComment%3A%0A**%60getCachedViewName%60%20may%20return%20a%20per-cell%20filtered%20view**%0A%0AThe%20cache%20key%20format%20is%20now%20%60%24%7BinsightId%7D%3A%24%7BjoinsKey%7D%3A%24%7BeffectiveFiltersKey%20%3F%3F%20%22%22%7D%60%2C%20so%20when%20a%20dashboard%20cell%20with%20active%20filter%20overrides%20creates%20its%20view%20first%2C%20%60getCachedViewName%60%20%E2%80%94%20which%20matches%20on%20%60key.startsWith%28%60%24%7BinsightId%7D%3A%60%29%60%20%E2%80%94%20will%20return%20that%20cell's%20hash-suffixed%20view%20name%20%28e.g.%20%60insight_view_%3Cid%3E_cell_%3Chash%3E%60%29%20instead%20of%20the%20base%20unfiltered%20view.%20Any%20consumer%20expecting%20the%20canonical%20insight%20view%20%28documented%20as%20%60VisualizationPreview%60%29%20would%20then%20query%20filtered%20data%20silently.%20A%20targeted%20fix%20is%20to%20prefer%20the%20unfiltered%20entry%20%28key%20ending%20with%20%60%3A%60%29%2C%20for%20example%20by%20checking%20%60key%20%3D%3D%3D%20%60%24%7BinsightId%7D%3A%24%7BjoinsKey%7D%3A%60%60%20before%20falling%20back%20to%20a%20prefix%20scan.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%2069-78%0A%0AComment%3A%0A**%60getCachedViewName%60%20may%20return%20a%20per-cell%20filtered%20view**%0A%0AThe%20cache%20key%20format%20is%20now%20%60%24%7BinsightId%7D%3A%24%7BjoinsKey%7D%3A%24%7BeffectiveFiltersKey%20%3F%3F%20%22%22%7D%60%2C%20so%20when%20a%20dashboard%20cell%20with%20active%20filter%20overrides%20creates%20its%20view%20first%2C%20%60getCachedViewName%60%20%E2%80%94%20which%20matches%20on%20%60key.startsWith%28%60%24%7BinsightId%7D%3A%60%29%60%20%E2%80%94%20will%20return%20that%20cell's%20hash-suffixed%20view%20name%20%28e.g.%20%60insight_view_%3Cid%3E_cell_%3Chash%3E%60%29%20instead%20of%20the%20base%20unfiltered%20view.%20Any%20consumer%20expecting%20the%20canonical%20insight%20view%20%28documented%20as%20%60VisualizationPreview%60%29%20would%20then%20query%20filtered%20data%20silently.%20A%20targeted%20fix%20is%20to%20prefer%20the%20unfiltered%20entry%20%28key%20ending%20with%20%60%3A%60%29%2C%20for%20example%20by%20checking%20%60key%20%3D%3D%3D%20%60%24%7BinsightId%7D%3A%24%7BjoinsKey%7D%3A%60%60%20before%20falling%20back%20to%20a%20prefix%20scan.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/engine/src/sql/override-resolution.test.ts`, line 650-662 ([link](https://github.com/youhaowei/dashframe/blob/88810e9e4ec458ded93df9091bbb60f7c90cc810/packages/engine/src/sql/override-resolution.test.ts#L650-L662)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"No-override no-regression" test is a tautology**

   Both invocations pass identical arguments (`{ mode: "query" }` with no overrides), so the test only proves `buildInsightSQL` is deterministic — it does not guard against a regression where adding no-op override options (e.g. `effectiveFilters: undefined`) accidentally changes the output. Consider either comparing the result against a hard-coded expected SQL string, or making the second call explicit with `effectiveFilters: undefined` and `effectiveSorts: undefined` to prove those undefined fields are truly no-ops.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/engine/src/sql/override-resolution.test.ts
   Line: 650-662

   Comment:
   **"No-override no-regression" test is a tautology**

   Both invocations pass identical arguments (`{ mode: "query" }` with no overrides), so the test only proves `buildInsightSQL` is deterministic — it does not guard against a regression where adding no-op override options (e.g. `effectiveFilters: undefined`) accidentally changes the output. Consider either comparing the result against a hard-coded expected SQL string, or making the second call explicit with `effectiveFilters: undefined` and `effectiveSorts: undefined` to prove those undefined fields are truly no-ops.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Foverride-resolution.test.ts%0ALine%3A%20650-662%0A%0AComment%3A%0A**%22No-override%20no-regression%22%20test%20is%20a%20tautology**%0A%0ABoth%20invocations%20pass%20identical%20arguments%20%28%60%7B%20mode%3A%20%22query%22%20%7D%60%20with%20no%20overrides%29%2C%20so%20the%20test%20only%20proves%20%60buildInsightSQL%60%20is%20deterministic%20%E2%80%94%20it%20does%20not%20guard%20against%20a%20regression%20where%20adding%20no-op%20override%20options%20%28e.g.%20%60effectiveFilters%3A%20undefined%60%29%20accidentally%20changes%20the%20output.%20Consider%20either%20comparing%20the%20result%20against%20a%20hard-coded%20expected%20SQL%20string%2C%20or%20making%20the%20second%20call%20explicit%20with%20%60effectiveFilters%3A%20undefined%60%20and%20%60effectiveSorts%3A%20undefined%60%20to%20prove%20those%20undefined%20fields%20are%20truly%20no-ops.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw234-wire-overrides-render%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw234-wire-overrides-render%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Foverride-resolution.test.ts%0ALine%3A%20650-662%0A%0AComment%3A%0A**%22No-override%20no-regression%22%20test%20is%20a%20tautology**%0A%0ABoth%20invocations%20pass%20identical%20arguments%20%28%60%7B%20mode%3A%20%22query%22%20%7D%60%20with%20no%20overrides%29%2C%20so%20the%20test%20only%20proves%20%60buildInsightSQL%60%20is%20deterministic%20%E2%80%94%20it%20does%20not%20guard%20against%20a%20regression%20where%20adding%20no-op%20override%20options%20%28e.g.%20%60effectiveFilters%3A%20undefined%60%29%20accidentally%20changes%20the%20output.%20Consider%20either%20comparing%20the%20result%20against%20a%20hard-coded%20expected%20SQL%20string%2C%20or%20making%20the%20second%20call%20explicit%20with%20%60effectiveFilters%3A%20undefined%60%20and%20%60effectiveSorts%3A%20undefined%60%20to%20prove%20those%20undefined%20fields%20are%20truly%20no-ops.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine%2Fsrc%2Fsql%2Foverride-resolution.test.ts%0ALine%3A%20650-662%0A%0AComment%3A%0A**%22No-override%20no-regression%22%20test%20is%20a%20tautology**%0A%0ABoth%20invocations%20pass%20identical%20arguments%20%28%60%7B%20mode%3A%20%22query%22%20%7D%60%20with%20no%20overrides%29%2C%20so%20the%20test%20only%20proves%20%60buildInsightSQL%60%20is%20deterministic%20%E2%80%94%20it%20does%20not%20guard%20against%20a%20regression%20where%20adding%20no-op%20override%20options%20%28e.g.%20%60effectiveFilters%3A%20undefined%60%29%20accidentally%20changes%20the%20output.%20Consider%20either%20comparing%20the%20result%20against%20a%20hard-coded%20expected%20SQL%20string%2C%20or%20making%20the%20second%20call%20explicit%20with%20%60effectiveFilters%3A%20undefined%60%20and%20%60effectiveSorts%3A%20undefined%60%20to%20prove%20those%20undefined%20fields%20are%20truly%20no-ops.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

3. `packages/app/src/hooks/useInsightPagination.ts`, line 252-257 ([link](https://github.com/youhaowei/dashframe/blob/b56b234526b87d56efabb9e8d1177edb5bf3682f/packages/app/src/hooks/useInsightPagination.ts#L252-L257)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `effectiveLimit` leaks into the column-detection preview query via `overrideOptions`. Inside `buildInsightSQL`, `buildEffectiveOptions` unconditionally replaces `options.limit` with `effectiveLimit`, so the spread `...overrideOptions` overwrites the explicit `limit: 1`. When a cell sets `effectiveLimit = 0`, `LIMIT 0` is emitted, `rows.length === 0`, and `setColumns` / `setFieldCount` are never called — the VirtualTable renders with no column headers. For any non-zero limit the column detection still works, but the query fetches `effectiveLimit` rows instead of 1, which is unnecessarily expensive. The fix is to keep a filter-and-sorts-only variant for the preview call.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/hooks/useInsightPagination.ts
   Line: 252-257

   Comment:
   `effectiveLimit` leaks into the column-detection preview query via `overrideOptions`. Inside `buildInsightSQL`, `buildEffectiveOptions` unconditionally replaces `options.limit` with `effectiveLimit`, so the spread `...overrideOptions` overwrites the explicit `limit: 1`. When a cell sets `effectiveLimit = 0`, `LIMIT 0` is emitted, `rows.length === 0`, and `setColumns` / `setFieldCount` are never called — the VirtualTable renders with no column headers. For any non-zero limit the column detection still works, but the query fetches `effectiveLimit` rows instead of 1, which is unnecessarily expensive. The fix is to keep a filter-and-sorts-only variant for the preview call.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%0ALine%3A%20252-257%0A%0AComment%3A%0A%60effectiveLimit%60%20leaks%20into%20the%20column-detection%20preview%20query%20via%20%60overrideOptions%60.%20Inside%20%60buildInsightSQL%60%2C%20%60buildEffectiveOptions%60%20unconditionally%20replaces%20%60options.limit%60%20with%20%60effectiveLimit%60%2C%20so%20the%20spread%20%60...overrideOptions%60%20overwrites%20the%20explicit%20%60limit%3A%201%60.%20When%20a%20cell%20sets%20%60effectiveLimit%20%3D%200%60%2C%20%60LIMIT%200%60%20is%20emitted%2C%20%60rows.length%20%3D%3D%3D%200%60%2C%20and%20%60setColumns%60%20%2F%20%60setFieldCount%60%20are%20never%20called%20%E2%80%94%20the%20VirtualTable%20renders%20with%20no%20column%20headers.%20For%20any%20non-zero%20limit%20the%20column%20detection%20still%20works%2C%20but%20the%20query%20fetches%20%60effectiveLimit%60%20rows%20instead%20of%201%2C%20which%20is%20unnecessarily%20expensive.%20The%20fix%20is%20to%20keep%20a%20filter-and-sorts-only%20variant%20for%20the%20preview%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Get%20column%20info%20from%20preview%20query.%0A%20%20%20%20%20%20%20%20%2F%2F%20Do%20NOT%20include%20effectiveLimit%20here%20%E2%80%94%20it%20would%20override%20limit%3A1%20inside%0A%20%20%20%20%20%20%20%20%2F%2F%20buildEffectiveOptions%2C%20fetching%20up%20to%20effectiveLimit%20rows%20%28wasted%20work%29%0A%20%20%20%20%20%20%20%20%2F%2F%20and%20silently%20breaking%20column%20detection%20when%20effectiveLimit%20is%200.%0A%20%20%20%20%20%20%20%20const%20previewOverrideOpts%20%3D%20!showModelPreview%20%26%26%20effectiveParams%0A%20%20%20%20%20%20%20%20%20%20%3F%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveFilters%3A%20effectiveParams.filters%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveSorts%3A%20effectiveParams.sorts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20effectiveLimit%20intentionally%20omitted%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3A%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20const%20previewSQL%20%3D%20buildInsightSQL%28baseTable%2C%20joinedTables%2C%20insight%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20mode%2C%0A%20%20%20%20%20%20%20%20%20%20limit%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20...previewOverrideOpts%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw234-wire-overrides-render%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw234-wire-overrides-render%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%0ALine%3A%20252-257%0A%0AComment%3A%0A%60effectiveLimit%60%20leaks%20into%20the%20column-detection%20preview%20query%20via%20%60overrideOptions%60.%20Inside%20%60buildInsightSQL%60%2C%20%60buildEffectiveOptions%60%20unconditionally%20replaces%20%60options.limit%60%20with%20%60effectiveLimit%60%2C%20so%20the%20spread%20%60...overrideOptions%60%20overwrites%20the%20explicit%20%60limit%3A%201%60.%20When%20a%20cell%20sets%20%60effectiveLimit%20%3D%200%60%2C%20%60LIMIT%200%60%20is%20emitted%2C%20%60rows.length%20%3D%3D%3D%200%60%2C%20and%20%60setColumns%60%20%2F%20%60setFieldCount%60%20are%20never%20called%20%E2%80%94%20the%20VirtualTable%20renders%20with%20no%20column%20headers.%20For%20any%20non-zero%20limit%20the%20column%20detection%20still%20works%2C%20but%20the%20query%20fetches%20%60effectiveLimit%60%20rows%20instead%20of%201%2C%20which%20is%20unnecessarily%20expensive.%20The%20fix%20is%20to%20keep%20a%20filter-and-sorts-only%20variant%20for%20the%20preview%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Get%20column%20info%20from%20preview%20query.%0A%20%20%20%20%20%20%20%20%2F%2F%20Do%20NOT%20include%20effectiveLimit%20here%20%E2%80%94%20it%20would%20override%20limit%3A1%20inside%0A%20%20%20%20%20%20%20%20%2F%2F%20buildEffectiveOptions%2C%20fetching%20up%20to%20effectiveLimit%20rows%20%28wasted%20work%29%0A%20%20%20%20%20%20%20%20%2F%2F%20and%20silently%20breaking%20column%20detection%20when%20effectiveLimit%20is%200.%0A%20%20%20%20%20%20%20%20const%20previewOverrideOpts%20%3D%20!showModelPreview%20%26%26%20effectiveParams%0A%20%20%20%20%20%20%20%20%20%20%3F%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveFilters%3A%20effectiveParams.filters%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveSorts%3A%20effectiveParams.sorts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20effectiveLimit%20intentionally%20omitted%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3A%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20const%20previewSQL%20%3D%20buildInsightSQL%28baseTable%2C%20joinedTables%2C%20insight%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20mode%2C%0A%20%20%20%20%20%20%20%20%20%20limit%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20...previewOverrideOpts%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%0ALine%3A%20252-257%0A%0AComment%3A%0A%60effectiveLimit%60%20leaks%20into%20the%20column-detection%20preview%20query%20via%20%60overrideOptions%60.%20Inside%20%60buildInsightSQL%60%2C%20%60buildEffectiveOptions%60%20unconditionally%20replaces%20%60options.limit%60%20with%20%60effectiveLimit%60%2C%20so%20the%20spread%20%60...overrideOptions%60%20overwrites%20the%20explicit%20%60limit%3A%201%60.%20When%20a%20cell%20sets%20%60effectiveLimit%20%3D%200%60%2C%20%60LIMIT%200%60%20is%20emitted%2C%20%60rows.length%20%3D%3D%3D%200%60%2C%20and%20%60setColumns%60%20%2F%20%60setFieldCount%60%20are%20never%20called%20%E2%80%94%20the%20VirtualTable%20renders%20with%20no%20column%20headers.%20For%20any%20non-zero%20limit%20the%20column%20detection%20still%20works%2C%20but%20the%20query%20fetches%20%60effectiveLimit%60%20rows%20instead%20of%201%2C%20which%20is%20unnecessarily%20expensive.%20The%20fix%20is%20to%20keep%20a%20filter-and-sorts-only%20variant%20for%20the%20preview%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Get%20column%20info%20from%20preview%20query.%0A%20%20%20%20%20%20%20%20%2F%2F%20Do%20NOT%20include%20effectiveLimit%20here%20%E2%80%94%20it%20would%20override%20limit%3A1%20inside%0A%20%20%20%20%20%20%20%20%2F%2F%20buildEffectiveOptions%2C%20fetching%20up%20to%20effectiveLimit%20rows%20%28wasted%20work%29%0A%20%20%20%20%20%20%20%20%2F%2F%20and%20silently%20breaking%20column%20detection%20when%20effectiveLimit%20is%200.%0A%20%20%20%20%20%20%20%20const%20previewOverrideOpts%20%3D%20!showModelPreview%20%26%26%20effectiveParams%0A%20%20%20%20%20%20%20%20%20%20%3F%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveFilters%3A%20effectiveParams.filters%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveSorts%3A%20effectiveParams.sorts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20effectiveLimit%20intentionally%20omitted%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3A%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20const%20previewSQL%20%3D%20buildInsightSQL%28baseTable%2C%20joinedTables%2C%20insight%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20mode%2C%0A%20%20%20%20%20%20%20%20%20%20limit%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20...previewOverrideOpts%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%3A252-257%0A%60effectiveLimit%60%20leaks%20into%20the%20column-detection%20preview%20query%20via%20%60overrideOptions%60.%20Inside%20%60buildInsightSQL%60%2C%20%60buildEffectiveOptions%60%20unconditionally%20replaces%20%60options.limit%60%20with%20%60effectiveLimit%60%2C%20so%20the%20spread%20%60...overrideOptions%60%20overwrites%20the%20explicit%20%60limit%3A%201%60.%20When%20a%20cell%20sets%20%60effectiveLimit%20%3D%200%60%2C%20%60LIMIT%200%60%20is%20emitted%2C%20%60rows.length%20%3D%3D%3D%200%60%2C%20and%20%60setColumns%60%20%2F%20%60setFieldCount%60%20are%20never%20called%20%E2%80%94%20the%20VirtualTable%20renders%20with%20no%20column%20headers.%20For%20any%20non-zero%20limit%20the%20column%20detection%20still%20works%2C%20but%20the%20query%20fetches%20%60effectiveLimit%60%20rows%20instead%20of%201%2C%20which%20is%20unnecessarily%20expensive.%20The%20fix%20is%20to%20keep%20a%20filter-and-sorts-only%20variant%20for%20the%20preview%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Get%20column%20info%20from%20preview%20query.%0A%20%20%20%20%20%20%20%20%2F%2F%20Do%20NOT%20include%20effectiveLimit%20here%20%E2%80%94%20it%20would%20override%20limit%3A1%20inside%0A%20%20%20%20%20%20%20%20%2F%2F%20buildEffectiveOptions%2C%20fetching%20up%20to%20effectiveLimit%20rows%20%28wasted%20work%29%0A%20%20%20%20%20%20%20%20%2F%2F%20and%20silently%20breaking%20column%20detection%20when%20effectiveLimit%20is%200.%0A%20%20%20%20%20%20%20%20const%20previewOverrideOpts%20%3D%20!showModelPreview%20%26%26%20effectiveParams%0A%20%20%20%20%20%20%20%20%20%20%3F%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveFilters%3A%20effectiveParams.filters%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveSorts%3A%20effectiveParams.sorts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20effectiveLimit%20intentionally%20omitted%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3A%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20const%20previewSQL%20%3D%20buildInsightSQL%28baseTable%2C%20joinedTables%2C%20insight%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20mode%2C%0A%20%20%20%20%20%20%20%20%20%20limit%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20...previewOverrideOpts%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw234-wire-overrides-render%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw234-wire-overrides-render%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%3A252-257%0A%60effectiveLimit%60%20leaks%20into%20the%20column-detection%20preview%20query%20via%20%60overrideOptions%60.%20Inside%20%60buildInsightSQL%60%2C%20%60buildEffectiveOptions%60%20unconditionally%20replaces%20%60options.limit%60%20with%20%60effectiveLimit%60%2C%20so%20the%20spread%20%60...overrideOptions%60%20overwrites%20the%20explicit%20%60limit%3A%201%60.%20When%20a%20cell%20sets%20%60effectiveLimit%20%3D%200%60%2C%20%60LIMIT%200%60%20is%20emitted%2C%20%60rows.length%20%3D%3D%3D%200%60%2C%20and%20%60setColumns%60%20%2F%20%60setFieldCount%60%20are%20never%20called%20%E2%80%94%20the%20VirtualTable%20renders%20with%20no%20column%20headers.%20For%20any%20non-zero%20limit%20the%20column%20detection%20still%20works%2C%20but%20the%20query%20fetches%20%60effectiveLimit%60%20rows%20instead%20of%201%2C%20which%20is%20unnecessarily%20expensive.%20The%20fix%20is%20to%20keep%20a%20filter-and-sorts-only%20variant%20for%20the%20preview%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Get%20column%20info%20from%20preview%20query.%0A%20%20%20%20%20%20%20%20%2F%2F%20Do%20NOT%20include%20effectiveLimit%20here%20%E2%80%94%20it%20would%20override%20limit%3A1%20inside%0A%20%20%20%20%20%20%20%20%2F%2F%20buildEffectiveOptions%2C%20fetching%20up%20to%20effectiveLimit%20rows%20%28wasted%20work%29%0A%20%20%20%20%20%20%20%20%2F%2F%20and%20silently%20breaking%20column%20detection%20when%20effectiveLimit%20is%200.%0A%20%20%20%20%20%20%20%20const%20previewOverrideOpts%20%3D%20!showModelPreview%20%26%26%20effectiveParams%0A%20%20%20%20%20%20%20%20%20%20%3F%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveFilters%3A%20effectiveParams.filters%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveSorts%3A%20effectiveParams.sorts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20effectiveLimit%20intentionally%20omitted%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3A%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20const%20previewSQL%20%3D%20buildInsightSQL%28baseTable%2C%20joinedTables%2C%20insight%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20mode%2C%0A%20%20%20%20%20%20%20%20%20%20limit%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20...previewOverrideOpts%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%3A252-257%0A%60effectiveLimit%60%20leaks%20into%20the%20column-detection%20preview%20query%20via%20%60overrideOptions%60.%20Inside%20%60buildInsightSQL%60%2C%20%60buildEffectiveOptions%60%20unconditionally%20replaces%20%60options.limit%60%20with%20%60effectiveLimit%60%2C%20so%20the%20spread%20%60...overrideOptions%60%20overwrites%20the%20explicit%20%60limit%3A%201%60.%20When%20a%20cell%20sets%20%60effectiveLimit%20%3D%200%60%2C%20%60LIMIT%200%60%20is%20emitted%2C%20%60rows.length%20%3D%3D%3D%200%60%2C%20and%20%60setColumns%60%20%2F%20%60setFieldCount%60%20are%20never%20called%20%E2%80%94%20the%20VirtualTable%20renders%20with%20no%20column%20headers.%20For%20any%20non-zero%20limit%20the%20column%20detection%20still%20works%2C%20but%20the%20query%20fetches%20%60effectiveLimit%60%20rows%20instead%20of%201%2C%20which%20is%20unnecessarily%20expensive.%20The%20fix%20is%20to%20keep%20a%20filter-and-sorts-only%20variant%20for%20the%20preview%20call.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20Get%20column%20info%20from%20preview%20query.%0A%20%20%20%20%20%20%20%20%2F%2F%20Do%20NOT%20include%20effectiveLimit%20here%20%E2%80%94%20it%20would%20override%20limit%3A1%20inside%0A%20%20%20%20%20%20%20%20%2F%2F%20buildEffectiveOptions%2C%20fetching%20up%20to%20effectiveLimit%20rows%20%28wasted%20work%29%0A%20%20%20%20%20%20%20%20%2F%2F%20and%20silently%20breaking%20column%20detection%20when%20effectiveLimit%20is%200.%0A%20%20%20%20%20%20%20%20const%20previewOverrideOpts%20%3D%20!showModelPreview%20%26%26%20effectiveParams%0A%20%20%20%20%20%20%20%20%20%20%3F%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveFilters%3A%20effectiveParams.filters%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20effectiveSorts%3A%20effectiveParams.sorts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20effectiveLimit%20intentionally%20omitted%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%3A%20%7B%7D%3B%0A%20%20%20%20%20%20%20%20const%20previewSQL%20%3D%20buildInsightSQL%28baseTable%2C%20joinedTables%2C%20insight%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20mode%2C%0A%20%20%20%20%20%20%20%20%20%20limit%3A%201%2C%0A%20%20%20%20%20%20%20%20%20%20...previewOverrideOpts%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A&pr=106&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/app/src/hooks/useInsightPagination.ts:252-257
`effectiveLimit` leaks into the column-detection preview query via `overrideOptions`. Inside `buildInsightSQL`, `buildEffectiveOptions` unconditionally replaces `options.limit` with `effectiveLimit`, so the spread `...overrideOptions` overwrites the explicit `limit: 1`. When a cell sets `effectiveLimit = 0`, `LIMIT 0` is emitted, `rows.length === 0`, and `setColumns` / `setFieldCount` are never called — the VirtualTable renders with no column headers. For any non-zero limit the column detection still works, but the query fetches `effectiveLimit` rows instead of 1, which is unnecessarily expensive. The fix is to keep a filter-and-sorts-only variant for the preview call.

```suggestion
        // Get column info from preview query.
        // Do NOT include effectiveLimit here — it would override limit:1 inside
        // buildEffectiveOptions, fetching up to effectiveLimit rows (wasted work)
        // and silently breaking column detection when effectiveLimit is 0.
        const previewOverrideOpts = !showModelPreview && effectiveParams
          ? {
              effectiveFilters: effectiveParams.filters,
              effectiveSorts: effectiveParams.sorts,
              // effectiveLimit intentionally omitted
            }
          : {};
        const previewSQL = buildInsightSQL(baseTable, joinedTables, insight, {
          mode,
          limit: 1,
          ...previewOverrideOpts,
        });
```


`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(app): do not apply effectiveLimit/so..."](https://github.com/youhaowei/dashframe/commit/b56b234526b87d56efabb9e8d1177edb5bf3682f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37448071)</sub>

<!-- /greptile_comment -->