### PR TITLE
refactor(app): YW-144 — semantic tokens, focus-visible, SparklesIcon adoption

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx
@@ -150,7 +150,7 @@ function FieldOption({ field, isJoined, onClick }: FieldOptionProps) {
       onClick={onClick}
       className={cn(
         "flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-neutral-bg-emphasis",
-        "focus:ring-2 focus:ring-palette-primary focus:outline-none",
+        "focus-visible:ring-2 focus-visible:ring-palette-primary focus-visible:outline-none",
       )}
     >
       <NumberTypeIcon className="h-4 w-4 shrink-0 text-neutral-fg-subtle" />
@@ -169,7 +169,7 @@ function FieldOption({ field, isJoined, onClick }: FieldOptionProps) {
         {isJoined && (
           <Badge
             variant="soft"
-            className="bg-blue-500/10 text-[10px] text-blue-600"
+            className="bg-palette-info/10 text-[10px] text-palette-info"
           >
             joined
           </Badge>

--- a/packages/app/src/app/insights/[insightId]/join/[tableId]/_components/JoinConfigureContent.tsx
+++ b/packages/app/src/app/insights/[insightId]/join/[tableId]/_components/JoinConfigureContent.tsx
@@ -1197,7 +1197,7 @@ export default function JoinConfigureContent({
                       {joinType === "inner" && (
                         <>
                           Result:{" "}
-                          <span className="text-amber-600">
+                          <span className="text-palette-warning">
                             {joinAnalysis.estimatedResultRows.toLocaleString()}
                           </span>{" "}
                           rows
@@ -1259,19 +1259,19 @@ export default function JoinConfigureContent({
                   {/* Legend for column colors */}
                   <div className="mb-3 flex flex-wrap items-center gap-4 text-xs">
                     <div className="flex items-center gap-1.5">
-                      <div className="h-3 w-3 rounded bg-blue-600" />
+                      <div className="h-3 w-3 rounded bg-palette-info" />
                       <span className="text-neutral-fg-subtle">
                         From {baseTable.name ?? "base table"}
                       </span>
                     </div>
                     <div className="flex items-center gap-1.5">
-                      <div className="h-3 w-3 rounded bg-emerald-600" />
+                      <div className="h-3 w-3 rounded bg-palette-success" />
                       <span className="text-neutral-fg-subtle">
                         From {joinTable.name ?? "join table"}
                       </span>
                     </div>
                     <div className="flex items-center gap-1.5">
-                      <div className="h-3 w-3 rounded bg-amber-500" />
+                      <div className="h-3 w-3 rounded bg-palette-warning" />
                       <span className="text-neutral-fg-subtle">
                         In both tables
                       </span>

--- a/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
+++ b/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
@@ -1083,7 +1083,7 @@ export default function VisualizationPageContent({
               <h3 className="mb-2 text-lg font-semibold text-palette-danger">
                 Invalid encoding configuration
               </h3>
-              <div className="space-y-2 text-sm text-palette-danger">
+              <div className="space-y-2 text-sm text-palette-danger/80">
                 {encodingErrors.x && (
                   <p>
                     <strong>X Axis:</strong> {encodingErrors.x}
@@ -1095,7 +1095,7 @@ export default function VisualizationPageContent({
                   </p>
                 )}
               </div>
-              <p className="mt-4 text-xs text-palette-danger">
+              <p className="mt-4 text-xs text-palette-danger/80">
                 Please update the axis configuration in the panel on the right.
               </p>
             </div>

--- a/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
+++ b/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
@@ -737,7 +737,7 @@ export default function VisualizationPageContent({
         <div className="flex flex-1 items-center justify-center p-6">
           <Card className="max-w-md">
             <CardContent className="p-6 text-center">
-              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-palette-warning/15">
                 {getVizIcon(visualization.visualizationType)}
               </div>
               <h3 className="mb-2 text-lg font-semibold">Data not available</h3>
@@ -1076,14 +1076,14 @@ export default function VisualizationPageContent({
       <div className="h-full overflow-hidden">
         {hasEncodingErrors ? (
           <div className="flex h-full items-center justify-center p-6">
-            <div className="max-w-md rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950">
-              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900">
-                <AlertCircleIcon className="h-6 w-6 text-red-600 dark:text-red-400" />
+            <div className="max-w-md rounded-xl border border-palette-danger/30 bg-palette-danger/5 p-6 text-center">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-palette-danger/15">
+                <AlertCircleIcon className="h-6 w-6 text-palette-danger" />
               </div>
-              <h3 className="mb-2 text-lg font-semibold text-red-800 dark:text-red-200">
+              <h3 className="mb-2 text-lg font-semibold text-palette-danger">
                 Invalid encoding configuration
               </h3>
-              <div className="space-y-2 text-sm text-red-700 dark:text-red-300">
+              <div className="space-y-2 text-sm text-palette-danger">
                 {encodingErrors.x && (
                   <p>
                     <strong>X Axis:</strong> {encodingErrors.x}
@@ -1095,7 +1095,7 @@ export default function VisualizationPageContent({
                   </p>
                 )}
               </div>
-              <p className="mt-4 text-xs text-red-600 dark:text-red-400">
+              <p className="mt-4 text-xs text-palette-danger">
                 Please update the axis configuration in the panel on the right.
               </p>
             </div>

--- a/packages/app/src/components/visualization-preview/SuggestedInsights.tsx
+++ b/packages/app/src/components/visualization-preview/SuggestedInsights.tsx
@@ -1,6 +1,7 @@
 import type { ChartSuggestion } from "@/lib/visualizations/suggest-charts";
 import { Chart, useVisualization } from "@dashframe/visualization";
 import { Button, Card } from "@wystack/ui";
+import { SparklesIcon } from "@wystack/ui-icons";
 
 /**
  * EncodingRow - Displays a single encoding channel
@@ -15,28 +16,6 @@ function EncodingRow({ label, value }: { label: string; value?: string }) {
     </div>
   );
 }
-
-// Simple Sparkles icon
-const Sparkles = ({ className }: { className?: string }) => (
-  <svg
-    className={className}
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="m12 3-1.9 5.8a2 2 0 0 1-1.287 1.288L3 12l5.8 1.9a2 2 0 0 1 1.287 1.287L12 21l1.9-5.8a2 2 0 0 1 1.287-1.287L21 12l-5.8-1.9a2 2 0 0 1-1.287-1.287Z" />
-    <path d="M5 3v4" />
-    <path d="M19 17v4" />
-    <path d="M3 5h4" />
-    <path d="M17 19h4" />
-  </svg>
-);
 
 interface SuggestedInsightsProps {
   /** DuckDB table name to render charts from */
@@ -95,7 +74,7 @@ export function SuggestedInsights({
             size="sm"
             onClick={onRegenerate}
           >
-            <Sparkles className="mr-2 h-3 w-3" />
+            <SparklesIcon className="mr-2 h-3 w-3" />
             Regenerate
           </Button>
         )}

--- a/packages/app/src/components/visualizations/AxisSelectField.tsx
+++ b/packages/app/src/components/visualizations/AxisSelectField.tsx
@@ -504,7 +504,7 @@ export function AxisSelectField({
             render={
               <Badge
                 variant="outline"
-                className="cursor-pointer border-blue-200 bg-blue-50 px-1.5 py-0.5 text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900"
+                className="cursor-pointer border-palette-info/30 bg-palette-info/10 px-1.5 py-0.5 text-palette-info transition-colors hover:bg-palette-info/20"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -531,7 +531,7 @@ export function AxisSelectField({
             render={
               <Badge
                 variant="outline"
-                className="border-amber-200 bg-amber-50 px-1.5 py-0.5 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                className="border-palette-warning/30 bg-palette-warning/10 px-1.5 py-0.5 text-palette-warning"
               >
                 <AlertCircleIcon className="mr-1 h-3 w-3" />
                 <span className="text-[10px]">{currentWarning.message}</span>


### PR DESCRIPTION
## Summary

Finishes the @wystack/ui token adoption pass across the app: replaces every hardcoded `bg-/text-/border-{amber,red,blue}-NNN` class in the targeted files with semantic palette tokens, fixes the one remaining `focus:` → `focus-visible:` ring prefix, and swaps the inline Sparkles SVG for `SparklesIcon` from `@wystack/ui-icons`.

Tracked internally as YW-144.

## Token mapping

| Site | Hardcoded class(es) | Semantic token | Rationale |
|------|--------------------|--------------------|-----------|
| `JoinConfigureContent` L1197 | `text-amber-600` | `text-palette-warning` | row-count estimate in a warning context |
| `JoinConfigureContent` L1262 | `bg-blue-600` | `bg-palette-info` | legend dot — base-table info color |
| `JoinConfigureContent` L1268 | `bg-emerald-600` | `bg-palette-success` | legend dot — join-table success color |
| `JoinConfigureContent` L1274 | `bg-amber-500` | `bg-palette-warning` | legend dot — overlapping columns warning |
| `InsightFieldEditorModal` L172 | `bg-blue-500/10 text-blue-600` | `bg-palette-info/10 text-palette-info` | "joined" badge — informational highlight |
| `InsightFieldEditorModal` L153 | `focus:ring-2 focus:ring-palette-primary focus:outline-none` | `focus-visible:ring-2 focus-visible:ring-palette-primary focus-visible:outline-none` | focus-visible only (keyboard, not mouse click) |
| `VisualizationPageContent` L740 | `bg-amber-100 dark:bg-amber-900/30` | `bg-palette-warning/15` | icon circle bg in "data not available" (warning state); semantic token is dark-mode-aware, drops explicit `dark:` |
| `VisualizationPageContent` L1079 | `border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950` | `border-palette-danger/30 bg-palette-danger/5` | error panel container; drops explicit `dark:` |
| `VisualizationPageContent` L1080 | `bg-red-100 dark:bg-red-900` | `bg-palette-danger/15` | error icon circle bg |
| `VisualizationPageContent` L1081 | `text-red-600 dark:text-red-400` | `text-palette-danger` | alert icon |
| `VisualizationPageContent` L1083 | `text-red-800 dark:text-red-200` | `text-palette-danger` | error heading |
| `VisualizationPageContent` L1086 | `text-red-700 dark:text-red-300` | `text-palette-danger` | error body text |
| `VisualizationPageContent` L1098 | `text-red-600 dark:text-red-400` | `text-palette-danger` | error footnote |
| `AxisSelectField` L507 | `border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900` | `border-palette-info/30 bg-palette-info/10 text-palette-info hover:bg-palette-info/20` | "Swap" badge — info/interactive; semantic token handles dark mode |
| `AxisSelectField` L534 | `border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300` | `border-palette-warning/30 bg-palette-warning/10 text-palette-warning` | warning badge; semantic token handles dark mode |

## Icon swap

`SuggestedInsights.tsx` — removed the inline `const Sparkles = ...` SVG component; now imports `SparklesIcon` from `@wystack/ui-icons` (already exported as an alias). Usage updated to `<SparklesIcon className="mr-2 h-3 w-3" />` preserving all props.

## Visual evidence

This PR targets color rendering; visual verification of the live app requires the Electron desktop (no headless capture available in the worktree). The semantic token choices are verified by:
- The token CSS (`libs/stdui/packages/ui/src/styles/tokens.css`): `palette-warning` = `amber-600` light / `amber-400` dark; `palette-danger` = `red-600` light / `red-400` dark; `palette-info` = `sky-600` light / `sky-400` dark — matching the removed hardcoded shades in intent.
- Existing precedent: `DuckDBTable.tsx` uses the same `bg-palette-danger/10 border-palette-danger/50 text-palette-danger` error-panel pattern; this PR aligns `VisualizationPageContent`'s error banner to match.
- The explicit `dark:` overrides on all replaced classes have been dropped — the semantic tokens are dark-mode-aware by definition.

Flagging per project rule: full cold-start Electron screenshot evidence was not captured (headless not feasible in this context). The token derivation is deterministic and precedent-matched; please spot-check the error banner and axis badges in the running app before merging.

## Verification

- `bun run typecheck` — 44/44 tasks pass
- `bun run check` — 71/71 tasks pass
- `bun run build` — 20/20 tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes the `@wystack/ui` semantic token adoption pass across five targeted files, replacing hardcoded Tailwind color classes (`amber-*`, `red-*`, `blue-*`, `emerald-*`) with `palette-warning`, `palette-danger`, `palette-info`, and `palette-success` tokens, which are dark-mode-aware and drop the explicit `dark:` overrides. It also fixes one `focus:` → `focus-visible:` ring prefix and swaps an inline Sparkles SVG for the shared `SparklesIcon` from `@wystack/ui-icons`.

- **Token replacements** cover 15 distinct sites across `JoinConfigureContent`, `InsightFieldEditorModal`, `VisualizationPageContent`, and `AxisSelectField`; all chosen tokens are confirmed valid in the codebase and semantically appropriate for their UI role (info, warning, danger, success).
- **`focus-visible:` fix** on the `FieldOption` button is correct — focus rings should only appear for keyboard navigation, not mouse clicks.
- **SparklesIcon swap** in `SuggestedInsights` removes a one-off inline SVG and aligns with the existing pattern used in 10+ other components.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a pure visual token-swap refactor with no logic changes; all replaced tokens are confirmed valid in the codebase and all build/type/lint checks pass.

Every change is a mechanical substitution of hardcoded Tailwind color classes for established semantic palette tokens that are already in use elsewhere in the app. The `focus-visible:` fix and the SparklesIcon swap are both low-risk, well-precedented changes. No new behavior is introduced.

No files require special attention. A quick visual spot-check of the error banner in `VisualizationPageContent` and the axis badges in `AxisSelectField` in the running app is the only recommended follow-up (as flagged by the author).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx | Two changes: `focus:` → `focus-visible:` on the field option button (correct keyboard-only focus ring), and `bg-blue-500/10 text-blue-600` → `bg-palette-info/10 text-palette-info` on the "joined" badge. Both are clean, no issues. |
| packages/app/src/app/insights/[insightId]/join/[tableId]/_components/JoinConfigureContent.tsx | Four legend dot colors and one warning-text span replaced with `bg-palette-info`, `bg-palette-success`, `bg-palette-warning`, and `text-palette-warning`. All tokens are confirmed valid in the codebase. |
| packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx | Two error panels and a warning icon circle converted to semantic tokens; explicit `dark:` overrides removed. Heading uses full `text-palette-danger`, body/footnote use `text-palette-danger/80`, preserving visual hierarchy. |
| packages/app/src/components/visualization-preview/SuggestedInsights.tsx | Inline `Sparkles` SVG removed; replaced with `SparklesIcon` from `@wystack/ui-icons`, consistent with all other sparkles usages in the codebase. Props preserved. |
| packages/app/src/components/visualizations/AxisSelectField.tsx | Swap badge and warning badge converted from verbose Tailwind blue/amber classes with explicit `dark:` overrides to `border-palette-info/*`, `bg-palette-info/*`, and `border-palette-warning/*` tokens. Hover state preserved on the Swap badge. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Hardcoded Tailwind classes] --> B{Semantic token mapping}
    B --> C["amber-* → palette-warning\n(JoinConfigureContent, VisualizationPageContent, AxisSelectField)"]
    B --> D["red-* → palette-danger\n(VisualizationPageContent)"]
    B --> E["blue-* → palette-info\n(InsightFieldEditorModal, JoinConfigureContent, AxisSelectField)"]
    B --> F["emerald-* → palette-success\n(JoinConfigureContent)"]
    C --> G[Semantic tokens — dark-mode-aware\nno explicit dark: overrides needed]
    D --> G
    E --> G
    F --> G
    H[focus: ring prefix] --> I[focus-visible: ring prefix\nInsightFieldEditorModal]
    J[Inline Sparkles SVG] --> K[SparklesIcon from @wystack/ui-icons\nSuggestedInsights]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Hardcoded Tailwind classes] --> B{Semantic token mapping}
    B --> C["amber-* → palette-warning\n(JoinConfigureContent, VisualizationPageContent, AxisSelectField)"]
    B --> D["red-* → palette-danger\n(VisualizationPageContent)"]
    B --> E["blue-* → palette-info\n(InsightFieldEditorModal, JoinConfigureContent, AxisSelectField)"]
    B --> F["emerald-* → palette-success\n(JoinConfigureContent)"]
    C --> G[Semantic tokens — dark-mode-aware\nno explicit dark: overrides needed]
    D --> G
    E --> G
    F --> G
    H[focus: ring prefix] --> I[focus-visible: ring prefix\nInsightFieldEditorModal]
    J[Inline Sparkles SVG] --> K[SparklesIcon from @wystack/ui-icons\nSuggestedInsights]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(app): restore danger-text hiera..."](https://github.com/youhaowei/dashframe/commit/d15abd011a892b5e7a186c7eb8711215e88cb87e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37824909)</sub>

**Context used:**

- Context used - NO OFF-TOKEN COLOR (invariant). No raw hex/rgb/okl... ([source](greptile.json))

<!-- /greptile_comment -->