### PR TITLE
fix(ui): strip IEEE-754 noise from numeric cell display [YW-220]

### DIFF
--- a/packages/ui/src/components/VirtualTable.tsx
+++ b/packages/ui/src/components/VirtualTable.tsx
@@ -3,6 +3,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn, Spinner } from "@wystack/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { formatNumeric } from "../lib/format-numeric";
 
 // ============================================================================
 // Types
@@ -113,6 +114,7 @@ function defaultFormatValue(value: unknown): string {
   if (value === null || value === undefined) return "—";
   const dateStr = formatDate(value);
   if (dateStr) return dateStr;
+  if (typeof value === "number") return formatNumeric(value);
   if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -75,3 +75,7 @@ export {
 export { Input as InputField } from "./fields/input";
 export { MultiSelect as MultiSelectField } from "./fields/multi-select";
 export { Select as SelectField } from "./fields/select";
+
+// -- Display-layer utilities --
+
+export { formatNumeric } from "./lib/format-numeric";

--- a/packages/ui/src/lib/format-numeric.test.ts
+++ b/packages/ui/src/lib/format-numeric.test.ts
@@ -17,6 +17,12 @@ describe("formatNumeric", () => {
     expect(formatNumeric(-42)).toBe("-42");
   });
 
+  it("leaves large integers exact (no toPrecision truncation)", () => {
+    // COUNT(*) or financial IDs with > 10 significant digits must never be rounded
+    expect(formatNumeric(12345678901)).toBe("12345678901");
+    expect(formatNumeric(100000000011)).toBe("100000000011");
+  });
+
   it("preserves genuine long-decimal precision within 10 sig-figs", () => {
     // 1234.5678 has 8 sig-figs — well within 10, should round-trip exactly
     expect(formatNumeric(1234.5678)).toBe("1234.5678");

--- a/packages/ui/src/lib/format-numeric.test.ts
+++ b/packages/ui/src/lib/format-numeric.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { formatNumeric } from "./format-numeric";
+
+describe("formatNumeric", () => {
+  it("strips IEEE-754 noise from SUM result (canonical bug case)", () => {
+    // DuckDB SUM(amount) for 409.95 produces this raw float:
+    expect(formatNumeric(409.95000000000005)).toBe("409.95");
+  });
+
+  it("leaves a clean decimal unchanged", () => {
+    expect(formatNumeric(409.95)).toBe("409.95");
+  });
+
+  it("leaves an integer unchanged (no decimal point added)", () => {
+    expect(formatNumeric(1000)).toBe("1000");
+    expect(formatNumeric(0)).toBe("0");
+    expect(formatNumeric(-42)).toBe("-42");
+  });
+
+  it("preserves genuine long-decimal precision within 10 sig-figs", () => {
+    // 1234.5678 has 8 sig-figs — well within 10, should round-trip exactly
+    expect(formatNumeric(1234.5678)).toBe("1234.5678");
+  });
+
+  it("does not over-truncate a legitimately precise value", () => {
+    // 10 sig-figs: 12345678.90 → stays as-is (trailing zero stripped by parseFloat)
+    expect(formatNumeric(12345678.9)).toBe("12345678.9");
+  });
+
+  it("handles negative floats with noise", () => {
+    // -0.1 - 0.2 = -0.30000000000000004 in IEEE-754
+    expect(formatNumeric(-0.30000000000000004)).toBe("-0.3");
+  });
+
+  it("handles AVG noise (fractional with many decimals)", () => {
+    // A representative AVG result with noise past the 10th sig-fig
+    expect(formatNumeric(12.333333333333334)).toBe("12.33333333");
+  });
+
+  it("passes through non-finite values as strings", () => {
+    expect(formatNumeric(Infinity)).toBe("Infinity");
+    expect(formatNumeric(-Infinity)).toBe("-Infinity");
+    expect(formatNumeric(NaN)).toBe("NaN");
+  });
+});

--- a/packages/ui/src/lib/format-numeric.ts
+++ b/packages/ui/src/lib/format-numeric.ts
@@ -21,6 +21,9 @@
  */
 export function formatNumeric(n: number): string {
   if (!isFinite(n)) return String(n);
+  // Integers are already exact — skip toPrecision so that values like
+  // COUNT(*) = 12345678901 are never rounded to 12345678900.
+  if (Number.isInteger(n)) return String(n);
   // toPrecision(10) → "4.095000000e+2" style strings for large exponents;
   // parseFloat normalises them back to the plain decimal representation.
   return String(parseFloat(n.toPrecision(10)));

--- a/packages/ui/src/lib/format-numeric.ts
+++ b/packages/ui/src/lib/format-numeric.ts
@@ -1,0 +1,27 @@
+/**
+ * Display-layer numeric formatting for aggregate query results.
+ *
+ * DuckDB float arithmetic can produce IEEE-754 noise tails
+ * (e.g. SUM(amount) = 409.95000000000005 instead of 409.95).
+ * This formatter strips that noise at the display boundary without
+ * mutating the underlying value.
+ *
+ * Strategy: round to 10 significant digits via `toPrecision`, then
+ * parse back to a number so JavaScript drops trailing zeros naturally
+ * (`parseFloat("409.9500000000"`) → 409.95`). 10 sig-figs preserves
+ * real precision for values like 1234.5678 while eliminating the
+ * sub-ULP error that appears in the 15th–16th digit.
+ *
+ * Rules:
+ * - Integers: returned as-is (no decimal point introduced).
+ * - Already-clean decimals: unchanged (e.g. "409.95" stays "409.95").
+ * - Very long but genuinely precise decimals: rounded to 10 sig-figs,
+ *   which is the practical limit of DuckDB DOUBLE precision anyway.
+ * - Non-finite (Infinity, -Infinity, NaN): returned as String(n).
+ */
+export function formatNumeric(n: number): string {
+  if (!isFinite(n)) return String(n);
+  // toPrecision(10) → "4.095000000e+2" style strings for large exponents;
+  // parseFloat normalises them back to the plain decimal representation.
+  return String(parseFloat(n.toPrecision(10)));
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
           name: "unit",
           environment: "node",
           globals: true,
-          include: ["src/**/*.test.ts"],
+          // Scope tightly to lib/ so DOM-touching component tests don't
+          // accidentally run in the node environment.
+          include: ["src/lib/**/*.test.ts"],
         },
       },
       {

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -16,6 +16,15 @@ const dirname =
 export default defineConfig({
   test: {
     projects: [
+      // Pure unit tests (no browser / DOM needed)
+      {
+        test: {
+          name: "unit",
+          environment: "node",
+          globals: true,
+          include: ["src/**/*.test.ts"],
+        },
+      },
       {
         extends: true,
         plugins: [


### PR DESCRIPTION
## Summary

- **Where:** `packages/ui/src/lib/format-numeric.ts` — new `formatNumeric` utility; `packages/ui/src/components/VirtualTable.tsx` — `defaultFormatValue` now routes numeric values through it
- **Before:** `SUM(amount)` → `409.95000000000005`
- **After:** `SUM(amount)` → `409.95`

## How it works

`formatNumeric` rounds to 10 significant digits via `n.toPrecision(10)`, then calls `parseFloat` to strip trailing zeros. 10 sig-figs is sufficient to eliminate sub-ULP noise (which appears in the 15th–16th significant digit) without truncating legitimate precision:

| Input | Output |
|-------|--------|
| `409.95000000000005` | `"409.95"` |
| `409.95` | `"409.95"` (clean, unchanged) |
| `1234.5678` | `"1234.5678"` (8 sig-figs, no truncation) |
| `1000` | `"1000"` (integer, no decimal added) |
| `-0.30000000000000004` | `"-0.3"` |

The raw DuckDB/engine value is never mutated — this is a display-only formatter applied at the `VirtualTable` cell render boundary.

## Test plan

- [x] `packages/ui/src/lib/format-numeric.test.ts` — 8 unit tests covering the canonical bug case, clean decimals, integers, genuinely-precise long decimals, negative floats, AVG noise, and non-finite values
- [x] `turbo typecheck` — 44/44 tasks pass
- [x] `turbo test` — 38/38 test tasks pass (170 server tests + all others)
- [x] Lint — 0 errors (1 pre-existing warning in unrelated `select.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `formatNumeric` display-layer utility to strip IEEE-754 floating-point noise from aggregate query results (e.g. `409.95000000000005` → `"409.95"`), and routes all numeric cell values in `VirtualTable` through it.

- **`format-numeric.ts`**: New formatter using `toPrecision(10)` + `parseFloat` for non-integer floats, with early exits for non-finite values and integers to avoid truncating large `COUNT(*)` or ID values.
- **`VirtualTable.tsx`**: One-line integration — `typeof value === "number"` routes to `formatNumeric` before the object/string fallbacks.
- **`vitest.config.ts`**: Adds a `"unit"` project scoped to `src/lib/**/*.test.ts` in a Node environment; correctly scoped to avoid pulling in DOM-dependent component tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — display-only change with no mutation of underlying data and good test coverage.

The formatter is applied only at the render boundary in VirtualTable, raw values are never mutated, and both previous feedback items (integer guard, scoped test include pattern) are now correctly addressed in this revision. The logic is straightforward and well-exercised by the test suite.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/lib/format-numeric.ts | New formatting utility with correct integer guard, non-finite guard, and toPrecision(10)+parseFloat strategy; all edge cases well-handled. |
| packages/ui/src/lib/format-numeric.test.ts | Comprehensive test suite covering canonical bug case, clean decimals, integers, large integers (>10 sig-figs), genuine precision, negative floats, AVG noise, and non-finite values. |
| packages/ui/src/components/VirtualTable.tsx | Minimal, correct integration — numeric branch added before the object/string fallback in defaultFormatValue. |
| packages/ui/vitest.config.ts | New "unit" project correctly scoped to src/lib/**/*.test.ts in node environment, avoiding accidental DOM-dependent test inclusion. |
| packages/ui/src/index.ts | Exports formatNumeric under a "Display-layer utilities" section; clean and appropriate. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["VirtualTable cell render\n(defaultFormatValue)"] --> B{typeof value}
    B -- null/undefined --> C["return '—'"]
    B -- date string --> D["return formatDate(value)"]
    B -- number --> E["formatNumeric(n)"]
    B -- object --> F["JSON.stringify(value)"]
    B -- other --> G["String(value)"]

    E --> H{isFinite?}
    H -- No --> I["String(n)\n(Infinity/-Infinity/NaN)"]
    H -- Yes --> J{Number.isInteger?}
    J -- Yes --> K["String(n)\n(exact, no toPrecision)"]
    J -- No --> L["parseFloat(n.toPrecision(10))"]
    L --> M["String(result)\n(trailing zeros stripped)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["VirtualTable cell render\n(defaultFormatValue)"] --> B{typeof value}
    B -- null/undefined --> C["return '—'"]
    B -- date string --> D["return formatDate(value)"]
    B -- number --> E["formatNumeric(n)"]
    B -- object --> F["JSON.stringify(value)"]
    B -- other --> G["String(value)"]

    E --> H{isFinite?}
    H -- No --> I["String(n)\n(Infinity/-Infinity/NaN)"]
    H -- Yes --> J{Number.isInteger?}
    J -- Yes --> K["String(n)\n(exact, no toPrecision)"]
    J -- No --> L["parseFloat(n.toPrecision(10))"]
    L --> M["String(result)\n(trailing zeros stripped)"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): guard integers from toPrecision..."](https://github.com/youhaowei/dashframe/commit/700a45db9b23dce8cb2734298120a624f6483b5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37811843)</sub>

<!-- /greptile_comment -->