### PR TITLE
refactor(app): remove unsafe as-never navigation casts, restore route type-safety [YW-249]

### DIFF
--- a/packages/app/src/app/_components/DashboardSection.test.tsx
+++ b/packages/app/src/app/_components/DashboardSection.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Navigation contracts for the home-page section components.
+ *
+ * Contracts:
+ * - DashboardSection: clicking "View all" calls navigate with the viewAllHref
+ *   that was passed in, without any unsafe cast.
+ * - RecentInsightsSection: selecting an item calls navigate with the typed
+ *   insight detail route.
+ * - RecentVisualizationsSection: selecting an item calls navigate with the
+ *   typed visualization detail route.
+ *
+ * These tests also serve as the typecheck-passes-without-`as never` proof:
+ * the mock returns a plain jest.fn() with type `(opts: { to: string }) => void`,
+ * which the real navigate call satisfies without any cast.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockNavigate } = vi.hoisted(() => {
+  const navigate = vi.fn();
+  return { mockNavigate: navigate };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@dashframe/core", () => ({
+  useInsights: () => ({
+    data: [
+      {
+        id: "ins-1",
+        name: "Revenue Trend",
+        createdAt: 1000,
+        metrics: [{ id: "m1" }],
+        selectedFields: ["field1", "field2"],
+      },
+    ],
+  }),
+  useVisualizations: () => ({
+    data: [
+      {
+        id: "viz-1",
+        name: "Bar Chart",
+        createdAt: 1000,
+      },
+    ],
+  }),
+}));
+
+// VisualizationPreview is a heavy component — stub it to avoid pulling in
+// chart renderer dependencies.
+vi.mock("@/components/visualizations/VisualizationPreview", () => ({
+  VisualizationPreview: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Import components after mocks are set up
+// ---------------------------------------------------------------------------
+
+import { DashboardSection } from "./DashboardSection";
+import { RecentInsightsSection } from "./RecentInsightsSection";
+import { RecentVisualizationsSection } from "./RecentVisualizationsSection";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DashboardSection – View all navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls navigate with viewAllHref when 'View all' is clicked", () => {
+    render(
+      <DashboardSection
+        title="Test Section"
+        viewAllHref="/insights"
+        items={[{ id: "1", title: "Item 1" }]}
+        onItemSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /view all/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/insights" });
+  });
+});
+
+describe("RecentInsightsSection – item navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls navigate with the typed insight route on item select", () => {
+    render(<RecentInsightsSection />);
+
+    // The section renders the item; click it to trigger onItemSelect → navigate
+    fireEvent.click(screen.getByText("Revenue Trend"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/insights/ins-1" });
+  });
+});
+
+describe("RecentVisualizationsSection – item navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls navigate with the typed visualization route on item select", () => {
+    render(<RecentVisualizationsSection />);
+
+    fireEvent.click(screen.getByText("Bar Chart"));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/visualizations/viz-1" });
+  });
+});

--- a/packages/app/src/app/_components/DashboardSection.tsx
+++ b/packages/app/src/app/_components/DashboardSection.tsx
@@ -50,7 +50,7 @@ export function DashboardSection({
           size="sm"
           icon={ArrowRightIcon}
           label="View all"
-          onClick={() => navigate({ to: viewAllHref } as never)}
+          onClick={() => navigate({ to: viewAllHref })}
         />
       </div>
       <ItemList

--- a/packages/app/src/app/_components/RecentInsightsSection.tsx
+++ b/packages/app/src/app/_components/RecentInsightsSection.tsx
@@ -35,7 +35,7 @@ export function RecentInsightsSection() {
       icon={SparklesIcon}
       viewAllHref="/insights"
       items={recentInsights}
-      onItemSelect={(id) => navigate({ to: `/insights/${id}` } as never)}
+      onItemSelect={(id) => navigate({ to: `/insights/${id}` })}
     />
   );
 }

--- a/packages/app/src/app/_components/RecentVisualizationsSection.tsx
+++ b/packages/app/src/app/_components/RecentVisualizationsSection.tsx
@@ -37,7 +37,7 @@ export function RecentVisualizationsSection() {
       icon={ChartIcon}
       viewAllHref="/visualizations"
       items={recentVisualizations}
-      onItemSelect={(id) => navigate({ to: `/visualizations/${id}` } as never)}
+      onItemSelect={(id) => navigate({ to: `/visualizations/${id}` })}
       gap={16}
     />
   );


### PR DESCRIPTION
Tracked internally as YW-249.

Remove three `as never` casts on `navigate({to: ...})` calls that were
suppressing compile-time route validation without providing any runtime
value. Adds navigation contract tests for each of the three components.

## Changes

- `DashboardSection.tsx`: remove `as never` from View All button `navigate` call
- `RecentInsightsSection.tsx`: remove `as never` from item-select `navigate` call
- `RecentVisualizationsSection.tsx`: remove `as never` from item-select `navigate` call
- `DashboardSection.test.tsx` (new): navigation contract tests for all three components

**Why the casts were safe to remove:** `packages/app` excludes `src/routes/**` from its tsconfig, so the `Register` module augmentation (defined in the host apps) is not present during `packages/app`'s own typecheck. This means `RegisteredRouter` falls back to `AnyRouter`, and `RoutePaths<any>` resolves to `string` — which already accepts any string literal without a cast. `QuickLinksSection.tsx` already used this cast-free pattern (`navigate({ to: \`/${id}\` })`); the three fixed components now match it.

## Screenshots

No UI change (type-safety refactor).

## Verification

- Typecheck (`tsc --noEmit`) passes on `packages/app` with zero new errors (pre-existing `app-data` error is unrelated and unchanged).
- Lint clean (`eslint .` on `@dashframe/app` exits 0).
- Test suite: 429 passing / 2 pre-existing failures in `dashboards/page.test.tsx` (unrelated, reproduce on `main`).
- New `DashboardSection.test.tsx` asserts `navigate` receives the exact expected typed route for each of the three components.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes three `as never` casts on `navigate({ to: ... })` calls in the home-page section components, replacing them with clean, cast-free calls that compile correctly thanks to `RegisteredRouter` falling back to `AnyRouter` (and thus `RoutePaths<any>` → `string`) in `packages/app`. A new `DashboardSection.test.tsx` adds navigation contract tests for all three components.

- **DashboardSection / RecentInsightsSection / RecentVisualizationsSection**: each `navigate` call drops the redundant `as never` cast, matching the existing pattern already used in `QuickLinksSection.tsx`.
- **DashboardSection.test.tsx** (new): adds `vi.hoisted` / `vi.mock` based contracts that verify each component calls `navigate` with the exact expected route string, and double as a compile-time proof that no cast is needed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — three one-line cast removals with no runtime behavior change, backed by new navigation contract tests.

Each change removes a cast that was suppressing the type-checker without altering what gets called at runtime. The new test file directly asserts the exact route strings passed to navigate, so any future regression in these call sites will be caught immediately. No logic, data flow, or API surface has changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/app/_components/DashboardSection.tsx | Removes `as never` from the "View all" button's `navigate({ to: viewAllHref })` call; no logic changes. |
| packages/app/src/app/_components/RecentInsightsSection.tsx | Removes `as never` from `navigate({ to: \`/insights/${id}\` })`; identical semantics at runtime. |
| packages/app/src/app/_components/RecentVisualizationsSection.tsx | Removes `as never` from `navigate({ to: \`/visualizations/${id}\` })`; identical semantics at runtime. |
| packages/app/src/app/_components/DashboardSection.test.tsx | New test file; uses vi.hoisted for a shared mockNavigate, mocks @tanstack/react-router and @dashframe/core, and covers navigation contracts for all three section components. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DashboardSection
    participant RecentInsightsSection
    participant RecentVisualizationsSection
    participant navigate

    User->>DashboardSection: click "View all"
    DashboardSection->>navigate: "navigate({ to: viewAllHref })"

    User->>RecentInsightsSection: click insight item
    RecentInsightsSection->>navigate: "navigate({ to: `/insights/${id}` })"

    User->>RecentVisualizationsSection: click visualization item
    RecentVisualizationsSection->>navigate: "navigate({ to: `/visualizations/${id}` })"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(app): remove unsafe as-never na..."](https://github.com/youhaowei/dashframe/commit/02d6923849c39e95b047ad5a1a48fd16eaff16e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37522503)</sub>

<!-- /greptile_comment -->