### PR TITLE
refactor(build): YW-257 uniform TS-main — bun condition in Electron bundler, drop server dist

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -24,6 +24,13 @@
  * The filter auto-handles new transitive npm deps and new workspace packages
  * without editing an allowlist — but externalized npm deps must resolve at
  * runtime from apps/desktop, so they're declared as direct desktop deps.
+ *
+ * conditions: ["bun"] tells esbuild to prefer the "bun" export condition when
+ * resolving workspace packages — that condition maps to ./src/index.ts (raw
+ * TypeScript source). esbuild merges this with the platform:"node" defaults,
+ * so workspace packages are resolved from src while npm packages continue to
+ * resolve via Node's default condition. This is what makes all @dashframe/*
+ * packages TS-main: no per-package dist is needed for the Electron bundle.
  */
 import esbuild from "esbuild";
 import path from "node:path";
@@ -50,6 +57,7 @@ await esbuild.build({
   bundle: true,
   platform: "node",
   format: "esm",
+  conditions: ["bun"],
   outfile: path.resolve(import.meta.dirname, "..", "dist", "main.js"),
   plugins: [externalizeNpm],
 });

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -37,47 +37,18 @@ function awaitProc(child, label) {
   });
 }
 
-// Desktop's main bundle marks workspace packages as external, so every
-// workspace dep main.ts reaches must exist as JS before it is bundled —
-// Electron 33 (Node 20) cannot load .ts entry points at runtime. Build the
-// dependency chain in order: wystack framework → server-core → engine-server
-// → server app.
+// The desktop main bundle resolves @dashframe/* and @wystack/* workspace
+// packages via the "bun" export condition → raw TypeScript source. esbuild
+// bundles them at build:main time, so no pre-built dist is needed for any
+// @dashframe/* package. Only @wystack/* still ship dist (submodule packages
+// outside this repo's control), so we build those first.
 const repoRoot = path.resolve(desktopDir, "..", "..");
 
-// 1a. Build the @wystack/* packages main consumes via @dashframe/server.
+// 1. Build the @wystack/* packages main consumes via @dashframe/server.
+// @dashframe/* packages are all TS-main; they resolve from src at bundle time.
 await awaitProc(
   spawn("bun", ["run", "build:wystack"], { cwd: repoRoot, stdio: "inherit" }),
   "wystack build",
-);
-
-// 1b. Build @dashframe/server-core (PGLite + Drizzle project DB).
-await awaitProc(
-  spawn("bun", ["run", "--filter", "@dashframe/server-core", "build"], {
-    cwd: repoRoot,
-    stdio: "inherit",
-  }),
-  "server-core build",
-);
-
-// 1c. Build @dashframe/engine-server (native DuckDB engine + Arrow data path).
-// @dashframe/server imports createArrowDataPath from it and its `types` export
-// points at dist/index.d.ts, so the server build below needs its emitted JS +
-// declarations present in a clean checkout.
-await awaitProc(
-  spawn("bun", ["run", "--filter", "@dashframe/engine-server", "build"], {
-    cwd: repoRoot,
-    stdio: "inherit",
-  }),
-  "engine-server build",
-);
-
-// 1d. Build @dashframe/server (the WyStack server app main starts on loopback).
-await awaitProc(
-  spawn("bun", ["run", "--filter", "@dashframe/server", "build"], {
-    cwd: repoRoot,
-    stdio: "inherit",
-  }),
-  "server build",
 );
 
 // 2. Build desktop main + preload

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,23 +9,18 @@
   "exports": {
     ".": "./src/index.ts",
     "./app": {
-      "types": "./dist/app.d.ts",
       "bun": "./src/app.ts",
-      "default": "./dist/app.js"
+      "default": "./src/app.ts"
     },
     "./functions": {
-      "types": "./dist/functions.d.ts",
       "bun": "./src/functions.ts",
-      "default": "./dist/functions.js"
+      "default": "./src/functions.ts"
     }
   },
   "scripts": {
     "dev": "bun run src/index.ts",
     "start": "bun run src/index.ts",
     "test": "vitest run",
-    "build": "bun run build:js && bun run build:types",
-    "build:js": "esbuild src/index.ts src/app.ts src/functions.ts --bundle --platform=node --packages=external --format=esm --outdir=dist",
-    "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "check": "bun run typecheck && bun run lint"

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -3,27 +3,19 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "bun": "./src/index.ts",
-      "default": "./dist/index.js"
+      "default": "./src/index.ts"
     },
     "./arrow-data-path": {
-      "types": "./dist/arrow-data-path.d.ts",
       "bun": "./src/arrow-data-path.ts",
-      "default": "./dist/arrow-data-path.js"
+      "default": "./src/arrow-data-path.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "scripts": {
-    "build": "bun run build:js && bun run build:types",
-    "build:js": "esbuild src/index.ts src/arrow-data-path.ts --bundle --platform=node --packages=external --format=esm --outdir=dist",
-    "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "node -e \"require('node:fs/promises').rm('dist',{recursive:true,force:true})\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -3,22 +3,15 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "bun": "./src/index.ts",
-      "default": "./dist/index.js"
+      "default": "./src/index.ts"
     }
   },
-  "files": [
-    "dist"
-  ],
   "scripts": {
-    "build": "bun run build:js && bun run build:types",
-    "build:js": "esbuild src/index.ts --bundle --platform=node --packages=external --format=esm --outfile=dist/index.js",
-    "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "node -e \"require('node:fs/promises').rm('dist',{recursive:true,force:true})\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",


### PR DESCRIPTION
## Summary

- **Bundler change** (`apps/desktop/scripts/build-main.mjs`): Added `conditions: ["bun"]` to the esbuild config. esbuild merges this with `platform: "node"` defaults, so `@dashframe/*` workspace packages now resolve via their `"bun": "./src/index.ts"` export condition (raw TypeScript source) instead of `"default": "./dist/index.js"`. npm packages continue resolving via Node's default condition — no breakage.
- **Dist stripped** from three packages: `packages/engine-server`, `packages/server-core`, `apps/server`. Removed `build`/`build:js`/`build:types` scripts; updated `main`/`types`/`exports` to point at `./src/index.ts` (and subpath variants). Shape matches the existing TS-main packages (`@dashframe/engine`, `@dashframe/types`, etc.).
- **`dev.mjs` updated**: Removed the now-unnecessary pre-build steps for engine-server, server-core, and server. Only `@wystack/*` still needs pre-building (submodule packages outside this repo's control).

## Bundler approach: `conditions: ["bun"]`

A single-line change to the esbuild config was sufficient. No alias map needed. The `"bun"` export condition was already present in all three packages' `exports`; the bundler just wasn't using it. This is the clean path the ticket anticipated.

**Proof of src resolution** (Step 1): Built `apps/desktop/dist/main.js` with no dist present for any of the three packages. The bundle header lines show all source files resolved from src — zero dist paths:
```
// ../../packages/engine-server/src/compile.ts
// ../../packages/engine-server/src/engine-selection.ts
// ../../packages/engine-server/src/native-engine.ts
// ../../packages/engine-server/src/parquet-cache.ts
// ../../packages/server-core/src/db.ts
// ../../packages/server-core/src/project.ts
// ../../packages/server-core/src/schema.ts
// ../server/src/app.ts
// ../server/src/functions.ts
```

## Desktop cold-start evidence

Real GUI cold-start on macOS. Built the bundle from clean state (no dist), then launched `Electron.app` with the `apps/desktop` directory. Captured from the Electron main process stdout:

```
[dashframe] main process started, waiting for app ready...
[dashframe] app ready, opening project...
[dashframe] project ready at /Users/youhaowei/.DashFrame/default-project
[dashframe] engine binding: native
[dashframe] native DuckDB engine ready
[dashframe] loopback server ready at http://127.0.0.1:59325
[dashframe] creating window with DEV_URL=http://localhost:5173...
```

The loopback server (backed by `engine-server` + `server-core` + `apps/server` all resolved from src) started successfully. The window failed to load `localhost:5173` (no Vite dev server running in the test environment — expected), but all server-side startup was complete and healthy before the window attempt.

## Verification gate

1. **Full clean build**: `turbo clean` → `bun run build` — **19 tasks, all successful**. Web and renderer Vite builds both green.
2. **Full-graph typecheck**: `turbo typecheck` — **42 tasks, all successful**. Includes desktop, app-data (which imports `@dashframe/server/functions` as a type), renderer, web, etc.
3. **`bun run check`**: `check:ticket-refs` + `turbo check --filter=!@wystack/*` — **70 tasks, all successful**. Lint warnings are pre-existing (not from this change). Tests for apps/server (PGLite integration, ~30s) all pass.
4. **Desktop cold-start**: Real GUI cold-start with log evidence above. Server-ready line confirmed.
5. **Vite/web build**: Both `@dashframe/web` and `@dashframe/renderer` built cleanly; `@dashframe/*` resolved from src via the existing Vite config aliases.

## Scope fence

Only touched the 5 files in scope:
- `apps/desktop/scripts/build-main.mjs`
- `apps/desktop/scripts/dev.mjs`
- `apps/server/package.json`
- `packages/engine-server/package.json`
- `packages/server-core/package.json`

Submodules (`libs/wystack`, `libs/stdui`) untouched. `@dashframe/engine` (already TS-main) untouched. No turbo.json changes needed — packages with no `build` script are silently skipped by turbo (same as `@dashframe/types`).

## AC checklist

- [x] `conditions: ["bun"]` added to `build-main.mjs` esbuild config
- [x] Bundle resolves engine-server, server-core, apps/server from src (proven: no dist present, build succeeded, src paths in bundle header)
- [x] `engine-server` `main`/`types`/`exports`/`scripts` → TS-main
- [x] `server-core` `main`/`types`/`exports`/`scripts` → TS-main
- [x] `apps/server` subpath exports and `build` scripts → TS-main
- [x] `dev.mjs` pre-build steps for the three packages removed
- [x] Full clean build green (19 tasks)
- [x] Full-graph typecheck green (42 tasks)
- [x] Full check green (70 tasks)
- [x] Desktop cold-start: loopback server started, engine initialized, log line captured
- [x] Web Vite build unaffected
- [x] No scope-fence breaches, submodules untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes a "TS-main" unification for the three remaining packages that still shipped compiled dist: `packages/engine-server`, `packages/server-core`, and `apps/server`. A single `conditions: ["bun"]` addition to the esbuild config is the key lever — esbuild now resolves `@dashframe/*` workspace packages through their `"bun"` export condition (raw TypeScript source) instead of pre-built JS, eliminating the per-package build step entirely.

- **`build-main.mjs`**: adds `conditions: ["bun"]` so esbuild resolves all `@dashframe/*` exports from `./src/*.ts`. The `externalizeNpm` plugin continues to externalize non-workspace packages before esbuild ever touches their exports, so the new condition cannot accidentally pull in a Bun-native npm package implementation.
- **Three `package.json` files** (`engine-server`, `server-core`, `apps/server`): `main`/`types`/`exports` all redirected to `.ts` source; `build`/`build:js`/`build:types` scripts and `files` arrays removed, matching the existing pattern of `@dashframe/engine` and `@dashframe/types`.
- **`dev.mjs`**: sequential pre-build steps for the three packages dropped; only the `@wystack/*` pre-build (external submodule) is kept.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The bundler change is a single well-scoped line and is provably working — npm packages are externalized before esbuild inspects their conditions, so no runtime mismatch is possible. The three package.json conversions follow an established pattern already used by other packages in the repo.

The refactor is clean and thoroughly tested. The only leftover is the now-unused esbuild devDependency in apps/server/package.json — a dead import entry that has no runtime impact but is worth tidying up.

apps/server/package.json — the esbuild devDependency can be dropped since no scripts invoke it any more.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/scripts/build-main.mjs | Adds conditions: ["bun"] to esbuild config so workspace packages resolve to their TypeScript source via the "bun" export condition. npm packages are still externalized by the plugin and are never resolved by esbuild, so the new condition cannot affect them. |
| apps/desktop/scripts/dev.mjs | Removes the sequential pre-build steps for server-core, engine-server, and apps/server (now TS-main); only @wystack/* pre-build step is retained. Comment updated to explain the reason. |
| apps/server/package.json | Drops build/build:js/build:types scripts and updates exports to point at .ts source for all conditions. The esbuild devDependency is now unused since the build scripts that invoked it were removed. |
| packages/engine-server/package.json | Converts to TS-main: main/types now point at ./src/index.ts, all export conditions redirect to src, build scripts removed, files array dropped. |
| packages/server-core/package.json | Converts to TS-main: same pattern as engine-server — main/types → ./src/index.ts, exports to src, build scripts and files removed. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["esbuild\nbuild-main.mjs\nplatform: node\nconditions: ['bun']"] --> B{Bare specifier?}
    B -- "@dashframe/* or @wystack/*" --> C[return undefined\ninline + bundle]
    B -- "anything else" --> D[external: true\nNode resolves at runtime]
    C --> E{Check export conditions}
    E -- "'bun' matched" --> F["./src/index.ts\n(TypeScript source)"]
    E -- "no 'bun', use 'default'" --> G["./src/index.ts\n(same, both conditions point to src)"]
    F --> H[esbuild bundles TS\ninto dist/main.js]
    G --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["esbuild\nbuild-main.mjs\nplatform: node\nconditions: ['bun']"] --> B{Bare specifier?}
    B -- "@dashframe/* or @wystack/*" --> C[return undefined\ninline + bundle]
    B -- "anything else" --> D[external: true\nNode resolves at runtime]
    C --> E{Check export conditions}
    E -- "'bun' matched" --> F["./src/index.ts\n(TypeScript source)"]
    E -- "no 'bun', use 'default'" --> G["./src/index.ts\n(same, both conditions point to src)"]
    F --> H[esbuild bundles TS\ninto dist/main.js]
    G --> H
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/server/package.json`, line 41-43 ([link](https://github.com/youhaowei/dashframe/blob/839e25322c719d0b010491d5dc297e40e29730ee/apps/server/package.json#L41-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `esbuild` devDependency is now dead weight. The only scripts that invoked it (`build:js`) were removed in this PR, so nothing in `apps/server` uses esbuild directly any more.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/package.json
   Line: 41-43

   Comment:
   The `esbuild` devDependency is now dead weight. The only scripts that invoked it (`build:js`) were removed in this PR, so nothing in `apps/server` uses esbuild directly any more.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fpackage.json%0ALine%3A%2041-43%0A%0AComment%3A%0AThe%20%60esbuild%60%20devDependency%20is%20now%20dead%20weight.%20The%20only%20scripts%20that%20invoked%20it%20%28%60build%3Ajs%60%29%20were%20removed%20in%20this%20PR%2C%20so%20nothing%20in%20%60apps%2Fserver%60%20uses%20esbuild%20directly%20any%20more.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22typescript%22%3A%20%225.7.2%22%2C%0A%20%20%20%20%22vitest%22%3A%20%22%5E4.1.6%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-257-uniform-ts-main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-257-uniform-ts-main%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fpackage.json%0ALine%3A%2041-43%0A%0AComment%3A%0AThe%20%60esbuild%60%20devDependency%20is%20now%20dead%20weight.%20The%20only%20scripts%20that%20invoked%20it%20%28%60build%3Ajs%60%29%20were%20removed%20in%20this%20PR%2C%20so%20nothing%20in%20%60apps%2Fserver%60%20uses%20esbuild%20directly%20any%20more.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22typescript%22%3A%20%225.7.2%22%2C%0A%20%20%20%20%22vitest%22%3A%20%22%5E4.1.6%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fpackage.json%0ALine%3A%2041-43%0A%0AComment%3A%0AThe%20%60esbuild%60%20devDependency%20is%20now%20dead%20weight.%20The%20only%20scripts%20that%20invoked%20it%20%28%60build%3Ajs%60%29%20were%20removed%20in%20this%20PR%2C%20so%20nothing%20in%20%60apps%2Fserver%60%20uses%20esbuild%20directly%20any%20more.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22typescript%22%3A%20%225.7.2%22%2C%0A%20%20%20%20%22vitest%22%3A%20%22%5E4.1.6%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fserver%2Fpackage.json%3A41-43%0AThe%20%60esbuild%60%20devDependency%20is%20now%20dead%20weight.%20The%20only%20scripts%20that%20invoked%20it%20%28%60build%3Ajs%60%29%20were%20removed%20in%20this%20PR%2C%20so%20nothing%20in%20%60apps%2Fserver%60%20uses%20esbuild%20directly%20any%20more.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22typescript%22%3A%20%225.7.2%22%2C%0A%20%20%20%20%22vitest%22%3A%20%22%5E4.1.6%22%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-257-uniform-ts-main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-257-uniform-ts-main%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fserver%2Fpackage.json%3A41-43%0AThe%20%60esbuild%60%20devDependency%20is%20now%20dead%20weight.%20The%20only%20scripts%20that%20invoked%20it%20%28%60build%3Ajs%60%29%20were%20removed%20in%20this%20PR%2C%20so%20nothing%20in%20%60apps%2Fserver%60%20uses%20esbuild%20directly%20any%20more.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22typescript%22%3A%20%225.7.2%22%2C%0A%20%20%20%20%22vitest%22%3A%20%22%5E4.1.6%22%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fserver%2Fpackage.json%3A41-43%0AThe%20%60esbuild%60%20devDependency%20is%20now%20dead%20weight.%20The%20only%20scripts%20that%20invoked%20it%20%28%60build%3Ajs%60%29%20were%20removed%20in%20this%20PR%2C%20so%20nothing%20in%20%60apps%2Fserver%60%20uses%20esbuild%20directly%20any%20more.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22typescript%22%3A%20%225.7.2%22%2C%0A%20%20%20%20%22vitest%22%3A%20%22%5E4.1.6%22%0A%60%60%60%0A%0A&pr=120&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/server/package.json:41-43
The `esbuild` devDependency is now dead weight. The only scripts that invoked it (`build:js`) were removed in this PR, so nothing in `apps/server` uses esbuild directly any more.

```suggestion
    "typescript": "5.7.2",
    "vitest": "^4.1.6"
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(build): uniform TS-main — resol..."](https://github.com/youhaowei/dashframe/commit/839e25322c719d0b010491d5dc297e40e29730ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37778580)</sub>

<!-- /greptile_comment -->