### PR TITLE
fix(app): YW-222 — deduplicate auto-draft insights per source table

### DIFF
--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -574,17 +574,30 @@ describe("useCreateInsight", () => {
       expect(mockPush).toHaveBeenCalledWith("/insights/insight-1");
 
       vi.clearAllMocks();
-      mockGetAllInsights.mockResolvedValue([]);
 
-      // Second call with a *different* table — should still create fresh.
-      mockCreateInsight.mockResolvedValueOnce("insight-2");
+      // Second call for the SAME table — the newly created draft now exists
+      // and is still unmodified. The gate should reuse it, not create again.
+      const existingDraft = createMockInsight({
+        id: "insight-1",
+        name: "Orders",
+        baseTableId: "table-shared",
+        selectedFields: [],
+      });
+      mockGetAllInsights.mockResolvedValueOnce([existingDraft]);
 
+      let secondId: string | null = null;
       await act(async () => {
-        await result.current.createInsightFromTable("table-other", "Revenue");
+        secondId = await result.current.createInsightFromTable(
+          "table-shared",
+          "Orders",
+        );
       });
 
-      expect(mockCreateInsight).toHaveBeenCalledTimes(1);
-      expect(mockPush).toHaveBeenCalledWith("/insights/insight-2");
+      // Must NOT create a second insight
+      expect(mockCreateInsight).not.toHaveBeenCalled();
+      // Must navigate to the existing draft
+      expect(mockPush).toHaveBeenCalledWith("/insights/insight-1");
+      expect(secondId).toBe("insight-1");
     });
 
     it("should create insight chain (table → insight → derived)", async () => {

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -305,6 +305,38 @@ describe("useCreateInsight", () => {
         selectedFields: [],
       });
     });
+
+    it("should find a gap-free suffix when an intermediate name was deleted", async () => {
+      // Simulate: user had "orders", "orders (2)", "orders (3)"; deleted "orders (2)".
+      // The next suffix should be "orders (2)" (fills the gap), not "orders (4)".
+      const insight1 = createMockInsight({
+        id: "i1",
+        name: "orders",
+        baseTableId: "table-orders",
+        selectedFields: ["field-a"],
+      });
+      const insight3 = createMockInsight({
+        id: "i3",
+        name: "orders (3)",
+        baseTableId: "table-orders",
+        selectedFields: ["field-b"],
+      });
+
+      mockGetAllInsights.mockResolvedValue([insight1, insight3]);
+      mockCreateInsight.mockResolvedValue("gap-fill-draft");
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      await act(async () => {
+        await result.current.createInsightFromTable("table-orders", "orders");
+      });
+
+      expect(mockCreateInsight).toHaveBeenCalledWith(
+        "orders (2)", // gap-free: (2) is missing, not (4)
+        "table-orders",
+        { selectedFields: [] },
+      );
+    });
   });
 
   describe("createInsightFromInsight", () => {

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -14,18 +14,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCreateInsight } from "./useCreateInsight";
 
 // Mock functions must be hoisted with vi.mock
-const { mockCreateInsight, mockGetInsight, mockMutations } = vi.hoisted(() => {
-  const create = vi.fn();
-  return {
-    mockCreateInsight: create,
-    mockGetInsight: vi.fn(),
-    mockMutations: { create },
-  };
-});
+const { mockCreateInsight, mockGetInsight, mockGetAllInsights, mockMutations } =
+  vi.hoisted(() => {
+    const create = vi.fn();
+    return {
+      mockCreateInsight: create,
+      mockGetInsight: vi.fn(),
+      mockGetAllInsights: vi.fn(),
+      mockMutations: { create },
+    };
+  });
 
 vi.mock("@dashframe/core", () => ({
   useInsightMutations: () => mockMutations,
   getInsight: mockGetInsight,
+  getAllInsights: mockGetAllInsights,
 }));
 
 const { mockPush, mockNavigate } = vi.hoisted(() => {
@@ -64,6 +67,8 @@ function createMockInsight(options: {
 describe("useCreateInsight", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no pre-existing insights (dedup gate finds nothing to reuse)
+    mockGetAllInsights.mockResolvedValue([]);
   });
 
   describe("createInsightFromTable", () => {
@@ -177,6 +182,128 @@ describe("useCreateInsight", () => {
           );
         });
       }).rejects.toThrow("Database error");
+    });
+  });
+
+  describe("createInsightFromTable — dedup", () => {
+    it("should reuse an existing unmodified draft for the same source table", async () => {
+      const existingDraft = createMockInsight({
+        id: "existing-draft",
+        name: "orders",
+        baseTableId: "table-orders",
+        selectedFields: [], // unmodified
+      });
+
+      mockGetAllInsights.mockResolvedValue([existingDraft]);
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      let insightId: string | null = null;
+      await act(async () => {
+        insightId = await result.current.createInsightFromTable(
+          "table-orders",
+          "orders",
+        );
+      });
+
+      // Must NOT create a new insight
+      expect(mockCreateInsight).not.toHaveBeenCalled();
+      // Must navigate to the existing draft
+      expect(mockPush).toHaveBeenCalledWith("/insights/existing-draft");
+      expect(insightId).toBe("existing-draft");
+    });
+
+    it("should create a new draft (no suffix) when no insights exist for the table", async () => {
+      mockGetAllInsights.mockResolvedValue([]);
+      mockCreateInsight.mockResolvedValue("new-draft");
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      await act(async () => {
+        await result.current.createInsightFromTable("table-orders", "orders");
+      });
+
+      expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
+        selectedFields: [],
+      });
+      expect(mockPush).toHaveBeenCalledWith("/insights/new-draft");
+    });
+
+    it("should create a suffixed draft when an existing modified insight is present", async () => {
+      const modifiedInsight = createMockInsight({
+        id: "modified-insight",
+        name: "orders",
+        baseTableId: "table-orders",
+        selectedFields: ["field-1"], // modified — has a selected field
+      });
+
+      mockGetAllInsights.mockResolvedValue([modifiedInsight]);
+      mockCreateInsight.mockResolvedValue("new-draft-2");
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      await act(async () => {
+        await result.current.createInsightFromTable("table-orders", "orders");
+      });
+
+      // A suffix is used rather than prompting — non-blocking, drive-feel
+      expect(mockCreateInsight).toHaveBeenCalledWith(
+        "orders (2)",
+        "table-orders",
+        { selectedFields: [] },
+      );
+      expect(mockPush).toHaveBeenCalledWith("/insights/new-draft-2");
+    });
+
+    it("should not reuse a modified insight that has filters set", async () => {
+      const modifiedInsight = createMockInsight({
+        id: "filtered-insight",
+        name: "orders",
+        baseTableId: "table-orders",
+        selectedFields: [],
+      });
+      // Add a filter to mark it as modified
+      modifiedInsight.filters = [
+        { field: "status", operator: "eq", value: "active" },
+      ];
+
+      mockGetAllInsights.mockResolvedValue([modifiedInsight]);
+      mockCreateInsight.mockResolvedValue("new-draft-filtered");
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      await act(async () => {
+        await result.current.createInsightFromTable("table-orders", "orders");
+      });
+
+      expect(mockCreateInsight).toHaveBeenCalledWith(
+        "orders (2)",
+        "table-orders",
+        { selectedFields: [] },
+      );
+    });
+
+    it("should not affect dedup for a different source table", async () => {
+      const otherTableDraft = createMockInsight({
+        id: "other-draft",
+        name: "customers",
+        baseTableId: "table-customers",
+        selectedFields: [],
+      });
+
+      mockGetAllInsights.mockResolvedValue([otherTableDraft]);
+      mockCreateInsight.mockResolvedValue("orders-draft");
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      await act(async () => {
+        await result.current.createInsightFromTable("table-orders", "orders");
+      });
+
+      // The existing draft is for a different table — a new insight is created
+      expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
+        selectedFields: [],
+      });
     });
   });
 
@@ -400,20 +527,31 @@ describe("useCreateInsight", () => {
   });
 
   describe("integration scenarios", () => {
-    it("should create multiple insights from same table", async () => {
-      mockCreateInsight
-        .mockResolvedValueOnce("insight-1")
-        .mockResolvedValueOnce("insight-2");
+    it("should reuse the unmodified draft on a second call for the same table", async () => {
+      // First call — no existing insights, creates a new draft.
+      mockGetAllInsights.mockResolvedValueOnce([]);
+      mockCreateInsight.mockResolvedValueOnce("insight-1");
 
       const { result } = renderHook(() => useCreateInsight());
 
       await act(async () => {
-        await result.current.createInsightFromTable("table-shared", "First");
-        await result.current.createInsightFromTable("table-shared", "Second");
+        await result.current.createInsightFromTable("table-shared", "Orders");
       });
 
-      expect(mockCreateInsight).toHaveBeenCalledTimes(2);
+      expect(mockCreateInsight).toHaveBeenCalledTimes(1);
       expect(mockPush).toHaveBeenCalledWith("/insights/insight-1");
+
+      vi.clearAllMocks();
+      mockGetAllInsights.mockResolvedValue([]);
+
+      // Second call with a *different* table — should still create fresh.
+      mockCreateInsight.mockResolvedValueOnce("insight-2");
+
+      await act(async () => {
+        await result.current.createInsightFromTable("table-other", "Revenue");
+      });
+
+      expect(mockCreateInsight).toHaveBeenCalledTimes(1);
       expect(mockPush).toHaveBeenCalledWith("/insights/insight-2");
     });
 

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -90,10 +90,19 @@ export function useCreateInsight() {
       // with a numeric suffix so the user can distinguish without a modal prompt.
       // Suffix-vs-prompt: suffix is non-blocking and fits the drive-feel of the
       // app; a prompt would interrupt a routine action just to confirm a name.
-      const name =
-        sameTableInsights.length > 0
-          ? `${tableName} (${sameTableInsights.length + 1})`
-          : tableName;
+      //
+      // Use the first gap-free suffix to avoid collisions when insights are
+      // deleted and re-created (e.g. "orders (2)" deleted → next should be
+      // "orders (2)", not "orders (3)").
+      let name = tableName;
+      if (sameTableInsights.length > 0) {
+        const existingNames = new Set(sameTableInsights.map((i) => i.name));
+        let suffix = 2;
+        while (existingNames.has(`${tableName} (${suffix})`)) {
+          suffix++;
+        }
+        name = `${tableName} (${suffix})`;
+      }
 
       // Create draft insight with empty fields (shows preview + suggestions)
       const insightId = await createInsight(

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -1,6 +1,26 @@
-import { getInsight, useInsightMutations } from "@dashframe/core";
+import {
+  getAllInsights,
+  getInsight,
+  useInsightMutations,
+} from "@dashframe/core";
+import type { Insight } from "@dashframe/types";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
+
+/**
+ * Returns true when an insight is an unmodified auto-draft: no fields selected,
+ * no metrics, no filters, no sorts, and no joins. These are safe to reuse
+ * rather than accumulate as duplicates.
+ */
+function isUnmodifiedDraft(insight: Insight): boolean {
+  return (
+    (insight.selectedFields?.length ?? 0) === 0 &&
+    (insight.metrics?.length ?? 0) === 0 &&
+    (insight.filters?.length ?? 0) === 0 &&
+    (insight.sorts?.length ?? 0) === 0 &&
+    (insight.joins?.length ?? 0) === 0
+  );
+}
 
 /**
  * Creates insights and navigates to their pages.
@@ -11,6 +31,14 @@ import { useCallback } from "react";
  *
  * Both methods create a draft insight with empty selectedFields and navigate
  * to the insight page (action hub) for further configuration.
+ *
+ * Auto-draft deduplication (createInsightFromTable only):
+ * - If an unmodified draft for the same source table already exists, it is
+ *   reused (navigated to) rather than creating a duplicate.
+ * - If the existing insight(s) have been modified/saved, a new draft is
+ *   created with a disambiguating numeric suffix, e.g. "orders (2)".
+ *   A prompt would be less disruptive but would interrupt a routine action;
+ *   the suffix matches the drive-feel expectation of the app.
  *
  * @example From table (standard flow)
  * ```tsx
@@ -38,12 +66,38 @@ export function useCreateInsight() {
 
   /**
    * Creates a draft insight from a data table and navigates to it.
+   *
+   * Dedup gate: if an unmodified draft for the same source table already
+   * exists, this reuses it instead of creating a new one. If the existing
+   * insight was modified, a new draft is created with a numeric suffix.
    */
   const createInsightFromTable = useCallback(
     async (tableId: string, tableName: string) => {
+      // --- Dedup gate ---
+      const allInsights = await getAllInsights();
+      const sameTableInsights = allInsights.filter(
+        (i) => i.baseTableId === tableId,
+      );
+
+      // Reuse an existing unmodified draft rather than accumulating duplicates.
+      const existingDraft = sameTableInsights.find(isUnmodifiedDraft);
+      if (existingDraft) {
+        navigate({ to: `/insights/${existingDraft.id}` } as never);
+        return existingDraft.id;
+      }
+
+      // One or more modified insights exist for this table — create a new draft
+      // with a numeric suffix so the user can distinguish without a modal prompt.
+      // Suffix-vs-prompt: suffix is non-blocking and fits the drive-feel of the
+      // app; a prompt would interrupt a routine action just to confirm a name.
+      const name =
+        sameTableInsights.length > 0
+          ? `${tableName} (${sameTableInsights.length + 1})`
+          : tableName;
+
       // Create draft insight with empty fields (shows preview + suggestions)
       const insightId = await createInsight(
-        tableName, // name
+        name,
         tableId, // baseTableId
         { selectedFields: [] }, // Empty for draft state
       );


### PR DESCRIPTION
## Summary

Fixes the accumulation of identical draft insights when the same CSV file is imported multiple times, or when "New Visualization" is clicked repeatedly for the same source table.

### Root cause

`createInsightFromTable` in `useCreateInsight.ts` unconditionally created a new insight on every call, with no check for pre-existing drafts for the same `baseTableId`. N imports → N identical `"orders"` drafts.

### Dedup gate

The fix adds a dedup check at the top of `createInsightFromTable`:

1. `getAllInsights()` is called (imperative, async — consistent with how `getInsight` is already used in `createInsightFromInsight`).
2. Existing insights are filtered to those with the same `baseTableId`.
3. **Unmodified draft** (`isUnmodifiedDraft`: `selectedFields`, `metrics`, `filters`, `sorts`, and `joins` are all empty) → **reuse**: navigate to the existing draft, return its id. No new insight created.
4. **Modified/saved insight(s) exist** → **create new draft** with a numeric disambiguating suffix (e.g. `orders (2)`).
5. **No existing insights** → create draft with the plain table name (no change to current behavior).

**The gate lives in:** `packages/app/src/hooks/useCreateInsight.ts` — the `createInsightFromTable` callback, plus the new module-level `isUnmodifiedDraft` helper.

### Suffix vs prompt

The ticket offered "disambiguating suffix OR prompt the user." The suffix is chosen because:
- It is non-blocking — no modal interrupts a routine action.
- It matches the drive-feel expectation of the app.
- A prompt adds friction every time the user has a prior modified insight, which is the normal state once they've done real work.

### Source-table identity

`baseTableId` (the UUID of the `DataTable` record) is used as the dedup key, matching the field already used in `createInsight` and throughout the insight model. It is stable across renames.

### Tests

Five new tests in the `createInsightFromTable — dedup` describe block:
- Existing unmodified draft → reused, `createInsight` not called.
- No existing insights → new draft created without suffix.
- Existing modified insight (has `selectedFields`) → new draft with suffix `"orders (2)"`.
- Existing modified insight (has `filters`) → treated as modified, suffix applied.
- Existing draft for a **different** table → not affected, new insight created without suffix.

The `integration scenarios` test for "create multiple insights from same table" was updated to reflect correct dedup behavior.

## Test output

```
Test Files  27 passed (27)
      Tests  459 passed (459)
```

`turbo typecheck` — 44 tasks successful. `turbo lint` — clean (pre-existing `@dashframe/ui` warning unrelated to this change).

## Checklist

- [x] Dedup gate checks for existing draft before creating
- [x] Existing unmodified draft → reused (opened), not duplicated
- [x] Existing modified/saved draft → new one created with suffix
- [x] No silent duplicate unmodified drafts
- [x] Tests cover all four dedup branches
- [x] Full gate: typecheck + lint + tests green

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a dedup gate to `createInsightFromTable` that reuses an existing unmodified draft for the same source table instead of creating a duplicate, and applies a gap-free numeric suffix when the existing insight has been modified.

- **Dedup gate** (`useCreateInsight.ts`): calls `getAllInsights`, filters by `baseTableId`, reuses the first unmodified draft or creates a suffixed new draft; the gap-free suffix loop (starting at 2, skipping occupied names) correctly handles deletion/recreation gaps, addressing the collision raised in the previous review cycle.
- **Tests** (`useCreateInsight.test.tsx`): six new dedup unit tests cover all four branches (reuse, no existing, modified present, different table) plus the new gap-free suffix case; the integration scenario is updated to verify the gate fires on a second same-table call; `beforeEach` seeds `mockGetAllInsights` with `[]` so pre-existing tests are unaffected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the dedup gate is well-scoped and all existing tests pass with the new mock default.

The change is confined to a single hook and its tests. The dedup logic correctly handles the primary cases (reuse unmodified draft, suffix for modified, different table), and the gap-free suffix algorithm fixes the collision scenario flagged in the prior review cycle. The only edge case is that the suffix is applied even when the plain table name is not taken by any existing insight — a naming quirk rather than a data or navigation correctness issue.

The suffix-assignment branch in useCreateInsight.ts (lines 97–105) is worth a second look for the scenario where all same-table insights have been renamed away from the table name.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/hooks/useCreateInsight.ts | Adds dedup gate to createInsightFromTable: reuses unmodified drafts, creates suffixed drafts otherwise. Gap-free suffix algorithm is correct; minor naming edge case when existing same-table insights have been renamed away from the table name. |
| packages/app/src/hooks/useCreateInsight.test.tsx | Six new dedup unit tests plus updated integration scenario; beforeEach sets empty getAllInsights default so existing tests remain unaffected. Covers all four dedup branches and the gap-free suffix case. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createInsightFromTable called
tableId, tableName] --> B[await getAllInsights]
    B --> C[filter by baseTableId == tableId
sameTableInsights]
    C --> D{sameTableInsights
.find isUnmodifiedDraft?}
    D -- Found --> E[navigate to existingDraft.id
return existingDraft.id
no new insight created]
    D -- Not Found --> F{sameTableInsights
.length > 0?}
    F -- No --> G[name = tableName
plain, no suffix]
    F -- Yes --> H[build existingNames Set
from sameTableInsights.name]
    H --> I[suffix = 2
while existingNames has
tableName with suffix
increment suffix]
    I --> J[name = tableName + suffix]
    G --> K[await createInsight name, tableId,
selectedFields empty]
    J --> K
    K --> L[navigate to /insights/insightId
return insightId]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[createInsightFromTable called
tableId, tableName] --> B[await getAllInsights]
    B --> C[filter by baseTableId == tableId
sameTableInsights]
    C --> D{sameTableInsights
.find isUnmodifiedDraft?}
    D -- Found --> E[navigate to existingDraft.id
return existingDraft.id
no new insight created]
    D -- Not Found --> F{sameTableInsights
.length > 0?}
    F -- No --> G[name = tableName
plain, no suffix]
    F -- Yes --> H[build existingNames Set
from sameTableInsights.name]
    H --> I[suffix = 2
while existingNames has
tableName with suffix
increment suffix]
    I --> J[name = tableName + suffix]
    G --> K[await createInsight name, tableId,
selectedFields empty]
    J --> K
    K --> L[navigate to /insights/insightId
return insightId]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/7e20d49ffb377f4331e89ceb9ea2aedc9b37334e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37811949)</sub>

<!-- /greptile_comment -->