### PR TITLE
feat(server,desktop): [YW-265] serve auth token behind SecretVault — first non-connector consumer

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -12,9 +12,15 @@ import {
   createDashframeServer,
   type DashframeServer,
 } from "@dashframe/server/app";
-import { SecretRegistry, SecretVault } from "@wystack/secret-vault";
+import {
+  isSecretRef,
+  SecretRegistry,
+  SecretVault,
+  type SecretRef,
+} from "@wystack/secret-vault";
 import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
 import path from "node:path";
 
 import { Lifecycle } from "./lifecycle.js";
@@ -36,6 +42,82 @@ let secretVault: SecretVault | null = null;
 
 function createLoopbackToken(): string {
   return randomBytes(32).toString("base64url");
+}
+
+/** Sidecar marker recording the current launch's serve-token vault ref. */
+const SERVE_TOKEN_REF_FILE = "serve-token.ref";
+
+/**
+ * Result of provisioning the per-launch serve token. A discriminated union so
+ * exactly one path is type-enforced (never both, never neither):
+ *   - `authRef`   — vault-backed path (keychain available). The server resolves
+ *                   the token from the vault; no plaintext at the server.
+ *   - `authToken` — process-memory fallback (keychain unavailable). The token
+ *                   lives only in memory for this launch; never written at rest.
+ */
+type ServeTokenResult =
+  | { authRef: SecretRef; authToken?: undefined }
+  | { authToken: string; authRef?: undefined };
+
+/**
+ * Provision the per-launch serve token through the SecretVault, with two
+ * non-happy-path behaviors:
+ *
+ *   1. Stale-entry cleanup — read the prior launch's ref from the sidecar
+ *      marker and `vault.delete` it before storing the new token, so the
+ *      `secret_mappings` row + keychain blob from the previous launch do not
+ *      accumulate unbounded. The new ref is then written back to the marker.
+ *
+ *   2. Keychain-unavailable fallback — the serve token is ephemeral (minted
+ *      every launch, never resolved across restarts). When the OS keychain is
+ *      unavailable (e.g. Linux without libsecret, or the rejected `basic_text`
+ *      backend), `vault.store` throws; rather than blocking startup, fall back
+ *      to a process-memory token. Plaintext-never-AT-REST is preserved either
+ *      way — the fallback keeps the token only in memory.
+ */
+async function storeServeToken(
+  vault: SecretVault,
+  projectDir: string,
+  token: string,
+): Promise<ServeTokenResult> {
+  const markerPath = path.join(projectDir, SERVE_TOKEN_REF_FILE);
+
+  // Cleanup: delete the prior launch's serve-token entry (mapping row + blob).
+  // Best-effort — a missing/corrupt marker or a delete failure must not block
+  // startup; the worst case is one orphaned entry, not a broken launch.
+  try {
+    const prior = (await fs.readFile(markerPath, "utf8")).trim();
+    if (isSecretRef(prior)) {
+      await vault.delete(prior);
+    }
+  } catch {
+    // No prior marker (first launch) or unreadable — nothing to clean up.
+  }
+
+  try {
+    const authRef = await vault.store(token, { class: "serve-token" });
+    // Persist the new ref so the next launch can clean it up. Best-effort: a
+    // write failure only risks a future orphan, not this launch.
+    try {
+      await fs.writeFile(markerPath, authRef, { mode: 0o600 });
+    } catch (err) {
+      console.warn(
+        "[dashframe] could not persist serve-token marker (cleanup may orphan one entry):",
+        err,
+      );
+    }
+    return { authRef };
+  } catch (err) {
+    // Keychain unavailable — the serve token is ephemeral, so degrade to a
+    // process-memory token instead of failing startup. Remove any stale marker
+    // (the vault path is not in use this launch).
+    console.warn(
+      "[dashframe] vault unavailable for serve token; falling back to in-memory token (not at rest):",
+      err,
+    );
+    await fs.rm(markerPath, { force: true }).catch(() => {});
+    return { authToken: token };
+  }
 }
 
 async function createWindow(): Promise<void> {
@@ -237,14 +319,32 @@ app
       // the OS keychain (registered above). No plaintext token persists in a
       // server field; the server resolves it from the vault at each request's
       // auth gate.
-      const authRef = await (secretVault as SecretVault).store(authToken, {
-        class: "serve-token",
-      });
+      //
+      // Two non-happy-path concerns are handled here:
+      //   - Stale-entry cleanup: each launch mints a fresh token, so the prior
+      //     launch's serve-token mapping row + keychain blob would accumulate
+      //     unbounded. We persist the ref in a sidecar marker and delete the
+      //     prior entry before storing the new one (overwrite semantics).
+      //   - Keychain unavailable: the serve token is EPHEMERAL (regenerated per
+      //     launch, never needed across restarts), so when the OS keychain is
+      //     unavailable (Linux without libsecret, or the rejected basic_text
+      //     backend) we fall back to a process-memory token instead of failing
+      //     startup. Plaintext-never-AT-REST holds either way — the fallback
+      //     keeps the token only in process memory.
+      const authResult = await storeServeToken(
+        secretVault as SecretVault,
+        project.dir,
+        authToken,
+      );
 
       server = await createDashframeServer({
         db: project.db,
         corsOrigin,
-        authRef,
+        // Vault path passes a ref (no plaintext at the server); the
+        // keychain-unavailable fallback passes the plaintext token directly
+        // (process-memory only). Exactly one of these is set.
+        authRef: authResult.authRef,
+        authToken: authResult.authToken,
         arrowEngine: engine,
         // Wire the debounced snapshot scheduler: fire touchSnapshot after every
         // committed artifact-DB write so a crash mid-session loses at most

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -233,10 +233,18 @@ app
       lifecycle.setEngine(engine);
       console.log("[dashframe] native DuckDB engine ready");
 
+      // Store the per-launch token in the vault — "serve-token" class routes to
+      // the OS keychain (registered above). No plaintext token persists in a
+      // server field; the server resolves it from the vault at each request's
+      // auth gate.
+      const authRef = await (secretVault as SecretVault).store(authToken, {
+        class: "serve-token",
+      });
+
       server = await createDashframeServer({
         db: project.db,
         corsOrigin,
-        authToken,
+        authRef,
         arrowEngine: engine,
         // Wire the debounced snapshot scheduler: fire touchSnapshot after every
         // committed artifact-DB write so a crash mid-session loses at most

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -10,6 +10,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { openProject, type ProjectHandle } from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  makeSecretRef,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -90,6 +97,19 @@ describe("bind-auth gate", () => {
     ).not.toThrow();
   });
 
+  it("non-loopback + authRef → allowed (vault ref satisfies the gate equally)", () => {
+    // A well-formed SecretRef is treated as equivalent to authToken for the
+    // bind-auth gate. The ref itself carries no secret — it is opaque.
+    const ref = makeSecretRef();
+    expect(() =>
+      assertBindAuthorized({
+        hostname: "0.0.0.0",
+        authRef: ref,
+        authToken: undefined,
+      }),
+    ).not.toThrow();
+  });
+
   it("loopback + no token → allowed (local dev path)", () => {
     // 127.0.0.1 is loopback and reachable only from this machine, so no token
     // is required.
@@ -121,6 +141,27 @@ describe("bind-auth gate", () => {
           // authToken deliberately omitted
         }),
       ).rejects.toThrow(/refusing to bind.*without an auth token/i);
+    } finally {
+      await project.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("createDashframeServer rejects authRef without vault (misconfiguration guard)", async () => {
+    // Defensive invariant: authRef requires vault. Without vault the ref cannot
+    // be resolved and the server would silently start unauthenticated. The guard
+    // must throw before any socket opens.
+    const root = mkdtempSync(join(tmpdir(), "dashframe-guard-"));
+    const project = await openProject({ dir: join(root, "proj") });
+    try {
+      const ref = makeSecretRef();
+      await expect(
+        createDashframeServer({
+          db: project.db,
+          authRef: ref,
+          // vault deliberately omitted
+        }),
+      ).rejects.toThrow(/authRef requires vault/i);
     } finally {
       await project.close();
       rmSync(root, { recursive: true, force: true });
@@ -409,5 +450,98 @@ describe("onWrite hook", () => {
     expect(verify.status).toBe(200);
     const verifyBody = (await verify.json()) as { data: { id: string } };
     expect(verifyBody.data.id).toBe(sourceId);
+  });
+});
+
+describe("vault-backed serve-token auth", () => {
+  /**
+   * Acceptance test for the vault-backed auth path.
+   *
+   * Uses TestBackend (InMemoryMappingStore) — test environments only.
+   * Proves: store → SecretRef → server resolves at gate →
+   *   valid Bearer accepted, invalid Bearer rejected.
+   *
+   * This is a non-connector credential flowing through the same vault —
+   * the class is "serve-token" (same class registered in Electron main for
+   * the OS keychain).
+   */
+  let root: string;
+  let project: ProjectHandle | null;
+  let server: DashframeServer | null;
+  let vault: SecretVault;
+
+  function buildTestVault(): SecretVault {
+    const backend = new TestBackend();
+    const registry = new SecretRegistry();
+    registry.register("test", backend, { fallback: true });
+    registry.setClassDefault("serve-token", "test");
+    return new SecretVault(registry, new InMemoryMappingStore());
+  }
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-vault-auth-"));
+    project = null;
+    server = null;
+    vault = buildTestVault();
+  });
+
+  afterEach(async () => {
+    server?.stop();
+    await project?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves token from vault: valid Bearer → 200, no auth → 401, wrong token → 401", async () => {
+    const plaintext = "vault-serve-token-test";
+    const authRef = await vault.store(plaintext, { class: "serve-token" });
+
+    project = await openProject({ dir: join(root, "proj"), name: "Vault Co" });
+    server = await createDashframeServer({
+      db: project.db,
+      authRef,
+      vault,
+      corsOrigin: "null",
+    });
+
+    const url = `${server.url}/api/projectInfo?args=${encodeURIComponent("{}")}`;
+
+    // No auth header → 401
+    const noAuth = await fetch(url);
+    expect(noAuth.status).toBe(401);
+
+    // Wrong token → 401
+    const wrongAuth = await fetch(url, {
+      headers: bearer("wrong-token"),
+    });
+    expect(wrongAuth.status).toBe(401);
+
+    // Correct token → 200
+    const ok = await fetch(url, {
+      headers: bearer(plaintext),
+    });
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as { data: ProjectInfoResult };
+    expect(body.data.name).toBe("Vault Co");
+  });
+
+  it("vault-backed resolver isolates per-request (token resolved fresh each time)", async () => {
+    const plaintext = "rotating-token";
+    const authRef = await vault.store(plaintext, { class: "serve-token" });
+
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({
+      db: project.db,
+      authRef,
+      vault,
+    });
+
+    const url = `${server.url}/api/projectInfo?args=${encodeURIComponent("{}")}`;
+
+    // Two successive correct-token requests both succeed — resolver is stateless
+    // and re-reads from vault each time.
+    for (let i = 0; i < 2; i++) {
+      const res = await fetch(url, { headers: bearer(plaintext) });
+      expect(res.status).toBe(200);
+    }
   });
 });

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -106,7 +106,7 @@ export function assertBindAuthorized(opts: {
   }
   if (opts.insecure && !hasAuth && !loopback) {
     console.warn(
-      "[dashframe] warning: insecure non-loopback bind without authToken exposes this project to the network",
+      "[dashframe] warning: insecure non-loopback bind without authToken or authRef exposes this project to the network",
     );
   }
 }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -40,7 +40,11 @@ import {
 } from "@dashframe/engine-server/arrow-data-path";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
-import type { SecretVault } from "@wystack/secret-vault";
+import {
+  isSecretRef,
+  type SecretRef,
+  type SecretVault,
+} from "@wystack/secret-vault";
 import { createRoutes, createWyStack, type WyStackApp } from "@wystack/server";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
@@ -88,17 +92,19 @@ function isLoopbackHost(hostname: string | undefined): boolean {
 export function assertBindAuthorized(opts: {
   hostname: string | undefined;
   authToken: string | undefined;
+  authRef?: SecretRef;
   insecure?: boolean;
 }): void {
   const loopback = isLoopbackHost(opts.hostname);
-  if (!loopback && !opts.authToken && !opts.insecure) {
+  const hasAuth = Boolean(opts.authToken) || isSecretRef(opts.authRef);
+  if (!loopback && !hasAuth && !opts.insecure) {
     throw new Error(
       `createDashframeServer: refusing to bind ${opts.hostname} without an auth token. ` +
         `A non-loopback bind exposes the project to the network. ` +
-        `Supply authToken, or set insecure: true to opt out deliberately.`,
+        `Supply authToken or authRef, or set insecure: true to opt out deliberately.`,
     );
   }
-  if (opts.insecure && !opts.authToken && !loopback) {
+  if (opts.insecure && !hasAuth && !loopback) {
     console.warn(
       "[dashframe] warning: insecure non-loopback bind without authToken exposes this project to the network",
     );
@@ -140,8 +146,20 @@ export interface DashframeServerOptions {
    *
    * Security: omitting this on a non-loopback bind causes `createDashframeServer`
    * to throw. Pass `insecure: true` to deliberately opt out of this requirement.
+   *
+   * Kept for backward compat — existing tests and `dashframe serve` pass
+   * plaintext here. Prefer `authRef` + `vault` for new surfaces.
    */
   authToken?: string;
+  /**
+   * Vault-backed alternative to `authToken`. When both `authRef` and `vault`
+   * are present the server resolves the expected token from the vault at each
+   * request's auth gate — no plaintext token is stored in a server field.
+   *
+   * `authToken` is ignored when this pair is set. Satisfies the non-loopback
+   * auth gate in the same way a plaintext `authToken` does.
+   */
+  authRef?: SecretRef;
   /**
    * Opt out of the non-loopback auth requirement. Use only in controlled
    * environments where the network exposure is intentional. The factory will
@@ -211,13 +229,32 @@ export async function createDashframeServer(
   assertBindAuthorized({
     hostname,
     authToken: opts.authToken,
+    authRef: opts.authRef,
     insecure: opts.insecure,
   });
 
   const corsOrigin = opts.corsOrigin ?? allowLocalhostOrigin;
-  const resolveContext = opts.authToken
-    ? createTokenResolver(opts.authToken)
-    : undefined;
+
+  // Resolve the auth context builder: vault-backed ref takes priority over
+  // plaintext token. Both produce the same (req) → context shape for WyStack.
+  //
+  // Defensive invariant: authRef requires vault — the ref is meaningless
+  // without the mapping store and backend. A missing vault silently falls
+  // through to unauthenticated without this guard; fail loudly instead.
+  if (opts.authRef && !opts.vault) {
+    throw new Error(
+      "createDashframeServer: authRef requires vault — supply a SecretVault " +
+        "instance when using vault-backed auth.",
+    );
+  }
+  let resolveContext:
+    | ((req: Request) => Promise<Record<string, unknown>>)
+    | undefined;
+  if (opts.authRef && opts.vault) {
+    resolveContext = createVaultTokenResolver(opts.authRef, opts.vault);
+  } else if (opts.authToken) {
+    resolveContext = createTokenResolver(opts.authToken);
+  }
 
   const rawApp = await createWyStack({ db: opts.db, functions });
 
@@ -296,7 +333,9 @@ export async function createDashframeServer(
       "/data",
       createArrowDataPath({
         engine: opts.arrowEngine,
-        authToken: opts.authToken,
+        ...(opts.authRef && opts.vault
+          ? { authRef: opts.authRef, vault: opts.vault }
+          : { authToken: opts.authToken }),
       }),
     );
   }
@@ -343,6 +382,30 @@ function createTokenResolver(
       ? auth.slice("Bearer ".length)
       : "";
     if (!tokenMatches(token, expectedToken)) {
+      throw new Error("Unauthorized");
+    }
+    return {};
+  };
+}
+
+/**
+ * Vault-backed token resolver. Resolves the expected token from the vault at
+ * each request — no plaintext is held in a server field. Returned resolver has
+ * the same signature as the one returned by `createTokenResolver`.
+ */
+function createVaultTokenResolver(
+  authRef: SecretRef,
+  vault: SecretVault,
+): (req: Request) => Promise<Record<string, unknown>> {
+  return async (req) => {
+    const auth = req.headers.get("authorization") ?? "";
+    const token = auth.startsWith("Bearer ")
+      ? auth.slice("Bearer ".length)
+      : "";
+    const authorized = await vault.withSecret(authRef, async (expected) =>
+      tokenMatches(token, expected),
+    );
+    if (!authorized) {
       throw new Error("Unauthorized");
     }
     return {};

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -392,6 +392,11 @@ function createTokenResolver(
  * Vault-backed token resolver. Resolves the expected token from the vault at
  * each request — no plaintext is held in a server field. Returned resolver has
  * the same signature as the one returned by `createTokenResolver`.
+ *
+ * FAIL-CLOSED: any failure to resolve the expected token (missing/corrupt
+ * keychain blob, vault error) denies the request. The throw propagates to
+ * WyStack's route handler, which maps it to 401 — never a 500 that would leak
+ * the vault state, and never an allow.
  */
 function createVaultTokenResolver(
   authRef: SecretRef,
@@ -402,9 +407,16 @@ function createVaultTokenResolver(
     const token = auth.startsWith("Bearer ")
       ? auth.slice("Bearer ".length)
       : "";
-    const authorized = await vault.withSecret(authRef, async (expected) =>
-      tokenMatches(token, expected),
-    );
+    let authorized = false;
+    try {
+      authorized = await vault.withSecret(authRef, async (expected) =>
+        tokenMatches(token, expected),
+      );
+    } catch {
+      // Resolution failed — cannot confirm the token, so deny. Fall through to
+      // the Unauthorized throw below (→ 401), never surface a 500 or allow.
+      authorized = false;
+    }
     if (!authorized) {
       throw new Error("Unauthorized");
     }

--- a/bun.lock
+++ b/bun.lock
@@ -555,6 +555,7 @@
         "@dashframe/engine": "workspace:*",
         "@dashframe/types": "workspace:*",
         "@duckdb/node-api": "1.5.3-r.3",
+        "@wystack/secret-vault": "workspace:*",
         "apache-arrow": "^21.1.0",
         "hono": "^4.12.9",
       },

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@dashframe/engine": "workspace:*",
     "@dashframe/types": "workspace:*",
+    "@wystack/secret-vault": "workspace:*",
     "@duckdb/node-api": "1.5.3-r.3",
     "apache-arrow": "^21.1.0",
     "hono": "^4.12.9"

--- a/packages/engine-server/src/arrow-data-path.test.ts
+++ b/packages/engine-server/src/arrow-data-path.test.ts
@@ -260,7 +260,6 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
 describe("Arrow data path — vault-backed auth (fail-closed)", () => {
   function buildVault(storedToken: string): {
     vault: SecretVault;
-    authRef: ReturnType<typeof makeSecretRef>;
     store: () => Promise<ReturnType<typeof makeSecretRef>>;
   } {
     const registry = new SecretRegistry();
@@ -269,7 +268,6 @@ describe("Arrow data path — vault-backed auth (fail-closed)", () => {
     const vault = new SecretVault(registry, new InMemoryMappingStore());
     return {
       vault,
-      authRef: makeSecretRef(),
       store: () => vault.store(storedToken, { class: "serve-token" }),
     };
   }

--- a/packages/engine-server/src/arrow-data-path.test.ts
+++ b/packages/engine-server/src/arrow-data-path.test.ts
@@ -1,3 +1,10 @@
+import {
+  InMemoryMappingStore,
+  makeSecretRef,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
 import { tableFromIPC } from "apache-arrow";
 import { describe, expect, it } from "vitest";
 
@@ -247,5 +254,84 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
       expect(engine.registrations).toHaveLength(1);
       expect(engine.registrations[0]?.name).toBe("df_ok");
     }
+  });
+});
+
+describe("Arrow data path — vault-backed auth (fail-closed)", () => {
+  function buildVault(storedToken: string): {
+    vault: SecretVault;
+    authRef: ReturnType<typeof makeSecretRef>;
+    store: () => Promise<ReturnType<typeof makeSecretRef>>;
+  } {
+    const registry = new SecretRegistry();
+    registry.register("test", new TestBackend(), { fallback: true });
+    registry.setClassDefault("serve-token", "test");
+    const vault = new SecretVault(registry, new InMemoryMappingStore());
+    return {
+      vault,
+      authRef: makeSecretRef(),
+      store: () => vault.store(storedToken, { class: "serve-token" }),
+    };
+  }
+
+  it("resolves the expected token from the vault: correct Bearer → 200", async () => {
+    const { vault, store } = buildVault(TOKEN);
+    const authRef = await store();
+    const app = createArrowDataPath({ engine: fakeEngine(), authRef, vault });
+    const res = await app.request("/arrow", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${TOKEN}`,
+      },
+      body: JSON.stringify({ sql: "SELECT 1" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a wrong token against the vault-stored token → 401", async () => {
+    const { vault, store } = buildVault(TOKEN);
+    const authRef = await store();
+    const app = createArrowDataPath({ engine: fakeEngine(), authRef, vault });
+    const res = await app.request("/arrow", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer wrong",
+      },
+      body: JSON.stringify({ sql: "SELECT 1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("FAIL-CLOSED: authRef without vault throws at construction (never an unguarded path)", () => {
+    // The worst failure for an auth gate is to serve traffic unauthenticated.
+    // A misconfigured caller (authRef set, vault missing) must not produce a
+    // router that waves requests through — it must refuse to construct.
+    expect(() =>
+      createArrowDataPath({ engine: fakeEngine(), authRef: makeSecretRef() }),
+    ).toThrow(/authRef requires vault/i);
+  });
+
+  it("FAIL-CLOSED: a vault resolution failure denies the request (401, not 500/allow)", async () => {
+    // authRef present but the ref was never stored → withSecret rejects. The
+    // gate must deny (401), never crash (500) and never allow.
+    const registry = new SecretRegistry();
+    registry.register("test", new TestBackend(), { fallback: true });
+    const vault = new SecretVault(registry, new InMemoryMappingStore());
+    const unstoredRef = makeSecretRef();
+    const engine = fakeEngine();
+    const app = createArrowDataPath({ engine, authRef: unstoredRef, vault });
+    const res = await app.request("/arrow", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${TOKEN}`,
+      },
+      body: JSON.stringify({ sql: "SELECT 1" }),
+    });
+    expect(res.status).toBe(401);
+    // The engine never ran — auth failed closed before dispatch.
+    expect(engine.calls).toHaveLength(0);
   });
 });

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -170,24 +170,43 @@ async function dispatchArrowQuery(
 /**
  * Resolve whether the incoming request is authorized.
  *
- * Priority:
- *   1. `authRef` + `vault` — resolves the expected token from the vault at
- *      call time; no plaintext token is held in a server field.
- *   2. `authToken` — compare against the plaintext bearer token (legacy /
- *      backward-compat path for tests and `dashframe serve`).
- *   3. Neither — open (no auth configured); returns `true`.
+ * FAIL-CLOSED contract. An auth gate must never wave a request through on an
+ * error or misconfiguration — that is the worst failure mode for a security
+ * boundary. Every branch that cannot positively confirm the token denies it.
  *
- * Returns `false` when auth is configured and the supplied header does not
- * match. Returns `true` when auth passes or is not configured.
+ * Priority:
+ *   1. `authRef` set — vault-backed auth is configured. The expected token is
+ *      resolved from the vault at call time (no plaintext held in a field). If
+ *      `vault` is missing (misconfiguration), or `withSecret` rejects (e.g. a
+ *      missing/corrupt keychain blob), the request is DENIED — never allowed.
+ *   2. `authToken` set — compare against the plaintext bearer token (legacy /
+ *      backward-compat path for tests and `dashframe serve`).
+ *   3. Neither — no auth configured; the path is open (loopback dev / serve
+ *      without a token). This is the only allow-without-token branch and it is
+ *      reached ONLY when the caller configured no auth at all.
+ *
+ * Returns `true` only when auth passes or no auth is configured; `false` in
+ * every other case (wrong token, missing vault, resolution failure).
  */
 async function checkAuth(
   authHeader: string | undefined,
   options: ArrowDataPathOptions,
 ): Promise<boolean> {
-  if (options.authRef && options.vault) {
-    return options.vault.withSecret(options.authRef, async (expected) =>
-      tokenOk(authHeader, expected),
-    );
+  if (options.authRef) {
+    // Vault is required whenever authRef is set. createArrowDataPath enforces
+    // this at construction, but defend here too: a missing vault means we
+    // cannot resolve the expected token, so we must DENY (fail closed), never
+    // fall through to the open branch.
+    if (!options.vault) return false;
+    try {
+      return await options.vault.withSecret(options.authRef, async (expected) =>
+        tokenOk(authHeader, expected),
+      );
+    } catch {
+      // Resolution failed (missing/corrupt keychain blob, vault error). Auth
+      // cannot be confirmed → deny. Surfaces to the caller as 401, not 500.
+      return false;
+    }
   }
   if (options.authToken) {
     return tokenOk(authHeader, options.authToken);
@@ -200,6 +219,16 @@ async function checkAuth(
  * Mount it on the loopback host (e.g. under `/data`).
  */
 export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
+  // Fail-closed invariant: authRef requires vault. Without the vault the ref
+  // cannot be resolved and the gate would have no way to validate tokens.
+  // Refuse to construct the router rather than silently run an unguarded path.
+  if (options.authRef && !options.vault) {
+    throw new Error(
+      "createArrowDataPath: authRef requires vault — supply a SecretVault " +
+        "instance when using vault-backed auth.",
+    );
+  }
+
   const app = new Hono();
 
   // -------------------------------------------------------------------------

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -29,6 +29,7 @@
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { tableFromIPC } from "apache-arrow";
 import { Hono } from "hono";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 export const ARROW_STREAM_CONTENT_TYPE = "application/vnd.apache.arrow.stream";
 
@@ -348,13 +349,11 @@ function arrowIpcToJsonRows(arrow: Uint8Array): Record<string, unknown>[] {
 function tokenOk(authHeader: string | undefined, expected: string): boolean {
   if (!authHeader?.startsWith("Bearer ")) return false;
   const token = authHeader.slice("Bearer ".length);
-  // Constant-time-ish: same-length compare. The loopback token is high-entropy
-  // and the surface is local-only, so a length-leak is not a meaningful vector
-  // here, but avoid early-exit on the common-prefix case.
-  if (token.length !== expected.length) return false;
-  let diff = 0;
-  for (let i = 0; i < token.length; i++) {
-    diff |= token.charCodeAt(i) ^ expected.charCodeAt(i);
-  }
-  return diff === 0;
+  // Hash both sides to fixed-length SHA-256 digests before the constant-time
+  // compare, so neither the length nor any prefix of the token leaks via timing.
+  // This matches the server's tokenMatches (app.ts) — one comparison discipline
+  // across both auth sinks.
+  const actualBytes = createHash("sha256").update(token).digest();
+  const expectedBytes = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(actualBytes, expectedBytes);
 }

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -26,6 +26,7 @@
  *   Only available when the engine implements `registerArrowTable` (i.e. the
  *   native engine is wired — not the web-WASM degenerate case).
  */
+import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { tableFromIPC } from "apache-arrow";
 import { Hono } from "hono";
 
@@ -49,12 +50,27 @@ export interface ArrowDataPathOptions {
   /** The engine that executes compiled SQL and returns Arrow IPC. */
   engine: ArrowQueryRunner & Partial<ArrowTableRegistrar>;
   /**
-   * Per-launch loopback bearer token. When set, every request must carry
-   * `Authorization: Bearer <token>`. When unset, the path is open (loopback
-   * `dashframe serve` without `--token`) — the same policy as the WyStack
-   * server's optional auth.
+   * Per-launch loopback bearer token (plaintext). When set, every request must
+   * carry `Authorization: Bearer <token>`. When unset, the path is open
+   * (loopback `dashframe serve` without `--token`) — the same policy as the
+   * WyStack server's optional auth.
+   *
+   * Mutually exclusive with `authRef` + `vault`. Kept for backward compat
+   * (existing tests and `dashframe serve`).
    */
   authToken?: string;
+  /**
+   * Vault-backed auth ref — the vault-stored alternative to `authToken`.
+   * When both `authRef` and `vault` are present, token verification resolves
+   * the expected value from the vault at each request rather than comparing
+   * against a plaintext field. `authToken` is ignored when this pair is set.
+   */
+  authRef?: SecretRef;
+  /**
+   * The SecretVault instance paired with `authRef`. Must be provided whenever
+   * `authRef` is set.
+   */
+  vault?: SecretVault;
 }
 
 /** Native shape: `{ sql, params? }` */
@@ -152,6 +168,34 @@ async function dispatchArrowQuery(
 }
 
 /**
+ * Resolve whether the incoming request is authorized.
+ *
+ * Priority:
+ *   1. `authRef` + `vault` — resolves the expected token from the vault at
+ *      call time; no plaintext token is held in a server field.
+ *   2. `authToken` — compare against the plaintext bearer token (legacy /
+ *      backward-compat path for tests and `dashframe serve`).
+ *   3. Neither — open (no auth configured); returns `true`.
+ *
+ * Returns `false` when auth is configured and the supplied header does not
+ * match. Returns `true` when auth passes or is not configured.
+ */
+async function checkAuth(
+  authHeader: string | undefined,
+  options: ArrowDataPathOptions,
+): Promise<boolean> {
+  if (options.authRef && options.vault) {
+    return options.vault.withSecret(options.authRef, async (expected) =>
+      tokenOk(authHeader, expected),
+    );
+  }
+  if (options.authToken) {
+    return tokenOk(authHeader, options.authToken);
+  }
+  return true; // no auth configured — path is open
+}
+
+/**
  * Build a Hono router exposing the Arrow data path.
  * Mount it on the loopback host (e.g. under `/data`).
  */
@@ -162,10 +206,7 @@ export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
   // POST /arrow  — query endpoint (native shape + Mosaic Coordinator shape)
   // -------------------------------------------------------------------------
   app.post("/arrow", async (c) => {
-    if (
-      options.authToken &&
-      !tokenOk(c.req.header("authorization"), options.authToken)
-    ) {
+    if (!(await checkAuth(c.req.header("authorization"), options))) {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
@@ -183,10 +224,7 @@ export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
   // POST /tables/:name  — register an Arrow IPC buffer as a named table
   // -------------------------------------------------------------------------
   app.post("/tables/:name", async (c) => {
-    if (
-      options.authToken &&
-      !tokenOk(c.req.header("authorization"), options.authToken)
-    ) {
+    if (!(await checkAuth(c.req.header("authorization"), options))) {
       return c.json({ error: "Unauthorized" }, 401);
     }
 


### PR DESCRIPTION
## Summary

- Moves the per-launch loopback bearer token from a plaintext server field to the SecretVault (`class: "serve-token"`, OS-keychain backend on desktop). The host (`Electron main`) stores the token via `vault.store()` at startup and passes an opaque `SecretRef` (`authRef`) to `createDashframeServer` — no plaintext token persists in any server field.
- The auth gate (`createVaultTokenResolver`) resolves the expected token via `vault.withSecret(authRef, ...)` at each request, comparing via `timingSafeEqual` on SHA-256 hashes. The gate is guarded against keychain errors by WyStack's `resolveContext` error handler, which maps any throw to 401.
- Covers the Arrow IPC data path (`/data/arrow`, `/data/tables/:name`) as well — both routes resolve via the same `checkAuth()` helper that supports either `authRef`+`vault` or legacy `authToken`.
- Adds a defensive invariant: `createDashframeServer` throws if `authRef` is supplied without `vault` (prevents silent unauthenticated fallback from misconfiguration).
- Backward-compatible: `authToken` on `DashframeServerOptions` is retained for `dashframe serve` and existing tests.

Tracked internally as YW-265.

## Test plan

- [x] New test suite `"vault-backed serve-token auth"` in `app.test.ts`: end-to-end `store → SecretRef → server → valid Bearer → 200 / no auth → 401 / wrong token → 401`
- [x] New `assertBindAuthorized` test: `authRef` satisfies non-loopback gate equivalently to `authToken`
- [x] New guard test: `createDashframeServer` rejects `authRef` without `vault` before any socket opens
- [x] All 193 existing tests pass (`bun check` — 71/71 turbo tasks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the per-launch loopback bearer token from a plaintext server field to the OS keychain via `SecretVault`, making it the first non-connector consumer. The server now receives an opaque `SecretRef` and resolves the expected token from the vault at each request using SHA-256 + `timingSafeEqual`, with a graceful in-memory fallback when the keychain is unavailable.

- **`storeServeToken` (desktop `main.ts`)**: mints a fresh token each launch, deletes the prior launch's vault entry using a sidecar `serve-token.ref` marker (addressing the previous accumulation concern), and falls back to a process-memory token when the keychain is unavailable — plaintext-never-at-rest holds on both paths.
- **`createVaultTokenResolver` / `createArrowDataPath` (server + engine-server)**: vault-backed resolvers added to both the WyStack and Arrow IPC auth paths, both using SHA-256 + `timingSafeEqual`; fail-closed construction guard (`authRef` without `vault` throws before any socket opens) added to both `createDashframeServer` and `createArrowDataPath`; `checkAuth` now returns `false` (not `true`) when `authRef` is set but `vault` is absent.
- **Tests**: new end-to-end vault auth suite in `app.test.ts` and `arrow-data-path.test.ts` covering valid bearer → 200, wrong token → 401, no-auth → 401, vault resolution failure → 401, and the misconfiguration guard.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three auth boundaries (WyStack gate, Arrow IPC gate, bind-auth gate) are updated consistently and all previously identified issues have been addressed.

The fail-closed construction guards, consistent SHA-256 + timingSafeEqual comparisons across both auth sinks, correct return false in checkAuth when vault is absent, and the stale-entry cleanup via sidecar marker together close all the gaps identified in prior review rounds. The test suite exercises the full store→resolve→200/401 flow and the vault-resolution-failure path. No new defects found.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main.ts | Adds storeServeToken helper that handles stale-entry cleanup via a sidecar marker file and falls back gracefully when the keychain is unavailable; wires the resulting authRef (or fallback authToken) into createDashframeServer. |
| apps/server/src/app.ts | Adds authRef/vault to DashframeServerOptions, guards authRef-without-vault before any socket opens, introduces createVaultTokenResolver with SHA-256+timingSafeEqual, updates assertBindAuthorized and the insecure warning to cover both authToken and authRef. |
| packages/engine-server/src/arrow-data-path.ts | Adds vault-backed auth to the Arrow IPC path via checkAuth; throws at construction if authRef is supplied without vault; upgrades tokenOk to SHA-256+timingSafeEqual matching app.ts. |
| apps/server/src/app.test.ts | Adds vault-backed end-to-end auth test suite (store→SecretRef→200/401), authRef bind-gate test, and misconfiguration guard test. Good coverage. |
| packages/engine-server/src/arrow-data-path.test.ts | Adds vault-backed auth tests for the Arrow path including correct/wrong token, construction guard, and vault-resolution-failure (fail-closed) scenarios. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Main as Electron Main
    participant Vault as SecretVault
    participant FS as Filesystem (serve-token.ref)
    participant Server as DashframeServer
    participant Gate as Auth Gate (WyStack / Arrow)
    participant KC as OS Keychain

    Main->>FS: read prior ref (best-effort)
    FS-->>Main: prior SecretRef (or error)
    Main->>Vault: vault.delete(prior) [best-effort]
    Main->>Main: createLoopbackToken()
    Main->>Vault: vault.store(token, class:serve-token)
    Vault->>KC: encrypt + store blob
    KC-->>Vault: locator
    Vault-->>Main: authRef (SecretRef)
    Main->>FS: writeFile(serve-token.ref, authRef, 0o600)
    Main->>Server: "createDashframeServer({ authRef, vault })"
    Note over Server: Guard: authRef requires vault
    Note over Gate: Per request
    Gate->>Vault: vault.withSecret(authRef, fn)
    Vault->>KC: decrypt blob
    KC-->>Vault: plaintext token
    Vault-->>Gate: tokenMatches / tokenOk (SHA-256 + timingSafeEqual)
    alt token OK
        Gate-->>Server: 200
    else token wrong / vault error
        Gate-->>Server: 401
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Main as Electron Main
    participant Vault as SecretVault
    participant FS as Filesystem (serve-token.ref)
    participant Server as DashframeServer
    participant Gate as Auth Gate (WyStack / Arrow)
    participant KC as OS Keychain

    Main->>FS: read prior ref (best-effort)
    FS-->>Main: prior SecretRef (or error)
    Main->>Vault: vault.delete(prior) [best-effort]
    Main->>Main: createLoopbackToken()
    Main->>Vault: vault.store(token, class:serve-token)
    Vault->>KC: encrypt + store blob
    KC-->>Vault: locator
    Vault-->>Main: authRef (SecretRef)
    Main->>FS: writeFile(serve-token.ref, authRef, 0o600)
    Main->>Server: "createDashframeServer({ authRef, vault })"
    Note over Server: Guard: authRef requires vault
    Note over Gate: Per request
    Gate->>Vault: vault.withSecret(authRef, fn)
    Vault->>KC: decrypt blob
    KC-->>Vault: plaintext token
    Vault-->>Gate: tokenMatches / tokenOk (SHA-256 + timingSafeEqual)
    alt token OK
        Gate-->>Server: 200
    else token wrong / vault error
        Gate-->>Server: 401
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/server/src/app.ts`, line 107-111 ([link](https://github.com/youhaowei/dashframe/blob/330661938026026542d95443c301230a6c4f4f1f/apps/server/src/app.ts#L107-L111)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `console.warn` message still names only `authToken`, even though `authRef` is now an equally valid auth option. Any operator reading the log would not know to supply `authRef`+`vault` instead.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/app.ts
   Line: 107-111

   Comment:
   The `console.warn` message still names only `authToken`, even though `authRef` is now an equally valid auth option. Any operator reading the log would not know to supply `authRef`+`vault` instead.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Fapp.ts%0ALine%3A%20107-111%0A%0AComment%3A%0AThe%20%60console.warn%60%20message%20still%20names%20only%20%60authToken%60%2C%20even%20though%20%60authRef%60%20is%20now%20an%20equally%20valid%20auth%20option.%20Any%20operator%20reading%20the%20log%20would%20not%20know%20to%20supply%20%60authRef%60%2B%60vault%60%20instead.%0A%0A%60%60%60suggestion%0A%20%20if%20%28opts.insecure%20%26%26%20!hasAuth%20%26%26%20!loopback%29%20%7B%0A%20%20%20%20console.warn%28%0A%20%20%20%20%20%20%22%5Bdashframe%5D%20warning%3A%20insecure%20non-loopback%20bind%20without%20authToken%20or%20authRef%20exposes%20this%20project%20to%20the%20network%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-265-secretvault-absorb-dashframe-serveloopback-auth-token-non%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-265-secretvault-absorb-dashframe-serveloopback-auth-token-non%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Fapp.ts%0ALine%3A%20107-111%0A%0AComment%3A%0AThe%20%60console.warn%60%20message%20still%20names%20only%20%60authToken%60%2C%20even%20though%20%60authRef%60%20is%20now%20an%20equally%20valid%20auth%20option.%20Any%20operator%20reading%20the%20log%20would%20not%20know%20to%20supply%20%60authRef%60%2B%60vault%60%20instead.%0A%0A%60%60%60suggestion%0A%20%20if%20%28opts.insecure%20%26%26%20!hasAuth%20%26%26%20!loopback%29%20%7B%0A%20%20%20%20console.warn%28%0A%20%20%20%20%20%20%22%5Bdashframe%5D%20warning%3A%20insecure%20non-loopback%20bind%20without%20authToken%20or%20authRef%20exposes%20this%20project%20to%20the%20network%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Fapp.ts%0ALine%3A%20107-111%0A%0AComment%3A%0AThe%20%60console.warn%60%20message%20still%20names%20only%20%60authToken%60%2C%20even%20though%20%60authRef%60%20is%20now%20an%20equally%20valid%20auth%20option.%20Any%20operator%20reading%20the%20log%20would%20not%20know%20to%20supply%20%60authRef%60%2B%60vault%60%20instead.%0A%0A%60%60%60suggestion%0A%20%20if%20%28opts.insecure%20%26%26%20!hasAuth%20%26%26%20!loopback%29%20%7B%0A%20%20%20%20console.warn%28%0A%20%20%20%20%20%20%22%5Bdashframe%5D%20warning%3A%20insecure%20non-loopback%20bind%20without%20authToken%20or%20authRef%20exposes%20this%20project%20to%20the%20network%22%2C%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/engine-server/src/arrow-data-path.ts`, line 319-331 ([link](https://github.com/youhaowei/dashframe/blob/330661938026026542d95443c301230a6c4f4f1f/packages/engine-server/src/arrow-data-path.ts#L319-L331)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inconsistent timing-safe comparison between WyStack and Arrow paths**

   The WyStack auth path (`createVaultTokenResolver` in `app.ts`) uses SHA-256 hashing plus `timingSafeEqual`, which produces fixed-length digests regardless of input and avoids all timing leaks. `tokenOk` here short-circuits on length mismatch, leaking the expected token's length, then performs a manual XOR comparison. The `authRef`+`vault` branch in `checkAuth` now routes through `tokenOk`, so the vault-backed Arrow path has weaker timing properties than the equivalent vault-backed WyStack path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/engine-server/src/arrow-data-path.ts
   Line: 319-331

   Comment:
   **Inconsistent timing-safe comparison between WyStack and Arrow paths**

   The WyStack auth path (`createVaultTokenResolver` in `app.ts`) uses SHA-256 hashing plus `timingSafeEqual`, which produces fixed-length digests regardless of input and avoids all timing leaks. `tokenOk` here short-circuits on length mismatch, leaking the expected token's length, then performs a manual XOR comparison. The `authRef`+`vault` branch in `checkAuth` now routes through `tokenOk`, so the vault-backed Arrow path has weaker timing properties than the equivalent vault-backed WyStack path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine-server%2Fsrc%2Farrow-data-path.ts%0ALine%3A%20319-331%0A%0AComment%3A%0A**Inconsistent%20timing-safe%20comparison%20between%20WyStack%20and%20Arrow%20paths**%0A%0AThe%20WyStack%20auth%20path%20%28%60createVaultTokenResolver%60%20in%20%60app.ts%60%29%20uses%20SHA-256%20hashing%20plus%20%60timingSafeEqual%60%2C%20which%20produces%20fixed-length%20digests%20regardless%20of%20input%20and%20avoids%20all%20timing%20leaks.%20%60tokenOk%60%20here%20short-circuits%20on%20length%20mismatch%2C%20leaking%20the%20expected%20token's%20length%2C%20then%20performs%20a%20manual%20XOR%20comparison.%20The%20%60authRef%60%2B%60vault%60%20branch%20in%20%60checkAuth%60%20now%20routes%20through%20%60tokenOk%60%2C%20so%20the%20vault-backed%20Arrow%20path%20has%20weaker%20timing%20properties%20than%20the%20equivalent%20vault-backed%20WyStack%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-265-secretvault-absorb-dashframe-serveloopback-auth-token-non%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-265-secretvault-absorb-dashframe-serveloopback-auth-token-non%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine-server%2Fsrc%2Farrow-data-path.ts%0ALine%3A%20319-331%0A%0AComment%3A%0A**Inconsistent%20timing-safe%20comparison%20between%20WyStack%20and%20Arrow%20paths**%0A%0AThe%20WyStack%20auth%20path%20%28%60createVaultTokenResolver%60%20in%20%60app.ts%60%29%20uses%20SHA-256%20hashing%20plus%20%60timingSafeEqual%60%2C%20which%20produces%20fixed-length%20digests%20regardless%20of%20input%20and%20avoids%20all%20timing%20leaks.%20%60tokenOk%60%20here%20short-circuits%20on%20length%20mismatch%2C%20leaking%20the%20expected%20token's%20length%2C%20then%20performs%20a%20manual%20XOR%20comparison.%20The%20%60authRef%60%2B%60vault%60%20branch%20in%20%60checkAuth%60%20now%20routes%20through%20%60tokenOk%60%2C%20so%20the%20vault-backed%20Arrow%20path%20has%20weaker%20timing%20properties%20than%20the%20equivalent%20vault-backed%20WyStack%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fengine-server%2Fsrc%2Farrow-data-path.ts%0ALine%3A%20319-331%0A%0AComment%3A%0A**Inconsistent%20timing-safe%20comparison%20between%20WyStack%20and%20Arrow%20paths**%0A%0AThe%20WyStack%20auth%20path%20%28%60createVaultTokenResolver%60%20in%20%60app.ts%60%29%20uses%20SHA-256%20hashing%20plus%20%60timingSafeEqual%60%2C%20which%20produces%20fixed-length%20digests%20regardless%20of%20input%20and%20avoids%20all%20timing%20leaks.%20%60tokenOk%60%20here%20short-circuits%20on%20length%20mismatch%2C%20leaking%20the%20expected%20token's%20length%2C%20then%20performs%20a%20manual%20XOR%20comparison.%20The%20%60authRef%60%2B%60vault%60%20branch%20in%20%60checkAuth%60%20now%20routes%20through%20%60tokenOk%60%2C%20so%20the%20vault-backed%20Arrow%20path%20has%20weaker%20timing%20properties%20than%20the%20equivalent%20vault-backed%20WyStack%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=130&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(server,engine-server): unify to..."](https://github.com/youhaowei/dashframe/commit/904c3ce26cf93cd21571f8cb379cf8d4ab0adf0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38024542)</sub>

<!-- /greptile_comment -->