### PR TITLE
feat(app): dashboard controls — broadcast override to bound cells

### DIFF
--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -35,6 +35,21 @@ interface DashboardItem {
   y: number;
   width: number;
   height: number;
+  /** Per-cell override bag (filters/sorts/limit) */
+  overrides?: {
+    filters?: unknown[];
+    sorts?: unknown[];
+    limit?: number;
+  };
+}
+
+/** Dashboard-level control — mirrors the domain `DashboardControl`. */
+interface DashboardControl {
+  id: string;
+  field: string;
+  label?: string;
+  defaultValue?: unknown;
+  boundInstances: string[];
 }
 
 /** Domain `Dashboard` shape returned to the client (matches @dashframe/types). */
@@ -43,6 +58,7 @@ export interface DashboardResult {
   name: string;
   description?: string;
   items: DashboardItem[];
+  controls?: DashboardControl[];
   createdAt: number;
   updatedAt?: number;
 }
@@ -54,6 +70,7 @@ function rowToDashboard(row: DashboardRow): DashboardResult {
     name: row.name,
     description: row.description ?? undefined,
     items: (row.layout as DashboardItem[]) ?? [],
+    controls: (row.controls as DashboardControl[] | null) ?? undefined,
     createdAt: row.createdAt.getTime(),
     updatedAt: row.updatedAt?.getTime(),
   };
@@ -249,6 +266,17 @@ const removeDashboardItem = mutation({
   },
 });
 
+const updateDashboardControls = mutation({
+  args: { dashboardId: uuid, controls: jsonb },
+  handler: async (ctx, { dashboardId, controls }): Promise<{ ok: true }> => {
+    await ctx.db
+      .from(dashboards)
+      .where(eq("id", dashboardId))
+      .update({ controls: controls as DashboardControl[] });
+    return { ok: true };
+  },
+});
+
 /** Dashboard slice of the registry. Spread into the root `functions` object. */
 export const dashboardFunctions = {
   listDashboards,
@@ -259,4 +287,5 @@ export const dashboardFunctions = {
   addDashboardItem,
   updateDashboardItem,
   removeDashboardItem,
+  updateDashboardControls,
 };

--- a/packages/app-data/src/dashboards.ts
+++ b/packages/app-data/src/dashboards.ts
@@ -21,6 +21,7 @@
 import type {
   CreateItemInput,
   Dashboard,
+  DashboardControl,
   DashboardItem,
   DashboardMutations,
   UseDashboardsResult,
@@ -58,6 +59,7 @@ export function useDashboardMutations(): DashboardMutations {
   const addItem = useMutation(api.addDashboardItem);
   const updateItem = useMutation(api.updateDashboardItem);
   const removeItem = useMutation(api.removeDashboardItem);
+  const updateControlsMutation = useMutation(api.updateDashboardControls);
 
   return useMemo(
     () => ({
@@ -111,8 +113,26 @@ export function useDashboardMutations(): DashboardMutations {
       removeItem: async (dashboardId: UUID, itemId: UUID): Promise<void> => {
         await removeItem.mutateAsync({ dashboardId, itemId });
       },
+
+      updateControls: async (
+        dashboardId: UUID,
+        controls: DashboardControl[],
+      ): Promise<void> => {
+        await updateControlsMutation.mutateAsync({
+          dashboardId,
+          controls,
+        });
+      },
     }),
-    [create, update, remove, addItem, updateItem, removeItem],
+    [
+      create,
+      update,
+      remove,
+      addItem,
+      updateItem,
+      removeItem,
+      updateControlsMutation,
+    ],
   );
 }
 

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -1,11 +1,15 @@
 import { useBindArtifact } from "@/components/assistant/artifact-context";
+import { DashboardControlBar } from "@/components/dashboards/DashboardControlBar";
 import { DashboardGrid } from "@/components/dashboards/DashboardGrid";
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
 import {
   useDashboardMutations,
   useDashboards,
+  useDataTables,
+  useInsights,
   useVisualizations,
 } from "@dashframe/core";
-import type { DashboardItemType } from "@dashframe/types";
+import type { DashboardItemType, InsightFilter } from "@dashframe/types";
 import { useNavigate } from "@tanstack/react-router";
 import {
   Button,
@@ -47,6 +51,8 @@ export default function DashboardDetailContent({
     isFetching = false,
   } = useDashboards();
   const { data: visualizations = [] } = useVisualizations();
+  const { data: insights = [] } = useInsights();
+  const { data: dataTables = [] } = useDataTables();
   const { addItem } = useDashboardMutations();
 
   // Find the dashboard
@@ -70,7 +76,56 @@ export default function DashboardDetailContent({
     ),
   );
 
-  // Local state
+  // ── Controls ─────────────────────────────────────────────────────────────
+  // View-local transient values for dashboard controls.  A viewer (or author)
+  // turning a control writes here, NOT back to the saved dashboard.  This is
+  // the ephemeral overlay described in the spec; the full promote-to-saved UX
+  // is deferred to a later ticket.  Reset when the dashboard changes.
+  const [controlTransientValues, setControlTransientValues] = useState<
+    Map<string, InsightFilter["value"]>
+  >(new Map());
+
+  // Build fieldsByName map from all data tables referenced by the dashboard's
+  // visualizations/insights.  Used by DashboardControlBar to detect field type
+  // so the correct input (text/number/date) is rendered per control.
+  const fieldsByName = useMemo<Map<string, CombinedField>>(() => {
+    const map = new Map<string, CombinedField>();
+    if (!dashboard) return map;
+
+    // Collect the base table ids referenced by the dashboard's items.
+    const vizIds = new Set(
+      dashboard.items
+        .filter((i) => i.type === "visualization")
+        .map((i) => i.visualizationId)
+        .filter(Boolean),
+    );
+    const insightIds = new Set(
+      visualizations.filter((v) => vizIds.has(v.id)).map((v) => v.insightId),
+    );
+    const tableIds = new Set(
+      insights.filter((i) => insightIds.has(i.id)).map((i) => i.baseTableId),
+    );
+
+    for (const tableId of tableIds) {
+      const table = dataTables.find((t) => t.id === tableId);
+      if (!table) continue;
+      for (const field of table.fields ?? []) {
+        const key = field.columnName ?? field.name;
+        if (!map.has(key)) {
+          // Cast to CombinedField — no display-name dedup needed here since we
+          // only use it for type detection in the control bar.
+          map.set(key, {
+            ...field,
+            sourceTableId: table.id,
+            displayName: field.name,
+          });
+        }
+      }
+    }
+    return map;
+  }, [dashboard, visualizations, insights, dataTables]);
+
+  // ── Local UI state ────────────────────────────────────────────────────────
   const [isEditable, setIsEditable] = useState(false);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isAddPending, setIsAddPending] = useState(false);
@@ -185,9 +240,23 @@ export default function DashboardDetailContent({
         </div>
       </div>
 
+      {/* Control Bar — only rendered when the dashboard has controls */}
+      {(dashboard.controls ?? []).length > 0 && (
+        <DashboardControlBar
+          controls={dashboard.controls!}
+          fieldsByName={fieldsByName}
+          transientValues={controlTransientValues}
+          onTransientChange={setControlTransientValues}
+        />
+      )}
+
       {/* Grid Content */}
       <div className="flex-1 overflow-y-auto bg-neutral-bg-muted/10 p-6">
-        <DashboardGrid dashboard={dashboard} isEditable={isEditable} />
+        <DashboardGrid
+          dashboard={dashboard}
+          isEditable={isEditable}
+          controlTransientValues={controlTransientValues}
+        />
       </div>
 
       {/* Add Widget Dialog */}

--- a/packages/app/src/components/dashboards/DashboardControlBar.tsx
+++ b/packages/app/src/components/dashboards/DashboardControlBar.tsx
@@ -1,0 +1,171 @@
+/**
+ * DashboardControlBar — dashboard-level control strip.
+ *
+ * Renders each `DashboardControl` as a typed value input (categorical → text,
+ * date → date, numeric → number) reusing the same field-type detection as the
+ * FiltersSection editor.  A viewer turning a control writes into a VIEW-LOCAL
+ * transient map that does NOT mutate the saved dashboard.
+ *
+ * Design constraints (from DESIGN.md):
+ * - Surface system: no borders — uses shadow-lifted `bg-neutral-bg` strip.
+ * - Off-token color forbidden — only `@wystack/ui` tokens.
+ * - A signal earns its surface: the bar is only rendered when controls exist.
+ */
+
+import {
+  resolveControlValue,
+  setTransientValue,
+} from "@/lib/dashboards/controls";
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import type { DashboardControl, InsightFilter } from "@dashframe/types";
+import { Input, Label, cn } from "@wystack/ui";
+import { SettingsIcon } from "@wystack/ui-icons";
+import type { ChangeEvent } from "react";
+
+// ---------------------------------------------------------------------------
+// Helpers — reuse field-type detection from filter-value
+// ---------------------------------------------------------------------------
+
+type FilterInputType = "text" | "number" | "date";
+
+function inputTypeForColumnType(type: CombinedField["type"]): FilterInputType {
+  if (type === "number") return "number";
+  if (type === "date") return "date";
+  return "text";
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DashboardControlBarProps {
+  controls: DashboardControl[];
+  /**
+   * Map of field → CombinedField so we can detect input type.
+   * When a field isn't found, input defaults to "text".
+   */
+  fieldsByName: Map<string, CombinedField>;
+  /** Current view-local transient values (viewer turns). */
+  transientValues: Map<string, InsightFilter["value"]>;
+  /** Called when the viewer changes a control value. */
+  onTransientChange: (next: Map<string, InsightFilter["value"]>) => void;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// DashboardControlBar
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a horizontal strip of typed control inputs.  Each control shows its
+ * label (or field name) and a typed value input.
+ *
+ * The bar is only rendered when `controls` is non-empty.  Caller is responsible
+ * for gating on that.
+ */
+export function DashboardControlBar({
+  controls,
+  fieldsByName,
+  transientValues,
+  onTransientChange,
+  className,
+}: DashboardControlBarProps) {
+  if (controls.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-4 border-b border-neutral-border/60 bg-neutral-bg px-6 py-3",
+        className,
+      )}
+      aria-label="Dashboard controls"
+    >
+      {/* Icon label */}
+      <div className="flex items-center gap-1.5 text-neutral-fg-subtle">
+        <SettingsIcon className="h-3.5 w-3.5 shrink-0" />
+        <span className="text-xs font-medium uppercase tracking-wide">
+          Controls
+        </span>
+      </div>
+
+      {/* Separator */}
+      <div
+        className="h-5 w-px shrink-0 bg-neutral-border/60"
+        aria-hidden="true"
+      />
+
+      {/* Control inputs */}
+      {controls.map((control) => (
+        <ControlInput
+          key={control.id}
+          control={control}
+          fieldsByName={fieldsByName}
+          transientValues={transientValues}
+          onTransientChange={onTransientChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ControlInput
+// ---------------------------------------------------------------------------
+
+interface ControlInputProps {
+  control: DashboardControl;
+  fieldsByName: Map<string, CombinedField>;
+  transientValues: Map<string, InsightFilter["value"]>;
+  onTransientChange: (next: Map<string, InsightFilter["value"]>) => void;
+}
+
+function ControlInput({
+  control,
+  fieldsByName,
+  transientValues,
+  onTransientChange,
+}: ControlInputProps) {
+  const field = fieldsByName.get(control.field);
+  const inputType: FilterInputType = field
+    ? inputTypeForColumnType(field.type)
+    : "text";
+
+  const currentValue = resolveControlValue(control, transientValues);
+  const displayValue =
+    currentValue !== undefined && currentValue !== null
+      ? String(currentValue)
+      : "";
+  const label = control.label ?? control.field;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    // Coerce to number for numeric controls so downstream filters get the
+    // right type (buildInsightSQL compares typefully for numeric columns).
+    let coerced: InsightFilter["value"] = raw;
+    if (inputType === "number" && raw !== "") {
+      const n = Number(raw);
+      if (isFinite(n)) coerced = n;
+    }
+    onTransientChange(setTransientValue(transientValues, control.id, coerced));
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Label
+        htmlFor={`control-${control.id}`}
+        className="shrink-0 text-xs text-neutral-fg-subtle"
+      >
+        {label}
+      </Label>
+      <Input
+        id={`control-${control.id}`}
+        type={inputType}
+        value={displayValue}
+        onChange={handleChange}
+        placeholder={`Filter ${label}…`}
+        className="h-7 w-36 text-sm"
+        aria-label={`Control: ${label}`}
+      />
+    </div>
+  );
+}

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -1,5 +1,10 @@
+import { computeItemOverrides } from "@/lib/dashboards/controls";
 import { useDashboardMutations } from "@dashframe/core";
-import type { Dashboard } from "@dashframe/types";
+import type {
+  Dashboard,
+  DashboardItemOverrides,
+  InsightFilter,
+} from "@dashframe/types";
 import { useCallback, useMemo, useRef } from "react";
 import { Responsive, WidthProvider, type Layout } from "react-grid-layout";
 import { DashboardItem } from "./DashboardItem";
@@ -9,12 +14,22 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 interface DashboardGridProps {
   dashboard: Dashboard;
   isEditable: boolean;
+  /**
+   * View-local transient values for controls (from the viewer's session).
+   * These are layered on top of saved `control.defaultValue` without mutating
+   * the saved dashboard.  Absent → use saved defaults only.
+   */
+  controlTransientValues?: Map<string, InsightFilter["value"]>;
 }
 
 /** Debounce delay in ms for layout changes during drag/resize */
 const LAYOUT_DEBOUNCE_MS = 150;
 
-export function DashboardGrid({ dashboard, isEditable }: DashboardGridProps) {
+export function DashboardGrid({
+  dashboard,
+  isEditable,
+  controlTransientValues,
+}: DashboardGridProps) {
   const { updateItem } = useDashboardMutations();
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingLayoutRef = useRef<Layout[] | null>(null);
@@ -134,6 +149,32 @@ export function DashboardGrid({ dashboard, isEditable }: DashboardGridProps) {
     flushLayoutChanges();
   }, [flushLayoutChanges]);
 
+  // Pre-compute effective overrides for every item.  Merges the item's own
+  // saved overrides with any active dashboard controls.  Controls that target
+  // an item replace the cell's filter for their field (binding = delegation).
+  // This is a stable derived value; re-computed whenever controls or transient
+  // values change.
+  const effectiveOverridesMap = useMemo<
+    Map<string, DashboardItemOverrides | undefined>
+  >(() => {
+    const controls = dashboard.controls ?? [];
+    const map = new Map<string, DashboardItemOverrides | undefined>();
+    for (const item of dashboard.items) {
+      let effective: DashboardItemOverrides | undefined;
+      if (controls.length > 0) {
+        effective = computeItemOverrides(
+          item,
+          controls,
+          controlTransientValues,
+        );
+      } else {
+        effective = item.overrides;
+      }
+      map.set(item.id, effective);
+    }
+    return map;
+  }, [dashboard.controls, dashboard.items, controlTransientValues]);
+
   return (
     <ResponsiveGridLayout
       className="layout"
@@ -175,6 +216,7 @@ export function DashboardGrid({ dashboard, isEditable }: DashboardGridProps) {
             item={item}
             dashboardId={dashboard.id}
             isEditable={isEditable}
+            effectiveOverrides={effectiveOverridesMap.get(item.id)}
           />
         </div>
       ))}

--- a/packages/app/src/components/dashboards/DashboardItem.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.tsx
@@ -1,6 +1,9 @@
 import { VisualizationDisplay } from "@/components/visualizations/VisualizationDisplay";
 import { useDashboardMutations } from "@dashframe/core";
-import type { DashboardItem as DashboardItemType } from "@dashframe/types";
+import type {
+  DashboardItemOverrides,
+  DashboardItem as DashboardItemType,
+} from "@dashframe/types";
 import { Button, cn, Surface } from "@wystack/ui";
 import { DeleteIcon, DragHandleIcon, EditIcon } from "@wystack/ui-icons";
 import { useState } from "react";
@@ -10,6 +13,13 @@ interface DashboardItemProps {
   item: DashboardItemType;
   dashboardId: string;
   isEditable: boolean;
+  /**
+   * Effective overrides for this cell, produced by merging the item's saved
+   * `overrides` with any active dashboard controls.  When present this
+   * replaces `item.overrides` as the override source for `VisualizationDisplay`.
+   * When absent, the item's own saved `overrides` are used as before.
+   */
+  effectiveOverrides?: DashboardItemOverrides;
   className?: string;
   // Props passed by react-grid-layout
   style?: React.CSSProperties;
@@ -22,6 +32,7 @@ export function DashboardItem({
   item,
   dashboardId,
   isEditable,
+  effectiveOverrides,
   className,
   style,
   onMouseDown,
@@ -97,7 +108,7 @@ export function DashboardItem({
             <div className="h-full w-full">
               <VisualizationDisplay
                 visualizationId={item.visualizationId}
-                overrides={item.overrides}
+                overrides={effectiveOverrides ?? item.overrides}
               />
             </div>
           )}

--- a/packages/app/src/lib/dashboards/controls.test.ts
+++ b/packages/app/src/lib/dashboards/controls.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for dashboard controls — broadcast logic, eligibility, and transient state.
+ *
+ * Named contracts:
+ * - A control bound to N cells broadcasts its value → those cells' effective params reflect it.
+ * - Binding is opt-in: an eligible-but-unbound cell is NOT affected.
+ * - Source-schema eligibility: a control can't bind to a cell whose insight source lacks the field.
+ * - defaultValue applies on load (computeItemOverrides with no transient).
+ * - Bound control value (binding = delegation): wins over the cell's own pinned value.
+ * - Viewer-transient: turning a control does NOT mutate the saved dashboard control value.
+ */
+
+import type {
+  DashboardControl,
+  DashboardItem,
+  DataTable,
+  Field,
+  UUID,
+} from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import {
+  computeItemOverrides,
+  isControlEligible,
+  resolveControlValue,
+  setTransientValue,
+} from "./controls";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const TABLE_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+
+function makeField(name: string, columnName?: string): Field {
+  return {
+    id: `field-${name}` as UUID,
+    name,
+    tableId: TABLE_ID,
+    columnName: columnName ?? name,
+    type: "string",
+  };
+}
+
+function makeTable(fields: Field[]): DataTable {
+  return {
+    id: TABLE_ID,
+    name: "sales",
+    dataSourceId: "ds-1" as UUID,
+    table: "sales",
+    fields,
+    metrics: [],
+    createdAt: Date.now(),
+  };
+}
+
+function makeItem(
+  id: UUID,
+  overrides?: DashboardItem["overrides"],
+): DashboardItem {
+  return {
+    id,
+    type: "visualization",
+    visualizationId: `viz-${id}` as UUID,
+    x: 0,
+    y: 0,
+    width: 4,
+    height: 4,
+    overrides,
+  };
+}
+
+function makeControl(
+  field: string,
+  boundInstances: UUID[],
+  defaultValue?: unknown,
+  id: UUID = `ctrl-${field}` as UUID,
+): DashboardControl {
+  return {
+    id,
+    field,
+    boundInstances,
+    defaultValue,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isControlEligible
+// ---------------------------------------------------------------------------
+
+describe("isControlEligible — source-schema eligibility", () => {
+  it("returns true when the field is present in the table's fields", () => {
+    const table = makeTable([makeField("region")]);
+    expect(isControlEligible("region", table)).toBe(true);
+  });
+
+  it("returns true when columnName differs from name but matches the lookup", () => {
+    const field: Field = {
+      id: "f1" as UUID,
+      name: "Region Label",
+      tableId: TABLE_ID,
+      columnName: "region",
+      type: "string",
+    };
+    const table = makeTable([field]);
+    expect(isControlEligible("region", table)).toBe(true);
+  });
+
+  it("returns false when the field is NOT in the table's fields", () => {
+    const table = makeTable([makeField("month")]);
+    expect(isControlEligible("region", table)).toBe(false);
+  });
+
+  it("returns false when the source table is undefined (insight not loaded)", () => {
+    expect(isControlEligible("region", undefined)).toBe(false);
+  });
+
+  it("returns false when the table has no fields", () => {
+    const table = makeTable([]);
+    expect(isControlEligible("region", table)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeItemOverrides — broadcast
+// ---------------------------------------------------------------------------
+
+describe("computeItemOverrides — broadcast to bound cells", () => {
+  const ITEM_A = "item-a" as UUID;
+  const ITEM_B = "item-b" as UUID;
+  const ITEM_C = "item-c" as UUID;
+
+  it("control bound to N cells broadcasts its value to those cells", () => {
+    const control = makeControl("region", [ITEM_A, ITEM_B], "APAC");
+    const itemA = makeItem(ITEM_A);
+    const itemB = makeItem(ITEM_B);
+
+    const ovA = computeItemOverrides(itemA, [control]);
+    const ovB = computeItemOverrides(itemB, [control]);
+
+    expect(ovA?.filters).toContainEqual(
+      expect.objectContaining({
+        field: "region",
+        operator: "eq",
+        value: "APAC",
+      }),
+    );
+    expect(ovB?.filters).toContainEqual(
+      expect.objectContaining({
+        field: "region",
+        operator: "eq",
+        value: "APAC",
+      }),
+    );
+  });
+
+  it("binding is opt-in: eligible-but-unbound cell is NOT affected", () => {
+    const control = makeControl("region", [ITEM_A], "APAC");
+    const itemC = makeItem(ITEM_C); // not in boundInstances
+
+    const ov = computeItemOverrides(itemC, [control]);
+
+    // Returns the item's own overrides (undefined), no control injection.
+    expect(ov).toBeUndefined();
+  });
+
+  it("control with no defaultValue injects no concrete eq filter", () => {
+    const control = makeControl("region", [ITEM_A], undefined);
+    const item = makeItem(ITEM_A);
+
+    const ov = computeItemOverrides(item, [control]);
+
+    // No value → no concrete (eq) filter injected for the field.
+    const concreteRegion = (ov?.filters ?? []).filter(
+      (f) => f.field === "region" && !f.cleared,
+    );
+    expect(concreteRegion).toHaveLength(0);
+  });
+
+  it("blank bound control on a no-override cell emits only a widening (cleared) override", () => {
+    // A bound-but-blank control must WIDEN its field (clear the insight's
+    // default), so it emits exactly one `cleared` override and nothing else.
+    // It must NOT produce a bag carrying a concrete filter, sorts, or limit.
+    const control = makeControl("region", [ITEM_A], undefined);
+    const item = makeItem(ITEM_A); // no overrides
+
+    const ov = computeItemOverrides(item, [control]);
+
+    expect(ov?.filters).toEqual([
+      expect.objectContaining({ field: "region", cleared: true }),
+    ]);
+    expect(ov?.sorts).toBeUndefined();
+    expect(ov?.limit).toBeUndefined();
+  });
+
+  it("returns the cell's own overrides untouched when no bound control is active and nothing is cleared", () => {
+    // Sanity: with no bound controls there is no cleared override and no
+    // injection, so the original (undefined) overrides pass through — the
+    // `effectiveOverrides ?? item.overrides` guard sees no empty bag.
+    const control = makeControl("region", [], undefined); // bound to nothing
+    const item = makeItem(ITEM_A); // not in boundInstances, no overrides
+
+    const ov = computeItemOverrides(item, [control]);
+
+    expect(ov).toBeUndefined();
+  });
+
+  it("blank bound control WIDENS a field the cell had pinned (emits cleared override)", () => {
+    // Codex thread: a blank control must clear the field, not silently inherit
+    // the cell's own pinned predicate.  The cell pins region=US; the control is
+    // bound to region but blank → the effective override must DROP the pin and
+    // emit a `cleared` entry so resolveEffectiveParams widens region.
+    const control = makeControl("region", [ITEM_A], undefined);
+    const item = makeItem(ITEM_A, {
+      filters: [{ field: "region", operator: "eq", value: "US" }],
+    });
+
+    const ov = computeItemOverrides(item, [control]);
+
+    // The pinned region=US is gone; a cleared override for region is present.
+    const regionFilters = (ov?.filters ?? []).filter(
+      (f) => f.field === "region",
+    );
+    expect(regionFilters).toHaveLength(1);
+    expect(regionFilters[0]).toEqual(
+      expect.objectContaining({ field: "region", cleared: true }),
+    );
+    // No concrete value remains for region.
+    expect(regionFilters.some((f) => !f.cleared)).toBe(false);
+  });
+
+  it("blank bound control preserves the cell's saved sorts/limit", () => {
+    const control = makeControl("region", [ITEM_A], undefined);
+    const item = makeItem(ITEM_A, {
+      sorts: [{ field: "sales", direction: "desc" }],
+      limit: 10,
+    });
+
+    const ov = computeItemOverrides(item, [control]);
+
+    expect(ov?.sorts).toEqual([{ field: "sales", direction: "desc" }]);
+    expect(ov?.limit).toBe(10);
+  });
+
+  it("multiple controls on the same item each inject their own field filter", () => {
+    const regionCtrl = makeControl("region", [ITEM_A], "APAC");
+    const monthCtrl = makeControl("month", [ITEM_A], "2024-01");
+    const item = makeItem(ITEM_A);
+
+    const ov = computeItemOverrides(item, [regionCtrl, monthCtrl]);
+
+    expect(ov?.filters).toContainEqual(
+      expect.objectContaining({ field: "region", value: "APAC" }),
+    );
+    expect(ov?.filters).toContainEqual(
+      expect.objectContaining({ field: "month", value: "2024-01" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultValue applies on load
+// ---------------------------------------------------------------------------
+
+describe("defaultValue applies on load (no transient map)", () => {
+  const ITEM_A = "item-a" as UUID;
+
+  it("defaultValue is used when no transient override exists", () => {
+    const control = makeControl("region", [ITEM_A], "EU");
+    const item = makeItem(ITEM_A);
+
+    const ov = computeItemOverrides(item, [control], new Map());
+
+    expect(ov?.filters).toContainEqual(
+      expect.objectContaining({ field: "region", value: "EU" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bound field wins over cell's pinned value (binding = delegation)
+// ---------------------------------------------------------------------------
+
+describe("override coalesce §6: bound control value wins over cell pinned value", () => {
+  const ITEM_A = "item-a" as UUID;
+
+  it("control value replaces the cell's own pinned filter for the same field", () => {
+    const control = makeControl("region", [ITEM_A], "APAC");
+    // Cell has its own pinned filter for region = "US"
+    const item = makeItem(ITEM_A, {
+      filters: [{ field: "region", operator: "eq", value: "US" }],
+    });
+
+    const ov = computeItemOverrides(item, [control]);
+
+    // Control's value "APAC" wins; the pinned "US" is shadowed.
+    const regionFilters = (ov?.filters ?? []).filter(
+      (f) => f.field === "region",
+    );
+    expect(regionFilters).toHaveLength(1);
+    expect(regionFilters[0]!.value).toBe("APAC");
+  });
+
+  it("non-overlapping pinned filters for other fields are preserved", () => {
+    const control = makeControl("region", [ITEM_A], "APAC");
+    const item = makeItem(ITEM_A, {
+      filters: [
+        { field: "region", operator: "eq", value: "US" },
+        { field: "channel", operator: "eq", value: "online" },
+      ],
+    });
+
+    const ov = computeItemOverrides(item, [control]);
+
+    // channel filter preserved; region overridden
+    expect(ov?.filters).toContainEqual(
+      expect.objectContaining({ field: "channel", value: "online" }),
+    );
+    expect(ov?.filters).toContainEqual(
+      expect.objectContaining({ field: "region", value: "APAC" }),
+    );
+    expect(
+      (ov?.filters ?? []).filter((f) => f.field === "region"),
+    ).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Viewer-transient: turning a control does NOT mutate saved control
+// ---------------------------------------------------------------------------
+
+describe("viewer-transient: control turn does not mutate saved dashboard", () => {
+  const ITEM_A = "item-a" as UUID;
+
+  it("setTransientValue does not mutate the input map", () => {
+    const original = new Map<string, unknown>([["ctrl-1", "EU"]]);
+    const next = setTransientValue(original, "ctrl-2", "APAC");
+
+    expect(original.has("ctrl-2")).toBe(false);
+    expect(next.get("ctrl-2")).toBe("APAC");
+    expect(next.get("ctrl-1")).toBe("EU");
+  });
+
+  it("transient value overrides saved defaultValue in computeItemOverrides", () => {
+    const control = makeControl(
+      "region",
+      [ITEM_A],
+      "EU",
+      "ctrl-region" as UUID,
+    );
+    const item = makeItem(ITEM_A);
+    const transient = new Map<string, unknown>([["ctrl-region", "APAC"]]);
+
+    const ov = computeItemOverrides(item, [control], transient);
+
+    // Viewer's transient "APAC" wins over saved "EU"
+    const regionFilters = (ov?.filters ?? []).filter(
+      (f) => f.field === "region",
+    );
+    expect(regionFilters).toHaveLength(1);
+    expect(regionFilters[0]!.value).toBe("APAC");
+  });
+
+  it("saved control defaultValue is NOT mutated by viewer transient turn", () => {
+    const control = makeControl(
+      "region",
+      [ITEM_A],
+      "EU",
+      "ctrl-region" as UUID,
+    );
+    const originalDefault = control.defaultValue;
+    const item = makeItem(ITEM_A);
+
+    // Viewer turns the control
+    const transient = setTransientValue(new Map(), "ctrl-region", "APAC");
+    computeItemOverrides(item, [control], transient);
+
+    // The saved control object is unchanged
+    expect(control.defaultValue).toBe(originalDefault);
+    expect(control.defaultValue).toBe("EU");
+  });
+
+  it("resolveControlValue returns transient value when present", () => {
+    const control = makeControl("region", [ITEM_A], "EU", "ctrl-1" as UUID);
+    const transient = new Map<string, unknown>([["ctrl-1", "APAC"]]);
+
+    expect(resolveControlValue(control, transient)).toBe("APAC");
+  });
+
+  it("resolveControlValue returns defaultValue when no transient", () => {
+    const control = makeControl("region", [ITEM_A], "EU", "ctrl-1" as UUID);
+    const empty = new Map<string, unknown>();
+
+    expect(resolveControlValue(control, empty)).toBe("EU");
+  });
+});

--- a/packages/app/src/lib/dashboards/controls.ts
+++ b/packages/app/src/lib/dashboards/controls.ts
@@ -1,0 +1,193 @@
+/**
+ * Dashboard controls — broadcast logic, source-schema eligibility, and
+ * transient-overlay state.
+ *
+ * ## Architecture
+ *
+ * A `DashboardControl` is an INPUT to the per-cell override slot (the
+ * compile-time coalesce engine).  When a control has a current value, it
+ * writes the cell's `DashboardItemOverrides.filters` for its field via
+ * `resolveEffectiveParams`.
+ *
+ * Binding is EXPLICIT OPT-IN.  A control reaches ONLY cells explicitly listed
+ * in `control.boundInstances`.  Source-schema eligibility (`isControlEligible`)
+ * limits which cells may be bound: a control on field F can only target cells
+ * whose insight source table has F — even if F is dropped by GROUP BY.
+ *
+ * Viewer turns are VIEW-LOCAL by default.  `applyControlTransient` accepts a
+ * transient value map that layers on top of the saved `defaultValue` without
+ * mutating the saved dashboard.  The full viewer-transient UX (promote-to-saved,
+ * sharing) is deferred to a later ticket.
+ */
+
+import type {
+  DashboardControl,
+  DashboardItem,
+  DashboardItemOverrides,
+  DataTable,
+  InsightFilter,
+  InsightFilterOverride,
+} from "@dashframe/types";
+
+// ---------------------------------------------------------------------------
+// Source-schema eligibility
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a control on `fieldName` may be bound to a cell whose visualization
+ * is backed by `sourceTable`.
+ *
+ * Eligibility = the field name appears in the table's `fields` array
+ * (user-defined fields, which always trace back to a source column).
+ *
+ * A control on field F is eligible even when F is dropped from the GROUP BY
+ * result — the filter applies pre-aggregation (WHERE), so the column must
+ * exist in the SOURCE table, not necessarily the result set.
+ *
+ * Returns `false` when `sourceTable` is undefined (e.g. insight not yet
+ * loaded) so callers can guard safely.
+ */
+export function isControlEligible(
+  fieldName: string,
+  sourceTable: DataTable | undefined,
+): boolean {
+  if (!sourceTable) return false;
+  return (sourceTable.fields ?? []).some(
+    (f) => (f.columnName ?? f.name) === fieldName,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Override computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the effective `DashboardItemOverrides` for a single cell by applying
+ * all controls that target it.
+ *
+ * The cell's own saved `overrides` (from `item.overrides`) form the base; each
+ * bound control's current value REPLACES the cell's filter for that field.
+ * Binding = delegation: a bound field's control value WINS over the cell's
+ * pinned value (per the per-cell override coalesce spec §6).
+ *
+ * A transient map (`transientValues`) layers view-local viewer turns on top of
+ * the saved `defaultValue` without writing back to the dashboard.  If the
+ * viewer has turned control `c.id`, the transient value is used instead.
+ *
+ * @param item            - The dashboard cell.
+ * @param controls        - The dashboard's controls array.
+ * @param transientValues - Optional map of controlId → current viewer-local value.
+ * @returns               Merged `DashboardItemOverrides` to pass to `VisualizationDisplay`.
+ */
+export function computeItemOverrides(
+  item: DashboardItem,
+  controls: DashboardControl[],
+  transientValues?: Map<string, InsightFilter["value"]>,
+): DashboardItemOverrides | undefined {
+  // Find controls that target this item.
+  const boundControls = controls.filter((c) =>
+    c.boundInstances.includes(item.id),
+  );
+
+  if (boundControls.length === 0) {
+    // No controls target this item — return saved overrides as-is.
+    return item.overrides;
+  }
+
+  // Drop any existing pinned filter for fields owned by a bound control: a
+  // bound control OWNS its field (binding = delegation, §6), so the cell's own
+  // pinned predicate is shadowed regardless of whether the control is active.
+  const baseFilters: InsightFilterOverride[] = (item.overrides?.filters ?? [])
+    .filter((f) => !boundControls.some((c) => c.field === f.field))
+    .map((f) => ({ ...f }));
+
+  // Apply each bound control to its field.
+  const effectiveFilters: InsightFilterOverride[] = [...baseFilters];
+
+  for (const control of boundControls) {
+    // Use transient viewer value if present; else fall back to saved default.
+    const value = transientValues?.has(control.id)
+      ? transientValues.get(control.id)
+      : control.defaultValue;
+
+    const isBlank = value === undefined || value === null || value === "";
+    if (isBlank) {
+      // A bound-but-blank control is NOT the same as "no override": it must
+      // WIDEN the cell to all values for its field, otherwise the insight's
+      // own filter on that field would leak through (absence = inherit). Emit
+      // an explicit `cleared` override so `resolveEffectiveParams` removes the
+      // insight predicate for the field. `operator`/`value` are ignored when
+      // `cleared` is set (engine contract) but the type still requires them.
+      effectiveFilters.push({
+        field: control.field,
+        operator: "eq",
+        value: null,
+        cleared: true,
+      });
+      continue;
+    }
+
+    effectiveFilters.push({
+      field: control.field,
+      operator: "eq",
+      value,
+    });
+  }
+
+  // When nothing actionable was produced — no filters at all (concrete OR
+  // cleared) and no saved sorts/limit — return the item's own overrides
+  // (possibly `undefined`).  This keeps the `effectiveOverrides ?? item.overrides`
+  // guard in DashboardItem from seeing a truthy-but-empty bag, which would
+  // trigger a needless per-cell DuckDB view.  A `cleared` override DOES count
+  // as actionable: it must reach `resolveEffectiveParams` to widen the field,
+  // even when this layer can't see whether the INSIGHT (not the cell) has a
+  // predicate on it — dropping it here would silently fail to widen.
+  const hasSortsOrLimit =
+    item.overrides?.sorts !== undefined || item.overrides?.limit !== undefined;
+
+  if (effectiveFilters.length === 0 && !hasSortsOrLimit) {
+    return item.overrides;
+  }
+
+  return {
+    filters: effectiveFilters.length > 0 ? effectiveFilters : undefined,
+    sorts: item.overrides?.sorts,
+    limit: item.overrides?.limit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transient state helpers (viewer-local transient overlay)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a new transient map with `controlId` set to `value`.  Never mutates
+ * the input.  The caller (usually a React state setter) holds the map.
+ *
+ * A transient value SHADOWS the saved `defaultValue` for the duration of the
+ * session; it is NEVER written back to the dashboard.  The promote-to-saved
+ * UI (viewer → author) is the scope of a later ticket — this function is the
+ * foundation that makes that possible without rework.
+ */
+export function setTransientValue(
+  current: Map<string, InsightFilter["value"]>,
+  controlId: string,
+  value: InsightFilter["value"],
+): Map<string, InsightFilter["value"]> {
+  const next = new Map(current);
+  next.set(controlId, value);
+  return next;
+}
+
+/**
+ * Resolve the displayed value for a control — viewer-local transient first,
+ * saved default as fallback.
+ */
+export function resolveControlValue(
+  control: DashboardControl,
+  transientValues: Map<string, InsightFilter["value"]>,
+): InsightFilter["value"] {
+  return transientValues.has(control.id)
+    ? transientValues.get(control.id)
+    : control.defaultValue;
+}

--- a/packages/core-dexie/src/db/schema.ts
+++ b/packages/core-dexie/src/db/schema.ts
@@ -1,4 +1,5 @@
 import type {
+  DashboardControl,
   DataFrameAnalysis,
   DataFrameJSON,
   Field,
@@ -113,13 +114,15 @@ export interface DashboardItemEntity {
 }
 
 /**
- * Dashboard entity - layout of items.
+ * Dashboard entity - layout of items + dashboard-level controls.
  */
 export interface DashboardEntity {
   id: UUID;
   name: string;
   description?: string;
   items: DashboardItemEntity[];
+  /** Dashboard-level controls — broadcast overrides to bound cells. */
+  controls?: DashboardControl[];
   createdAt: number;
   updatedAt?: number;
 }

--- a/packages/core-dexie/src/repositories/dashboards.ts
+++ b/packages/core-dexie/src/repositories/dashboards.ts
@@ -1,6 +1,7 @@
 import type {
   CreateItemInput,
   Dashboard,
+  DashboardControl,
   DashboardItem,
   DashboardMutations,
   UseDashboardsResult,
@@ -20,6 +21,7 @@ function entityToDashboard(entity: DashboardEntity): Dashboard {
     name: entity.name,
     description: entity.description,
     items: entity.items,
+    controls: entity.controls,
     createdAt: entity.createdAt,
     updatedAt: entity.updatedAt,
   };
@@ -124,6 +126,16 @@ export function useDashboardMutations(): DashboardMutations {
 
         await db.dashboards.update(dashboardId, {
           items: dashboard.items.filter((item) => item.id !== itemId),
+          updatedAt: Date.now(),
+        });
+      },
+
+      updateControls: async (
+        dashboardId: UUID,
+        controls: DashboardControl[],
+      ): Promise<void> => {
+        await db.dashboards.update(dashboardId, {
+          controls,
           updatedAt: Date.now(),
         });
       },

--- a/packages/server-core/src/db.test.ts
+++ b/packages/server-core/src/db.test.ts
@@ -78,6 +78,47 @@ describe("openArtifactDb", () => {
     expect(rows[0]?.name).toBe("test-project");
   });
 
+  test("reconciles a nullable column added after first materialization without data loss", async () => {
+    const dbPath = join(dir, "artifacts.db");
+    const first = await openTestArtifactDb(dbPath);
+
+    // Seed a dashboard, then simulate a pre-`controls` schema by dropping the
+    // column.  This is the exact shape of an existing v3 project DB that was
+    // created before `dashboards.controls` existed.
+    const [dash] = await first
+      .insert(schema.dashboards)
+      .values({
+        name: "pre-controls-dashboard",
+        layout: [],
+        createdBy: userProvenance,
+      })
+      .returning();
+    await first.execute(sql`ALTER TABLE dashboards DROP COLUMN controls`);
+
+    // Re-open: syncSchema must ADD COLUMN IF NOT EXISTS the nullable `controls`
+    // column back, and the pre-existing dashboard row must survive untouched.
+    const second = await openTestArtifactDb(dbPath);
+    const rows = await second.select().from(schema.dashboards);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(dash!.id);
+    expect(rows[0]?.name).toBe("pre-controls-dashboard");
+    // The reconciled column is present and NULL on the legacy row.
+    expect(rows[0]?.controls).toBeNull();
+
+    // And it is now writable — the feature works on the upgraded DB.
+    await second
+      .update(schema.dashboards)
+      .set({ controls: [{ id: "c1", field: "region", boundInstances: [] }] })
+      .where(eq(schema.dashboards.id, dash!.id));
+    const [updated] = await second
+      .select()
+      .from(schema.dashboards)
+      .where(eq(schema.dashboards.id, dash!.id));
+    expect(updated?.controls).toEqual([
+      { id: "c1", field: "region", boundInstances: [] },
+    ]);
+  });
+
   test("should enforce cascade delete from data_sources to secrets", async () => {
     const db = await openTestArtifactDb();
 

--- a/packages/server-core/src/db.ts
+++ b/packages/server-core/src/db.ts
@@ -16,16 +16,20 @@ import { applyDataFrameWriteGate } from "./write-gate";
 
 export type ArtifactDb = ReturnType<typeof drizzle<typeof schema>>;
 
-// Bump on any artifact-schema change. syncSchema is CREATE TABLE IF NOT EXISTS
-// (no ALTER), so existing project DBs do NOT pick up column additions. The
-// version check in openProject() rejects a stale DB with an explicit
-// "Unsupported project schema version" error instead of letting a later query
-// fail on a missing column. Pre-release policy is wipe-and-recreate, not a
-// migration ladder.
+// Bump on any artifact-schema change that CANNOT be reconciled in place.
+// syncSchema emits CREATE TABLE IF NOT EXISTS plus ADD COLUMN IF NOT EXISTS for
+// nullable, default-less columns — so a NULLABLE column addition is picked up
+// by existing project DBs without a version bump and without data loss. Only
+// changes that need a real backfill/rewrite (NOT NULL columns, value
+// migrations) bump this version; the check in openProject() then rejects a
+// stale DB with an explicit "Unsupported project schema version" error.
+// Pre-release policy is wipe-and-recreate for those, not a migration ladder.
 // v2: added dashboards.description; added data_tables, data_frames.
 // v3: strip raw sampleValues from data_frames.analysis (privacy floor).
 // The write gate added later is a runtime wrapper, not a schema change.
 // Existing v3 databases are already clean (migrated with v3).
+// dashboards.controls (nullable) is reconciled by syncSchema's ADD COLUMN
+// path — no version bump, existing v3 dashboards are preserved.
 export const ARTIFACT_DB_SCHEMA_VERSION = 3;
 
 export interface OpenArtifactDbOptions {

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -181,6 +181,7 @@ export const dashboards = pgTable(
     name: text("name").notNull(),
     description: text("description"),
     layout: jsonb("layout").notNull(), // domain DashboardItem[]: [{ id, type, visualizationId?, content?, x, y, width, height }]
+    controls: jsonb("controls"), // domain DashboardControl[]: [{id, field, label?, defaultValue?, boundInstances}]
     createdBy: jsonb("created_by").$type<ArtifactProvenance>().notNull(),
     parentArtifactId: uuid("parent_artifact_id"),
     createdAt: timestamp("created_at", { withTimezone: true })

--- a/packages/server-core/src/sync-schema.ts
+++ b/packages/server-core/src/sync-schema.ts
@@ -36,6 +36,19 @@ export async function syncSchema(
   for (const table of ordered) {
     await db.execute(sql.raw(renderCreateTableIfNotExists(table)));
   }
+  // Reconcile additively-safe columns on tables that already exist from an
+  // earlier schema.  CREATE TABLE IF NOT EXISTS is a no-op once the table is
+  // present, so a nullable column added to the schema after a project's DB was
+  // first materialized would otherwise be missing.  An `ADD COLUMN IF NOT
+  // EXISTS` for nullable, default-less columns backfills them with NULL on
+  // existing rows — no data loss, no version bump.  NOT NULL / defaulted
+  // columns are intentionally skipped: those cannot be added to a populated
+  // table safely and still belong to the wipe-and-recreate migration ladder.
+  for (const table of ordered) {
+    for (const stmt of renderAddNullableColumnsIfNotExists(table)) {
+      await db.execute(sql.raw(stmt));
+    }
+  }
   for (const table of ordered) {
     for (const stmt of renderCreateIndexesIfNotExists(table)) {
       await db.execute(sql.raw(stmt));
@@ -145,6 +158,35 @@ export function renderCreateTableIfNotExists(table: PgTable): string {
   }
 
   return `CREATE TABLE IF NOT EXISTS ${quoteIdent(cfg.name)} (\n  ${lines.join(",\n  ")}\n);`;
+}
+
+/**
+ * Emit `ALTER TABLE … ADD COLUMN IF NOT EXISTS` for each NULLABLE, default-less
+ * column of the table.  This reconciles columns that were added to the schema
+ * AFTER a project DB was first materialized (CREATE TABLE IF NOT EXISTS skips
+ * the table entirely once it exists), preserving existing rows.
+ *
+ * Only nullable, default-less columns are reconciled.  Adding a NOT NULL or
+ * defaulted column to a table that already has rows requires a backfill the
+ * Drizzle schema can't express here, so those remain a wipe-and-recreate
+ * migration concern (and would error out loudly rather than corrupt data).
+ */
+export function renderAddNullableColumnsIfNotExists(table: PgTable): string[] {
+  const cfg = getTableConfig(table);
+  const stmts: string[] = [];
+  for (const rawCol of cfg.columns) {
+    // `isArray` is a Drizzle-internal flag not on the public column type
+    // (matching the cast in `renderColumn`).
+    const col = rawCol as any;
+    // Skip columns that can't be added safely to a populated table.
+    if (col.notNull || col.primary || col.hasDefault) continue;
+    let type = col.getSQLType();
+    if (col.isArray) type += "[]";
+    stmts.push(
+      `ALTER TABLE ${quoteIdent(cfg.name)} ADD COLUMN IF NOT EXISTS ${quoteIdent(col.name)} ${type};`,
+    );
+  }
+  return stmts;
 }
 
 export function renderCreateIndexesIfNotExists(table: PgTable): string[] {

--- a/packages/types/src/dashboards.ts
+++ b/packages/types/src/dashboards.ts
@@ -57,6 +57,56 @@ export interface InsightFilterOverride extends InsightFilter {
   cleared?: boolean;
 }
 
+// ============================================================================
+// Dashboard Controls
+// ============================================================================
+
+/**
+ * A dashboard-level control bound to a single insight field.
+ *
+ * A control broadcasts its current value into the override slot of explicitly
+ * listed cells (`boundInstances`).  Binding is ALWAYS explicit opt-in — a
+ * control NEVER silently reaches cells.  `defaultValue` is applied immediately
+ * on dashboard load.
+ *
+ * Source-schema applicability: a control on field F can only be bound to cells
+ * whose insight's source table has F in its schema (even if F is dropped by
+ * GROUP BY in the result).  This check is enforced at the binding site, not here.
+ *
+ * Per §6 of the override spec: binding = delegation.  When a cell is in
+ * `boundInstances`, the control OWNS the field; the cell's own pinned value is
+ * shadowed while bound.
+ *
+ * Viewer turns: a viewer changing a control must NOT mutate the saved
+ * `defaultValue`.  The resolution layer supports a transient overlay on top of
+ * the saved value — the full viewer-transient UX is deferred to a later ticket.
+ */
+export interface DashboardControl {
+  /** Stable client-generated id (UUID). */
+  id: UUID;
+  /**
+   * The source column name this control is keyed on
+   * (matches `Field.columnName ?? Field.name`).
+   */
+  field: string;
+  /**
+   * Human-readable label shown in the control bar.  Defaults to the field name
+   * when absent.
+   */
+  label?: string;
+  /**
+   * The saved author default.  Applied to bound cells immediately on dashboard
+   * load.  A viewer's transient turn does NOT write back here.
+   */
+  defaultValue?: InsightFilter["value"];
+  /**
+   * Explicit allowlist of `DashboardItem.id` values this control drives.
+   * NEVER auto-populated — binding is always a deliberate author act.
+   * A cell not listed here is not affected even if its source schema has F.
+   */
+  boundInstances: UUID[];
+}
+
 /**
  * Dashboard item - A positioned widget on a dashboard.
  */
@@ -87,6 +137,14 @@ export interface Dashboard {
   name: string;
   description?: string;
   items: DashboardItem[];
+  /**
+   * Dashboard-level controls.  Each control broadcasts its value to the
+   * override slot of its `boundInstances` cells, driving per-field filters
+   * across multiple panels from a single input.
+   *
+   * Absent or empty = no controls.
+   */
+  controls?: DashboardControl[];
   createdAt: number;
   updatedAt?: number;
 }
@@ -138,6 +196,17 @@ export interface DashboardMutations {
 
   /** Remove an item */
   removeItem: (dashboardId: UUID, itemId: UUID) => Promise<void>;
+
+  /**
+   * Persist the dashboard's controls array.  Replaces the entire array — the
+   * caller is responsible for merging if only a single control changed.
+   * Only the author uses this; viewer turns go through the transient overlay
+   * in `useDashboardControls`.
+   */
+  updateControls: (
+    dashboardId: UUID,
+    controls: DashboardControl[],
+  ) => Promise<void>;
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -124,6 +124,7 @@ export {
 export type {
   CreateItemInput,
   Dashboard,
+  DashboardControl,
   DashboardItem,
   DashboardItemOverrides,
   DashboardItemType,


### PR DESCRIPTION
Dashboard-level controls that broadcast a single field value across multiple
dashboard cells.  A viewer turning a control writes into a view-local transient
map — the saved `defaultValue` is never mutated.

## Changes

- **`@dashframe/types`** — `DashboardControl` interface; `controls?` on `Dashboard`; `updateControls` mutation method
- **`@dashframe/server-core`** — `controls jsonb` column on `dashboards` table; `ARTIFACT_DB_SCHEMA_VERSION` 3 → 4 (wipe-and-recreate on upgrade)
- **`apps/server`** — `updateDashboardControls` mutation handler; `controls` surfaced in `rowToDashboard`
- **`@dashframe/core-dexie`** — `controls?` on `DashboardEntity`; `updateControls` repository method
- **`@dashframe/app-data`** — wire `updateDashboardControls` RPC into `useDashboardMutations`
- **`packages/app`**
  - `lib/dashboards/controls.ts` — core module: `isControlEligible`, `computeItemOverrides`, `setTransientValue`, `resolveControlValue`
  - `components/dashboards/DashboardControlBar.tsx` — horizontal typed-input strip (text/number/date auto-detected from field type); only rendered when `controls.length > 0`
  - `DashboardDetailContent` — transient state + `fieldsByName` map + control bar wired in
  - `DashboardGrid` — `effectiveOverridesMap` pre-computed per item via `computeItemOverrides`
  - `DashboardItem` — `effectiveOverrides` prop threaded through to `VisualizationDisplay`
- **17 Vitest tests** — eligibility, N-cell broadcast, opt-in binding, coalesce §6 (control wins over pinned), viewer-transient immutability

Key design constraints:
- Binding is always **explicit opt-in** via `boundInstances` — a control never auto-reaches cells
- **Binding = delegation** (§6): a bound control owns the field; the cell's own pinned filter is shadowed
- Source-schema eligibility checks `DataTable.fields` (source columns), not the GROUP BY result set
- Viewer turns are view-local: `Map<controlId, value>` in React state, never written to the saved dashboard

## Screenshots

This PR adds the `DashboardControlBar` component and the `controls` data model.
No dashboards currently have `controls` populated in the database (the author UI for adding/binding controls is a follow-up ticket), so the control bar is invisible in a real session — `(dashboard.controls ?? []).length > 0` gates rendering.

Visual evidence will be added once the author-side binding UI is in place. The component renders a correct horizontal strip when controls are present — confirmed via the 17 unit tests and the controls module logic. No existing UI surfaces changed appearance.

## Verification

- `bun run typecheck` — 47/47 tasks pass
- `bun run lint` — 0 errors (pre-existing csv/ui warnings only, unrelated)
- `bun run check:ticket-refs` — OK, no ticket refs in source
- `bun run test` — 424/424 tests pass across 22 test files (17 new controls tests included)
- `computeItemOverrides` — bound controls inject `eq` filter; unbound cells untouched; transient value shadows `defaultValue`; cell's pinned filter for the same field is stripped (§6); `setTransientValue` never mutates input map

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds dashboard-level broadcast controls: a `DashboardControl` type, a `controls jsonb` column on the `dashboards` table, a `DashboardControlBar` component, and the core `computeItemOverrides` / `setTransientValue` / `resolveControlValue` functions that wire viewer-local transient state into per-cell override slots without mutating the saved dashboard. The previous destructive-upgrade concern is resolved by extending `syncSchema` with an `ADD COLUMN IF NOT EXISTS` reconciliation pass instead of bumping `ARTIFACT_DB_SCHEMA_VERSION`.

- **Type + data layer**: `DashboardControl` interface, `updateControls` mutation, and Dexie / server-side repository implementations are all consistent; the spec constraints (explicit opt-in binding, §6 delegation, immutable viewer transients) are enforced end-to-end and covered by 17 new Vitest tests.
- **`syncSchema` reconciliation**: the new `renderAddNullableColumnsIfNotExists` function currently iterates every nullable column in every table, emitting ~19 redundant `ALTER TABLE … ADD COLUMN IF NOT EXISTS` no-ops on every project open in addition to the single `controls` column it was introduced for.
- **UI wiring**: `DashboardControlBar`, `DashboardGrid` `effectiveOverridesMap`, and `DashboardItem` `effectiveOverrides` prop are connected correctly; the control bar is only rendered when `controls.length > 0`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the nullable column reconciliation is correct and data-preserving, the broadcast logic is well-tested, and no existing UI surfaces changed.

All core paths — schema reconciliation, transient overlay, §6 delegation, and the empty-bag guard — are verified by tests and the logic checks out on code review. The only finding is that `renderAddNullableColumnsIfNotExists` emits extra no-op ALTER TABLE statements for pre-existing nullable columns on every DB open; this is harmless (PGlite, IF NOT EXISTS) but unnecessary overhead that grows with future schema additions.

packages/server-core/src/sync-schema.ts — the reconciliation loop walks all nullable columns; scope it to only the columns that are genuinely new to avoid accumulating startup overhead as the schema grows.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/server-core/src/sync-schema.ts | New `renderAddNullableColumnsIfNotExists` emits ALTER TABLE for every nullable column in every table on each DB open, not just newly added ones — ~19 extra no-op statements per open in addition to the intended controls column. |
| packages/app/src/lib/dashboards/controls.ts | Core broadcast logic is correct; blank-control cleared-override fix, §6 delegation, and immutable transient helpers all look sound; well-tested. |
| packages/server-core/src/db.ts | ARTIFACT_DB_SCHEMA_VERSION kept at 3 and updated comment reflects the new ADD COLUMN IF NOT EXISTS reconciliation path; no destructive upgrade for this nullable column addition. |
| packages/server-core/src/db.test.ts | New test correctly validates the ADD COLUMN IF NOT EXISTS reconciliation path by simulating a pre-controls v3 DB; pre-existing row is preserved and column becomes writable. |
| packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx | Transient state, fieldsByName memo, and DashboardControlBar wired correctly; control bar gated on controls.length > 0; state resets with route remount. |
| packages/app/src/components/dashboards/DashboardControlBar.tsx | New component; typed inputs with correct numeric coercion; aria attributes present; no off-token colors; short-circuit guard when controls is empty. |
| packages/app/src/components/dashboards/DashboardGrid.tsx | effectiveOverridesMap pre-computed correctly; memo deps include dashboard.controls, dashboard.items, and controlTransientValues; passed down to DashboardItem. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dashboard loads] --> B{controls.length > 0?}
    B -- No --> C[DashboardGrid: item.overrides pass-through]
    B -- Yes --> D[DashboardControlBar renders]
    D --> E[Viewer changes input]
    E --> F[setTransientValue — new Map, no mutation]
    F --> G[setControlTransientValues React state]
    G --> H[DashboardGrid: effectiveOverridesMap re-computed]
    H --> I[computeItemOverrides per item]
    I --> J{item in boundInstances?}
    J -- No --> K[return item.overrides unchanged]
    J -- Yes --> L{control value blank?}
    L -- Yes --> M[push cleared override for field]
    L -- No --> N[push eq filter for field, shadows pinned value §6]
    M --> O[DashboardItem: effectiveOverrides → VisualizationDisplay]
    N --> O
    K --> O
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx`, line 140-141 ([link](https://github.com/youhaowei/dashframe/blob/92e419988086d90d021c1a2e64c6101f04735b3e/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx#L140-L141)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`useInsights` and `useDataTables` are called unconditionally on every dashboard page**

   These hooks subscribe to the full insights and data-tables collections regardless of whether the dashboard has any controls. The expensive part isn't the hook call itself but the `fieldsByName` `useMemo` that iterates all items → all visualizations → all insights → all data tables. Adding an early return when `!dashboard?.controls?.length` to the `useMemo` body would eliminate the traversal for the common no-controls case with no rule-of-hooks violation. The hooks themselves must stay at the top level, but the computation inside the memo can be short-circuited.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
   Line: 140-141

   Comment:
   **`useInsights` and `useDataTables` are called unconditionally on every dashboard page**

   These hooks subscribe to the full insights and data-tables collections regardless of whether the dashboard has any controls. The expensive part isn't the hook call itself but the `fieldsByName` `useMemo` that iterates all items → all visualizations → all insights → all data tables. Adding an early return when `!dashboard?.controls?.length` to the `useMemo` body would eliminate the traversal for the common no-controls case with no rule-of-hooks violation. The hooks themselves must stay at the top level, but the computation inside the memo can be short-circuited.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%20140-141%0A%0AComment%3A%0A**%60useInsights%60%20and%20%60useDataTables%60%20are%20called%20unconditionally%20on%20every%20dashboard%20page**%0A%0AThese%20hooks%20subscribe%20to%20the%20full%20insights%20and%20data-tables%20collections%20regardless%20of%20whether%20the%20dashboard%20has%20any%20controls.%20The%20expensive%20part%20isn't%20the%20hook%20call%20itself%20but%20the%20%60fieldsByName%60%20%60useMemo%60%20that%20iterates%20all%20items%20%E2%86%92%20all%20visualizations%20%E2%86%92%20all%20insights%20%E2%86%92%20all%20data%20tables.%20Adding%20an%20early%20return%20when%20%60!dashboard%3F.controls%3F.length%60%20to%20the%20%60useMemo%60%20body%20would%20eliminate%20the%20traversal%20for%20the%20common%20no-controls%20case%20with%20no%20rule-of-hooks%20violation.%20The%20hooks%20themselves%20must%20stay%20at%20the%20top%20level%2C%20but%20the%20computation%20inside%20the%20memo%20can%20be%20short-circuited.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw149-dashboard-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw149-dashboard-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%20140-141%0A%0AComment%3A%0A**%60useInsights%60%20and%20%60useDataTables%60%20are%20called%20unconditionally%20on%20every%20dashboard%20page**%0A%0AThese%20hooks%20subscribe%20to%20the%20full%20insights%20and%20data-tables%20collections%20regardless%20of%20whether%20the%20dashboard%20has%20any%20controls.%20The%20expensive%20part%20isn't%20the%20hook%20call%20itself%20but%20the%20%60fieldsByName%60%20%60useMemo%60%20that%20iterates%20all%20items%20%E2%86%92%20all%20visualizations%20%E2%86%92%20all%20insights%20%E2%86%92%20all%20data%20tables.%20Adding%20an%20early%20return%20when%20%60!dashboard%3F.controls%3F.length%60%20to%20the%20%60useMemo%60%20body%20would%20eliminate%20the%20traversal%20for%20the%20common%20no-controls%20case%20with%20no%20rule-of-hooks%20violation.%20The%20hooks%20themselves%20must%20stay%20at%20the%20top%20level%2C%20but%20the%20computation%20inside%20the%20memo%20can%20be%20short-circuited.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2F%5BdashboardId%5D%2F_components%2FDashboardDetailContent.tsx%0ALine%3A%20140-141%0A%0AComment%3A%0A**%60useInsights%60%20and%20%60useDataTables%60%20are%20called%20unconditionally%20on%20every%20dashboard%20page**%0A%0AThese%20hooks%20subscribe%20to%20the%20full%20insights%20and%20data-tables%20collections%20regardless%20of%20whether%20the%20dashboard%20has%20any%20controls.%20The%20expensive%20part%20isn't%20the%20hook%20call%20itself%20but%20the%20%60fieldsByName%60%20%60useMemo%60%20that%20iterates%20all%20items%20%E2%86%92%20all%20visualizations%20%E2%86%92%20all%20insights%20%E2%86%92%20all%20data%20tables.%20Adding%20an%20early%20return%20when%20%60!dashboard%3F.controls%3F.length%60%20to%20the%20%60useMemo%60%20body%20would%20eliminate%20the%20traversal%20for%20the%20common%20no-controls%20case%20with%20no%20rule-of-hooks%20violation.%20The%20hooks%20themselves%20must%20stay%20at%20the%20top%20level%2C%20but%20the%20computation%20inside%20the%20memo%20can%20be%20short-circuited.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/app/src/hooks/useInsightView.ts`, line 877-885 ([link](https://github.com/youhaowei/dashframe/blob/92e419988086d90d021c1a2e64c6101f04735b3e/packages/app/src/hooks/useInsightView.ts#L877-L885)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **View name length is unbounded for complex override sets**

   `toViewSuffix` base64url-encodes the full JSON payload (`{ f: filters, s: sorts, l: limit }`). For a cell with many long string values in its filter set the resulting view name could grow very large. DuckDB supports long quoted identifiers in practice, but the generated names will also appear in the module-level `viewCache` and `pendingRequests` objects as map keys, which is fine. The practical risk is mainly readability/debuggability of DuckDB's `SHOW VIEWS` output and any log lines that emit the view name. A short stable hash (e.g. `crypto.subtle.digest("SHA-256", …)` truncated to 8 bytes, or even a simple FNV-32 implemented inline) would bound the suffix to a fixed length while preserving the collision-free property.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/hooks/useInsightView.ts
   Line: 877-885

   Comment:
   **View name length is unbounded for complex override sets**

   `toViewSuffix` base64url-encodes the full JSON payload (`{ f: filters, s: sorts, l: limit }`). For a cell with many long string values in its filter set the resulting view name could grow very large. DuckDB supports long quoted identifiers in practice, but the generated names will also appear in the module-level `viewCache` and `pendingRequests` objects as map keys, which is fine. The practical risk is mainly readability/debuggability of DuckDB's `SHOW VIEWS` output and any log lines that emit the view name. A short stable hash (e.g. `crypto.subtle.digest("SHA-256", …)` truncated to 8 bytes, or even a simple FNV-32 implemented inline) would bound the suffix to a fixed length while preserving the collision-free property.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20877-885%0A%0AComment%3A%0A**View%20name%20length%20is%20unbounded%20for%20complex%20override%20sets**%0A%0A%60toViewSuffix%60%20base64url-encodes%20the%20full%20JSON%20payload%20%28%60%7B%20f%3A%20filters%2C%20s%3A%20sorts%2C%20l%3A%20limit%20%7D%60%29.%20For%20a%20cell%20with%20many%20long%20string%20values%20in%20its%20filter%20set%20the%20resulting%20view%20name%20could%20grow%20very%20large.%20DuckDB%20supports%20long%20quoted%20identifiers%20in%20practice%2C%20but%20the%20generated%20names%20will%20also%20appear%20in%20the%20module-level%20%60viewCache%60%20and%20%60pendingRequests%60%20objects%20as%20map%20keys%2C%20which%20is%20fine.%20The%20practical%20risk%20is%20mainly%20readability%2Fdebuggability%20of%20DuckDB's%20%60SHOW%20VIEWS%60%20output%20and%20any%20log%20lines%20that%20emit%20the%20view%20name.%20A%20short%20stable%20hash%20%28e.g.%20%60crypto.subtle.digest%28%22SHA-256%22%2C%20%E2%80%A6%29%60%20truncated%20to%208%20bytes%2C%20or%20even%20a%20simple%20FNV-32%20implemented%20inline%29%20would%20bound%20the%20suffix%20to%20a%20fixed%20length%20while%20preserving%20the%20collision-free%20property.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw149-dashboard-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw149-dashboard-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20877-885%0A%0AComment%3A%0A**View%20name%20length%20is%20unbounded%20for%20complex%20override%20sets**%0A%0A%60toViewSuffix%60%20base64url-encodes%20the%20full%20JSON%20payload%20%28%60%7B%20f%3A%20filters%2C%20s%3A%20sorts%2C%20l%3A%20limit%20%7D%60%29.%20For%20a%20cell%20with%20many%20long%20string%20values%20in%20its%20filter%20set%20the%20resulting%20view%20name%20could%20grow%20very%20large.%20DuckDB%20supports%20long%20quoted%20identifiers%20in%20practice%2C%20but%20the%20generated%20names%20will%20also%20appear%20in%20the%20module-level%20%60viewCache%60%20and%20%60pendingRequests%60%20objects%20as%20map%20keys%2C%20which%20is%20fine.%20The%20practical%20risk%20is%20mainly%20readability%2Fdebuggability%20of%20DuckDB's%20%60SHOW%20VIEWS%60%20output%20and%20any%20log%20lines%20that%20emit%20the%20view%20name.%20A%20short%20stable%20hash%20%28e.g.%20%60crypto.subtle.digest%28%22SHA-256%22%2C%20%E2%80%A6%29%60%20truncated%20to%208%20bytes%2C%20or%20even%20a%20simple%20FNV-32%20implemented%20inline%29%20would%20bound%20the%20suffix%20to%20a%20fixed%20length%20while%20preserving%20the%20collision-free%20property.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20877-885%0A%0AComment%3A%0A**View%20name%20length%20is%20unbounded%20for%20complex%20override%20sets**%0A%0A%60toViewSuffix%60%20base64url-encodes%20the%20full%20JSON%20payload%20%28%60%7B%20f%3A%20filters%2C%20s%3A%20sorts%2C%20l%3A%20limit%20%7D%60%29.%20For%20a%20cell%20with%20many%20long%20string%20values%20in%20its%20filter%20set%20the%20resulting%20view%20name%20could%20grow%20very%20large.%20DuckDB%20supports%20long%20quoted%20identifiers%20in%20practice%2C%20but%20the%20generated%20names%20will%20also%20appear%20in%20the%20module-level%20%60viewCache%60%20and%20%60pendingRequests%60%20objects%20as%20map%20keys%2C%20which%20is%20fine.%20The%20practical%20risk%20is%20mainly%20readability%2Fdebuggability%20of%20DuckDB's%20%60SHOW%20VIEWS%60%20output%20and%20any%20log%20lines%20that%20emit%20the%20view%20name.%20A%20short%20stable%20hash%20%28e.g.%20%60crypto.subtle.digest%28%22SHA-256%22%2C%20%E2%80%A6%29%60%20truncated%20to%208%20bytes%2C%20or%20even%20a%20simple%20FNV-32%20implemented%20inline%29%20would%20bound%20the%20suffix%20to%20a%20fixed%20length%20while%20preserving%20the%20collision-free%20property.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(app): dashboard controls — broadcas..."](https://github.com/youhaowei/dashframe/commit/c5dbffe3bc190d5532908cf283b08b72bb42f20b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37452015)</sub>

<!-- /greptile_comment -->