### PR TITLE
refactor(server): [YW-161] PreviewDiff compute via WyStack query — drop bespoke /preview/batch route

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -38,7 +38,6 @@ import {
   createArrowDataPath,
   type ArrowQueryRunner,
 } from "@dashframe/engine-server/arrow-data-path";
-import type { ArtifactDb } from "@dashframe/server-core";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import {
@@ -52,7 +51,6 @@ import { cors } from "hono/cors";
 import { createHash, timingSafeEqual } from "node:crypto";
 
 import { functions } from "./functions";
-import { buildPreviewDiff } from "./functions/preview-diff";
 
 type CorsOrigin =
   | string
@@ -280,39 +278,38 @@ export async function createDashframeServer(
 
   // Build the static context additions once so every call shares the same object
   // reference (vault identity is stable for the server lifetime).
+  // wyStackApp and artifactDb are injected after app is assigned (see below).
   const staticContext: Record<string, unknown> = vault != null ? { vault } : {};
-  const hasStaticContext = Object.keys(staticContext).length > 0;
 
-  const app: WyStackApp =
-    vault == null && onWrite == null
-      ? rawApp
-      : {
-          ...rawApp,
-          async call(path, args, context) {
-            // Static context wins over per-request context: spread per-request
-            // first so that static keys (vault) cannot be shadowed by a crafted
-            // request context. The vault identity must be fixed for the server
-            // lifetime; a request-supplied vault key would be ignored.
-            const merged = hasStaticContext
-              ? { ...(context ?? {}), ...staticContext }
-              : context;
-            const result = await rawApp.call(path, args, merged);
-            if (onWrite != null && result.tablesWritten.size > 0) {
-              try {
-                onWrite();
-              } catch (err) {
-                console.error("[dashframe] onWrite hook threw:", err);
-              }
-            }
-            return result;
-          },
-          async runHandler(path, args, tracked, context) {
-            const merged = hasStaticContext
-              ? { ...(context ?? {}), ...staticContext }
-              : context;
-            return rawApp.runHandler(path, args, tracked, merged);
-          },
-        };
+  const app: WyStackApp = {
+    ...rawApp,
+    async call(path, args, context) {
+      // Static context wins over per-request context: spread per-request
+      // first so that static keys (vault, wyStackApp, artifactDb) cannot be
+      // shadowed by a crafted request context. The vault identity must be
+      // fixed for the server lifetime; a request-supplied vault key would
+      // be ignored.
+      const merged = { ...(context ?? {}), ...staticContext };
+      const result = await rawApp.call(path, args, merged);
+      if (onWrite != null && result.tablesWritten.size > 0) {
+        try {
+          onWrite();
+        } catch (err) {
+          console.error("[dashframe] onWrite hook threw:", err);
+        }
+      }
+      return result;
+    },
+    async runHandler(path, args, tracked, context) {
+      const merged = { ...(context ?? {}), ...staticContext };
+      return rawApp.runHandler(path, args, tracked, merged);
+    },
+  };
+
+  // Inject app + db references needed by the previewDiff query handler.
+  // Done post-assignment because app itself is the wrapped version.
+  staticContext.wyStackApp = app;
+  staticContext.artifactDb = opts.db;
 
   // Mirror @wystack/server/node's serve() composition, adding CORS in front.
   const honoApp = new Hono();
@@ -341,18 +338,6 @@ export async function createDashframeServer(
       }),
     );
   }
-
-  // Preview batch endpoint — SPLIT-TIER (settled): returns METADATA ONLY.
-  // No row data, no compute slots — those are filled client-side via local DuckDB.
-  // Mounted before WyStack so `/preview/batch` isn't shadowed by the catch-all.
-  honoApp.route(
-    "/preview",
-    createPreviewPath({
-      app,
-      db: opts.db as ArtifactDb,
-      authToken: opts.authToken,
-    }),
-  );
 
   honoApp.route("/", createRoutes({ app, resolveContext }, upgradeWebSocket));
 
@@ -442,79 +427,6 @@ function tokenMatches(actual: string, expected: string): boolean {
   const actualBytes = createHash("sha256").update(actual).digest();
   const expectedBytes = createHash("sha256").update(expected).digest();
   return timingSafeEqual(actualBytes, expectedBytes);
-}
-
-/**
- * Hono sub-app for the preview batch endpoint.
- *
- * `POST /batch` accepts a JSON body `{ commands: Command[] }` and returns a
- * `PreviewDiff` (METADATA ONLY — compute slots are always `undefined`). The
- * diff carries the split-tier invariant: no row data, no head samples. Clients
- * fill the compute slot locally via DuckDB-WASM on preview-open.
- *
- * Auth reuses the same optional bearer token as the WyStack server.
- */
-function createPreviewPath(opts: {
-  app: WyStackApp;
-  db: ArtifactDb;
-  authToken?: string;
-}): Hono {
-  const { app, db, authToken } = opts;
-  const hono = new Hono();
-
-  hono.post("/batch", async (c) => {
-    // Auth guard — same policy as the WyStack server (loopback may omit token).
-    if (authToken) {
-      const auth = c.req.header("authorization") ?? "";
-      const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
-      if (!tokenMatches(token, authToken)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-    }
-
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
-
-    if (
-      !body ||
-      typeof body !== "object" ||
-      !Array.isArray((body as { commands?: unknown }).commands)
-    ) {
-      return c.json({ error: "Expected { commands: Command[] }" }, 400);
-    }
-
-    const { commands } = body as { commands: unknown[] };
-
-    // Validate each command has a path (minimal guard — handler validation does
-    // the rest inside applyCommands).
-    for (const cmd of commands) {
-      if (
-        !cmd ||
-        typeof cmd !== "object" ||
-        typeof (cmd as { path?: unknown }).path !== "string"
-      ) {
-        return c.json({ error: "Each command must have a string `path`" }, 400);
-      }
-    }
-
-    try {
-      const diff = await buildPreviewDiff(
-        app,
-        db,
-        commands as Array<{ path: string; args: unknown }>,
-      );
-      return c.json(diff);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return c.json({ error: message }, 500);
-    }
-  });
-
-  return hono;
 }
 
 export type { Functions } from "./functions";

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -38,6 +38,7 @@ import {
   createArrowDataPath,
   type ArrowQueryRunner,
 } from "@dashframe/engine-server/arrow-data-path";
+import type { ArtifactDb } from "@dashframe/server-core";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import {
@@ -51,6 +52,7 @@ import { cors } from "hono/cors";
 import { createHash, timingSafeEqual } from "node:crypto";
 
 import { functions } from "./functions";
+import { buildPreviewDiff } from "./functions/preview-diff";
 
 type CorsOrigin =
   | string
@@ -340,6 +342,18 @@ export async function createDashframeServer(
     );
   }
 
+  // Preview batch endpoint — SPLIT-TIER (settled): returns METADATA ONLY.
+  // No row data, no compute slots — those are filled client-side via local DuckDB.
+  // Mounted before WyStack so `/preview/batch` isn't shadowed by the catch-all.
+  honoApp.route(
+    "/preview",
+    createPreviewPath({
+      app,
+      db: opts.db as ArtifactDb,
+      authToken: opts.authToken,
+    }),
+  );
+
   honoApp.route("/", createRoutes({ app, resolveContext }, upgradeWebSocket));
 
   const { port, server } = await listen(honoApp, hostname, requestedPort);
@@ -428,6 +442,79 @@ function tokenMatches(actual: string, expected: string): boolean {
   const actualBytes = createHash("sha256").update(actual).digest();
   const expectedBytes = createHash("sha256").update(expected).digest();
   return timingSafeEqual(actualBytes, expectedBytes);
+}
+
+/**
+ * Hono sub-app for the preview batch endpoint.
+ *
+ * `POST /batch` accepts a JSON body `{ commands: Command[] }` and returns a
+ * `PreviewDiff` (METADATA ONLY — compute slots are always `undefined`). The
+ * diff carries the split-tier invariant: no row data, no head samples. Clients
+ * fill the compute slot locally via DuckDB-WASM on preview-open.
+ *
+ * Auth reuses the same optional bearer token as the WyStack server.
+ */
+function createPreviewPath(opts: {
+  app: WyStackApp;
+  db: ArtifactDb;
+  authToken?: string;
+}): Hono {
+  const { app, db, authToken } = opts;
+  const hono = new Hono();
+
+  hono.post("/batch", async (c) => {
+    // Auth guard — same policy as the WyStack server (loopback may omit token).
+    if (authToken) {
+      const auth = c.req.header("authorization") ?? "";
+      const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+      if (!tokenMatches(token, authToken)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+
+    if (
+      !body ||
+      typeof body !== "object" ||
+      !Array.isArray((body as { commands?: unknown }).commands)
+    ) {
+      return c.json({ error: "Expected { commands: Command[] }" }, 400);
+    }
+
+    const { commands } = body as { commands: unknown[] };
+
+    // Validate each command has a path (minimal guard — handler validation does
+    // the rest inside applyCommands).
+    for (const cmd of commands) {
+      if (
+        !cmd ||
+        typeof cmd !== "object" ||
+        typeof (cmd as { path?: unknown }).path !== "string"
+      ) {
+        return c.json({ error: "Each command must have a string `path`" }, 400);
+      }
+    }
+
+    try {
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        commands as Array<{ path: string; args: unknown }>,
+      );
+      return c.json(diff);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 500);
+    }
+  });
+
+  return hono;
 }
 
 export type { Functions } from "./functions";

--- a/apps/server/src/functions.ts
+++ b/apps/server/src/functions.ts
@@ -14,6 +14,7 @@ import { query } from "@wystack/server";
 import { appArtifactFunctions } from "./functions/app-artifacts";
 import { commandFunctions } from "./functions/commands";
 import { dashboardFunctions } from "./functions/dashboards";
+import { previewDiffFunctions } from "./functions/preview-diff";
 
 const { projectMeta } = schema;
 
@@ -59,6 +60,7 @@ export const functions = {
   ...appArtifactFunctions,
   ...commandFunctions,
   ...dashboardFunctions,
+  ...previewDiffFunctions,
 };
 
 /** Public type surface — what the renderer imports to type its client. */

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -57,8 +57,9 @@ import type {
   PreviewIntent,
   UUID,
 } from "@dashframe/types";
+import { jsonb } from "@wystack/db";
 import type { Command, CommandResult } from "@wystack/server";
-import { applyCommands, type WyStackApp } from "@wystack/server";
+import { applyCommands, query, type WyStackApp } from "@wystack/server";
 
 import { commandFunctions } from "./commands";
 
@@ -1128,3 +1129,65 @@ function dashboardVisRefs(layout: unknown): string[] {
   }
   return refs;
 }
+
+// ---------------------------------------------------------------------------
+// WyStack query registration
+// ---------------------------------------------------------------------------
+
+/**
+ * previewDiff — WyStack query (not mutation) that runs a command batch in
+ * preview mode and returns the artifact diff (METADATA ONLY — compute slots
+ * are undefined).
+ *
+ * Registered as a `query` — not a `mutation` — because `applyCommands` in
+ * preview mode executes-then-rolls-back; the canonical DB is untouched on
+ * return, so no `tablesWritten` signal is emitted and no reactive invalidation
+ * fires. A `mutation` registration would be incorrect: it would trigger
+ * spurious invalidation on every preview open despite nothing being persisted.
+ *
+ * The compute slots are filled client-side via local DuckDB; no row data
+ * ever crosses the RPC boundary. This is the settled split-tier invariant.
+ *
+ * `wyStackApp` and `artifactDb` are injected into the handler context via
+ * `staticContext` in `createDashframeServer`.
+ *
+ * Partial-failure response: `buildPreviewDiff` never throws — it returns a
+ * renderable `PreviewDiff` with an `error` slot on partial failure. The caller
+ * must inspect `result.error` to distinguish a successful diff from a
+ * partial/failed one. Infrastructure failures (missing context keys) do throw
+ * and surface as RPC errors.
+ */
+const previewDiff = query({
+  args: { commands: jsonb },
+  handler: async (ctx, { commands }): Promise<PreviewDiff> => {
+    const wyStackApp = ctx.wyStackApp as WyStackApp | undefined;
+    const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
+    if (!wyStackApp || !artifactDb) {
+      throw new Error(
+        "previewDiff: wyStackApp/artifactDb not in handler context — " +
+          "ensure createDashframeServer injects them via staticContext",
+      );
+    }
+    // Validate commands is an array before the cast — `jsonb` accepts any
+    // JSON value; a non-array input would crash applyCommands rather than
+    // returning a structured error (guard-the-sink: validate at the call site).
+    if (!Array.isArray(commands)) {
+      throw new Error("previewDiff: commands must be an array");
+    }
+    // Pass through vault and per-request auth context to buildPreviewDiff.
+    // Strip runtime-only keys (db, wyStackApp, artifactDb) that don't belong
+    // in the applyCommands context.
+    const handlerContext: Record<string, unknown> = {};
+    if (ctx.vault !== undefined) handlerContext.vault = ctx.vault;
+    return buildPreviewDiff(
+      wyStackApp,
+      artifactDb,
+      commands as Command[],
+      handlerContext,
+    );
+  },
+});
+
+export const previewDiffFunctions = {
+  previewDiff,
+};

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -99,8 +99,4 @@ export {
 export { DatabaseProvider, useDatabase } from "./compat";
 
 // Preview batch — SPLIT-TIER: returns metadata only, no row data over the wire.
-export {
-  previewBatch,
-  setPreviewAuthToken,
-  type PreviewCommand,
-} from "./preview-diff";
+export { previewBatch, type PreviewCommand } from "./preview-diff";

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -97,3 +97,10 @@ export {
 } from "./notion";
 
 export { DatabaseProvider, useDatabase } from "./compat";
+
+// Preview batch — SPLIT-TIER: returns metadata only, no row data over the wire.
+export {
+  previewBatch,
+  setPreviewAuthToken,
+  type PreviewCommand,
+} from "./preview-diff";

--- a/packages/app-data/src/preview-diff.ts
+++ b/packages/app-data/src/preview-diff.ts
@@ -1,0 +1,113 @@
+/**
+ * Client-side preview-batch helper.
+ *
+ * Calls the server's `POST /preview/batch` endpoint with a command array and
+ * returns a `PreviewDiff` (METADATA ONLY — compute slots are `undefined`).
+ * Row data is NEVER sent over this path; the caller fills compute client-side
+ * via local DuckDB.
+ *
+ * Split-tier invariant: the server returns metadata, the renderer fills data.
+ */
+import type { PreviewDiff } from "@dashframe/types";
+
+import { getWyStackClient } from "./client";
+
+/**
+ * One command envelope, mirroring `@wystack/server`'s `Command` type without
+ * importing the server package on the client side.
+ */
+export interface PreviewCommand {
+  id?: string;
+  path: string;
+  args: unknown;
+}
+
+/**
+ * Send a batch of commands to the server for preview.
+ *
+ * Returns a `PreviewDiff` with `compute: undefined` on every direct node.
+ * The caller is responsible for filling compute slots locally.
+ *
+ * @throws when the server returns a non-OK status or the response is not a
+ *         valid `PreviewDiff`.
+ */
+export async function previewBatch(
+  commands: PreviewCommand[],
+): Promise<PreviewDiff> {
+  const client = getWyStackClient();
+  const baseUrl = client.url; // e.g. "http://127.0.0.1:53017"
+
+  // Auth — the WyStack client holds the bearer token via its getToken function.
+  // We mirror what the WyStack HTTP transport does: read the token from the
+  // client's auth headers. The client exposes a `ws` manager but not `getToken`
+  // directly; replicate the auth-header logic via a one-shot query to get the
+  // token's header, then use it on the custom endpoint.
+  //
+  // Simpler: the WyStack client accepts a `getToken` callback, and `client.ws`
+  // carries the same config. We reach the token via the client's `query()` flow
+  // only indirectly. Instead, we store auth data in the client URL — but
+  // `client.url` is just the base URL.
+  //
+  // The cleanest approach: derive the Authorization header ourselves from the
+  // server URL, which the client has resolved at startup. The token is injected
+  // into the client via `createWyStackRuntime` which calls `createWyStack` with
+  // a `getToken`. The WyStackClient does not expose `getToken` as a public
+  // member, so we accept an optional token override here.
+  //
+  // In practice the Electron renderer mints a per-launch token that the client
+  // carries; the web surface uses same-origin (no token). `resolveWyStackConfig`
+  // returns `{ url, token? }` — the host passes both to `createWyStackRuntime`.
+  // We don't have the token here; `getPreviewAuthHeader` is the seam.
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  // Attempt to get the auth header by issuing a minimal WyStack call to see
+  // what headers it would use. We can't cleanly access the token. Instead we
+  // fall back to the app-level auth header provider if available.
+  // On Electron (loopback + token): the window.dashframe.getServerInfo() result
+  // is stored in the client's getToken. We can retrieve it indirectly.
+  // The simplest correct approach: export a module-level token setter alongside
+  // setWyStackClient, and let the host call it.
+  const authHeader = getPreviewAuthHeader();
+  if (authHeader) {
+    headers["Authorization"] = authHeader;
+  }
+
+  const res = await fetch(`${baseUrl}/preview/batch`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ commands }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `previewBatch: server returned ${String(res.status)}: ${text}`,
+    );
+  }
+
+  return (await res.json()) as PreviewDiff;
+}
+
+// ---------------------------------------------------------------------------
+// Auth header seam — the host calls setPreviewAuthToken once at startup.
+// ---------------------------------------------------------------------------
+
+let _previewAuthHeader: string | null = null;
+
+/**
+ * Wire the bearer token for the preview-batch endpoint.
+ *
+ * On Electron: call this alongside `setWyStackClient`, passing the same
+ * per-launch token from `window.dashframe.getServerInfo()`.
+ * On web (same-origin, loopback without token): omit.
+ */
+export function setPreviewAuthToken(token: string | null): void {
+  _previewAuthHeader = token ? `Bearer ${token}` : null;
+}
+
+function getPreviewAuthHeader(): string | null {
+  return _previewAuthHeader;
+}

--- a/packages/app-data/src/preview-diff.ts
+++ b/packages/app-data/src/preview-diff.ts
@@ -1,15 +1,16 @@
 /**
- * Client-side preview-batch helper.
+ * Client-side preview-diff helper.
  *
- * Calls the server's `POST /preview/batch` endpoint with a command array and
+ * Calls the server's `previewDiff` WyStack query with a command batch and
  * returns a `PreviewDiff` (METADATA ONLY — compute slots are `undefined`).
- * Row data is NEVER sent over this path; the caller fills compute client-side
- * via local DuckDB.
+ * Row data is NEVER sent over this path; the caller fills compute slots
+ * client-side via local DuckDB.
  *
  * Split-tier invariant: the server returns metadata, the renderer fills data.
  */
 import type { PreviewDiff } from "@dashframe/types";
 
+import { api } from "./api";
 import { getWyStackClient } from "./client";
 
 /**
@@ -23,91 +24,18 @@ export interface PreviewCommand {
 }
 
 /**
- * Send a batch of commands to the server for preview.
+ * Send a batch of commands to the server for preview via the WyStack RPC layer.
  *
  * Returns a `PreviewDiff` with `compute: undefined` on every direct node.
  * The caller is responsible for filling compute slots locally.
  *
- * @throws when the server returns a non-OK status or the response is not a
- *         valid `PreviewDiff`.
+ * Auth is handled transparently by the WyStack client — no separate token
+ * management required.
+ *
+ * @throws when the RPC call fails or the response is not a valid `PreviewDiff`.
  */
 export async function previewBatch(
   commands: PreviewCommand[],
 ): Promise<PreviewDiff> {
-  const client = getWyStackClient();
-  const baseUrl = client.url; // e.g. "http://127.0.0.1:53017"
-
-  // Auth — the WyStack client holds the bearer token via its getToken function.
-  // We mirror what the WyStack HTTP transport does: read the token from the
-  // client's auth headers. The client exposes a `ws` manager but not `getToken`
-  // directly; replicate the auth-header logic via a one-shot query to get the
-  // token's header, then use it on the custom endpoint.
-  //
-  // Simpler: the WyStack client accepts a `getToken` callback, and `client.ws`
-  // carries the same config. We reach the token via the client's `query()` flow
-  // only indirectly. Instead, we store auth data in the client URL — but
-  // `client.url` is just the base URL.
-  //
-  // The cleanest approach: derive the Authorization header ourselves from the
-  // server URL, which the client has resolved at startup. The token is injected
-  // into the client via `createWyStackRuntime` which calls `createWyStack` with
-  // a `getToken`. The WyStackClient does not expose `getToken` as a public
-  // member, so we accept an optional token override here.
-  //
-  // In practice the Electron renderer mints a per-launch token that the client
-  // carries; the web surface uses same-origin (no token). `resolveWyStackConfig`
-  // returns `{ url, token? }` — the host passes both to `createWyStackRuntime`.
-  // We don't have the token here; `getPreviewAuthHeader` is the seam.
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  // Attempt to get the auth header by issuing a minimal WyStack call to see
-  // what headers it would use. We can't cleanly access the token. Instead we
-  // fall back to the app-level auth header provider if available.
-  // On Electron (loopback + token): the window.dashframe.getServerInfo() result
-  // is stored in the client's getToken. We can retrieve it indirectly.
-  // The simplest correct approach: export a module-level token setter alongside
-  // setWyStackClient, and let the host call it.
-  const authHeader = getPreviewAuthHeader();
-  if (authHeader) {
-    headers["Authorization"] = authHeader;
-  }
-
-  const res = await fetch(`${baseUrl}/preview/batch`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ commands }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(
-      `previewBatch: server returned ${String(res.status)}: ${text}`,
-    );
-  }
-
-  return (await res.json()) as PreviewDiff;
-}
-
-// ---------------------------------------------------------------------------
-// Auth header seam — the host calls setPreviewAuthToken once at startup.
-// ---------------------------------------------------------------------------
-
-let _previewAuthHeader: string | null = null;
-
-/**
- * Wire the bearer token for the preview-batch endpoint.
- *
- * On Electron: call this alongside `setWyStackClient`, passing the same
- * per-launch token from `window.dashframe.getServerInfo()`.
- * On web (same-origin, loopback without token): omit.
- */
-export function setPreviewAuthToken(token: string | null): void {
-  _previewAuthHeader = token ? `Bearer ${token}` : null;
-}
-
-function getPreviewAuthHeader(): string | null {
-  return _previewAuthHeader;
+  return getWyStackClient().query(api.previewDiff, { commands });
 }

--- a/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
@@ -1,0 +1,64 @@
+/**
+ * PreviewDiffDialog — the preview-open surface.
+ *
+ * Wraps PreviewDiffRenderer in a dialog that:
+ *   1. Accepts a PreviewDiff (metadata-only from the server).
+ *   2. Fills compute slots lazily via usePreviewComputeFill (client-side DuckDB).
+ *   3. Renders immediately with metadata; compute fills progressively per node.
+ *
+ * SPLIT-TIER: this component owns the compute-fill boundary. It takes a
+ * `PreviewDiff` with `compute: undefined` on all direct nodes and hands the
+ * filled diff to `PreviewDiffRenderer` as compute resolves. No server round-trip
+ * for row data — all compute is local DuckDB.
+ */
+
+import type { PreviewDiff } from "@dashframe/types";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@wystack/ui";
+
+import { PreviewDiffRenderer } from "./PreviewDiffRenderer";
+import { usePreviewComputeFill } from "./usePreviewComputeFill";
+
+interface PreviewDiffDialogProps {
+  /** The diff received from the server — compute slots are always `undefined`. */
+  diff: PreviewDiff | null;
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Called when the dialog requests to close. */
+  onClose: () => void;
+  /** Optional title override. Defaults to "Preview changes". */
+  title?: string;
+}
+
+/**
+ * Preview-open surface: shows the diff immediately with metadata; fills compute
+ * (rowCounts + head rows) lazily via local DuckDB as each node resolves.
+ */
+export function PreviewDiffDialog({
+  diff,
+  open,
+  onClose,
+  title = "Preview changes",
+}: PreviewDiffDialogProps) {
+  // Fill compute slots lazily — runs entirely client-side, no server RPC.
+  const { diff: filledDiff } = usePreviewComputeFill(diff);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose();
+      }}
+    >
+      <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {filledDiff ? (
+          <PreviewDiffRenderer diff={filledDiff} className="pb-2" />
+        ) : (
+          <p className="text-sm text-neutral-fg/50">No changes to preview.</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
@@ -40,7 +40,10 @@ export function PreviewDiffDialog({
   title = "Preview changes",
 }: PreviewDiffDialogProps) {
   // Fill compute slots lazily — runs entirely client-side, no server RPC.
-  const { diff: filledDiff } = usePreviewComputeFill(diff);
+  // Gate on `open`: a closed (hidden) dialog must not kick DuckDB compute work.
+  // Passing null when closed also flips the hook's effect-cleanup cancellation,
+  // freeing the single DuckDB-WASM worker.
+  const { diff: filledDiff } = usePreviewComputeFill(open ? diff : null);
 
   return (
     <Dialog

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -238,6 +238,43 @@ describe("PreviewDiffRenderer", () => {
     });
   });
 
+  // FIX 5 — RESOLVED-but-empty must render an honest "unavailable" state, not an
+  // infinite spinner. A resolved compute with rowCountAfter=null AND head=[] is
+  // the "couldn't compute" sentinel (missing base table / SQL build failure /
+  // un-resolvable proposed source). It must be visually distinct from PENDING.
+  describe("FIX 5 — resolved-but-empty renders the unavailable state", () => {
+    it("shows the 'Preview unavailable' message, not the pending spinner", () => {
+      const compute: PreviewCompute = {
+        rowCountBefore: null,
+        rowCountAfter: null,
+        head: [],
+      };
+      const diff = makeDiff([insightNode("ins-empty", "update", compute)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      // The honest unavailable message is shown.
+      expect(screen.getByText(/Preview unavailable/)).toBeDefined();
+      // It is NOT the pending spinner (compute is defined, just empty).
+      expect(screen.queryByText(/Computing row counts/)).toBeNull();
+      expect(screen.queryByLabelText("Computing...")).toBeNull();
+    });
+
+    it("does NOT show unavailable state when a real count is present", () => {
+      const compute: PreviewCompute = {
+        rowCountBefore: 3,
+        rowCountAfter: 7,
+        head: [],
+      };
+      const diff = makeDiff([insightNode("ins-ok", "update", compute)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.queryByText(/Preview unavailable/)).toBeNull();
+      expect(screen.getByText(/7/)).toBeDefined();
+    });
+  });
+
   describe("downstream blast radius", () => {
     it("renders downstream section when affectedDownstream is non-empty", () => {
       const diff = makeDiff([insightNode("ins-ds", "update")], {

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -1,0 +1,297 @@
+/**
+ * Tests for PreviewDiffRenderer.
+ *
+ * Contracts tested:
+ * 1. Metadata renders immediately — insight node name, kind badge, and change
+ *    badge appear without waiting for compute.
+ * 2. Pending indicator: when compute===undefined for an insight node with a
+ *    non-noop change, the "Computing row counts…" pending state is shown.
+ * 3. Compute display: once compute is present, row counts and head rows render.
+ * 4. noop insight nodes: no compute display at all (no pending, no counts).
+ * 5. Non-insight nodes: no compute display regardless of compute presence.
+ * 6. Downstream blast-radius and partial-failure error sections render.
+ * 7. Empty state when no direct nodes and no error.
+ */
+
+import type {
+  PreviewCompute,
+  PreviewDiff,
+  PreviewDirectNode,
+  PreviewDownstreamNode,
+} from "@dashframe/types";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PreviewDiffRenderer } from "./PreviewDiffRenderer";
+
+// ---------------------------------------------------------------------------
+// Lightweight @wystack/ui stub — avoids pulling in the full component library.
+// ---------------------------------------------------------------------------
+
+vi.mock("@wystack/ui", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function insightNode(
+  nodeId: string,
+  change: PreviewDirectNode["change"],
+  compute?: PreviewCompute,
+): PreviewDirectNode {
+  return {
+    nodeId: nodeId as PreviewDirectNode["nodeId"],
+    kind: "insight",
+    name: `Insight ${nodeId}`,
+    change,
+    intent: [],
+    before: change === "create" ? null : { baseTableId: "t1" },
+    proposedDefinition: { baseTableId: "t1" },
+    compute,
+  };
+}
+
+function dataTableNode(nodeId: string): PreviewDirectNode {
+  return {
+    nodeId: nodeId as PreviewDirectNode["nodeId"],
+    kind: "dataTable",
+    name: `Table ${nodeId}`,
+    change: "update",
+    intent: [],
+    before: { name: "old" },
+    proposedDefinition: { name: "new" },
+  };
+}
+
+function downstreamNode(nodeId: string): PreviewDownstreamNode {
+  return {
+    nodeId: nodeId as PreviewDownstreamNode["nodeId"],
+    kind: "dataFrame",
+    name: `Frame ${nodeId}`,
+    edge: "insight->dataFrame",
+    via: { kind: "insight", id: "ins-1" as PreviewDirectNode["nodeId"] },
+    flag: "recompute",
+  };
+}
+
+function makeDiff(
+  directNodes: PreviewDirectNode[],
+  opts: {
+    downstream?: PreviewDownstreamNode[];
+    error?: PreviewDiff["error"];
+  } = {},
+): PreviewDiff {
+  return {
+    mode: "preview",
+    directNodes,
+    affectedDownstream: opts.downstream ?? [],
+    tablesWritten: [],
+    error: opts.error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PreviewDiffRenderer", () => {
+  describe("metadata renders immediately (before compute)", () => {
+    it("renders insight node name and badges without compute", () => {
+      // compute is undefined — simulates the server-delivered state (pre-fill).
+      const diff = makeDiff([insightNode("ins-1", "update", undefined)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      // getByText throws if absent — wrap in expect so sonarjs sees an assertion.
+      expect(screen.getByText("Insight ins-1")).toBeDefined();
+      expect(screen.getByText("Insight")).toBeDefined(); // kind badge
+      expect(screen.getByText("Changed")).toBeDefined(); // change badge
+    });
+
+    it("renders create node name and badges immediately", () => {
+      const diff = makeDiff([insightNode("ins-new", "create", undefined)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText("Insight ins-new")).toBeDefined();
+      expect(screen.getByText("New")).toBeDefined();
+    });
+
+    it("renders non-insight node metadata without any compute display", () => {
+      const diff = makeDiff([dataTableNode("dt-1")]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText("Table dt-1")).toBeDefined();
+      expect(screen.getByText("Data Table")).toBeDefined();
+      expect(screen.queryByText(/Computing/)).toBeNull();
+    });
+  });
+
+  describe("pending indicator — compute===undefined for active insight node", () => {
+    it("shows pending indicator when compute is undefined on an update node", () => {
+      const diff = makeDiff([insightNode("ins-pending", "update", undefined)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      // Pending text visible — getByText throws if absent.
+      expect(screen.getByText(/Computing row counts/)).toBeDefined();
+      // The pulse-dot aria label.
+      expect(screen.getByLabelText("Computing...")).toBeDefined();
+    });
+
+    it("shows pending indicator when compute is undefined on a create node", () => {
+      const diff = makeDiff([insightNode("ins-create", "create", undefined)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText(/Computing row counts/)).toBeDefined();
+    });
+
+    it("does NOT show pending indicator for a noop insight node", () => {
+      const diff = makeDiff([insightNode("ins-noop", "noop", undefined)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.queryByText(/Computing/)).toBeNull();
+      expect(screen.queryByLabelText("Computing...")).toBeNull();
+    });
+
+    it("does NOT show pending indicator for a non-insight node (even with undefined compute)", () => {
+      // dataTable nodes have no compute slot at all.
+      const diff = makeDiff([dataTableNode("dt-no-compute")]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.queryByText(/Computing/)).toBeNull();
+    });
+  });
+
+  describe("compute display — when compute is present", () => {
+    it("renders row count delta when compute is filled", () => {
+      const compute: PreviewCompute = {
+        rowCountBefore: 10,
+        rowCountAfter: 15,
+        head: [],
+      };
+      const diff = makeDiff([insightNode("ins-count", "update", compute)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      // Should show 15 rows with a +5 delta.
+      expect(screen.getByText(/15/)).toBeDefined();
+      expect(screen.getByText(/\+5/)).toBeDefined();
+    });
+
+    it("renders head rows when compute is filled with head data", () => {
+      const compute: PreviewCompute = {
+        rowCountBefore: null,
+        rowCountAfter: 3,
+        head: [
+          { name: "Alice", score: 100 },
+          { name: "Bob", score: 200 },
+        ],
+      };
+      const diff = makeDiff([insightNode("ins-head", "create", compute)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      // Column headers.
+      expect(screen.getByText("name")).toBeDefined();
+      expect(screen.getByText("score")).toBeDefined();
+      // Row values.
+      expect(screen.getByText("Alice")).toBeDefined();
+      expect(screen.getByText("Bob")).toBeDefined();
+      expect(screen.getByText("100")).toBeDefined();
+      expect(screen.getByText("200")).toBeDefined();
+    });
+
+    it("renders null values as 'null' in head table", () => {
+      const compute: PreviewCompute = {
+        rowCountBefore: null,
+        rowCountAfter: 1,
+        head: [{ col: null }],
+      };
+      const diff = makeDiff([insightNode("ins-null-val", "create", compute)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText("null")).toBeDefined();
+    });
+
+    it("does NOT show pending indicator when compute is present", () => {
+      const compute: PreviewCompute = {
+        rowCountBefore: 0,
+        rowCountAfter: 5,
+        head: [],
+      };
+      const diff = makeDiff([insightNode("ins-no-pending", "update", compute)]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.queryByText(/Computing/)).toBeNull();
+    });
+  });
+
+  describe("downstream blast radius", () => {
+    it("renders downstream section when affectedDownstream is non-empty", () => {
+      const diff = makeDiff([insightNode("ins-ds", "update")], {
+        downstream: [downstreamNode("df-1")],
+      });
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText("Also affected")).toBeDefined();
+      expect(screen.getByText("Frame df-1")).toBeDefined();
+      expect(screen.getByText("Will recompute")).toBeDefined();
+    });
+
+    it("does not render downstream section when affectedDownstream is empty", () => {
+      const diff = makeDiff([insightNode("ins-nods", "update")]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.queryByText("Also affected")).toBeNull();
+    });
+  });
+
+  describe("partial-failure error banner", () => {
+    it("renders the error banner with command index and message", () => {
+      const diff = makeDiff([], {
+        error: { commandIndex: 2, message: "Table not found: sales_data" },
+      });
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByRole("alert")).toBeDefined();
+      expect(screen.getByText("Command 3 failed")).toBeDefined();
+      expect(screen.getByText("Table not found: sales_data")).toBeDefined();
+    });
+
+    it("changes 'Changes' section header to 'Would change' when error present", () => {
+      const diff = makeDiff([insightNode("ins-err", "update")], {
+        error: { commandIndex: 1, message: "boom" },
+      });
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText("Would change")).toBeDefined();
+      expect(screen.queryByText("Changes")).toBeNull();
+    });
+  });
+
+  describe("empty state", () => {
+    it("renders empty state when there are no direct nodes and no error", () => {
+      const diff = makeDiff([]);
+
+      render(<PreviewDiffRenderer diff={diff} />);
+
+      expect(screen.getByText("No changes in this batch.")).toBeDefined();
+    });
+  });
+});

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -121,14 +121,16 @@ function HeadTable({ head }: { head: Array<Record<string, unknown>> }) {
   if (columns.length === 0) return null;
 
   return (
-    <div className="mt-2 overflow-x-auto rounded-[var(--surface-radius)] border border-neutral-border/30 bg-neutral-bg/40">
+    <div className="mt-2 overflow-x-auto rounded-[var(--surface-radius)] bg-neutral-bg/40">
       <table className="w-full text-[11px]">
         <thead>
-          <tr>
+          {/* Header band — a slightly stronger surface tint separates it from
+              the body rows. No borders (surface system: elevation/tint only). */}
+          <tr className="bg-neutral-bg/70">
             {columns.map((col) => (
               <th
                 key={col}
-                className="border-b border-neutral-border/30 px-2 py-1 text-left font-semibold text-neutral-fg/60"
+                className="px-2 py-1 text-left font-semibold text-neutral-fg/60"
               >
                 {col}
               </th>
@@ -137,9 +139,11 @@ function HeadTable({ head }: { head: Array<Record<string, unknown>> }) {
         </thead>
         <tbody>
           {head.map((row, rowIdx) => (
+            // Zebra banding via background tint — readable row separation with
+            // no borders (surface system).
             <tr
               key={rowIdx}
-              className="border-b border-neutral-border/20 last:border-0"
+              className={rowIdx % 2 === 1 ? "bg-neutral-bg/30" : undefined}
             >
               {columns.map((col) => (
                 <td key={col} className="px-2 py-1 text-neutral-fg/80">
@@ -185,6 +189,18 @@ function ComputeDisplay({
           aria-label="Computing..."
         />
         Computing row counts…
+      </div>
+    );
+  }
+
+  // RESOLVED-but-empty: compute ran but couldn't produce a result (missing base
+  // table, un-resolvable proposed source, or SQL build failure). Distinguish
+  // this from PENDING so the reviewer isn't stuck on an infinite spinner. Calm,
+  // on-token, no raw error string (DESIGN.md "raw runtime errors" anti-pattern).
+  if (compute.rowCountAfter === null && compute.head.length === 0) {
+    return (
+      <div className="mt-2 text-xs text-neutral-fg/50">
+        Preview unavailable — couldn't compute row counts for this change.
       </div>
     );
   }
@@ -267,7 +283,7 @@ function DownstreamNodeRow({ node }: { node: PreviewDownstreamNode }) {
   const flagLabel = FLAG_LABELS[node.flag];
 
   return (
-    <div className="flex items-center gap-2 py-1">
+    <div className="flex items-center gap-2 rounded-[var(--surface-radius)] bg-neutral-bg/60 px-3 py-1.5">
       <span className="min-w-0 flex-1 truncate text-sm text-neutral-fg/80">
         {node.name || node.nodeId}
       </span>
@@ -342,15 +358,15 @@ export function PreviewDiffRenderer({
           <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-fg/50">
             Also affected
           </h3>
-          <div className="rounded-[var(--surface-radius)] bg-neutral-bg/60 px-3 py-2">
-            <div className="flex flex-col divide-y divide-neutral-border/30">
-              {diff.affectedDownstream.map((node) => (
-                <DownstreamNodeRow
-                  key={`${node.kind}:${node.nodeId}`}
-                  node={node}
-                />
-              ))}
-            </div>
+          {/* Row separation via surface tint, not borders/divide-y (surface
+              system: elevation + tint only, no borders). */}
+          <div className="flex flex-col gap-0.5">
+            {diff.affectedDownstream.map((node) => (
+              <DownstreamNodeRow
+                key={`${node.kind}:${node.nodeId}`}
+                node={node}
+              />
+            ))}
           </div>
         </section>
       )}

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -16,6 +16,7 @@
 
 import type {
   ArtifactKind,
+  PreviewCompute,
   PreviewDiff,
   PreviewDirectNode,
   PreviewDownstreamNode,
@@ -64,6 +65,140 @@ const FLAG_LABELS: Record<PreviewDownstreamNode["flag"], string> = {
   stale: "Stale",
   orphaned: "Orphaned",
 };
+
+// ---------------------------------------------------------------------------
+// Compute display helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Row count delta summary — "+12 rows" / "−3 rows" / "unchanged".
+ * Only emitted when both before and after counts are non-null.
+ */
+function RowCountDelta({
+  before,
+  after,
+}: {
+  before: number | null;
+  after: number | null;
+}) {
+  if (after === null) return null;
+
+  if (before === null) {
+    // Create node: no before count.
+    return (
+      <span className="text-xs text-palette-success">
+        {after.toLocaleString()} rows
+      </span>
+    );
+  }
+
+  const delta = after - before;
+  if (delta === 0) {
+    return (
+      <span className="text-xs text-neutral-fg/60">
+        {after.toLocaleString()} rows (unchanged)
+      </span>
+    );
+  }
+  const sign = delta > 0 ? "+" : "−";
+  const absStr = Math.abs(delta).toLocaleString();
+  const colorClass = delta > 0 ? "text-palette-success" : "text-palette-danger";
+  return (
+    <span className={cn("text-xs", colorClass)}>
+      {after.toLocaleString()} rows ({sign}
+      {absStr})
+    </span>
+  );
+}
+
+/**
+ * A head-rows sample table for the compute display.
+ * Renders the first N rows of the proposed result as a compact table.
+ */
+function HeadTable({ head }: { head: Array<Record<string, unknown>> }) {
+  if (head.length === 0) return null;
+  const columns = Object.keys(head[0] ?? {});
+  if (columns.length === 0) return null;
+
+  return (
+    <div className="mt-2 overflow-x-auto rounded-[var(--surface-radius)] border border-neutral-border/30 bg-neutral-bg/40">
+      <table className="w-full text-[11px]">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col}
+                className="border-b border-neutral-border/30 px-2 py-1 text-left font-semibold text-neutral-fg/60"
+              >
+                {col}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {head.map((row, rowIdx) => (
+            <tr
+              key={rowIdx}
+              className="border-b border-neutral-border/20 last:border-0"
+            >
+              {columns.map((col) => (
+                <td key={col} className="px-2 py-1 text-neutral-fg/80">
+                  {row[col] === null || row[col] === undefined ? (
+                    <span className="text-neutral-fg/30">null</span>
+                  ) : (
+                    String(row[col])
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * The compute display for a direct node — shows row counts and head rows.
+ * When compute is `undefined` (pending), shows a pending indicator.
+ * Only rendered for insight nodes (the only kind with computable DuckDB views).
+ */
+function ComputeDisplay({
+  compute,
+  change,
+  kind,
+}: {
+  compute: PreviewCompute | undefined;
+  change: PreviewDirectNode["change"];
+  kind: ArtifactKind;
+}) {
+  // Only insight nodes have compute — other kinds have no DuckDB view.
+  if (kind !== "insight") return null;
+  // noop nodes don't change — no compute display.
+  if (change === "noop") return null;
+
+  if (compute === undefined) {
+    return (
+      <div className="mt-2 flex items-center gap-1.5 text-xs text-neutral-fg/50">
+        <span
+          className="inline-block h-2 w-2 animate-pulse rounded-full bg-neutral-fg/30"
+          aria-label="Computing..."
+        />
+        Computing row counts…
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 space-y-1">
+      <RowCountDelta
+        before={compute.rowCountBefore}
+        after={compute.rowCountAfter}
+      />
+      <HeadTable head={compute.head} />
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -115,6 +250,12 @@ function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
             ))}
           </ul>
         )}
+        {/* Compute display — row counts + head sample (insight nodes only) */}
+        <ComputeDisplay
+          compute={node.compute}
+          change={node.change}
+          kind={node.kind}
+        />
       </div>
     </div>
   );

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
@@ -18,7 +18,10 @@ import type {
 } from "@dashframe/types";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { usePreviewComputeFill } from "./usePreviewComputeFill";
+import {
+  mergeComputeResult,
+  usePreviewComputeFill,
+} from "./usePreviewComputeFill";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks — hoisted so vi.mock can close over them
@@ -503,6 +506,175 @@ describe("usePreviewComputeFill", () => {
           20,
         );
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FIX 1 — fold command args onto the canonical stored definition.
+  //
+  // `before` is the RAW insights row: config lives under `before.definition`.
+  // `proposedDefinition` carries RAW COMMAND ARGS with DIFFERENT key names
+  // (`fieldIds` not `selectedFields`). The proposed InsightLike handed to
+  // buildInsightSQL must reflect the PROPOSED query, not the stale one — else
+  // the after-count is wrong and the node looks stuck.
+  // -------------------------------------------------------------------------
+  describe("FIX 1 — proposed shape folds command args onto before.definition", () => {
+    it("maps proposedDefinition.fieldIds → selectedFields over the canonical base", async () => {
+      const tableId = "table-fold";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM fold");
+      mockQuery.mockResolvedValue(makeCountResult(1));
+
+      // Canonical before: a RAW insights row — config nested under .definition.
+      const node: PreviewDirectNode = {
+        nodeId: "n-fold" as PreviewDirectNode["nodeId"],
+        kind: "insight",
+        name: "Insight fold",
+        change: "update",
+        intent: [],
+        before: {
+          id: "n-fold",
+          name: "Insight fold",
+          definition: {
+            baseTableId: tableId,
+            selectedFields: ["fld-a"],
+            metrics: [],
+          },
+        },
+        // Proposed change: SelectFields replace-all with [a, b] under `fieldIds`.
+        proposedDefinition: { fieldIds: ["fld-a", "fld-b"] },
+      };
+      const diff = makeDiff([node]);
+
+      renderHook(() => usePreviewComputeFill(diff));
+
+      await waitFor(() => {
+        expect(mockBuildInsightSQL).toHaveBeenCalled();
+      });
+
+      // Find the call whose insight has TWO selected fields — the PROPOSED shape.
+      const proposedCall = mockBuildInsightSQL.mock.calls.find(
+        (c) =>
+          (c[2] as { selectedFields: string[] }).selectedFields.length === 2,
+      );
+      expect(proposedCall).toBeDefined();
+      const proposedInsight = proposedCall![2] as {
+        baseTableId: string;
+        selectedFields: string[];
+      };
+      // Folded: selectedFields is the PROPOSED [a, b], not the stale [a].
+      expect(proposedInsight.selectedFields).toEqual(["fld-a", "fld-b"]);
+      // baseTableId comes from the canonical definition (not lost in the fold).
+      expect(proposedInsight.baseTableId).toBe(tableId);
+    });
+
+    it("maps proposedDefinition.source.sourceId → baseTableId (SetInsightSource)", async () => {
+      const oldTable = "table-old";
+      const newTable = "table-new";
+      mockGetDataTable.mockImplementation(async (id: string) =>
+        makeDataTable(id),
+      );
+      mockGetDataFrame.mockImplementation(async (id: string) =>
+        makeDataFrame(id),
+      );
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM src");
+      mockQuery.mockResolvedValue(makeCountResult(1));
+
+      const node: PreviewDirectNode = {
+        nodeId: "n-src" as PreviewDirectNode["nodeId"],
+        kind: "insight",
+        name: "Insight src",
+        change: "update",
+        intent: [],
+        before: {
+          definition: {
+            baseTableId: oldTable,
+            selectedFields: [],
+            metrics: [],
+          },
+        },
+        // SetInsightSource args: { source: { sourceType, sourceId } }.
+        proposedDefinition: {
+          source: { sourceType: "dataTable", sourceId: newTable },
+        },
+      };
+      const diff = makeDiff([node]);
+
+      renderHook(() => usePreviewComputeFill(diff));
+
+      await waitFor(() => expect(mockBuildInsightSQL).toHaveBeenCalled());
+
+      // The proposed shape must point at the NEW base table.
+      const proposedCall = mockBuildInsightSQL.mock.calls.find(
+        (c) => (c[2] as { baseTableId: string }).baseTableId === newTable,
+      );
+      expect(proposedCall).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FIX 2 — stale-guard reducer. A late result for a superseded diff (A) must
+  // NOT clobber the current diff (B). Tested at the pure-reducer seam rather
+  // than through a DuckDB mock-thicket.
+  // -------------------------------------------------------------------------
+  describe("FIX 2 — mergeComputeResult stale guard", () => {
+    const diffA = makeDiff([insightNode("a1", "update")]);
+    const diffB = makeDiff([insightNode("b1", "update")]);
+    const compute: PreviewCompute = {
+      rowCountBefore: 1,
+      rowCountAfter: 2,
+      head: [],
+    };
+
+    it("merges a result whose diff is the current diff", () => {
+      const prev = { diff: diffA, computeByNodeId: new Map() };
+      // forDiff === currentDiff === prev.diff → normal progressive merge.
+      const next = mergeComputeResult(prev, diffA, diffA, "a1", compute);
+      expect(next.computeByNodeId.get("a1")).toBe(compute);
+      expect(next.diff).toBe(diffA);
+    });
+
+    it("resets to a fresh map on the first result of a freshly-active diff", () => {
+      // State still holds diffA's entries, but the live diff is now diffB.
+      const stateA = {
+        diff: diffA,
+        computeByNodeId: new Map<string, PreviewCompute>([["a1", compute]]),
+      };
+      // B's first result arrives; forDiff === currentDiff === diffB.
+      const next = mergeComputeResult(stateA, diffB, diffB, "b1", compute);
+      expect(next.diff).toBe(diffB);
+      // Stale A entry dropped; only B's node present.
+      expect(next.computeByNodeId.has("a1")).toBe(false);
+      expect(next.computeByNodeId.get("b1")).toBe(compute);
+    });
+
+    it("drops a late A-result after the live diff has moved on to B (A→B race)", () => {
+      // State has already advanced to diff B (user opened B).
+      const stateB = {
+        diff: diffB,
+        computeByNodeId: new Map<string, PreviewCompute>([["b1", compute]]),
+      };
+      // A's async work resolves LAST: forDiff=A but the live diff is now B.
+      const next = mergeComputeResult(stateB, diffA, diffB, "a1", compute);
+      // B's state is intact and untouched — no A node leaked in, identity kept.
+      expect(next).toBe(stateB);
+      expect(next.diff).toBe(diffB);
+      expect(next.computeByNodeId.has("a1")).toBe(false);
+      expect(next.computeByNodeId.get("b1")).toBe(compute);
+    });
+
+    it("never writes the stale diff's identity back onto current state", () => {
+      const stateB = { diff: diffB, computeByNodeId: new Map() };
+      const next = mergeComputeResult(stateB, diffA, diffB, "a1", compute);
+      // The classic bug: writing { diff: A, ... } back clobbers B. Guard holds.
+      expect(next.diff).not.toBe(diffA);
+      expect(next.diff).toBe(diffB);
     });
   });
 });

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
@@ -616,6 +616,45 @@ describe("usePreviewComputeFill", () => {
       );
       expect(proposedCall).toBeDefined();
     });
+
+    it("fails honest (no compute) on an un-foldable incremental edit (AddMetric)", async () => {
+      const tableId = "table-incr";
+      mockGetDataTable.mockResolvedValue(makeDataTable(tableId));
+      mockGetDataFrame.mockResolvedValue(makeDataFrame(`df-${tableId}`));
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM incr");
+      mockQuery.mockResolvedValue(makeCountResult(7));
+
+      const node: PreviewDirectNode = {
+        nodeId: "n-incr" as PreviewDirectNode["nodeId"],
+        kind: "insight",
+        name: "Insight incr",
+        change: "update",
+        intent: [],
+        before: {
+          definition: { baseTableId: tableId, selectedFields: [], metrics: [] },
+        },
+        // AddMetric args carry a single `metric` element — un-foldable post-hoc.
+        proposedDefinition: { metric: { id: "m1", aggregation: "count" } },
+      };
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      // The node resolves to the empty sentinel (unavailable), NOT a stale count:
+      // buildInsightSQL is never invoked for the proposed shape, and the node's
+      // compute slot is the null sentinel rather than a stuck-undefined spinner.
+      await waitFor(() => expect(result.current.allResolved).toBe(true));
+      expect(mockBuildInsightSQL).not.toHaveBeenCalled();
+      const filled = result.current.diff?.directNodes.find(
+        (n) => n.nodeId === "n-incr",
+      );
+      expect(filled?.compute).toEqual({
+        rowCountBefore: null,
+        rowCountAfter: null,
+        head: [],
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Tests for usePreviewComputeFill.
+ *
+ * Contracts tested:
+ * 1. Compute-fill: insight direct nodes receive rowCountBefore, rowCountAfter,
+ *    and head from local DuckDB — the mocked compute helpers are called, the
+ *    computed slots appear in the returned diff.
+ * 2. Non-insight nodes and noop insight nodes never trigger compute.
+ * 3. allResolved progresses correctly from false → true as nodes settle.
+ * 4. A null diff is returned untouched (allResolved=true).
+ * 5. Compute stays client-side: the mock seam is DuckDB, not an RPC call.
+ */
+
+import type {
+  PreviewCompute,
+  PreviewDiff,
+  PreviewDirectNode,
+} from "@dashframe/types";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePreviewComputeFill } from "./usePreviewComputeFill";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — hoisted so vi.mock can close over them
+// ---------------------------------------------------------------------------
+
+const { mockQuery, mockConnection, mockUseDuckDB } = vi.hoisted(() => {
+  const query = vi.fn();
+  return {
+    mockQuery: query,
+    mockConnection: { query },
+    mockUseDuckDB: vi.fn(),
+  };
+});
+
+vi.mock("@/components/providers/DuckDBProvider", () => ({
+  useDuckDB: () => mockUseDuckDB(),
+}));
+
+const { mockGetDataFrame, mockGetDataTable } = vi.hoisted(() => ({
+  mockGetDataFrame: vi.fn(),
+  mockGetDataTable: vi.fn(),
+}));
+
+vi.mock("@dashframe/core", () => ({
+  getDataFrame: mockGetDataFrame,
+  getDataTable: mockGetDataTable,
+}));
+
+const { mockBuildInsightSQL, mockEnsureTableLoaded } = vi.hoisted(() => ({
+  mockBuildInsightSQL: vi.fn(),
+  mockEnsureTableLoaded: vi.fn(),
+}));
+
+vi.mock("@dashframe/engine-browser", () => ({
+  buildInsightSQL: mockBuildInsightSQL,
+  ensureTableLoaded: mockEnsureTableLoaded,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makeDataTable(id: string, dataFrameId = `df-${id}`) {
+  return {
+    id,
+    name: `Table ${id}`,
+    dataSourceId: "ds-1",
+    table: id,
+    dataFrameId,
+    fields: [],
+    metrics: [],
+    createdAt: 0,
+  };
+}
+
+function makeDataFrame(id: string) {
+  return {
+    id,
+    storage: { type: "indexeddb" as const, key: `arrow-${id}` },
+    fieldIds: [],
+    createdAt: 0,
+  };
+}
+
+/** A minimal row-count result (DuckDB-style: bigint cnt). */
+function makeCountResult(n: number) {
+  return {
+    toArray: () => [{ cnt: BigInt(n) }],
+  };
+}
+
+/** A head result with `n` rows. */
+function makeHeadResult(rows: Array<Record<string, unknown>>) {
+  return {
+    toArray: () => rows,
+  };
+}
+
+/** Build a minimal `PreviewDirectNode` for an insight. */
+function insightNode(
+  nodeId: string,
+  change: PreviewDirectNode["change"],
+  opts: {
+    baseTableId?: string;
+    before?: Record<string, unknown> | null;
+    proposedDefinition?: Record<string, unknown>;
+  } = {},
+): PreviewDirectNode {
+  const baseTableId = opts.baseTableId ?? `table-${nodeId}`;
+  const defaultBefore =
+    change === "create"
+      ? null
+      : { baseTableId, selectedFields: [], metrics: [] };
+  const before = opts.before !== undefined ? opts.before : defaultBefore;
+  const proposedDefinition = opts.proposedDefinition ?? {
+    baseTableId,
+    selectedFields: [],
+    metrics: [],
+  };
+  return {
+    nodeId: nodeId as PreviewDirectNode["nodeId"],
+    kind: "insight",
+    name: `Insight ${nodeId}`,
+    change,
+    intent: [],
+    before,
+    proposedDefinition,
+  };
+}
+
+/** Build a `PreviewDirectNode` for a non-insight kind. */
+function nonInsightNode(
+  nodeId: string,
+  kind: PreviewDirectNode["kind"] = "dataTable",
+): PreviewDirectNode {
+  return {
+    nodeId: nodeId as PreviewDirectNode["nodeId"],
+    kind,
+    name: `Node ${nodeId}`,
+    change: "update",
+    intent: [],
+    before: { name: "test" },
+    proposedDefinition: { name: "test-v2" },
+  };
+}
+
+/** Build a minimal `PreviewDiff`. */
+function makeDiff(directNodes: PreviewDirectNode[]): PreviewDiff {
+  return {
+    mode: "preview",
+    directNodes,
+    affectedDownstream: [],
+    tablesWritten: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default DuckDB mock — DuckDB ready, query returns generic results.
+// Individual tests override as needed.
+// ---------------------------------------------------------------------------
+
+function setupReadyDuckDB() {
+  mockUseDuckDB.mockReturnValue({
+    connection: mockConnection,
+    isInitialized: true,
+    db: {},
+    error: null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupReadyDuckDB();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePreviewComputeFill", () => {
+  describe("null diff passthrough", () => {
+    it("returns null diff + allResolved=true immediately", () => {
+      const { result } = renderHook(() => usePreviewComputeFill(null));
+      expect(result.current.diff).toBeNull();
+      expect(result.current.allResolved).toBe(true);
+    });
+  });
+
+  describe("insight node compute fill", () => {
+    it("fills compute slot on a single update insight node", async () => {
+      const tableId = "table-fill";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM fill_test");
+
+      // Promise.all order: rowCountAfter, head, rowCountBefore
+      mockQuery
+        .mockResolvedValueOnce(makeCountResult(42))
+        .mockResolvedValueOnce(makeHeadResult([{ x: "hello" }, { x: "world" }]))
+        .mockResolvedValueOnce(makeCountResult(30));
+
+      const node = insightNode("n1", "update", { baseTableId: tableId });
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      // Immediately after mount: diff is returned without compute (still undefined).
+      expect(result.current.diff?.directNodes[0].compute).toBeUndefined();
+
+      // Wait for the async fill to complete.
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      const compute = result.current.diff?.directNodes[0]
+        .compute as PreviewCompute;
+      expect(compute).toBeDefined();
+      expect(compute.rowCountAfter).toBe(42);
+      expect(compute.rowCountBefore).toBe(30);
+      expect(compute.head).toEqual([{ x: "hello" }, { x: "world" }]);
+    });
+
+    it("fills compute slot on a create insight node (no before → rowCountBefore=null)", async () => {
+      const tableId = "table-create";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT 1 AS col");
+
+      // For a create node: before=null → canonical insight is null → rowCountBefore stays null.
+      // Promise.all: rowCountAfter, head, rowCountBefore(never awaited for canonical=null)
+      // The hook calls `canonical ? computeRowCount(canonical, conn) : Promise.resolve(null)`.
+      mockQuery
+        .mockResolvedValueOnce(makeCountResult(5)) // rowCountAfter
+        .mockResolvedValueOnce(makeHeadResult([{ col: 1 }])); // head
+
+      const node = insightNode("n-create", "create", { baseTableId: tableId });
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      const compute = result.current.diff?.directNodes[0]
+        .compute as PreviewCompute;
+      expect(compute.rowCountBefore).toBeNull();
+      expect(compute.rowCountAfter).toBe(5);
+      expect(compute.head).toEqual([{ col: 1 }]);
+    });
+  });
+
+  describe("noop insight node — no compute", () => {
+    it("does not trigger compute for a noop insight node", async () => {
+      const node = insightNode("n-noop", "noop");
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      // allResolved is true immediately — noop is not computable.
+      expect(result.current.allResolved).toBe(true);
+      // compute slot stays undefined.
+      expect(result.current.diff?.directNodes[0].compute).toBeUndefined();
+      // No DuckDB queries fired.
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-insight node — no compute", () => {
+    it("does not trigger compute for dataTable, dataSource, etc. nodes", async () => {
+      const diff = makeDiff([
+        nonInsightNode("nt1", "dataTable"),
+        nonInsightNode("nt2", "dataSource"),
+      ]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      expect(result.current.allResolved).toBe(true);
+      expect(result.current.diff?.directNodes[0].compute).toBeUndefined();
+      expect(result.current.diff?.directNodes[1].compute).toBeUndefined();
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mixed node types", () => {
+    it("fills insight nodes and leaves non-insight nodes untouched", async () => {
+      const tableId = "table-mixed";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM mixed");
+
+      mockQuery
+        .mockResolvedValueOnce(makeCountResult(7))
+        .mockResolvedValueOnce(makeHeadResult([{ v: "r1" }]))
+        .mockResolvedValueOnce(makeCountResult(5));
+
+      const diff = makeDiff([
+        nonInsightNode("dt1", "dataTable"),
+        insightNode("ins1", "update", { baseTableId: tableId }),
+        nonInsightNode("ds1", "dataSource"),
+      ]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      // Non-insight nodes: untouched.
+      expect(result.current.diff?.directNodes[0].compute).toBeUndefined();
+      expect(result.current.diff?.directNodes[2].compute).toBeUndefined();
+
+      // Insight node: filled.
+      const compute = result.current.diff?.directNodes[1]
+        .compute as PreviewCompute;
+      expect(compute.rowCountAfter).toBe(7);
+      expect(compute.rowCountBefore).toBe(5);
+      expect(compute.head).toEqual([{ v: "r1" }]);
+    });
+  });
+
+  describe("renders before compute completes (progressive fill)", () => {
+    it("returns the diff immediately with compute undefined, then fills progressively", async () => {
+      const tableId = "table-prog";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM prog");
+
+      // Collect all resolvers so we can unblock all pending queries at once.
+      const resolvers: Array<() => void> = [];
+      mockQuery.mockImplementation(
+        () =>
+          new Promise<ReturnType<typeof makeCountResult>>((resolve) => {
+            resolvers.push(() => resolve(makeCountResult(3)));
+          }),
+      );
+
+      const node = insightNode("n-prog", "update", { baseTableId: tableId });
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      // Immediately: diff exists but compute is not yet filled.
+      expect(result.current.diff).not.toBeNull();
+      expect(result.current.diff?.directNodes[0].compute).toBeUndefined();
+      // allResolved is false because a computable node is pending.
+      expect(result.current.allResolved).toBe(false);
+
+      // Unblock all pending queries (the Promise.all fires 3 in parallel).
+      await waitFor(() => expect(resolvers.length).toBeGreaterThan(0));
+      resolvers.forEach((r) => r());
+
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      expect(result.current.diff?.directNodes[0].compute).toBeDefined();
+    });
+  });
+
+  describe("DuckDB not ready", () => {
+    it("does not kick off compute when DuckDB is not initialized", () => {
+      mockUseDuckDB.mockReturnValue({
+        connection: null,
+        isInitialized: false,
+        db: null,
+        error: null,
+      });
+
+      const node = insightNode("n-notready", "update");
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      // No compute fires — allResolved stays false (the node is computable but
+      // hasn't been computed yet because DuckDB isn't ready).
+      expect(result.current.diff?.directNodes[0].compute).toBeUndefined();
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("missing base table — graceful non-fatal", () => {
+    it("keeps compute undefined (non-fatal) when base table is missing", async () => {
+      mockGetDataTable.mockResolvedValue(null);
+
+      const node = insightNode("n-notable", "update", {
+        baseTableId: "table-missing",
+      });
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      // The node is marked computable then kicks off — but ensureInsightDataFrames
+      // returns null, so the compute resolves to a null rowCountAfter and empty head.
+      // The slot is still filled (with nulls).
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      const compute = result.current.diff?.directNodes[0].compute;
+      // Still filled — graceful path: null counts + empty head.
+      expect(compute).toBeDefined();
+      expect(compute?.rowCountAfter).toBeNull();
+      expect(compute?.head).toEqual([]);
+    });
+  });
+
+  describe("buildInsightSQL returns null — graceful non-fatal", () => {
+    it("fills slot with null counts when SQL can't be generated", async () => {
+      const tableId = "table-nosql";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      // SQL build returns null — unsupported insight config.
+      mockBuildInsightSQL.mockReturnValue(null);
+
+      const node = insightNode("n-nosql", "update", { baseTableId: tableId });
+      const diff = makeDiff([node]);
+
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      const compute = result.current.diff?.directNodes[0].compute;
+      expect(compute).toBeDefined();
+      expect(compute?.rowCountAfter).toBeNull();
+      expect(compute?.head).toEqual([]);
+    });
+  });
+
+  describe("diff identity change — reset", () => {
+    it("resets compute when a new diff is passed", async () => {
+      const tableId = "table-reset";
+      const table = makeDataTable(tableId);
+      const frame = makeDataFrame(`df-${tableId}`);
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(frame);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT 1");
+
+      mockQuery
+        .mockResolvedValueOnce(makeCountResult(10))
+        .mockResolvedValueOnce(makeHeadResult([{ x: 1 }]))
+        .mockResolvedValueOnce(makeCountResult(8));
+
+      const node1 = insightNode("n-r1", "update", { baseTableId: tableId });
+      const diff1 = makeDiff([node1]);
+
+      const { result, rerender } = renderHook(
+        ({ diff }: { diff: PreviewDiff }) => usePreviewComputeFill(diff),
+        { initialProps: { diff: diff1 } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.allResolved).toBe(true);
+      });
+
+      // First diff: compute is filled.
+      expect(result.current.diff?.directNodes[0].compute).toBeDefined();
+
+      // Swap in a new diff (different object identity).
+      const node2 = insightNode("n-r2", "update", { baseTableId: tableId });
+      const diff2 = makeDiff([node2]);
+
+      // Reset queries for the second diff.
+      mockQuery
+        .mockResolvedValueOnce(makeCountResult(20))
+        .mockResolvedValueOnce(makeHeadResult([{ y: 2 }]))
+        .mockResolvedValueOnce(makeCountResult(15));
+
+      rerender({ diff: diff2 });
+
+      await waitFor(() => {
+        // The NEW node's compute is filled.
+        expect(result.current.diff?.directNodes[0].nodeId).toBe("n-r2");
+        expect(result.current.diff?.directNodes[0].compute).toBeDefined();
+        expect(result.current.diff?.directNodes[0].compute?.rowCountAfter).toBe(
+          20,
+        );
+      });
+    });
+  });
+});

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -344,8 +344,8 @@ async function ensureInsightDataFrames(
 
 /**
  * Convert a DuckDB COUNT(*) cell to a `number | null`, preserving correctness in
- * the face of IEEE-754 limits. Same discipline as YW-220: never silently emit a
- * wrong precise number.
+ * the face of IEEE-754 limits. Same discipline as the data-preview numeric
+ * display: never silently emit a wrong precise number.
  *
  * A COUNT(*) above Number.MAX_SAFE_INTEGER (2^53−1 ≈ 9e15) cannot be represented
  * exactly as a JS number; `Number(bigint)` would round it. We guard that case by
@@ -579,9 +579,11 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
   });
 
   // Always-current mirror of the live `diff` prop. The stale-guard reducer reads
-  // this to distinguish a legitimate new-diff result from a superseded one.
+  // this (inside async callbacks) to distinguish a legitimate new-diff result
+  // from a superseded one. Updated INSIDE the effect (not during render) — the
+  // effect re-runs on every `diff` change, so the mirror stays current for the
+  // async callbacks without an illegal ref-write during render.
   const currentDiffRef = useRef<PreviewDiff | null>(diff);
-  currentDiffRef.current = diff;
 
   // Derive the active compute map: if the stored diff has diverged from the
   // current diff (new preview opened), treat the map as empty until the async
@@ -590,6 +592,13 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
     state.diff === diff
       ? state.computeByNodeId
       : new Map<string, PreviewCompute>();
+
+  // Keep the live-diff mirror current on every `diff` change — independent of
+  // DuckDB readiness, so a late async result is correctly judged stale even if
+  // the compute effect below early-returned (DuckDB not yet ready) for diff B.
+  useEffect(() => {
+    currentDiffRef.current = diff;
+  }, [diff]);
 
   // Kick off compute for each insight node when DuckDB is ready.
   useEffect(() => {
@@ -678,9 +687,8 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
     };
     // `state` is intentionally excluded from deps: including it would re-run on
     // every partial fill, re-kicking compute. The skip-check reads `resolvedRef`
-    // (a stable ref that mirrors the active diff + already-kicked ids), so it is
+    // (a stable ref that mirrors the active diff + completed-node ids), so it is
     // reliable without `state` in the dependency array.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [diff, connection, isInitialized]);
 
   if (!diff) return { diff: null, allResolved: true };

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -1,0 +1,377 @@
+/**
+ * usePreviewComputeFill — fills the `compute` slot on insight direct nodes.
+ *
+ * SPLIT-TIER (settled): the server always emits `compute: undefined` on every
+ * PreviewDirectNode. This hook fills each node's slot lazily on preview-open,
+ * computing rowCountBefore / rowCountAfter / head entirely via local DuckDB
+ * (WASM). No row data ever rides the WyStack RPC.
+ *
+ * Open-Q#6 resolution: we re-compile (buildInsightSQL) and re-execute for each
+ * node. This reuses the EXACT same compile→execute path as the live insight
+ * view (useInsightView → buildInsightSQL → conn.query). Re-execute-only would
+ * require a pre-existing view for the proposed definition, which doesn't exist
+ * for preview (the transaction rolled back). Re-compile+execute is clean and
+ * correct: no parallel compute path, no forked SQL generation.
+ *
+ * Scope: only `kind === 'insight'` nodes compute rowCount + head. Other kinds
+ * (dataTable, dataSource, etc.) don't have a queryable SQL view in DuckDB, so
+ * their compute slot stays `undefined`.
+ */
+
+import { useDuckDB } from "@/components/providers/DuckDBProvider";
+import { getDataFrame, getDataTable } from "@dashframe/core";
+import { buildInsightSQL, ensureTableLoaded } from "@dashframe/engine-browser";
+import type {
+  DataTable,
+  Insight,
+  PreviewCompute,
+  PreviewDiff,
+  PreviewDirectNode,
+  UUID,
+} from "@dashframe/types";
+import { useEffect, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Helpers to coerce proposedDefinition / before into a partial Insight shape
+// ---------------------------------------------------------------------------
+
+type InsightLike = Pick<
+  Insight,
+  | "id"
+  | "baseTableId"
+  | "selectedFields"
+  | "metrics"
+  | "joins"
+  | "filters"
+  | "sorts"
+>;
+
+/**
+ * Coerce a raw `Record<string, unknown>` (proposedDefinition or before slice)
+ * to a partial insight shape. Unknown/missing fields fall back to safe defaults.
+ */
+function coerceToInsightLike(
+  raw: Record<string, unknown>,
+  nodeId: UUID,
+): InsightLike {
+  // source.sourceId is the canonical field for insight-on-insight composition.
+  const sourceRecord = raw.source as Record<string, unknown> | undefined;
+  const sourceId =
+    typeof sourceRecord?.sourceId === "string"
+      ? (sourceRecord.sourceId as UUID)
+      : undefined;
+  const baseTableId =
+    typeof raw.baseTableId === "string" ? (raw.baseTableId as UUID) : sourceId;
+
+  return {
+    id: nodeId,
+    baseTableId: (baseTableId ?? "") as UUID,
+    selectedFields: Array.isArray(raw.selectedFields)
+      ? (raw.selectedFields as UUID[])
+      : [],
+    metrics: Array.isArray(raw.metrics)
+      ? (raw.metrics as Insight["metrics"])
+      : [],
+    joins: Array.isArray(raw.joins)
+      ? (raw.joins as Insight["joins"])
+      : undefined,
+    filters: Array.isArray(raw.filters)
+      ? (raw.filters as Insight["filters"])
+      : undefined,
+    sorts: Array.isArray(raw.sorts)
+      ? (raw.sorts as Insight["sorts"])
+      : undefined,
+  };
+}
+
+/**
+ * Merge `before` (canonical) with `proposedDefinition` (the proposed change)
+ * to produce the PROPOSED insight config that would take effect after the batch
+ * commits. The merge mirrors how `foldCommand` in the server builder accumulates
+ * command args: later args override earlier ones (Object.assign semantics).
+ */
+function buildProposedInsight(node: PreviewDirectNode): InsightLike | null {
+  if (node.kind !== "insight") return null;
+
+  // Merge: start from the canonical before slice, overlay proposedDefinition.
+  // For a `create` node there is no before slice — use proposedDefinition only.
+  const base: Record<string, unknown> =
+    node.before !== null
+      ? { ...node.before, ...node.proposedDefinition }
+      : { ...node.proposedDefinition };
+
+  const result = coerceToInsightLike(base, node.nodeId);
+  if (!result.baseTableId) return null;
+  return result;
+}
+
+/**
+ * Build a canonical (pre-batch) insight shape for rowCountBefore.
+ * Uses the `before` slice only — the state BEFORE the batch would apply.
+ */
+function buildCanonicalInsight(node: PreviewDirectNode): InsightLike | null {
+  if (node.kind !== "insight" || node.before === null) return null;
+  const result = coerceToInsightLike(node.before, node.nodeId);
+  if (!result.baseTableId) return null;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// DuckDB query helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure all DataFrames for an insight are loaded in DuckDB.
+ * Returns the Map of rightTableId → DataTable needed by buildInsightSQL.
+ */
+async function ensureInsightDataFrames(
+  insightLike: InsightLike,
+  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+): Promise<{
+  baseTable: DataTable;
+  joinedTables: Map<UUID, DataTable>;
+} | null> {
+  const baseTable = await getDataTable(insightLike.baseTableId);
+  if (!baseTable?.dataFrameId) return null;
+
+  const baseDF = await getDataFrame(baseTable.dataFrameId);
+  if (!baseDF) return null;
+
+  await ensureTableLoaded(baseDF, conn);
+
+  const joinedTables = new Map<UUID, DataTable>();
+  const joins = insightLike.joins ?? [];
+  await Promise.all(
+    joins.map(async (join) => {
+      const joinTable = await getDataTable(join.rightTableId);
+      if (!joinTable?.dataFrameId) return;
+      const joinDF = await getDataFrame(joinTable.dataFrameId);
+      if (!joinDF) return;
+      await ensureTableLoaded(joinDF, conn);
+      joinedTables.set(join.rightTableId, joinTable);
+    }),
+  );
+
+  return { baseTable, joinedTables };
+}
+
+/**
+ * Compute the row count for a given insight config against local DuckDB.
+ * Returns `null` if the data isn't available or SQL can't be generated.
+ */
+async function computeRowCount(
+  insightLike: InsightLike,
+  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+): Promise<number | null> {
+  const tables = await ensureInsightDataFrames(insightLike, conn);
+  if (!tables) return null;
+
+  const { baseTable, joinedTables } = tables;
+
+  // Use "query" mode — that gives the aggregated result set (matching what the
+  // insight would actually produce). Fall back to "model" if no selectedFields/metrics.
+  const hasAggregation =
+    insightLike.selectedFields.length > 0 ||
+    (insightLike.metrics?.length ?? 0) > 0;
+  const mode = hasAggregation ? "query" : "model";
+
+  // Treat insightLike as a minimal Insight for SQL generation.
+  const sql = buildInsightSQL(
+    baseTable,
+    joinedTables,
+    insightLike as unknown as Insight,
+    { mode },
+  );
+  if (!sql) return null;
+
+  try {
+    const result = await conn.query(`SELECT COUNT(*) AS cnt FROM (${sql})`);
+    const rows = result.toArray();
+    const row = rows[0] as Record<string, unknown> | undefined;
+    if (!row) return 0;
+    const cnt = row.cnt;
+    if (typeof cnt === "bigint") return Number(cnt);
+    if (typeof cnt === "number") return cnt;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** HEAD_N is the number of sample rows to return in the `head` slot. */
+const HEAD_N = 5;
+
+/**
+ * Compute the head rows (first N rows) for a given insight config.
+ * Returns an empty array if the data isn't available or SQL can't be generated.
+ */
+async function computeHead(
+  insightLike: InsightLike,
+  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+): Promise<Array<Record<string, unknown>>> {
+  const tables = await ensureInsightDataFrames(insightLike, conn);
+  if (!tables) return [];
+
+  const { baseTable, joinedTables } = tables;
+
+  const hasAggregation =
+    insightLike.selectedFields.length > 0 ||
+    (insightLike.metrics?.length ?? 0) > 0;
+  const mode = hasAggregation ? "query" : "model";
+
+  const sql = buildInsightSQL(
+    baseTable,
+    joinedTables,
+    insightLike as unknown as Insight,
+    { mode, limit: HEAD_N },
+  );
+  if (!sql) return [];
+
+  try {
+    const result = await conn.query(sql);
+    return result
+      .toArray()
+      .map((row) => ({ ...(row as Record<string, unknown>) }));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The hook
+// ---------------------------------------------------------------------------
+
+/**
+ * A diff with per-node compute slots that may be progressively filled.
+ * Each node's `compute` is either `undefined` (pending/unsupported) or a
+ * `PreviewCompute` once its data is resolved from local DuckDB.
+ */
+export interface DiffWithCompute {
+  /** The original diff with compute slots filled in-place as they resolve. */
+  diff: PreviewDiff;
+  /** Whether ALL computable nodes have resolved their compute slots. */
+  allResolved: boolean;
+}
+
+/**
+ * Fill the `compute` slot on each insight direct node progressively.
+ *
+ * - Returns immediately with the original diff (renders before compute).
+ * - Each node resolves independently; state updates per resolved node.
+ * - Non-insight kinds never get a compute slot (stays `undefined`).
+ * - If DuckDB is not yet ready, waits until it initialises.
+ *
+ * Privacy: all computation is client-side. No row data leaves the renderer.
+ */
+export function usePreviewComputeFill(diff: PreviewDiff | null): {
+  diff: PreviewDiff | null;
+  allResolved: boolean;
+} {
+  const { connection, isInitialized } = useDuckDB();
+
+  // Store per-node compute results alongside the diff they belong to.
+  // Coupling them in one state object means a diff change atomically resets
+  // the map via the functional updater (in async callbacks, not in the effect
+  // body), keeping cascading render cycles to a minimum.
+  const [state, setState] = useState<{
+    diff: PreviewDiff | null;
+    computeByNodeId: Map<string, PreviewCompute>;
+  }>({ diff, computeByNodeId: new Map() });
+
+  // Derive the active compute map: if the stored diff has diverged from the
+  // current diff (new preview opened), treat the map as empty until the async
+  // fills for the new diff start arriving.
+  const computeByNodeId =
+    state.diff === diff
+      ? state.computeByNodeId
+      : new Map<string, PreviewCompute>();
+
+  // Kick off compute for each insight node when DuckDB is ready.
+  useEffect(() => {
+    if (!diff || !connection || !isInitialized) return;
+
+    const conn = connection;
+    const thisDiff = diff;
+
+    for (const node of diff.directNodes) {
+      // Only insight nodes get compute; skip if already resolved.
+      if (node.kind !== "insight") continue;
+      // noop nodes don't change — no compute needed.
+      if (node.change === "noop") continue;
+
+      const proposed = buildProposedInsight(node);
+      if (!proposed) continue;
+
+      // Skip nodes already resolved for this exact diff.
+      if (state.diff === diff && state.computeByNodeId.has(node.nodeId))
+        continue;
+
+      const canonical = buildCanonicalInsight(node);
+
+      // Fire-and-forget: each node resolves independently.
+      const nodeId = node.nodeId;
+      (async () => {
+        const computeResult: PreviewCompute = await (async () => {
+          try {
+            // Compute proposed counts + head in parallel with canonical count.
+            const [rowCountAfter, head, rowCountBefore] = await Promise.all([
+              computeRowCount(proposed, conn),
+              computeHead(proposed, conn),
+              canonical
+                ? computeRowCount(canonical, conn)
+                : Promise.resolve(null),
+            ]);
+            return { rowCountBefore, rowCountAfter, head };
+          } catch {
+            // Non-fatal: sentinel with nulls so allResolved stops waiting.
+            return { rowCountBefore: null, rowCountAfter: null, head: [] };
+          }
+        })();
+
+        // Functional update: merges into the state for the correct diff and
+        // resets implicitly if a stale diff's update arrives after a swap.
+        setState((prev) => {
+          const prevMap =
+            prev.diff === thisDiff
+              ? prev.computeByNodeId
+              : new Map<string, PreviewCompute>();
+          const next = new Map(prevMap);
+          next.set(nodeId, computeResult);
+          return { diff: thisDiff, computeByNodeId: next };
+        });
+      })();
+    }
+    // state intentionally excluded from deps: including it would re-run on each
+    // partial fill, causing duplicate compute kicks.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [diff, connection, isInitialized]);
+
+  if (!diff) return { diff: null, allResolved: true };
+
+  // Derive computable node ids directly from the diff (pure render logic, no ref).
+  // A node is computable when: insight kind, non-noop change, has a valid baseTableId.
+  const computableIds = diff.directNodes
+    .filter(
+      (n) =>
+        n.kind === "insight" &&
+        n.change !== "noop" &&
+        buildProposedInsight(n) !== null,
+    )
+    .map((n) => n.nodeId);
+
+  // Build the filled diff — shallow-clone only; mutate compute slots on a per-
+  // node basis rather than cloning the entire diff on every partial fill.
+  const filledNodes = diff.directNodes.map((node) => {
+    const filled = computeByNodeId.get(node.nodeId);
+    if (!filled) return node;
+    return { ...node, compute: filled };
+  });
+
+  const filledDiff: PreviewDiff = { ...diff, directNodes: filledNodes };
+
+  const allResolved =
+    computableIds.length === 0 ||
+    computableIds.every((id) => computeByNodeId.has(id));
+
+  return { diff: filledDiff, allResolved };
+}

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -16,6 +16,14 @@
  * Scope: only `kind === 'insight'` nodes compute rowCount + head. Other kinds
  * (dataTable, dataSource, etc.) don't have a queryable SQL view in DuckDB, so
  * their compute slot stays `undefined`.
+ *
+ * DATA-MODEL NOTE (the load-bearing correctness detail): a node's `before` is
+ * the RAW `insights` DB row — the query config lives under `before.definition`
+ * (a StoredInsightDefinition), NOT at `before` top-level. `proposedDefinition`
+ * is assembled from RAW COMMAND ARGS, whose key names DIFFER from the stored
+ * definition (e.g. `fieldIds` not `selectedFields`, `source.sourceId` not
+ * `baseTableId`). `foldInsightArgs` reconciles both into a single canonical
+ * insight shape so the after-count reflects the PROPOSED query, not the old one.
  */
 
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
@@ -29,10 +37,10 @@ import type {
   PreviewDirectNode,
   UUID,
 } from "@dashframe/types";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // ---------------------------------------------------------------------------
-// Helpers to coerce proposedDefinition / before into a partial Insight shape
+// Helpers to coerce proposedDefinition / before into a canonical Insight shape
 // ---------------------------------------------------------------------------
 
 type InsightLike = Pick<
@@ -47,91 +55,270 @@ type InsightLike = Pick<
 >;
 
 /**
- * Coerce a raw `Record<string, unknown>` (proposedDefinition or before slice)
- * to a partial insight shape. Unknown/missing fields fall back to safe defaults.
+ * Pull the canonical StoredInsightDefinition out of a `before` slice.
+ *
+ * `before` is the raw `insights` DB row: the query config lives under
+ * `before.definition`. We unwrap defensively — if `.definition` is an object we
+ * use it; otherwise we fall back to `before` itself (forward-compat for a slice
+ * that is already a bare definition).
  */
-function coerceToInsightLike(
-  raw: Record<string, unknown>,
+function unwrapDefinition(
+  before: Record<string, unknown> | null,
+): Record<string, unknown> {
+  if (before === null) return {};
+  const definition = before.definition;
+  if (
+    definition &&
+    typeof definition === "object" &&
+    !Array.isArray(definition)
+  )
+    return definition as Record<string, unknown>;
+  return before;
+}
+
+/**
+ * Read a `{ sourceType, sourceId }` source descriptor's `sourceId` if present.
+ */
+function readSourceId(
+  source: unknown,
+): { sourceId: UUID; source: Record<string, unknown> } | null {
+  if (!source || typeof source !== "object") return null;
+  const rec = source as Record<string, unknown>;
+  if (typeof rec.sourceId !== "string") return null;
+  return { sourceId: rec.sourceId as UUID, source: rec };
+}
+
+/**
+ * Coerce a canonical StoredInsightDefinition record (already unwrapped — config
+ * at top level, stored key names) into a partial insight shape.
+ */
+function definitionToInsightLike(
+  def: Record<string, unknown>,
   nodeId: UUID,
 ): InsightLike {
-  // source.sourceId is the canonical field for insight-on-insight composition.
-  const sourceRecord = raw.source as Record<string, unknown> | undefined;
-  const sourceId =
-    typeof sourceRecord?.sourceId === "string"
-      ? (sourceRecord.sourceId as UUID)
-      : undefined;
+  const sourceId = readSourceId(def.source)?.sourceId;
   const baseTableId =
-    typeof raw.baseTableId === "string" ? (raw.baseTableId as UUID) : sourceId;
+    typeof def.baseTableId === "string" ? (def.baseTableId as UUID) : sourceId;
 
   return {
     id: nodeId,
     baseTableId: (baseTableId ?? "") as UUID,
-    selectedFields: Array.isArray(raw.selectedFields)
-      ? (raw.selectedFields as UUID[])
+    selectedFields: Array.isArray(def.selectedFields)
+      ? (def.selectedFields as UUID[])
       : [],
-    metrics: Array.isArray(raw.metrics)
-      ? (raw.metrics as Insight["metrics"])
+    metrics: Array.isArray(def.metrics)
+      ? (def.metrics as Insight["metrics"])
       : [],
-    joins: Array.isArray(raw.joins)
-      ? (raw.joins as Insight["joins"])
+    joins: Array.isArray(def.joins)
+      ? (def.joins as Insight["joins"])
       : undefined,
-    filters: Array.isArray(raw.filters)
-      ? (raw.filters as Insight["filters"])
+    filters: Array.isArray(def.filters)
+      ? (def.filters as Insight["filters"])
       : undefined,
-    sorts: Array.isArray(raw.sorts)
-      ? (raw.sorts as Insight["sorts"])
+    sorts: Array.isArray(def.sorts)
+      ? (def.sorts as Insight["sorts"])
       : undefined,
   };
 }
 
 /**
- * Merge `before` (canonical) with `proposedDefinition` (the proposed change)
- * to produce the PROPOSED insight config that would take effect after the batch
- * commits. The merge mirrors how `foldCommand` in the server builder accumulates
- * command args: later args override earlier ones (Object.assign semantics).
+ * Fold raw command args (`proposedDefinition`) onto a canonical base definition,
+ * producing the SAME final insight shape the mutation would persist.
+ *
+ * The command-arg key names differ from the stored-definition names; this maps
+ * them explicitly (see apps/server/src/functions/commands.ts):
+ *   - `fieldIds`            → selectedFields  (SelectFields: replace-all)
+ *   - `source`             → baseTableId = source.sourceId (+ keep source)
+ *   - `selectedFields`     → pass through    (CreateInsight)
+ *   - `filters`/`sorts`/`metrics`/`joins` → pass through (replace-all commands)
+ *   - `baseTableId`        → pass through if present
+ *   - `join` (object)      → append/merge onto joins[] (AddJoin/UpdateJoin)
+ *
+ * Genuinely-incremental commands that need the original command replayed to fold
+ * cleanly (`joinId`-only RemoveJoin/UpdateJoin, AddField/RemoveField/AddMetric
+ * with no replace-all array present) can't be reconstructed from args alone. We
+ * do the best reconstruction available; if the result has no resolvable base
+ * table, `buildProposedInsight` returns null and the renderer shows an honest
+ * "unavailable" state rather than a stuck spinner.
+ */
+function foldInsightArgs(
+  canonicalDef: Record<string, unknown>,
+  proposedArgs: Record<string, unknown>,
+  nodeId: UUID,
+): InsightLike {
+  // Start from the canonical definition (stored key names), then overlay the
+  // proposed change with key-name translation.
+  const folded: Record<string, unknown> = { ...canonicalDef };
+
+  // source → baseTableId + keep source (SetInsightSource / CreateInsight).
+  const proposedSource = readSourceId(proposedArgs.source);
+  if (proposedSource) {
+    folded.source = proposedSource.source;
+    folded.baseTableId = proposedSource.sourceId;
+  }
+  // Explicit baseTableId arg (rare, but pass through).
+  if (typeof proposedArgs.baseTableId === "string") {
+    folded.baseTableId = proposedArgs.baseTableId;
+  }
+
+  // fieldIds → selectedFields (SelectFields is replace-all).
+  if (Array.isArray(proposedArgs.fieldIds)) {
+    folded.selectedFields = proposedArgs.fieldIds;
+  }
+  // Replace-all arrays whose arg names match the stored names.
+  if (Array.isArray(proposedArgs.selectedFields)) {
+    folded.selectedFields = proposedArgs.selectedFields;
+  }
+  if (Array.isArray(proposedArgs.metrics)) {
+    folded.metrics = proposedArgs.metrics;
+  }
+  if (Array.isArray(proposedArgs.filters)) {
+    folded.filters = proposedArgs.filters;
+  }
+  if (Array.isArray(proposedArgs.sorts)) {
+    folded.sorts = proposedArgs.sorts;
+  }
+  if (Array.isArray(proposedArgs.joins)) {
+    folded.joins = proposedArgs.joins;
+  }
+
+  // Incremental single-join arg (AddJoin / UpdateJoin carry a `join` object).
+  // Best-effort fold: append onto the joins array (or merge by rightTableId).
+  if (
+    proposedArgs.join &&
+    typeof proposedArgs.join === "object" &&
+    !Array.isArray(proposedArgs.join)
+  ) {
+    const incoming = proposedArgs.join as Record<string, unknown>;
+    const existing = Array.isArray(folded.joins)
+      ? [...(folded.joins as Record<string, unknown>[])]
+      : [];
+    const idx = existing.findIndex(
+      (j) => j.rightTableId === incoming.rightTableId,
+    );
+    if (idx >= 0) existing[idx] = { ...existing[idx], ...incoming };
+    else existing.push(incoming);
+    folded.joins = existing;
+  }
+
+  return definitionToInsightLike(folded, nodeId);
+}
+
+/**
+ * Build the PROPOSED (post-batch) insight shape by folding command args onto the
+ * canonical `before.definition` base. Returns null when the result has no
+ * resolvable base table (genuinely non-computable — renderer shows "unavailable").
  */
 function buildProposedInsight(node: PreviewDirectNode): InsightLike | null {
   if (node.kind !== "insight") return null;
 
-  // Merge: start from the canonical before slice, overlay proposedDefinition.
-  // For a `create` node there is no before slice — use proposedDefinition only.
-  const base: Record<string, unknown> =
-    node.before !== null
-      ? { ...node.before, ...node.proposedDefinition }
-      : { ...node.proposedDefinition };
-
-  const result = coerceToInsightLike(base, node.nodeId);
+  const canonicalDef = unwrapDefinition(node.before);
+  const result = foldInsightArgs(
+    canonicalDef,
+    node.proposedDefinition,
+    node.nodeId,
+  );
   if (!result.baseTableId) return null;
   return result;
 }
 
 /**
- * Build a canonical (pre-batch) insight shape for rowCountBefore.
- * Uses the `before` slice only — the state BEFORE the batch would apply.
+ * Build the canonical (pre-batch) insight shape for rowCountBefore, read from
+ * `before.definition`. Returns null for `create` (no canonical row existed).
  */
 function buildCanonicalInsight(node: PreviewDirectNode): InsightLike | null {
   if (node.kind !== "insight" || node.before === null) return null;
-  const result = coerceToInsightLike(node.before, node.nodeId);
+  const result = definitionToInsightLike(
+    unwrapDefinition(node.before),
+    node.nodeId,
+  );
   if (!result.baseTableId) return null;
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Proposed-source resolution (FIX 4)
+// ---------------------------------------------------------------------------
+
+/**
+ * A lookup over a diff's direct nodes keyed by `nodeId`, used to resolve a
+ * proposed source (a DataTable or insight created/changed IN THIS BATCH) before
+ * falling back to the canonical client store.
+ */
+type DirectNodeIndex = Map<UUID, PreviewDirectNode>;
+
+function indexDirectNodes(diff: PreviewDiff): DirectNodeIndex {
+  const index: DirectNodeIndex = new Map();
+  for (const node of diff.directNodes) index.set(node.nodeId, node);
+  return index;
+}
+
+/**
+ * Resolve a base-table id to a loadable DataTable.
+ *
+ * Resolution order:
+ *  1. If the id names a `dataTable` direct node IN THIS DIFF (proposed/refreshed
+ *     in the same batch), use its proposed/canonical definition. The DataFrame
+ *     it references must already be in local DuckDB for compute to succeed; a
+ *     brand-new DataTable whose DataFrame is not yet local returns null (honest
+ *     "unavailable" rather than a wrong count).
+ *  2. Fall back to the canonical client store (`getDataTable`).
+ *
+ * Insight-on-insight sources resolve their base recursively via the same diff
+ * index; if the source insight is itself a proposed node we cannot materialise a
+ * DataTable for it client-side (no DuckDB view exists for an un-persisted
+ * insight), so that case returns null → "unavailable".
+ */
+async function resolveBaseTable(
+  baseTableId: UUID,
+  nodeIndex: DirectNodeIndex,
+): Promise<DataTable | null> {
+  const proposedNode = nodeIndex.get(baseTableId);
+  if (proposedNode && proposedNode.kind === "dataTable") {
+    // A DataTable proposed/changed in this batch. Its proposedDefinition (or
+    // before) carries the schema metadata; the DataFrame must be local. We read
+    // the canonical store FIRST (covers update/noop where the row exists) and
+    // fall back to whatever the proposed definition can give us.
+    const canonical = await getDataTable(baseTableId);
+    if (canonical?.dataFrameId) return canonical;
+    // create-node DataTable: the canonical store has no row (preview rolled
+    // back). We can only compute if a proposed definition names a local
+    // dataFrameId. Otherwise the DataFrame isn't local → unavailable.
+    const def = proposedNode.proposedDefinition;
+    if (typeof def.dataFrameId === "string") {
+      return def as unknown as DataTable;
+    }
+    return null;
+  }
+  if (proposedNode && proposedNode.kind === "insight") {
+    // Insight-on-insight where the source is itself a proposed node: no DuckDB
+    // view exists for an un-persisted insight, so it's not computable here.
+    return null;
+  }
+  // Not in this diff — resolve from the canonical client store.
+  return (await getDataTable(baseTableId)) ?? null;
 }
 
 // ---------------------------------------------------------------------------
 // DuckDB query helpers
 // ---------------------------------------------------------------------------
 
+type ResolvedTables = {
+  baseTable: DataTable;
+  joinedTables: Map<UUID, DataTable>;
+};
+
 /**
- * Ensure all DataFrames for an insight are loaded in DuckDB.
- * Returns the Map of rightTableId → DataTable needed by buildInsightSQL.
+ * Ensure all DataFrames for an insight are loaded in DuckDB and return the
+ * resolved `{ baseTable, joinedTables }`. Resolved ONCE per insight shape and
+ * passed into both computeRowCount and computeHead (FIX 7 — no double-load).
  */
 async function ensureInsightDataFrames(
   insightLike: InsightLike,
   conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
-): Promise<{
-  baseTable: DataTable;
-  joinedTables: Map<UUID, DataTable>;
-} | null> {
-  const baseTable = await getDataTable(insightLike.baseTableId);
+  nodeIndex: DirectNodeIndex,
+): Promise<ResolvedTables | null> {
+  const baseTable = await resolveBaseTable(insightLike.baseTableId, nodeIndex);
   if (!baseTable?.dataFrameId) return null;
 
   const baseDF = await getDataFrame(baseTable.dataFrameId);
@@ -143,7 +330,7 @@ async function ensureInsightDataFrames(
   const joins = insightLike.joins ?? [];
   await Promise.all(
     joins.map(async (join) => {
-      const joinTable = await getDataTable(join.rightTableId);
+      const joinTable = await resolveBaseTable(join.rightTableId, nodeIndex);
       if (!joinTable?.dataFrameId) return;
       const joinDF = await getDataFrame(joinTable.dataFrameId);
       if (!joinDF) return;
@@ -156,16 +343,41 @@ async function ensureInsightDataFrames(
 }
 
 /**
- * Compute the row count for a given insight config against local DuckDB.
- * Returns `null` if the data isn't available or SQL can't be generated.
+ * Convert a DuckDB COUNT(*) cell to a `number | null`, preserving correctness in
+ * the face of IEEE-754 limits. Same discipline as YW-220: never silently emit a
+ * wrong precise number.
+ *
+ * A COUNT(*) above Number.MAX_SAFE_INTEGER (2^53−1 ≈ 9e15) cannot be represented
+ * exactly as a JS number; `Number(bigint)` would round it. We guard that case by
+ * returning null so the renderer shows an honest "unavailable" state rather than
+ * a count that is off by a few. (Real row counts at that scale are not expected
+ * client-side, but the guard keeps the display honest if it ever happens.)
+ */
+function countCellToNumber(cell: unknown): number | null {
+  if (typeof cell === "bigint") {
+    if (
+      cell > BigInt(Number.MAX_SAFE_INTEGER) ||
+      cell < BigInt(Number.MIN_SAFE_INTEGER)
+    ) {
+      return null;
+    }
+    return Number(cell);
+  }
+  if (typeof cell === "number") {
+    return Number.isSafeInteger(cell) ? cell : null;
+  }
+  return null;
+}
+
+/**
+ * Compute the row count for a pre-resolved insight against local DuckDB.
+ * Takes the pre-resolved tables (FIX 7) so it never re-loads DataFrames.
  */
 async function computeRowCount(
   insightLike: InsightLike,
+  tables: ResolvedTables,
   conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
 ): Promise<number | null> {
-  const tables = await ensureInsightDataFrames(insightLike, conn);
-  if (!tables) return null;
-
   const { baseTable, joinedTables } = tables;
 
   // Use "query" mode — that gives the aggregated result set (matching what the
@@ -175,7 +387,6 @@ async function computeRowCount(
     (insightLike.metrics?.length ?? 0) > 0;
   const mode = hasAggregation ? "query" : "model";
 
-  // Treat insightLike as a minimal Insight for SQL generation.
   const sql = buildInsightSQL(
     baseTable,
     joinedTables,
@@ -189,10 +400,7 @@ async function computeRowCount(
     const rows = result.toArray();
     const row = rows[0] as Record<string, unknown> | undefined;
     if (!row) return 0;
-    const cnt = row.cnt;
-    if (typeof cnt === "bigint") return Number(cnt);
-    if (typeof cnt === "number") return cnt;
-    return null;
+    return countCellToNumber(row.cnt);
   } catch {
     return null;
   }
@@ -202,16 +410,14 @@ async function computeRowCount(
 const HEAD_N = 5;
 
 /**
- * Compute the head rows (first N rows) for a given insight config.
- * Returns an empty array if the data isn't available or SQL can't be generated.
+ * Compute the head rows (first N rows) for a pre-resolved insight.
+ * Takes the pre-resolved tables (FIX 7) so it never re-loads DataFrames.
  */
 async function computeHead(
   insightLike: InsightLike,
+  tables: ResolvedTables,
   conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
 ): Promise<Array<Record<string, unknown>>> {
-  const tables = await ensureInsightDataFrames(insightLike, conn);
-  if (!tables) return [];
-
   const { baseTable, joinedTables } = tables;
 
   const hasAggregation =
@@ -237,6 +443,86 @@ async function computeHead(
   }
 }
 
+/**
+ * Compute the full PreviewCompute for one node: resolve the proposed and
+ * canonical insight tables ONCE each (FIX 7), then derive counts + head.
+ */
+async function computeNode(
+  proposed: InsightLike,
+  canonical: InsightLike | null,
+  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+  nodeIndex: DirectNodeIndex,
+): Promise<PreviewCompute> {
+  const [proposedTables, canonicalTables] = await Promise.all([
+    ensureInsightDataFrames(proposed, conn, nodeIndex),
+    canonical
+      ? ensureInsightDataFrames(canonical, conn, nodeIndex)
+      : Promise.resolve(null),
+  ]);
+
+  if (!proposedTables) {
+    // Proposed source not resolvable client-side → honest "unavailable".
+    return { rowCountBefore: null, rowCountAfter: null, head: [] };
+  }
+
+  const [rowCountAfter, head, rowCountBefore] = await Promise.all([
+    computeRowCount(proposed, proposedTables, conn),
+    computeHead(proposed, proposedTables, conn),
+    canonical && canonicalTables
+      ? computeRowCount(canonical, canonicalTables, conn)
+      : Promise.resolve(null),
+  ]);
+
+  return { rowCountBefore, rowCountAfter, head };
+}
+
+// ---------------------------------------------------------------------------
+// Stale-guard reducer (FIX 2) — extracted as a pure function for unit testing
+// ---------------------------------------------------------------------------
+
+interface ComputeState {
+  diff: PreviewDiff | null;
+  computeByNodeId: Map<string, PreviewCompute>;
+}
+
+/**
+ * Merge a freshly-resolved compute into state, guarding against stale writes.
+ *
+ * `forDiff` is the diff the result was computed for; `currentDiff` is the diff
+ * the hook currently cares about (the live prop at merge time).
+ *
+ * Three cases:
+ *  - `forDiff !== currentDiff` → STALE: the user has moved on (opened diff B
+ *    while A was still resolving). The late A result must NOT touch state —
+ *    return `prev` unchanged. This is the A→B race guard.
+ *  - `forDiff === currentDiff` but `prev.diff !== forDiff` → the FIRST result of
+ *    a freshly-swapped-in diff: reset to a new map keyed to `forDiff`, dropping
+ *    the previous diff's stale entries.
+ *  - `forDiff === currentDiff === prev.diff` → normal progressive merge.
+ *
+ * Pure + total: makes the A→B race testable without a DuckDB mock-thicket.
+ */
+export function mergeComputeResult(
+  prev: ComputeState,
+  forDiff: PreviewDiff,
+  currentDiff: PreviewDiff | null,
+  nodeId: string,
+  result: PreviewCompute,
+): ComputeState {
+  // Stale guard: a late result for a superseded diff must not clobber the
+  // current diff's state — drop it entirely.
+  if (forDiff !== currentDiff) return prev;
+  // First result of a freshly-active diff: start a fresh map keyed to it.
+  // Otherwise progressive-merge into the existing map.
+  const baseMap =
+    prev.diff === forDiff
+      ? prev.computeByNodeId
+      : new Map<string, PreviewCompute>();
+  const next = new Map(baseMap);
+  next.set(nodeId, result);
+  return { diff: forDiff, computeByNodeId: next };
+}
+
 // ---------------------------------------------------------------------------
 // The hook
 // ---------------------------------------------------------------------------
@@ -260,6 +546,8 @@ export interface DiffWithCompute {
  * - Each node resolves independently; state updates per resolved node.
  * - Non-insight kinds never get a compute slot (stays `undefined`).
  * - If DuckDB is not yet ready, waits until it initialises.
+ * - In-flight queries are cancelled on diff-swap / unmount; stale results for a
+ *   superseded diff are dropped (FIX 2).
  *
  * Privacy: all computation is client-side. No row data leaves the renderer.
  */
@@ -271,12 +559,29 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
 
   // Store per-node compute results alongside the diff they belong to.
   // Coupling them in one state object means a diff change atomically resets
-  // the map via the functional updater (in async callbacks, not in the effect
-  // body), keeping cascading render cycles to a minimum.
-  const [state, setState] = useState<{
-    diff: PreviewDiff | null;
-    computeByNodeId: Map<string, PreviewCompute>;
-  }>({ diff, computeByNodeId: new Map() });
+  // the map via the functional updater, keeping cascading render cycles minimal.
+  const [state, setState] = useState<ComputeState>({
+    diff,
+    computeByNodeId: new Map(),
+  });
+
+  // Stable mirror of which nodes have COMPLETED compute for the active diff. The
+  // effect reads THIS for its skip-check (not the captured `state`, which would
+  // be stale — `state` is excluded from the effect deps to avoid re-running on
+  // every partial fill). Crucially we mark a node done on COMPLETION, not on
+  // kick: if the effect re-runs for the same diff after a cancellation (e.g. a
+  // DuckDB reconnect flips `isInitialized`), a node whose work was cancelled
+  // mid-flight is NOT yet in this set, so it re-kicks rather than being skipped
+  // forever. The ref tracks the active diff identity + the completed-node ids.
+  const resolvedRef = useRef<{ diff: PreviewDiff | null; ids: Set<string> }>({
+    diff,
+    ids: new Set(),
+  });
+
+  // Always-current mirror of the live `diff` prop. The stale-guard reducer reads
+  // this to distinguish a legitimate new-diff result from a superseded one.
+  const currentDiffRef = useRef<PreviewDiff | null>(diff);
+  currentDiffRef.current = diff;
 
   // Derive the active compute map: if the stored diff has diverged from the
   // current diff (new preview opened), treat the map as empty until the async
@@ -292,64 +597,96 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
 
     const conn = connection;
     const thisDiff = diff;
+    const nodeIndex = indexDirectNodes(diff);
+
+    // Reset the resolved-id mirror when the diff identity changes.
+    if (resolvedRef.current.diff !== diff) {
+      resolvedRef.current = { diff, ids: new Set() };
+    }
+
+    // Cancellation flag: flipped in cleanup so late async results bail out and
+    // do not touch state or hold the single DuckDB-WASM worker (FIX 2a).
+    let cancelled = false;
+
+    // Dedupe kicks WITHIN this single effect pass. Completed-node skipping uses
+    // the cross-render `resolvedRef`; this local set only prevents kicking the
+    // same node twice in one pass (it can't span passes, so a cancelled node
+    // re-kicks on the next pass).
+    const kickedThisPass = new Set<string>();
 
     for (const node of diff.directNodes) {
-      // Only insight nodes get compute; skip if already resolved.
+      // Only insight nodes get compute; skip noop (unchanged) nodes.
       if (node.kind !== "insight") continue;
-      // noop nodes don't change — no compute needed.
       if (node.change === "noop") continue;
 
       const proposed = buildProposedInsight(node);
       if (!proposed) continue;
 
-      // Skip nodes already resolved for this exact diff.
-      if (state.diff === diff && state.computeByNodeId.has(node.nodeId))
-        continue;
+      // Skip nodes already COMPLETED for this diff (cross-render, via the ref)
+      // or already kicked earlier in this same pass.
+      if (resolvedRef.current.ids.has(node.nodeId)) continue;
+      if (kickedThisPass.has(node.nodeId)) continue;
+      kickedThisPass.add(node.nodeId);
 
       const canonical = buildCanonicalInsight(node);
+      const nodeId = node.nodeId;
 
       // Fire-and-forget: each node resolves independently.
-      const nodeId = node.nodeId;
       (async () => {
-        const computeResult: PreviewCompute = await (async () => {
-          try {
-            // Compute proposed counts + head in parallel with canonical count.
-            const [rowCountAfter, head, rowCountBefore] = await Promise.all([
-              computeRowCount(proposed, conn),
-              computeHead(proposed, conn),
-              canonical
-                ? computeRowCount(canonical, conn)
-                : Promise.resolve(null),
-            ]);
-            return { rowCountBefore, rowCountAfter, head };
-          } catch {
-            // Non-fatal: sentinel with nulls so allResolved stops waiting.
-            return { rowCountBefore: null, rowCountAfter: null, head: [] };
-          }
-        })();
-
-        // Functional update: merges into the state for the correct diff and
-        // resets implicitly if a stale diff's update arrives after a swap.
-        setState((prev) => {
-          const prevMap =
-            prev.diff === thisDiff
-              ? prev.computeByNodeId
-              : new Map<string, PreviewCompute>();
-          const next = new Map(prevMap);
-          next.set(nodeId, computeResult);
-          return { diff: thisDiff, computeByNodeId: next };
-        });
+        if (cancelled) return;
+        let computeResult: PreviewCompute;
+        try {
+          computeResult = await computeNode(
+            proposed,
+            canonical,
+            conn,
+            nodeIndex,
+          );
+        } catch {
+          // Non-fatal: sentinel with nulls so allResolved stops waiting and the
+          // renderer shows the honest "unavailable" state.
+          computeResult = {
+            rowCountBefore: null,
+            rowCountAfter: null,
+            head: [],
+          };
+        }
+        // Bail before writing if a swap/unmount happened mid-flight (FIX 2a).
+        if (cancelled) return;
+        // Mark COMPLETED for the active diff so a same-diff re-run (e.g. DuckDB
+        // reconnect) skips it — but only when this result is for the live diff
+        // (a stale result for a superseded diff must not poison the ref).
+        if (resolvedRef.current.diff === thisDiff) {
+          resolvedRef.current.ids.add(nodeId);
+        }
+        // Stale guard (FIX 2b): drop a late result for a superseded diff. The
+        // reducer compares against the live diff via currentDiffRef.
+        setState((prev) =>
+          mergeComputeResult(
+            prev,
+            thisDiff,
+            currentDiffRef.current,
+            nodeId,
+            computeResult,
+          ),
+        );
       })();
     }
-    // state intentionally excluded from deps: including it would re-run on each
-    // partial fill, causing duplicate compute kicks.
+
+    return () => {
+      cancelled = true;
+    };
+    // `state` is intentionally excluded from deps: including it would re-run on
+    // every partial fill, re-kicking compute. The skip-check reads `resolvedRef`
+    // (a stable ref that mirrors the active diff + already-kicked ids), so it is
+    // reliable without `state` in the dependency array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [diff, connection, isInitialized]);
 
   if (!diff) return { diff: null, allResolved: true };
 
-  // Derive computable node ids directly from the diff (pure render logic, no ref).
-  // A node is computable when: insight kind, non-noop change, has a valid baseTableId.
+  // Derive computable node ids directly from the diff (pure render logic).
+  // A node is computable when: insight kind, non-noop change, valid baseTableId.
   const computableIds = diff.directNodes
     .filter(
       (n) =>
@@ -359,8 +696,8 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
     )
     .map((n) => n.nodeId);
 
-  // Build the filled diff — shallow-clone only; mutate compute slots on a per-
-  // node basis rather than cloning the entire diff on every partial fill.
+  // Build the filled diff — shallow-clone only; mutate compute slots per-node
+  // rather than cloning the entire diff on every partial fill.
   const filledNodes = diff.directNodes.map((node) => {
     const filled = computeByNodeId.get(node.nodeId);
     if (!filled) return node;

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -122,6 +122,42 @@ function definitionToInsightLike(
 }
 
 /**
+ * Command-arg keys that carry a genuinely-INCREMENTAL insight edit which cannot
+ * be reconstructed into the final shape from args alone (the original array
+ * element / index must be replayed against the canonical definition):
+ *   - AddField (`field`) / UpdateField (`fieldId`,`updates`) / RemoveField (`fieldId`)
+ *   - AddMetric (`metric`) / UpdateMetric (`metricId`,`updates`) / RemoveMetric (`metricId`)
+ *   - UpdateJoin / RemoveJoin (`joinIndex`,`updates`)
+ *
+ * If `proposedDefinition` carries any of these (and no replace-all array
+ * superseded the same slice), `foldInsightArgs` returns null — the proposed
+ * shape is non-computable, so the renderer shows an honest "unavailable" state
+ * rather than a SILENT STALE count (the canonical count mislabeled as proposed).
+ * `join` (AddJoin) is excluded: it carries a full join object and IS foldable.
+ */
+const UNFOLDABLE_INCREMENTAL_KEYS = [
+  "field",
+  "fieldId",
+  "metric",
+  "metricId",
+  "joinIndex",
+  "updates",
+] as const;
+
+/**
+ * Replace-all command-arg array keys that map 1:1 onto stored-definition keys
+ * (CreateInsight / SetInsightFilter / SetInsightSort / replace-all metrics/joins).
+ * `fieldIds`→`selectedFields` is handled separately (key rename).
+ */
+const REPLACE_ALL_KEYS = [
+  "selectedFields",
+  "metrics",
+  "filters",
+  "sorts",
+  "joins",
+] as const;
+
+/**
  * Fold raw command args (`proposedDefinition`) onto a canonical base definition,
  * producing the SAME final insight shape the mutation would persist.
  *
@@ -132,20 +168,25 @@ function definitionToInsightLike(
  *   - `selectedFields`     → pass through    (CreateInsight)
  *   - `filters`/`sorts`/`metrics`/`joins` → pass through (replace-all commands)
  *   - `baseTableId`        → pass through if present
- *   - `join` (object)      → append/merge onto joins[] (AddJoin/UpdateJoin)
+ *   - `join` (object)      → append/merge onto joins[] (AddJoin)
  *
- * Genuinely-incremental commands that need the original command replayed to fold
- * cleanly (`joinId`-only RemoveJoin/UpdateJoin, AddField/RemoveField/AddMetric
- * with no replace-all array present) can't be reconstructed from args alone. We
- * do the best reconstruction available; if the result has no resolvable base
- * table, `buildProposedInsight` returns null and the renderer shows an honest
- * "unavailable" state rather than a stuck spinner.
+ * Returns null for an un-foldable INCREMENTAL edit (see
+ * UNFOLDABLE_INCREMENTAL_KEYS) so `buildProposedInsight` propagates null and the
+ * renderer shows "unavailable" — fail-honest rather than a silent stale count.
  */
 function foldInsightArgs(
   canonicalDef: Record<string, unknown>,
   proposedArgs: Record<string, unknown>,
   nodeId: UUID,
-): InsightLike {
+): InsightLike | null {
+  // Fail-honest on un-foldable incremental args: we cannot reconstruct the
+  // proposed shape from a single field/metric/join element + the canonical def
+  // without replaying the command, so computing here would mislabel the
+  // canonical (stale) count as the proposed one. Return null → "unavailable".
+  for (const key of UNFOLDABLE_INCREMENTAL_KEYS) {
+    if (proposedArgs[key] !== undefined) return null;
+  }
+
   // Start from the canonical definition (stored key names), then overlay the
   // proposed change with key-name translation.
   const folded: Record<string, unknown> = { ...canonicalDef };
@@ -165,43 +206,41 @@ function foldInsightArgs(
   if (Array.isArray(proposedArgs.fieldIds)) {
     folded.selectedFields = proposedArgs.fieldIds;
   }
-  // Replace-all arrays whose arg names match the stored names.
-  if (Array.isArray(proposedArgs.selectedFields)) {
-    folded.selectedFields = proposedArgs.selectedFields;
-  }
-  if (Array.isArray(proposedArgs.metrics)) {
-    folded.metrics = proposedArgs.metrics;
-  }
-  if (Array.isArray(proposedArgs.filters)) {
-    folded.filters = proposedArgs.filters;
-  }
-  if (Array.isArray(proposedArgs.sorts)) {
-    folded.sorts = proposedArgs.sorts;
-  }
-  if (Array.isArray(proposedArgs.joins)) {
-    folded.joins = proposedArgs.joins;
+  // Replace-all arrays whose arg names match the stored names — pass through.
+  for (const key of REPLACE_ALL_KEYS) {
+    if (Array.isArray(proposedArgs[key])) folded[key] = proposedArgs[key];
   }
 
-  // Incremental single-join arg (AddJoin / UpdateJoin carry a `join` object).
-  // Best-effort fold: append onto the joins array (or merge by rightTableId).
+  // Incremental single-join arg (AddJoin carries a full `join` object).
   if (
     proposedArgs.join &&
     typeof proposedArgs.join === "object" &&
     !Array.isArray(proposedArgs.join)
   ) {
-    const incoming = proposedArgs.join as Record<string, unknown>;
-    const existing = Array.isArray(folded.joins)
-      ? [...(folded.joins as Record<string, unknown>[])]
-      : [];
-    const idx = existing.findIndex(
-      (j) => j.rightTableId === incoming.rightTableId,
+    folded.joins = foldSingleJoin(
+      folded.joins,
+      proposedArgs.join as Record<string, unknown>,
     );
-    if (idx >= 0) existing[idx] = { ...existing[idx], ...incoming };
-    else existing.push(incoming);
-    folded.joins = existing;
   }
 
   return definitionToInsightLike(folded, nodeId);
+}
+
+/**
+ * Fold one AddJoin `join` object onto the existing joins array: merge by
+ * `rightTableId` if a join on that table already exists, else append.
+ */
+function foldSingleJoin(
+  existingJoins: unknown,
+  incoming: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const joins = Array.isArray(existingJoins)
+    ? [...(existingJoins as Record<string, unknown>[])]
+    : [];
+  const idx = joins.findIndex((j) => j.rightTableId === incoming.rightTableId);
+  if (idx >= 0) joins[idx] = { ...joins[idx], ...incoming };
+  else joins.push(incoming);
+  return joins;
 }
 
 /**
@@ -218,7 +257,8 @@ function buildProposedInsight(node: PreviewDirectNode): InsightLike | null {
     node.proposedDefinition,
     node.nodeId,
   );
-  if (!result.baseTableId) return null;
+  // null = un-foldable incremental edit (fail-honest → "unavailable").
+  if (!result || !result.baseTableId) return null;
   return result;
 }
 
@@ -408,6 +448,17 @@ async function computeRowCount(
 
 /** HEAD_N is the number of sample rows to return in the `head` slot. */
 const HEAD_N = 5;
+
+/**
+ * The "unavailable" compute sentinel — a resolved-but-empty result. Distinct
+ * from `undefined` (pending): the renderer shows an honest "unavailable" state
+ * for this, a spinner for `undefined`.
+ */
+const EMPTY_COMPUTE: PreviewCompute = {
+  rowCountBefore: null,
+  rowCountAfter: null,
+  head: [],
+};
 
 /**
  * Compute the head rows (first N rows) for a pre-resolved insight.
@@ -623,13 +674,28 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
     // re-kicks on the next pass).
     const kickedThisPass = new Set<string>();
 
+    // Commit a node's result: mark it COMPLETED for the active diff (so a
+    // same-diff re-run skips it, but only when still the live diff so a stale
+    // result can't poison the ref) and write it through the stale-guard reducer.
+    const commit = (nodeId: string, computeResult: PreviewCompute) => {
+      if (resolvedRef.current.diff === thisDiff) {
+        resolvedRef.current.ids.add(nodeId);
+      }
+      setState((prev) =>
+        mergeComputeResult(
+          prev,
+          thisDiff,
+          currentDiffRef.current,
+          nodeId,
+          computeResult,
+        ),
+      );
+    };
+
     for (const node of diff.directNodes) {
       // Only insight nodes get compute; skip noop (unchanged) nodes.
       if (node.kind !== "insight") continue;
       if (node.change === "noop") continue;
-
-      const proposed = buildProposedInsight(node);
-      if (!proposed) continue;
 
       // Skip nodes already COMPLETED for this diff (cross-render, via the ref)
       // or already kicked earlier in this same pass.
@@ -637,8 +703,17 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
       if (kickedThisPass.has(node.nodeId)) continue;
       kickedThisPass.add(node.nodeId);
 
-      const canonical = buildCanonicalInsight(node);
       const nodeId = node.nodeId;
+      const proposed = buildProposedInsight(node);
+      // Changed insight node we cannot compute (un-foldable incremental edit or
+      // no resolvable base table): commit the empty sentinel NOW so the renderer
+      // shows the honest "unavailable" state instead of a stuck pending spinner.
+      if (!proposed) {
+        commit(nodeId, EMPTY_COMPUTE);
+        continue;
+      }
+
+      const canonical = buildCanonicalInsight(node);
 
       // Fire-and-forget: each node resolves independently.
       (async () => {
@@ -652,33 +727,13 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
             nodeIndex,
           );
         } catch {
-          // Non-fatal: sentinel with nulls so allResolved stops waiting and the
-          // renderer shows the honest "unavailable" state.
-          computeResult = {
-            rowCountBefore: null,
-            rowCountAfter: null,
-            head: [],
-          };
+          // Non-fatal: empty sentinel → allResolved stops waiting, renderer
+          // shows the honest "unavailable" state.
+          computeResult = EMPTY_COMPUTE;
         }
         // Bail before writing if a swap/unmount happened mid-flight (FIX 2a).
         if (cancelled) return;
-        // Mark COMPLETED for the active diff so a same-diff re-run (e.g. DuckDB
-        // reconnect) skips it — but only when this result is for the live diff
-        // (a stale result for a superseded diff must not poison the ref).
-        if (resolvedRef.current.diff === thisDiff) {
-          resolvedRef.current.ids.add(nodeId);
-        }
-        // Stale guard (FIX 2b): drop a late result for a superseded diff. The
-        // reducer compares against the live diff via currentDiffRef.
-        setState((prev) =>
-          mergeComputeResult(
-            prev,
-            thisDiff,
-            currentDiffRef.current,
-            nodeId,
-            computeResult,
-          ),
-        );
+        commit(nodeId, computeResult);
       })();
     }
 
@@ -693,15 +748,12 @@ export function usePreviewComputeFill(diff: PreviewDiff | null): {
 
   if (!diff) return { diff: null, allResolved: true };
 
-  // Derive computable node ids directly from the diff (pure render logic).
-  // A node is computable when: insight kind, non-noop change, valid baseTableId.
+  // Every changed insight node gets a compute slot — either a real count or the
+  // empty sentinel ("unavailable"). Non-computable nodes (un-foldable
+  // incremental edit, no base table) resolve synchronously to the sentinel, so
+  // they still count toward allResolved (they are not stuck pending).
   const computableIds = diff.directNodes
-    .filter(
-      (n) =>
-        n.kind === "insight" &&
-        n.change !== "noop" &&
-        buildProposedInsight(n) !== null,
-    )
+    .filter((n) => n.kind === "insight" && n.change !== "noop")
     .map((n) => n.nodeId);
 
   // Build the filled diff — shallow-clone only; mutate compute slots per-node

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -319,13 +319,22 @@ async function resolveBaseTable(
     // before) carries the schema metadata; the DataFrame must be local. We read
     // the canonical store FIRST (covers update/noop where the row exists) and
     // fall back to whatever the proposed definition can give us.
+    const def = proposedNode.proposedDefinition;
+    const proposedFrameId =
+      typeof def.dataFrameId === "string" ? def.dataFrameId : undefined;
     const canonical = await getDataTable(baseTableId);
-    if (canonical?.dataFrameId) return canonical;
+    if (canonical?.dataFrameId) {
+      // Same-batch update may re-point this table's dataFrameId. Overlay the
+      // PROPOSED frame id so the count reflects the proposed table, not the
+      // stale canonical one. (No proposed override → use canonical as-is.)
+      return proposedFrameId
+        ? { ...canonical, dataFrameId: proposedFrameId }
+        : canonical;
+    }
     // create-node DataTable: the canonical store has no row (preview rolled
     // back). We can only compute if a proposed definition names a local
     // dataFrameId. Otherwise the DataFrame isn't local → unavailable.
-    const def = proposedNode.proposedDefinition;
-    if (typeof def.dataFrameId === "string") {
+    if (proposedFrameId) {
       return def as unknown as DataTable;
     }
     return null;


### PR DESCRIPTION
## Summary

- **Removes `POST /preview/batch`** — the prior agent added a bespoke Hono HTTP route in `apps/server/src/app.ts` as a parallel authenticated endpoint. This route bypassed the WyStack RPC layer (it even mounted before the WyStack catch-all to avoid routing conflicts) and re-implemented bearer-token auth independently. The owner ruled this must not exist.

- **Re-expresses as WyStack query** — `previewDiff` is now registered in `apps/server/src/functions/preview-diff.ts` as a standard `query({...})` through the same RPC dispatch as every other function. Auth, egress-gate boundary, and runHandler/context threading are all inherited. `wyStackApp` and `artifactDb` are injected into `staticContext` in `createDashframeServer` so the handler can access them via `FunctionContext`'s index signature.

- **Re-wires the client** — `packages/app-data/src/preview-diff.ts` replaces `fetch('/preview/batch')` with `getWyStackClient().query(api.previewDiff, { commands })`. The separate `setPreviewAuthToken` auth seam is removed — auth is handled transparently by the WyStack client.

- **Preserves the split-tier invariant** — metadata-only crosses the RPC boundary; compute slots (`rowCount`/`head`) are still filled client-side via local DuckDB (`usePreviewComputeFill`). No raw row data ever leaves the renderer.

- **ONE server boundary** — no parallel HTTP API alongside WyStack. All server calls go through the same RPC boundary.

## Why query not mutation

`applyCommands` in preview mode executes-then-rolls-back; the canonical DB is untouched, so no `tablesWritten` signal fires and no reactive invalidation should trigger. A mutation registration would cause spurious invalidation on every preview open.

## Test plan

- [ ] Typecheck passes (no new errors vs baseline — pre-existing `@wystack/secret-vault` module resolution failures are on `origin/main` too)
- [ ] Lint clean on touched files
- [ ] `grep -rn "POST /preview/batch\|createPreviewPath\|setPreviewAuthToken" apps/ packages/` → empty
- [ ] Preview diff dialog opens and fills `rowCount`/`head` correctly via the WyStack query path
- [ ] Auth is enforced (Electron with vault-backed token: request rejected without token)

Tracked internally as YW-161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the bespoke `POST /preview/batch` Hono route and re-expresses the preview-diff computation as a standard WyStack `query` (`previewDiff`), bringing it in line with the rest of the RPC surface. The `app.ts` wrapper is simplified to always wrap `rawApp` (unconditionally), and `wyStackApp`/`artifactDb` are injected into `staticContext` after the wrapper is assigned so the new handler can access them via `FunctionContext`.

- **Server**: `previewDiff` registered as a `query` in `apps/server/src/functions/preview-diff.ts`; `wyStackApp` and `artifactDb` injected into `staticContext` post-assignment in `createDashframeServer`.
- **Client**: `previewBatch` in `packages/app-data/src/preview-diff.ts` replaced from a raw `fetch('/preview/batch')` to `getWyStackClient().query(api.previewDiff, { commands })`, removing the separate `setPreviewAuthToken` seam.
- **UI**: New `PreviewDiffDialog` wraps `PreviewDiffRenderer`; `ComputeDisplay`, `RowCountDelta`, and `HeadTable` helpers added; compute slots filled lazily client-side via `usePreviewComputeFill` (local DuckDB WASM), never crossing the RPC boundary.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the architectural shift from bespoke HTTP route to WyStack query is clean, auth and context threading are correctly inherited, and no row data crosses the RPC boundary.

The `staticContext` post-assignment mutation in `app.ts` is correct for the current code path (mutations land synchronously before `listen()` starts accepting requests), and the `previewDiff` handler throws loudly if the context keys are absent. All custom-rule invariants are respected: no ticket IDs in source, no `isElectron` forks, no off-token colors, no raw runtime error strings in new UI paths. Test coverage for both the renderer and the compute-fill hook is thorough.

apps/server/src/app.ts — the ordering dependency between `app` construction and `staticContext` mutation is worth a second look if the initialization sequence is ever extended.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Unconditionally wraps rawApp; adds post-assignment mutation of staticContext to inject wyStackApp and artifactDb. Correct because closures read staticContext at call-time and mutations complete before listen(), but fragile to future code inserted between those two lines. |
| apps/server/src/functions/preview-diff.ts | Adds previewDiff WyStack query registration. Array.isArray guard on jsonb commands, vault-only handlerContext forwarding, and clear infrastructure-failure throws are well-structured. Rationale for query-not-mutation is documented. |
| packages/app-data/src/preview-diff.ts | Thin client wrapper replacing raw fetch with getWyStackClient().query(api.previewDiff, { commands }). Auth and error handling delegated to WyStack client. Clean split-tier boundary documented. |
| packages/app/src/components/preview-diff/PreviewDiffDialog.tsx | New dialog wrapping PreviewDiffRenderer; gates usePreviewComputeFill on open prop to avoid spurious DuckDB compute when hidden. No isElectron forks, no off-token colors. |
| packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx | Adds RowCountDelta, HeadTable, and ComputeDisplay helpers. Resolved-but-empty sentinel correctly shows 'Preview unavailable' instead of infinite spinner. All colors use semantic tokens. |
| packages/app/src/components/preview-diff/usePreviewComputeFill.ts | New hook filling compute slots from local DuckDB WASM. foldInsightArgs correctly reconciles stored vs command key names. Graceful non-fatal paths for missing base table and null SQL. Known limitations around duplicate ensureInsightDataFrames calls flagged in prior review. |
| packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx | New test file with good coverage: metadata-renders-immediately, pending indicator, resolved-but-empty sentinel, downstream blast radius, partial-failure error banner, and empty state all tested. |
| packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts | New test file covering null passthrough, insight fill, noop/non-insight skip, progressive fill, DuckDB-not-ready guard, missing base table graceful path, SQL null path, diff identity reset, and FIX 1 field-mapping contract. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as PreviewDiffDialog
    participant Fill as usePreviewComputeFill
    participant Client as previewBatch (app-data)
    participant WyStack as WyStack Client/RPC
    participant Server as previewDiff handler
    participant BPD as buildPreviewDiff
    participant DuckDB as DuckDB WASM (local)

    UI->>Client: previewBatch(commands)
    Client->>WyStack: "getWyStackClient().query(api.previewDiff, { commands })"
    WyStack->>Server: RPC call (authenticated via WyStack auth layer)
    Server->>Server: validate ctx.wyStackApp and ctx.artifactDb
    Server->>BPD: buildPreviewDiff(wyStackApp, artifactDb, commands, handlerContext)
    BPD-->>Server: PreviewDiff (compute: undefined on all nodes — metadata only)
    Server-->>WyStack: PreviewDiff
    WyStack-->>Client: PreviewDiff
    Client-->>UI: PreviewDiff (compute: undefined)

    UI->>Fill: usePreviewComputeFill(diff) [client-side only]
    loop For each insight direct node
        Fill->>DuckDB: computeRowCount + computeHead via local DuckDB WASM
        DuckDB-->>Fill: rowCountBefore, rowCountAfter, head[]
        Fill->>UI: setState (partial fill per node)
    end
    UI->>UI: Render with filled compute slots
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as PreviewDiffDialog
    participant Fill as usePreviewComputeFill
    participant Client as previewBatch (app-data)
    participant WyStack as WyStack Client/RPC
    participant Server as previewDiff handler
    participant BPD as buildPreviewDiff
    participant DuckDB as DuckDB WASM (local)

    UI->>Client: previewBatch(commands)
    Client->>WyStack: "getWyStackClient().query(api.previewDiff, { commands })"
    WyStack->>Server: RPC call (authenticated via WyStack auth layer)
    Server->>Server: validate ctx.wyStackApp and ctx.artifactDb
    Server->>BPD: buildPreviewDiff(wyStackApp, artifactDb, commands, handlerContext)
    BPD-->>Server: PreviewDiff (compute: undefined on all nodes — metadata only)
    Server-->>WyStack: PreviewDiff
    WyStack-->>Client: PreviewDiff
    Client-->>UI: PreviewDiff (compute: undefined)

    UI->>Fill: usePreviewComputeFill(diff) [client-side only]
    loop For each insight direct node
        Fill->>DuckDB: computeRowCount + computeHead via local DuckDB WASM
        DuckDB-->>Fill: rowCountBefore, rowCountAfter, head[]
        Fill->>UI: setState (partial fill per node)
    end
    UI->>UI: Render with filled compute slots
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(app): gate preview compute on dialog..."](https://github.com/youhaowei/dashframe/commit/2a769f9c1a952808b05211438ea739da022ae4b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37828480)</sub>

<!-- /greptile_comment -->