### PR TITLE
fix(app): guard dashboard creation against failure and undefined id before navigation [YW-254]

### DIFF
--- a/packages/app/src/app/dashboards/page.test.tsx
+++ b/packages/app/src/app/dashboards/page.test.tsx
@@ -141,5 +141,8 @@ describe("DashboardsPage – handleCreate failure paths", () => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/dashboards/dash-abc" });
     });
     expect(mockShowError).not.toHaveBeenCalled();
+
+    // Dialog is closed — the input is no longer in the document
+    expect(screen.queryByPlaceholderText(/sales overview/i)).toBeNull();
   });
 });

--- a/packages/app/src/app/dashboards/page.test.tsx
+++ b/packages/app/src/app/dashboards/page.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Tests for the DashboardsPage create-dashboard handler.
+ *
+ * Contracts:
+ * - When createDashboard rejects, navigation must NOT occur and the user
+ *   must see an error toast. The dialog must remain open.
+ * - When createDashboard resolves undefined, navigation must NOT occur and
+ *   the user must see an error toast. The dialog must remain open.
+ * - On success the dialog closes, the input resets, and navigate is called
+ *   with the returned id.
+ */
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (vi.mock hoisting requires these to be declared with vi.hoisted)
+// ---------------------------------------------------------------------------
+
+const { mockCreate, mockMutations } = vi.hoisted(() => {
+  const create = vi.fn();
+  const remove = vi.fn();
+  return {
+    mockCreate: create,
+    mockMutations: { create, remove },
+  };
+});
+
+vi.mock("@dashframe/core", () => ({
+  useDashboards: () => ({ data: [], isLoading: false }),
+  useDashboardMutations: () => mockMutations,
+}));
+
+const { mockNavigate } = vi.hoisted(() => {
+  const navigate = vi.fn();
+  return { mockNavigate: navigate };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const { mockShowError } = vi.hoisted(() => {
+  const showError = vi.fn();
+  return { mockShowError: showError };
+});
+
+vi.mock("@/lib/stores", () => ({
+  useToastStore: () => ({ showError: mockShowError }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the component after mocks are set up
+// ---------------------------------------------------------------------------
+
+import DashboardsPage from "./page";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function openCreateDialog() {
+  fireEvent.click(screen.getByRole("button", { name: /new dashboard/i }));
+}
+
+function typeName(name: string) {
+  const input = screen.getByPlaceholderText(/sales overview/i);
+  fireEvent.change(input, { target: { value: name } });
+}
+
+async function submitCreate() {
+  fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DashboardsPage – handleCreate failure paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows error toast and does NOT navigate when createDashboard rejects", async () => {
+    mockCreate.mockRejectedValue(new Error("network error"));
+
+    render(<DashboardsPage />);
+    openCreateDialog();
+    typeName("My Board");
+    await act(async () => {
+      await submitCreate();
+    });
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledTimes(1);
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // Dialog remains open — getByPlaceholderText throws if the element is absent
+    screen.getByPlaceholderText(/sales overview/i);
+  });
+
+  it("shows error toast and does NOT navigate when createDashboard resolves undefined", async () => {
+    mockCreate.mockResolvedValue(undefined);
+
+    render(<DashboardsPage />);
+    openCreateDialog();
+    typeName("Another Board");
+    await act(async () => {
+      await submitCreate();
+    });
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledTimes(1);
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // Dialog remains open — getByPlaceholderText throws if the element is absent
+    screen.getByPlaceholderText(/sales overview/i);
+  });
+
+  it("navigates to the dashboard and closes the dialog on success", async () => {
+    mockCreate.mockResolvedValue("dash-abc");
+
+    render(<DashboardsPage />);
+    openCreateDialog();
+    typeName("Success Board");
+    await act(async () => {
+      await submitCreate();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/dashboards/dash-abc" });
+    });
+    expect(mockShowError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/app/dashboards/page.tsx
+++ b/packages/app/src/app/dashboards/page.tsx
@@ -1,3 +1,4 @@
+import { useToastStore } from "@/lib/stores";
 import { useDashboardMutations, useDashboards } from "@dashframe/core";
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
@@ -19,6 +20,7 @@ export default function DashboardsPage() {
   const { data: dashboards = [], isLoading } = useDashboards();
   const { create: createDashboard, remove: removeDashboard } =
     useDashboardMutations();
+  const { showError } = useToastStore();
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [newDashboardName, setNewDashboardName] = useState("");
@@ -26,7 +28,18 @@ export default function DashboardsPage() {
   const handleCreate = async () => {
     if (!newDashboardName.trim()) return;
 
-    const id = await createDashboard(newDashboardName);
+    let id: string | undefined;
+    try {
+      id = await createDashboard(newDashboardName);
+    } catch {
+      showError("Failed to create dashboard. Please try again.");
+      return;
+    }
+
+    if (!id) {
+      showError("Dashboard creation returned an unexpected result.");
+      return;
+    }
 
     setIsCreateOpen(false);
     setNewDashboardName("");


### PR DESCRIPTION
Tracked internally as YW-254.

## Changes

- Wrap `handleCreate` in `try/catch` — a `createDashboard` rejection no longer propagates as an unhandled Promise rejection; on error an error toast is shown and the dialog stays open (no close, no name reset) so the user can retry.
- Guard navigation with an `id` check before `navigate()` — when `createDashboard` resolves `undefined` the user no longer lands on `/dashboards/undefined`.
- Add `page.test.tsx` covering both failure paths (reject + undefined resolve) and the success path.

## Screenshots

Error-path hardening (UI change is the error toast on failure + dialog staying open). Working-flow is unchanged: user fills name, clicks Create, navigates to the new dashboard.

No visual regression to the happy path.

## Verification

- `vitest run` — 431/431 pass including the 3 new failure-path tests.
- `eslint` on changed files — 0 errors, 0 warnings.
- Both new test cases confirm navigation is blocked and `showError` fires exactly once.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the dashboard creation flow by wrapping `createDashboard` in a `try/catch` and adding a falsy-`id` guard, preventing both unhandled rejections and `/dashboards/undefined` navigations. On either failure the dialog stays open and an error toast is shown so the user can retry without losing their input.

- `page.tsx`: two new early-return paths (rejection + undefined result) each call `showError`; the success path is unchanged.
- `page.test.tsx`: new test file with three focused cases that verify all branches — including the regression guards against navigation and the dialog-stays-open contract.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-tested defensive wrapper around a single async call with no impact on the happy path.

Both error paths are exercised by new tests, the success path is unchanged, and the component contract (dialog closes, name resets, navigation fires) is fully verified.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/app/dashboards/page.tsx | Adds try/catch around createDashboard and an undefined-id guard; both error paths show a toast and bail early, leaving the dialog open for retry. Success path unchanged. |
| packages/app/src/app/dashboards/page.test.tsx | New test file covering all three handleCreate paths (reject, undefined resolve, success). Mocks are hoisted correctly; success test asserts dialog closes via queryByPlaceholderText null-check. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([handleCreate called]) --> B{name trimmed?}
    B -->|No| Z([return early])
    B -->|Yes| C[await createDashboard name]
    C -->|throws| D[showError Failed to create]
    D --> Z
    C -->|resolves falsy| E[showError Unexpected result]
    E --> Z
    C -->|resolves id string| F[setIsCreateOpen false]
    F --> G[setNewDashboardName empty]
    G --> H[navigate to /dashboards/id]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app/src/app/dashboards/page.tsx`, line 28-47 ([link](https://github.com/youhaowei/dashframe/blob/ea94c423ecbfdc7c942b68def82c6c1366477038/packages/app/src/app/dashboards/page.tsx#L28-L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Create button not disabled during in-flight request**

   While the dialog now stays open on error (enabling retry), the "Create" button remains enabled for the entire duration of the `createDashboard` await. On a slow network a user can click multiple times before the promise resolves, firing several concurrent `createDashboard` calls and potentially creating duplicate dashboards.

   Consider tracking an `isCreating` boolean with `useState`, setting it to `true` before the `try` and back to `false` in a `finally` block, then passing `disabled={!newDashboardName.trim() || isCreating}` to the Create button.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/app/dashboards/page.tsx
   Line: 28-47

   Comment:
   **Create button not disabled during in-flight request**

   While the dialog now stays open on error (enabling retry), the "Create" button remains enabled for the entire duration of the `createDashboard` await. On a slow network a user can click multiple times before the promise resolves, firing several concurrent `createDashboard` calls and potentially creating duplicate dashboards.

   Consider tracking an `isCreating` boolean with `useState`, setting it to `true` before the `try` and back to `false` in a `finally` block, then passing `disabled={!newDashboardName.trim() || isCreating}` to the Create button.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2Fpage.tsx%0ALine%3A%2028-47%0A%0AComment%3A%0A**Create%20button%20not%20disabled%20during%20in-flight%20request**%0A%0AWhile%20the%20dialog%20now%20stays%20open%20on%20error%20%28enabling%20retry%29%2C%20the%20%22Create%22%20button%20remains%20enabled%20for%20the%20entire%20duration%20of%20the%20%60createDashboard%60%20await.%20On%20a%20slow%20network%20a%20user%20can%20click%20multiple%20times%20before%20the%20promise%20resolves%2C%20firing%20several%20concurrent%20%60createDashboard%60%20calls%20and%20potentially%20creating%20duplicate%20dashboards.%0A%0AConsider%20tracking%20an%20%60isCreating%60%20boolean%20with%20%60useState%60%2C%20setting%20it%20to%20%60true%60%20before%20the%20%60try%60%20and%20back%20to%20%60false%60%20in%20a%20%60finally%60%20block%2C%20then%20passing%20%60disabled%3D%7B!newDashboardName.trim%28%29%20%7C%7C%20isCreating%7D%60%20to%20the%20Create%20button.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=114&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw-254-dashboard-create-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw-254-dashboard-create-guard%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2Fpage.tsx%0ALine%3A%2028-47%0A%0AComment%3A%0A**Create%20button%20not%20disabled%20during%20in-flight%20request**%0A%0AWhile%20the%20dialog%20now%20stays%20open%20on%20error%20%28enabling%20retry%29%2C%20the%20%22Create%22%20button%20remains%20enabled%20for%20the%20entire%20duration%20of%20the%20%60createDashboard%60%20await.%20On%20a%20slow%20network%20a%20user%20can%20click%20multiple%20times%20before%20the%20promise%20resolves%2C%20firing%20several%20concurrent%20%60createDashboard%60%20calls%20and%20potentially%20creating%20duplicate%20dashboards.%0A%0AConsider%20tracking%20an%20%60isCreating%60%20boolean%20with%20%60useState%60%2C%20setting%20it%20to%20%60true%60%20before%20the%20%60try%60%20and%20back%20to%20%60false%60%20in%20a%20%60finally%60%20block%2C%20then%20passing%20%60disabled%3D%7B!newDashboardName.trim%28%29%20%7C%7C%20isCreating%7D%60%20to%20the%20Create%20button.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=114&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Fdashboards%2Fpage.tsx%0ALine%3A%2028-47%0A%0AComment%3A%0A**Create%20button%20not%20disabled%20during%20in-flight%20request**%0A%0AWhile%20the%20dialog%20now%20stays%20open%20on%20error%20%28enabling%20retry%29%2C%20the%20%22Create%22%20button%20remains%20enabled%20for%20the%20entire%20duration%20of%20the%20%60createDashboard%60%20await.%20On%20a%20slow%20network%20a%20user%20can%20click%20multiple%20times%20before%20the%20promise%20resolves%2C%20firing%20several%20concurrent%20%60createDashboard%60%20calls%20and%20potentially%20creating%20duplicate%20dashboards.%0A%0AConsider%20tracking%20an%20%60isCreating%60%20boolean%20with%20%60useState%60%2C%20setting%20it%20to%20%60true%60%20before%20the%20%60try%60%20and%20back%20to%20%60false%60%20in%20a%20%60finally%60%20block%2C%20then%20passing%20%60disabled%3D%7B!newDashboardName.trim%28%29%20%7C%7C%20isCreating%7D%60%20to%20the%20Create%20button.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=114&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(app): assert dialog closes on succe..."](https://github.com/youhaowei/dashframe/commit/5396bb849bb62263a4455f41c3787c4ee1a5c9e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37522323)</sub>

<!-- /greptile_comment -->