### PR TITLE
chore(deps): bump wystack submodule — @wystack/secret-vault substrate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -322,6 +322,13 @@
         "pino-pretty",
       ],
     },
+    "libs/wystack/packages/secret-vault": {
+      "name": "@wystack/secret-vault",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.8.3",
+      },
+    },
     "libs/wystack/packages/server": {
       "name": "@wystack/server",
       "version": "0.0.1",
@@ -1683,6 +1690,8 @@
     "@wystack/db": ["@wystack/db@workspace:libs/wystack/packages/db"],
 
     "@wystack/log": ["@wystack/log@workspace:libs/wystack/packages/log"],
+
+    "@wystack/secret-vault": ["@wystack/secret-vault@workspace:libs/wystack/packages/secret-vault"],
 
     "@wystack/server": ["@wystack/server@workspace:libs/wystack/packages/server"],
 
@@ -3613,6 +3622,8 @@
     "@wystack/db/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@wystack/log/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@wystack/secret-vault/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@wystack/server/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 


### PR DESCRIPTION
Re-points `libs/wystack` onto wystack main `6b5f7c1` (merged [wystack#43](https://github.com/youhaowei/wystack/pull/43)), which adds the `@wystack/secret-vault` substrate from YW-261.

Single-gitlink change: `5d0a23f → 6b5f7c1`. No DashFrame package imports the new substrate yet — that lands in YW-263 (data-plane bound-resolver) and YW-264 (control-plane migration), which this bump unblocks.

`bun install` resolves the new workspace package clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `libs/wystack` submodule pointer one commit forward (`5d0a23f → 6b5f7c1`) to pull in the merged wystack#43 change, which introduces the `@wystack/secret-vault` package. No DashFrame package consumes the new substrate yet; that integration is deferred to YW-263 and YW-264.

- The gitlink change is minimal and correctly recorded; the submodule URL is unchanged and the bump targets the wystack `main` branch HEAD.
- `bun.lock` was not updated: all existing `@wystack/*` packages have workspace entries in the lock file, but `@wystack/secret-vault` is absent — meaning downstream PRs that import it may encounter resolution failures until the lock is committed.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as a submodule pointer change, but the accompanying bun.lock update is missing — the new workspace package won't resolve reliably in CI or on fresh checkouts until it is committed.

The submodule gitlink itself is a one-line change pointing at a known wystack main branch commit. The only meaningful risk is that bun.lock was not updated to include the new @wystack/secret-vault workspace entry, leaving the lock file inconsistent with the actual workspace graph. Any downstream PR that imports the new package will likely fail in a clean bun install environment until the lock is regenerated and committed.

bun.lock — needs to be regenerated and committed to include the new @wystack/secret-vault workspace entry that this submodule bump adds
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/wystack | Submodule pointer bumped from 5d0a23f to 6b5f7c1 to add @wystack/secret-vault; bun.lock not updated to include the new workspace entry |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant DashFrame as DashFrame monorepo
    participant Submodule as libs/wystack (submodule)
    participant BunWS as Bun Workspace

    Note over Submodule: 5d0a23f → 6b5f7c1<br/>(wystack#43 merged)
    Submodule-->>BunWS: "adds @wystack/secret-vault package"
    BunWS-->>DashFrame: "workspace:* resolution (bun.lock should update)"
    Note over DashFrame: YW-263 (data-plane bound-resolver) blocked on this bump
    Note over DashFrame: YW-264 (control-plane migration) blocked on this bump
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant DashFrame as DashFrame monorepo
    participant Submodule as libs/wystack (submodule)
    participant BunWS as Bun Workspace

    Note over Submodule: 5d0a23f → 6b5f7c1<br/>(wystack#43 merged)
    Submodule-->>BunWS: "adds @wystack/secret-vault package"
    BunWS-->>DashFrame: "workspace:* resolution (bun.lock should update)"
    Note over DashFrame: YW-263 (data-plane bound-resolver) blocked on this bump
    Note over DashFrame: YW-264 (control-plane migration) blocked on this bump
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Fwystack%3A1%0A**Lock%20file%20not%20updated%20with%20new%20workspace%20package**%0A%0AThe%20PR%20description%20claims%20%22%60bun%20install%60%20resolves%20the%20new%20workspace%20package%20clean%2C%22%20but%20%60bun.lock%60%20was%20not%20modified%20in%20this%20commit.%20Every%20other%20existing%20%60%40wystack%2F*%60%20package%20under%20%60libs%2Fwystack%2Fpackages%2F%60%20has%20an%20entry%20in%20%60bun.lock%60%20%28e.g.%20%60%22libs%2Fwystack%2Fpackages%2Fclient%22%60%2C%20%60%22libs%2Fwystack%2Fpackages%2Fdb%22%60%29%2C%20yet%20%60%40wystack%2Fsecret-vault%60%20is%20absent.%20Without%20committing%20the%20updated%20lock%20file%2C%20the%20resolved%20workspace%20graph%20is%20not%20reproducible%20across%20CI%20environments%20%E2%80%94%20any%20package%20that%20imports%20%60%40wystack%2Fsecret-vault%60%20in%20the%20upcoming%20YW-263%2FYW-264%20PRs%20will%20fail%20to%20resolve%20if%20bun's%20lock%20is%20stale.%0A%0A&repo=youhaowei%2Fdashframe&pr=121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22chore%2Fbump-wystack-secret-vault%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fbump-wystack-secret-vault%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Fwystack%3A1%0A**Lock%20file%20not%20updated%20with%20new%20workspace%20package**%0A%0AThe%20PR%20description%20claims%20%22%60bun%20install%60%20resolves%20the%20new%20workspace%20package%20clean%2C%22%20but%20%60bun.lock%60%20was%20not%20modified%20in%20this%20commit.%20Every%20other%20existing%20%60%40wystack%2F*%60%20package%20under%20%60libs%2Fwystack%2Fpackages%2F%60%20has%20an%20entry%20in%20%60bun.lock%60%20%28e.g.%20%60%22libs%2Fwystack%2Fpackages%2Fclient%22%60%2C%20%60%22libs%2Fwystack%2Fpackages%2Fdb%22%60%29%2C%20yet%20%60%40wystack%2Fsecret-vault%60%20is%20absent.%20Without%20committing%20the%20updated%20lock%20file%2C%20the%20resolved%20workspace%20graph%20is%20not%20reproducible%20across%20CI%20environments%20%E2%80%94%20any%20package%20that%20imports%20%60%40wystack%2Fsecret-vault%60%20in%20the%20upcoming%20YW-263%2FYW-264%20PRs%20will%20fail%20to%20resolve%20if%20bun's%20lock%20is%20stale.%0A%0A&repo=youhaowei%2Fdashframe&pr=121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Fwystack%3A1%0A**Lock%20file%20not%20updated%20with%20new%20workspace%20package**%0A%0AThe%20PR%20description%20claims%20%22%60bun%20install%60%20resolves%20the%20new%20workspace%20package%20clean%2C%22%20but%20%60bun.lock%60%20was%20not%20modified%20in%20this%20commit.%20Every%20other%20existing%20%60%40wystack%2F*%60%20package%20under%20%60libs%2Fwystack%2Fpackages%2F%60%20has%20an%20entry%20in%20%60bun.lock%60%20%28e.g.%20%60%22libs%2Fwystack%2Fpackages%2Fclient%22%60%2C%20%60%22libs%2Fwystack%2Fpackages%2Fdb%22%60%29%2C%20yet%20%60%40wystack%2Fsecret-vault%60%20is%20absent.%20Without%20committing%20the%20updated%20lock%20file%2C%20the%20resolved%20workspace%20graph%20is%20not%20reproducible%20across%20CI%20environments%20%E2%80%94%20any%20package%20that%20imports%20%60%40wystack%2Fsecret-vault%60%20in%20the%20upcoming%20YW-263%2FYW-264%20PRs%20will%20fail%20to%20resolve%20if%20bun's%20lock%20is%20stale.%0A%0A&pr=121&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
libs/wystack:1
**Lock file not updated with new workspace package**

The PR description claims "`bun install` resolves the new workspace package clean," but `bun.lock` was not modified in this commit. Every other existing `@wystack/*` package under `libs/wystack/packages/` has an entry in `bun.lock` (e.g. `"libs/wystack/packages/client"`, `"libs/wystack/packages/db"`), yet `@wystack/secret-vault` is absent. Without committing the updated lock file, the resolved workspace graph is not reproducible across CI environments — any package that imports `@wystack/secret-vault` in the upcoming YW-263/YW-264 PRs will fail to resolve if bun's lock is stale.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump wystack submodule to i..."](https://github.com/youhaowei/dashframe/commit/124f68f85c59b4fca8b13bc9869912ce756c6dc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37786169)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->