### PR TITLE
refactor(engine-server): reuse engine quoteIdentifier/quoteLiteral in parquet-cache

### DIFF
--- a/packages/engine-server/src/parquet-cache.ts
+++ b/packages/engine-server/src/parquet-cache.ts
@@ -33,6 +33,7 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { quoteIdentifier, quoteLiteral } from "@dashframe/engine";
 import type { FieldSensitivity } from "@dashframe/types";
 import type { DuckDBConnection, DuckDBValue } from "@duckdb/node-api";
 
@@ -217,7 +218,7 @@ export class ParquetCache {
 
     await fs.mkdir(this.cacheDir, { recursive: true });
     const target = this.pathFor(query);
-    const selectList = decision.columns.map(quoteIdent).join(", ");
+    const selectList = decision.columns.map(quoteIdentifier).join(", ");
     // Bind the compiled query's positional params natively: DuckDB accepts the
     // `?` placeholders inside the COPY wrapper's inner SELECT and fills them from
     // `values`. This avoids text-scanning the SQL for `?` (which would also
@@ -233,12 +234,4 @@ export class ParquetCache {
     );
     return target;
   }
-}
-
-function quoteIdent(name: string): string {
-  return `"${name.replace(/"/g, '""')}"`;
-}
-
-function quoteLiteral(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
 }


### PR DESCRIPTION
Replace the two private SQL-quoting helpers (`quoteIdent`/`quoteLiteral`) in `parquet-cache.ts` with the canonical exports from `@dashframe/engine`. The implementations were byte-identical, so behavior is unchanged.

## Changes

- Add `import { quoteIdentifier, quoteLiteral } from "@dashframe/engine"` to `parquet-cache.ts`
- Replace `.map(quoteIdent)` call site with `.map(quoteIdentifier)`
- Delete both now-dead private function definitions (`quoteIdent` and `quoteLiteral`)

## Screenshots

No UI change.

## Verification

- `bun run --cwd packages/engine-server typecheck` — clean (no errors)
- `bun run --cwd packages/engine-server lint` — clean (no warnings)
- `bun run --cwd packages/engine-server test` — 72 tests passed (7 test files)
- `clawpatch review --since origin/main --json` — `{"next": "no features touched by diff"}`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR deduplicates SQL-quoting logic by replacing two private helpers (`quoteIdent`/`quoteLiteral`) in `parquet-cache.ts` with the canonical `quoteIdentifier`/`quoteLiteral` exports from `@dashframe/engine`. The canonical implementations are byte-identical to the removed ones, so runtime behavior is unchanged.

- **Removed private helpers**: `quoteIdent` and `quoteLiteral` are deleted from `parquet-cache.ts`; the single call site (`decision.columns.map(quoteIdent)`) is updated to use the imported `quoteIdentifier`.
- **Import added**: `import { quoteIdentifier, quoteLiteral } from "@dashframe/engine"` is the only net-new line; both functions were already exported from the engine package's public index.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only change is swapping two private helpers for their byte-identical equivalents from the shared engine package.

Both removed functions have implementations that are character-for-character identical to the quoteIdentifier and quoteLiteral exports in packages/engine/src/sql/quoting.ts. No logic changes, no new dependencies beyond what the monorepo already has, and no call-site signature changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/engine-server/src/parquet-cache.ts | Replaces two private quoting helpers with canonical imports from @dashframe/engine; implementations are byte-identical so behavior is unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parquet-cache.ts\nParquetCache.write()"]
    B["quoteIdentifier()\n@dashframe/engine"]
    C["quoteLiteral()\n@dashframe/engine"]
    D["DuckDB COPY … TO"]

    A -- "column names → selectList" --> B
    A -- "file path → SQL literal" --> C
    B & C --> D

    style B fill:#d4edda,stroke:#28a745
    style C fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(engine-server): reuse engine qu..."](https://github.com/youhaowei/dashframe/commit/f9415be1207d7af170635ff248d2e53765a303b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37458701)</sub>

<!-- /greptile_comment -->