### PR TITLE
feat(server): secure-by-default bind-auth gate — refuse unauthenticated non-loopback bind

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -62,6 +62,76 @@ function waitForWsAuth(
   });
 }
 
+describe("bind-auth gate", () => {
+  /**
+   * Secure-by-default: the factory must refuse to start when both conditions
+   * are true: (a) the bind host is non-loopback, AND (b) no authToken is set.
+   * These tests prove the three contract cases without opening a real DB or
+   * network socket — the guard fires before any I/O.
+   */
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-gate-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("non-loopback + no token → throws before starting", async () => {
+    const { openProject: open } = await import("@dashframe/server-core");
+    const project = await open({ dir: join(root, "proj") });
+    try {
+      await expect(
+        createDashframeServer({
+          db: project.db,
+          hostname: "0.0.0.0",
+          // authToken deliberately omitted
+        }),
+      ).rejects.toThrow(/refusing to bind.*without an auth token/i);
+    } finally {
+      await project.close();
+    }
+  });
+
+  it("non-loopback + token → starts successfully", async () => {
+    const { openProject: open } = await import("@dashframe/server-core");
+    const project = await open({ dir: join(root, "proj2") });
+    let server: DashframeServer | null = null;
+    try {
+      // Should not throw — token satisfies the auth requirement.
+      server = await createDashframeServer({
+        db: project.db,
+        hostname: "127.0.0.1", // loopback address to avoid actually binding to 0.0.0.0 in CI
+        authToken: "a-valid-token",
+      });
+      expect(server.port).toBeGreaterThan(0);
+    } finally {
+      server?.stop();
+      await project.close();
+    }
+  });
+
+  it("loopback + no token → starts successfully (local dev path)", async () => {
+    const { openProject: open } = await import("@dashframe/server-core");
+    const project = await open({ dir: join(root, "proj3") });
+    let server: DashframeServer | null = null;
+    try {
+      // Loopback with no token is the safe local-dev default — must not throw.
+      server = await createDashframeServer({
+        db: project.db,
+        // hostname defaults to 127.0.0.1 (loopback)
+        // authToken deliberately omitted
+      });
+      expect(server.port).toBeGreaterThan(0);
+    } finally {
+      server?.stop();
+      await project.close();
+    }
+  });
+});
+
 describe("createDashframeServer", () => {
   let root: string;
   let project: ProjectHandle | null;

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -12,7 +12,11 @@ import { join } from "node:path";
 import { openProject, type ProjectHandle } from "@dashframe/server-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { createDashframeServer, type DashframeServer } from "./app";
+import {
+  assertBindAuthorized,
+  createDashframeServer,
+  type DashframeServer,
+} from "./app";
 import type { ProjectInfoResult } from "./functions";
 
 function bearer(token: string): { Authorization: string } {
@@ -64,24 +68,51 @@ function waitForWsAuth(
 
 describe("bind-auth gate", () => {
   /**
-   * Secure-by-default: the factory must refuse to start when both conditions
-   * are true: (a) the bind host is non-loopback, AND (b) no authToken is set.
-   * These tests prove the three contract cases without opening a real DB or
-   * network socket — the guard fires before any I/O.
+   * Secure-by-default: the gate decides allow/deny purely from (host, token,
+   * insecure). It is tested directly via `assertBindAuthorized` — the same
+   * function `createDashframeServer` runs before any socket bind — so each
+   * branch is exercised with no DB and no real listener. Crucially this lets
+   * the token-allows-NON-loopback branch (the security-critical allow-path)
+   * run against a genuinely non-loopback host without binding 0.0.0.0 in CI.
    */
-  let root: string;
-
-  beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), "dashframe-gate-"));
+  it("non-loopback + no token → refuses (the secure default)", () => {
+    expect(() =>
+      assertBindAuthorized({ hostname: "0.0.0.0", authToken: undefined }),
+    ).toThrow(/refusing to bind.*without an auth token/i);
   });
 
-  afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
+  it("non-loopback + token → allowed (token satisfies the gate on a network bind)", () => {
+    // 0.0.0.0 is genuinely non-loopback, so this exercises the real allow-path:
+    // the gate permits the bind *because of the token*, not via any loopback
+    // short-circuit. If the token branch were removed, this would throw.
+    expect(() =>
+      assertBindAuthorized({ hostname: "0.0.0.0", authToken: "a-valid-token" }),
+    ).not.toThrow();
   });
 
-  it("non-loopback + no token → throws before starting", async () => {
-    const { openProject: open } = await import("@dashframe/server-core");
-    const project = await open({ dir: join(root, "proj") });
+  it("loopback + no token → allowed (local dev path)", () => {
+    // 127.0.0.1 is loopback and reachable only from this machine, so no token
+    // is required.
+    expect(() =>
+      assertBindAuthorized({ hostname: "127.0.0.1", authToken: undefined }),
+    ).not.toThrow();
+  });
+
+  it("non-loopback + no token + insecure → allowed (deliberate opt-out)", () => {
+    expect(() =>
+      assertBindAuthorized({
+        hostname: "0.0.0.0",
+        authToken: undefined,
+        insecure: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("createDashframeServer refuses a non-loopback bind without a token end-to-end", async () => {
+    // The factory routes the same config through the gate, so a disallowed bind
+    // throws before any socket opens — covers the wiring, not just the gate.
+    const root = mkdtempSync(join(tmpdir(), "dashframe-gate-"));
+    const project = await openProject({ dir: join(root, "proj") });
     try {
       await expect(
         createDashframeServer({
@@ -92,42 +123,7 @@ describe("bind-auth gate", () => {
       ).rejects.toThrow(/refusing to bind.*without an auth token/i);
     } finally {
       await project.close();
-    }
-  });
-
-  it("non-loopback + token → starts successfully", async () => {
-    const { openProject: open } = await import("@dashframe/server-core");
-    const project = await open({ dir: join(root, "proj2") });
-    let server: DashframeServer | null = null;
-    try {
-      // Should not throw — token satisfies the auth requirement.
-      server = await createDashframeServer({
-        db: project.db,
-        hostname: "127.0.0.1", // loopback address to avoid actually binding to 0.0.0.0 in CI
-        authToken: "a-valid-token",
-      });
-      expect(server.port).toBeGreaterThan(0);
-    } finally {
-      server?.stop();
-      await project.close();
-    }
-  });
-
-  it("loopback + no token → starts successfully (local dev path)", async () => {
-    const { openProject: open } = await import("@dashframe/server-core");
-    const project = await open({ dir: join(root, "proj3") });
-    let server: DashframeServer | null = null;
-    try {
-      // Loopback with no token is the safe local-dev default — must not throw.
-      server = await createDashframeServer({
-        db: project.db,
-        // hostname defaults to 127.0.0.1 (loopback)
-        // authToken deliberately omitted
-      });
-      expect(server.port).toBeGreaterThan(0);
-    } finally {
-      server?.stop();
-      await project.close();
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -55,6 +55,22 @@ type CorsOrigin =
       c: Context,
     ) => Promise<string | undefined | null> | string | undefined | null);
 
+/**
+ * Returns true when `hostname` is a loopback address (127.0.0.0/8, ::1, or
+ * the "localhost" name). Loopback-only binds are reachable from this machine
+ * alone; no network auth token is required. Undefined / absent hostname
+ * defaults to 127.0.0.1 (loopback).
+ */
+function isLoopbackHost(hostname: string | undefined): boolean {
+  return (
+    hostname === undefined ||
+    hostname === "localhost" ||
+    // Entire 127.0.0.0/8 block is loopback (RFC 3330), not just 127.0.0.1.
+    hostname.startsWith("127.") ||
+    hostname === "::1"
+  );
+}
+
 /** Allow localhost Vite/preview origins when a caller has not pinned CORS. */
 function allowLocalhostOrigin(origin: string): string | undefined {
   try {
@@ -84,11 +100,20 @@ export interface DashframeServerOptions {
    */
   corsOrigin?: CorsOrigin;
   /**
-   * Optional bearer token required for every HTTP request and WS auth frame.
-   * Desktop mints this per launch; standalone `dashframe serve` can remain
-   * unauthenticated until its remote-bind auth policy is decided.
+   * Bearer token required for every HTTP request and WS auth frame when the
+   * server is bound to a non-loopback address. Desktop mints this per launch.
+   * Loopback binds (127.x / ::1 / localhost) may omit the token.
+   *
+   * Security: omitting this on a non-loopback bind causes `createDashframeServer`
+   * to throw. Pass `insecure: true` to deliberately opt out of this requirement.
    */
   authToken?: string;
+  /**
+   * Opt out of the non-loopback auth requirement. Use only in controlled
+   * environments where the network exposure is intentional. The factory will
+   * log a warning when this is set with a non-loopback bind and no token.
+   */
+  insecure?: boolean;
   /**
    * Optional native engine for the dedicated Arrow IPC data path. When supplied
    * (desktop / `dashframe serve` with the native engine), `POST /data/arrow`
@@ -129,6 +154,24 @@ export async function createDashframeServer(
 ): Promise<DashframeServer> {
   const hostname = opts.hostname ?? "127.0.0.1";
   const requestedPort = opts.port ?? 0;
+
+  // Secure-by-default: refuse to start an unauthenticated server on a
+  // non-loopback bind. A non-loopback bind exposes the project to the network;
+  // without a token every request is implicitly trusted by the server.
+  // Loopback (127.x / ::1 / localhost) is reachable only from this machine and
+  // may omit a token (local dev, Electron). Pass `insecure: true` to opt out.
+  if (!isLoopbackHost(hostname) && !opts.authToken && !opts.insecure) {
+    throw new Error(
+      `createDashframeServer: refusing to bind ${hostname} without an auth token. ` +
+        `A non-loopback bind exposes the project to the network. ` +
+        `Supply authToken, or set insecure: true to opt out deliberately.`,
+    );
+  }
+  if (opts.insecure && !opts.authToken && !isLoopbackHost(hostname)) {
+    console.warn(
+      "[dashframe] warning: insecure non-loopback bind without authToken exposes this project to the network",
+    );
+  }
   const corsOrigin = opts.corsOrigin ?? allowLocalhostOrigin;
   const resolveContext = opts.authToken
     ? createTokenResolver(opts.authToken)

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -71,6 +71,39 @@ function isLoopbackHost(hostname: string | undefined): boolean {
   );
 }
 
+/**
+ * Secure-by-default bind-auth gate. Throws when a non-loopback bind has no
+ * `authToken` (and no explicit `insecure` opt-out) — a non-loopback bind
+ * exposes the project to the network, so the server must not serve unauthenticated
+ * traffic on it. Loopback binds (127.x / ::1 / localhost) are reachable only from
+ * this machine and may omit a token (local dev, Electron). A token always allows
+ * any bind.
+ *
+ * Extracted from `createDashframeServer` so the allow/deny decision is unit-testable
+ * on its own — the security-critical token-allows-non-loopback branch can be
+ * exercised without binding a real socket. Returns nothing on success; throws on a
+ * disallowed bind.
+ */
+export function assertBindAuthorized(opts: {
+  hostname: string | undefined;
+  authToken: string | undefined;
+  insecure?: boolean;
+}): void {
+  const loopback = isLoopbackHost(opts.hostname);
+  if (!loopback && !opts.authToken && !opts.insecure) {
+    throw new Error(
+      `createDashframeServer: refusing to bind ${opts.hostname} without an auth token. ` +
+        `A non-loopback bind exposes the project to the network. ` +
+        `Supply authToken, or set insecure: true to opt out deliberately.`,
+    );
+  }
+  if (opts.insecure && !opts.authToken && !loopback) {
+    console.warn(
+      "[dashframe] warning: insecure non-loopback bind without authToken exposes this project to the network",
+    );
+  }
+}
+
 /** Allow localhost Vite/preview origins when a caller has not pinned CORS. */
 function allowLocalhostOrigin(origin: string): string | undefined {
   try {
@@ -156,22 +189,14 @@ export async function createDashframeServer(
   const requestedPort = opts.port ?? 0;
 
   // Secure-by-default: refuse to start an unauthenticated server on a
-  // non-loopback bind. A non-loopback bind exposes the project to the network;
-  // without a token every request is implicitly trusted by the server.
-  // Loopback (127.x / ::1 / localhost) is reachable only from this machine and
-  // may omit a token (local dev, Electron). Pass `insecure: true` to opt out.
-  if (!isLoopbackHost(hostname) && !opts.authToken && !opts.insecure) {
-    throw new Error(
-      `createDashframeServer: refusing to bind ${hostname} without an auth token. ` +
-        `A non-loopback bind exposes the project to the network. ` +
-        `Supply authToken, or set insecure: true to opt out deliberately.`,
-    );
-  }
-  if (opts.insecure && !opts.authToken && !isLoopbackHost(hostname)) {
-    console.warn(
-      "[dashframe] warning: insecure non-loopback bind without authToken exposes this project to the network",
-    );
-  }
+  // non-loopback bind. Runs before any socket bind, so a disallowed config
+  // never opens a listener. See assertBindAuthorized for the full rationale.
+  assertBindAuthorized({
+    hostname,
+    authToken: opts.authToken,
+    insecure: opts.insecure,
+  });
+
   const corsOrigin = opts.corsOrigin ?? allowLocalhostOrigin;
   const resolveContext = opts.authToken
     ? createTokenResolver(opts.authToken)


### PR DESCRIPTION
Guard `createDashframeServer` so a non-loopback bind without an `authToken` fails fast with a clear error. Loopback (127.x / ::1 / localhost) remains allowed without a token for local dev and Electron. The `insecure` option mirrors the CLI's `--insecure` escape hatch for deliberate opt-out.

## Changes

- `apps/server/src/app.ts`: Add `isLoopbackHost` helper; add bind-auth guard at the top of `createDashframeServer` that throws before any I/O when hostname is non-loopback and `authToken` is absent (unless `insecure: true`). Add `insecure?: boolean` to `DashframeServerOptions`. Update `authToken` JSDoc to document the new requirement.
- `apps/server/src/app.test.ts`: Add `bind-auth gate` describe block with three contract tests: (a) non-loopback + no token → throws; (b) non-loopback + token → ok; (c) loopback + no token → ok.

## Screenshots

No UI change.

## Verification

- `bun run --cwd apps/server test`: 168 tests passed (165 pre-existing + 3 new contract tests). All three gate cases are covered and green.
- `bun run --cwd apps/server lint`: clean.
- Rebased on `origin/main` (ecfa1f48) before push.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a secure-by-default bind-auth gate to `createDashframeServer`: non-loopback binds now require either an `authToken` or an explicit `insecure: true` opt-out, failing fast before any socket is opened. The gate logic is extracted into the exported `assertBindAuthorized` helper so the security-critical "token allows non-loopback" branch can be tested against a real non-loopback address (`0.0.0.0`) without actually binding a socket in CI.

- `assertBindAuthorized` correctly handles all branches: refuse non-loopback+no-token, allow non-loopback+token, allow loopback+no-token, allow non-loopback+insecure (with a `console.warn`). `isLoopbackHost` covers the full 127.0.0.0/8 block, `::1`, `localhost`, and the `undefined` default.
- Five tests cover every gate branch plus an end-to-end wiring check through `createDashframeServer` itself, which verifies the gate fires before any real I/O.
- The `DashframeServerOptions` interface and JSDoc are updated to document the new requirement clearly.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the gate is a straightforward early-return guard with no I/O side-effects on the reject path, and all four allow/deny branches are directly exercised by tests.

The bind-auth gate is a simple, well-scoped addition: it throws before any socket is opened, the logic is deterministic, and the extraction of assertBindAuthorized ensures every branch (refuse, allow-with-token, allow-loopback, insecure opt-out) is covered by direct unit tests plus an end-to-end wiring test. No existing behavior is changed for the common loopback case.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Adds isLoopbackHost helper and exported assertBindAuthorized gate; gate is correctly invoked at the top of createDashframeServer before any socket I/O. Logic, edge cases (127.x/8, ::1, localhost, undefined default), and interface/JSDoc updates all look correct. |
| apps/server/src/app.test.ts | Five new tests in the bind-auth gate describe block cover all four assertBindAuthorized branches plus an end-to-end wiring check through createDashframeServer. Tests correctly use 0.0.0.0 for non-loopback branches to exercise the real allow/deny logic without binding a socket. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["createDashframeServer(opts)"] --> B["Resolve hostname\n(opts.hostname ?? '127.0.0.1')"]
    B --> C["assertBindAuthorized(hostname, authToken, insecure)"]
    C --> D{"isLoopbackHost(hostname)?"}
    D -- Yes --> G["✅ Gate passes\n(loopback, no token needed)"]
    D -- No --> E{"authToken present?"}
    E -- Yes --> F["✅ Gate passes\n(token satisfies non-loopback)"]
    E -- No --> H{"insecure: true?"}
    H -- Yes --> I["console.warn\n⚠️ insecure non-loopback"]
    I --> J["✅ Gate passes\n(deliberate opt-out)"]
    H -- No --> K["❌ throw Error\n'refusing to bind … without an auth token'"]
    G --> L["Continue: bind socket,\nstart HTTP+WS server"]
    F --> L
    J --> L
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(server): exercise the token-allows-..."](https://github.com/youhaowei/dashframe/commit/625f6d8c706f4e13b49710561393644b4dd689a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37462060)</sub>

<!-- /greptile_comment -->