### PR TITLE
fix(app): YW-221 type-aware date formatting in data-preview table

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/sections/DataPreviewSection.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/sections/DataPreviewSection.tsx
@@ -1,4 +1,5 @@
 import { useInsightPagination } from "@/hooks/useInsightPagination";
+import { formatCellValue } from "@/lib/cell-formatter";
 import type { Insight } from "@dashframe/types";
 import { VirtualTable, type VirtualTableColumnConfig } from "@dashframe/ui";
 import { Section, Toggle } from "@wystack/ui";
@@ -80,17 +81,35 @@ export const DataPreviewSection = memo(function DataPreviewSection({
   // Select the active pagination based on mode
   const activePagination =
     previewMode === "join" ? joinPagination : resultPagination;
-  const { fetchData, totalCount, fieldCount, isReady, columnDisplayNames } =
-    activePagination;
+  const {
+    fetchData,
+    totalCount,
+    fieldCount,
+    isReady,
+    columnDisplayNames,
+    columnTypeMap,
+  } = activePagination;
 
-  // Build column configs for VirtualTable to show human-readable headers
-  // This maps UUID column aliases (field_<uuid>) to display names
+  // Build column configs for VirtualTable:
+  // - human-readable label (from display names)
+  // - type-aware format function (from type map) so date columns render as
+  //   formatted date strings instead of raw epoch milliseconds
   const columnConfigs = useMemo((): VirtualTableColumnConfig[] => {
-    return Object.entries(columnDisplayNames).map(([id, label]) => ({
-      id,
-      label,
-    }));
-  }, [columnDisplayNames]);
+    return Object.entries(columnDisplayNames).map(([id, label]) => {
+      const colType = columnTypeMap[id];
+      return {
+        id,
+        label,
+        // Only attach a custom formatter when the column has a declared type.
+        // Non-date columns get undefined here and VirtualTable falls back to
+        // its own defaultFormatValue — keeping non-date rendering unchanged.
+        format:
+          colType !== undefined
+            ? (value: unknown) => formatCellValue(value, colType)
+            : undefined,
+      };
+    });
+  }, [columnDisplayNames, columnTypeMap]);
 
   // Compute display counts
   const displayRowCount = totalCount || 0;

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -7,7 +7,13 @@ import {
   metricIdToColumnAlias,
 } from "@dashframe/engine";
 import { ensureTableLoaded } from "@dashframe/engine-browser";
-import type { DataTable, Field, Insight, UUID } from "@dashframe/types";
+import type {
+  ColumnType,
+  DataTable,
+  Field,
+  Insight,
+  UUID,
+} from "@dashframe/types";
 import type { FetchDataParams, FetchDataResult } from "@dashframe/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -147,6 +153,26 @@ export function useInsightPagination({
     }
 
     return displayNames;
+  }, [resolvedFields, insight.metrics]);
+
+  // Build mapping from UUID column aliases to ColumnType.
+  // Metrics are always numeric (aggregations); fields carry their declared type.
+  // Consumers use this to drive type-aware cell formatting (e.g. epoch → date).
+  const columnTypeMap = useMemo((): Record<string, ColumnType> => {
+    const typeMap: Record<string, ColumnType> = {};
+
+    for (const field of resolvedFields) {
+      const alias = fieldIdToColumnAlias(field.id);
+      typeMap[alias] = field.type;
+    }
+
+    // Metrics are aggregations — always numeric
+    for (const metric of insight.metrics ?? []) {
+      const alias = metricIdToColumnAlias(metric.id);
+      typeMap[alias] = "number";
+    }
+
+    return typeMap;
   }, [resolvedFields, insight.metrics]);
 
   // Load DataFrames into DuckDB (parallel loading for performance)
@@ -398,5 +424,13 @@ export function useInsightPagination({
      * Values: Human-readable field/metric names
      */
     columnDisplayNames,
+    /**
+     * Mapping from UUID column aliases to ColumnType.
+     * Use this to drive type-aware cell formatting (e.g. epoch millis → date).
+     *
+     * Keys: `field_<uuid>` or `metric_<uuid>`
+     * Values: "string" | "number" | "boolean" | "date" | "unknown"
+     */
+    columnTypeMap,
   };
 }

--- a/packages/app/src/lib/cell-formatter.test.ts
+++ b/packages/app/src/lib/cell-formatter.test.ts
@@ -30,6 +30,14 @@ describe("formatCellValue", () => {
     expect(formatCellValue("not-a-date", "date")).toBe("—");
   });
 
+  it("returns — for a boolean value in a date column (non-parseable type)", () => {
+    expect(formatCellValue(true, "date")).toBe("—");
+  });
+
+  it("returns — for an object value in a date column (non-parseable type)", () => {
+    expect(formatCellValue({ a: 1 }, "date")).toBe("—");
+  });
+
   // ── non-date types (the critical guard: keys off type, not value) ──────────
 
   it("does NOT format a large number as a date when the column type is number", () => {

--- a/packages/app/src/lib/cell-formatter.test.ts
+++ b/packages/app/src/lib/cell-formatter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { formatCellValue } from "./cell-formatter";
+
+describe("formatCellValue", () => {
+  // ── date type ─────────────────────────────────────────────────────────────
+
+  it("formats an epoch-millisecond number as YYYY-MM-DD for date columns", () => {
+    // 2024-01-18T00:00:00.000Z in epoch ms
+    expect(formatCellValue(1705536000000, "date")).toBe("2024-01-18");
+  });
+
+  it("formats a Date object as YYYY-MM-DD for date columns", () => {
+    const date = new Date("2024-06-15T00:00:00.000Z");
+    expect(formatCellValue(date, "date")).toBe("2024-06-15");
+  });
+
+  it("formats an ISO date string as YYYY-MM-DD for date columns", () => {
+    expect(formatCellValue("2024-03-25", "date")).toBe("2024-03-25");
+  });
+
+  it("returns — for null in a date column", () => {
+    expect(formatCellValue(null, "date")).toBe("—");
+  });
+
+  it("returns — for undefined in a date column", () => {
+    expect(formatCellValue(undefined, "date")).toBe("—");
+  });
+
+  it("returns — for an unparseable value in a date column", () => {
+    expect(formatCellValue("not-a-date", "date")).toBe("—");
+  });
+
+  // ── non-date types (the critical guard: keys off type, not value) ──────────
+
+  it("does NOT format a large number as a date when the column type is number", () => {
+    // 1705536000000 looks like a date epoch, but the column type is number
+    const result = formatCellValue(1705536000000, "number");
+    expect(result).toBe("1705536000000");
+    // Ensure it was NOT treated as a date
+    expect(result).not.toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("passes strings through unchanged for string columns", () => {
+    expect(formatCellValue("hello world", "string")).toBe("hello world");
+  });
+
+  it("coerces booleans to string for boolean columns", () => {
+    expect(formatCellValue(true, "boolean")).toBe("true");
+    expect(formatCellValue(false, "boolean")).toBe("false");
+  });
+
+  it("returns — for null in a non-date column", () => {
+    expect(formatCellValue(null, "string")).toBe("—");
+  });
+
+  it("serialises objects as JSON for unknown columns", () => {
+    expect(formatCellValue({ a: 1 }, "unknown")).toBe('{"a":1}');
+  });
+});

--- a/packages/app/src/lib/cell-formatter.ts
+++ b/packages/app/src/lib/cell-formatter.ts
@@ -1,0 +1,49 @@
+import type { ColumnType } from "@dashframe/types";
+
+/**
+ * Format a cell value based on the column's declared type.
+ *
+ * Keys off the column's ColumnType, NOT the JS runtime type of the value.
+ * This is deliberate: date columns carry epoch-millisecond numbers from DuckDB
+ * and must be formatted by type declaration, not by `typeof value`.
+ *
+ * Supported types:
+ * - "date" → ISO date string (YYYY-MM-DD)
+ * - everything else → default string coercion (null/undefined → "—")
+ */
+export function formatCellValue(value: unknown, type: ColumnType): string {
+  if (value === null || value === undefined) return "—";
+
+  if (type === "date") {
+    return formatEpochAsDate(value);
+  }
+
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Format an epoch-millisecond number (or Date/string) as an ISO date string.
+ * Returns "—" when the value cannot be parsed as a valid date.
+ */
+function formatEpochAsDate(value: unknown): string {
+  let date: Date;
+
+  if (value instanceof Date) {
+    date = value;
+  } else if (typeof value === "number") {
+    date = new Date(value);
+  } else if (typeof value === "string") {
+    date = new Date(value);
+  } else {
+    return String(value);
+  }
+
+  if (isNaN(date.getTime())) return "—";
+
+  // Use UTC to avoid timezone shifts on bare date values
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/packages/app/src/lib/cell-formatter.ts
+++ b/packages/app/src/lib/cell-formatter.ts
@@ -36,7 +36,7 @@ function formatEpochAsDate(value: unknown): string {
   } else if (typeof value === "string") {
     date = new Date(value);
   } else {
-    return String(value);
+    return "—";
   }
 
   if (isNaN(date.getTime())) return "—";


### PR DESCRIPTION
## Summary

- **Bug**: Date-typed columns in the data-preview table rendered raw Unix epoch milliseconds (`1705536000000`) instead of formatted dates (`2024-01-18`). The renderer passed values through a JS-typeof check which cannot distinguish a date epoch from any other number.
- **Fix**: Added `formatCellValue(value, ColumnType)` in `packages/app/src/lib/cell-formatter.ts` that keys formatting off the column's **declared type**, not the runtime JS type. The hook now exposes `columnTypeMap` (alias → ColumnType); `DataPreviewSection` threads this into each VirtualTable column's `format` callback.
- **Scope**: Display layer only — no schema, SQL, or data-model changes.

## Formatter site

**`packages/app/src/lib/cell-formatter.ts`** — new utility:
- `formatCellValue(value: unknown, type: ColumnType): string`
- `type === "date"` → format epoch-ms / Date / string as `YYYY-MM-DD` (UTC-based to avoid timezone shift on bare dates)
- All other types → default string coercion (null/undefined → `—`)

**`packages/app/src/hooks/useInsightPagination.ts`** — how column type reaches the renderer:
- New `columnTypeMap` useMemo (same deps as `columnDisplayNames`: `resolvedFields` + `insight.metrics`)
- Iterates `resolvedFields` (which carry `Field.type: ColumnType`) → maps alias → type
- Metrics hardcoded to `"number"` (all aggregations are numeric)
- Returned alongside existing `columnDisplayNames`

**`packages/app/src/app/insights/[insightId]/_components/sections/DataPreviewSection.tsx`**:
- Destructures `columnTypeMap` from the active pagination
- `columnConfigs` memo now includes a `format` function per column (when type is known), delegating to `formatCellValue`; columns without a declared type fall through to VirtualTable's built-in `defaultFormatValue`

## Before / After

| Column type | Value | Before | After |
|-------------|-------|--------|-------|
| `date` | `1705536000000` | `1705536000000` | `2024-01-18` |
| `number` | `1705536000000` | `1705536000000` | `1705536000000` ✓ |
| `string` | `"hello"` | `hello` | `hello` ✓ |

## Test output

```
✓ src/lib/cell-formatter.test.ts > formatCellValue > formats an epoch-millisecond number as YYYY-MM-DD for date columns
✓ src/lib/cell-formatter.test.ts > formatCellValue > formats a Date object as YYYY-MM-DD for date columns
✓ src/lib/cell-formatter.test.ts > formatCellValue > formats an ISO date string as YYYY-MM-DD for date columns
✓ src/lib/cell-formatter.test.ts > formatCellValue > returns — for null in a date column
✓ src/lib/cell-formatter.test.ts > formatCellValue > returns — for undefined in a date column
✓ src/lib/cell-formatter.test.ts > formatCellValue > returns — for an unparseable value in a date column
✓ src/lib/cell-formatter.test.ts > formatCellValue > does NOT format a large number as a date when the column type is number
✓ src/lib/cell-formatter.test.ts > formatCellValue > passes strings through unchanged for string columns
✓ src/lib/cell-formatter.test.ts > formatCellValue > coerces booleans to string for boolean columns
✓ src/lib/cell-formatter.test.ts > formatCellValue > returns — for null in a non-date column
✓ src/lib/cell-formatter.test.ts > formatCellValue > serialises objects as JSON for unknown columns

Test Files  28 passed (28)
     Tests  465 passed (465)
```

All 44 typecheck tasks and 18 lint tasks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes date-typed columns in the data-preview table rendering raw epoch milliseconds instead of formatted dates, by introducing a type-aware cell formatter that keys off the column's declared `ColumnType` rather than the JS runtime type.

- **`cell-formatter.ts`**: New `formatCellValue(value, ColumnType)` utility — date columns format epoch-ms/Date/string as `YYYY-MM-DD` (UTC-based), all others fall through to string coercion; non-parseable inputs consistently return `"—"`.
- **`useInsightPagination.ts`**: Adds `columnTypeMap` (alias → ColumnType) alongside the existing `columnDisplayNames`, with metrics hardcoded to `"number"` and fields using their declared type from `resolvedFields`.
- **`DataPreviewSection.tsx`**: Threads `columnTypeMap` into each column's `format` callback; columns without a declared type fall back to VirtualTable's built-in `defaultFormatValue`, keeping non-date rendering unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Display-layer only change with no schema, SQL, or data-model impact; all code paths have test coverage including the edge cases flagged in the previous review round.

The fix is well-scoped: a new pure utility function with exhaustive branch coverage, a hook addition that mirrors existing memoization patterns exactly, and a component change that gracefully degrades to the existing default formatter for untyped columns. The previous reviewer concerns (wrong fallback value in the else branch, missing test cases) have both been addressed in this revision.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/lib/cell-formatter.ts | New formatting utility: type-keyed dispatch with correct "—" fallback in all unparseable paths; else branch previously flagged now returns "—" |
| packages/app/src/lib/cell-formatter.test.ts | Comprehensive test suite covering all branches including the previously-missing boolean and object date-column cases, now asserting "—" |
| packages/app/src/hooks/useInsightPagination.ts | Adds columnTypeMap useMemo with identical deps to columnDisplayNames; metrics hardcoded to "number", fields use declared type from resolvedFields |
| packages/app/src/app/insights/[insightId]/_components/sections/DataPreviewSection.tsx | Threads columnTypeMap into columnConfigs memo; only attaches format callback when type is known, correctly falling back to VirtualTable's default for untyped columns |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DuckDB query result\ncell value: unknown] --> B[DataPreviewSection\ncolumnConfigs memo]
    B --> C{colType defined\nin columnTypeMap?}
    C -- No --> D[VirtualTable\ndefaultFormatValue]
    C -- Yes --> E[formatCellValue\nvalue, colType]
    E --> F{value null\nor undefined?}
    F -- Yes --> G[return —]
    F -- No --> H{type === date?}
    H -- No --> I{typeof value\n=== object?}
    I -- Yes --> J[JSON.stringify]
    I -- No --> K[String coercion]
    H -- Yes --> L[formatEpochAsDate]
    L --> M{instanceof Date\nnumber or string?}
    M -- No --> G
    M -- Yes --> N{isNaN getTime?}
    N -- Yes --> G
    N -- No --> O[UTC YYYY-MM-DD string]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DuckDB query result\ncell value: unknown] --> B[DataPreviewSection\ncolumnConfigs memo]
    B --> C{colType defined\nin columnTypeMap?}
    C -- No --> D[VirtualTable\ndefaultFormatValue]
    C -- Yes --> E[formatCellValue\nvalue, colType]
    E --> F{value null\nor undefined?}
    F -- Yes --> G[return —]
    F -- No --> H{type === date?}
    H -- No --> I{typeof value\n=== object?}
    I -- Yes --> J[JSON.stringify]
    I -- No --> K[String coercion]
    H -- Yes --> L[formatEpochAsDate]
    L --> M{instanceof Date\nnumber or string?}
    M -- No --> G
    M -- Yes --> N{isNaN getTime?}
    N -- Yes --> G
    N -- No --> O[UTC YYYY-MM-DD string]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/e49e4c5664e6eea67658af550a7827c3d157b1b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37811978)</sub>

<!-- /greptile_comment -->