### PR TITLE
fix(server): [YW-267] atomic auto-draft dedup — close TOCTOU race

### DIFF
--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -1,10 +1,15 @@
 /**
- * Tests for the privacy-floor write boundary in app-artifacts.
+ * Tests for the privacy-floor write boundary in app-artifacts, and the
+ * atomic auto-draft dedup contract on createInsight.
  *
- * Contract: any DataFrameAnalysis written through putDataFrameEntry or
+ * Privacy floor: any DataFrameAnalysis written through putDataFrameEntry or
  * updateDataFrameEntry lands in the artifact DB with zero raw sampleValues.
  * The invariant is structural — it cannot be broken by the caller passing
  * sampleValues, because the boundary strips them before every write.
+ *
+ * Auto-draft dedup: createInsight wraps check-and-insert in a single
+ * transaction so two concurrent calls for the same baseTableId always
+ * converge on one unmodified draft (no TOCTOU race).
  *
  * Pattern matches commands.test.ts: real PGLite, 'should ...' names,
  * structural-invariant testing.
@@ -176,5 +181,184 @@ describe("privacy floor — no raw sampleValues persist in artifact DB", () => {
 
     const stored = await readAnalysis(id);
     expect(stored).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createInsight — atomic auto-draft dedup (TOCTOU fix)
+// ---------------------------------------------------------------------------
+//
+// Contract: two concurrent createInsight calls for the same baseTableId and
+// both with empty options (unmodified-draft shape) must converge on exactly
+// ONE insight row in the DB. The check-and-insert runs inside a single
+// transaction, so the dedup decision is atomic with the write.
+//
+// PGLite is single-connection: true concurrent writes serialize at the event
+// loop rather than via OS-level locking. The structural fix is therefore
+// tested the same way as GetOrCreateDataSource in commands.test.ts — by
+// checking the RESULT (one row, same id), not by forcing a true interleave.
+// Two sequential calls that both start from "no existing draft" are the
+// minimal probe: the pre-fix code would insert two rows; the post-fix code
+// returns the existing row on the second call.
+
+describe("createInsight — atomic auto-draft dedup", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+
+  const { insights } = schema;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-dedup-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await createWyStack({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function call(path: string, args: unknown): Promise<unknown> {
+    const { result } = await app.call(path, args);
+    return result;
+  }
+
+  async function allInsights() {
+    return db.select().from(insights);
+  }
+
+  it("should return the existing unmodified draft on a second call for the same table", async () => {
+    const tableId = crypto.randomUUID();
+
+    const first = (await call("createInsight", {
+      name: "orders",
+      baseTableId: tableId,
+      options: { selectedFields: [] },
+    })) as { id: string };
+
+    const second = (await call("createInsight", {
+      name: "orders",
+      baseTableId: tableId,
+      options: { selectedFields: [] },
+    })) as { id: string };
+
+    // Both calls must return the same id — the second reuses the first draft.
+    expect(second.id).toBe(first.id);
+
+    // Exactly one row in the DB — no duplicate draft created.
+    const rows = await allInsights();
+    expect(rows).toHaveLength(1);
+  });
+
+  it("should produce exactly one unmodified draft when two calls fire without awaiting the first (TOCTOU simulation)", async () => {
+    // Both calls start before either resolves, simulating the race. On PGLite
+    // (single-connection WASM) the event loop serializes them, but the FIX is
+    // structural: the transaction prevents a second insert after the first
+    // commits. Without the fix, both calls would insert (both read "no draft"
+    // before either inserts). The test pins the POST-FIX contract.
+    const tableId = crypto.randomUUID();
+
+    const [r1, r2] = (await Promise.all([
+      call("createInsight", {
+        name: "orders",
+        baseTableId: tableId,
+        options: { selectedFields: [] },
+      }),
+      call("createInsight", {
+        name: "orders",
+        baseTableId: tableId,
+        options: { selectedFields: [] },
+      }),
+    ])) as [{ id: string }, { id: string }];
+
+    // Both calls must resolve to the same id.
+    expect(r1.id).toBe(r2.id);
+
+    // Exactly one insight row — no duplicate draft.
+    const rows = await allInsights();
+    expect(rows).toHaveLength(1);
+  });
+
+  it("should still create a new draft when the existing insight has been modified", async () => {
+    // A modified insight (selectedFields populated) must NOT be reused as a
+    // draft — createInsight should insert a fresh row.
+    const tableId = crypto.randomUUID();
+
+    // First: create a draft and simulate modification by calling updateInsight.
+    const { id: draftId } = (await call("createInsight", {
+      name: "orders",
+      baseTableId: tableId,
+      options: { selectedFields: [] },
+    })) as { id: string };
+
+    await call("updateInsight", {
+      id: draftId,
+      updates: { selectedFields: ["field-1"] },
+    });
+
+    // Second: create another draft for the same table — must be a NEW row.
+    const second = (await call("createInsight", {
+      name: "orders (2)",
+      baseTableId: tableId,
+      options: { selectedFields: [] },
+    })) as { id: string };
+
+    expect(second.id).not.toBe(draftId);
+
+    const rows = await allInsights();
+    expect(rows).toHaveLength(2);
+  });
+
+  it("should always insert when the incoming insight is pre-populated (not a draft)", async () => {
+    // When the caller explicitly passes metrics or selectedFields, the incoming
+    // insight is NOT a draft — even if an unmodified draft already exists, a
+    // fresh row should be created (different intent).
+    const tableId = crypto.randomUUID();
+
+    // Create an unmodified draft first.
+    const { id: draftId } = (await call("createInsight", {
+      name: "orders",
+      baseTableId: tableId,
+      options: { selectedFields: [] },
+    })) as { id: string };
+
+    // Create a pre-populated insight — should NOT reuse the draft.
+    const prepopulated = (await call("createInsight", {
+      name: "orders with fields",
+      baseTableId: tableId,
+      options: { selectedFields: ["field-a", "field-b"] },
+    })) as { id: string };
+
+    expect(prepopulated.id).not.toBe(draftId);
+
+    const rows = await allInsights();
+    expect(rows).toHaveLength(2);
+  });
+
+  it("should always insert when skipDedup is true, even when an unmodified draft exists", async () => {
+    // createInsightFromInsight passes skipDedup: true so that derived insights
+    // are never silently rerouted to an existing unmodified draft for the same
+    // baseTableId.
+    const tableId = crypto.randomUUID();
+
+    // Create an unmodified draft first.
+    const { id: draftId } = (await call("createInsight", {
+      name: "orders",
+      baseTableId: tableId,
+      options: { selectedFields: [] },
+    })) as { id: string };
+
+    // A skipDedup call with empty opts must create a new row, not reuse the draft.
+    const derived = (await call("createInsight", {
+      name: "orders (derived)",
+      baseTableId: tableId,
+      options: { selectedFields: [], skipDedup: true },
+    })) as { id: string };
+
+    expect(derived.id).not.toBe(draftId);
+
+    const rows = await allInsights();
+    expect(rows).toHaveLength(2);
   });
 });

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -364,4 +364,31 @@ describe("createInsight — atomic auto-draft dedup", () => {
     const rows = await allInsights();
     expect(rows).toHaveLength(2);
   });
+
+  it("should insert a fresh suffixed draft when reuse is explicitly false", async () => {
+    // The client's suffix path (createInsightFromTable when a modified insight
+    // already exists) sends reuseUnmodifiedDraft: false so the named draft is
+    // created rather than rerouted to an existing unmodified "orders" draft.
+    const tableId = crypto.randomUUID();
+
+    const { id: draftId } = (await call("createInsight", {
+      name: "orders",
+      baseTableId: tableId,
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
+    })) as { id: string };
+
+    // Explicit reuse=false with the suffixed name must produce a NEW row, even
+    // though an unmodified "orders" draft already exists for this table.
+    const suffixed = (await call("createInsight", {
+      name: "orders (2)",
+      baseTableId: tableId,
+      options: { selectedFields: [], reuseUnmodifiedDraft: false },
+    })) as { id: string };
+
+    expect(suffixed.id).not.toBe(draftId);
+
+    const rows = await allInsights();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.name).sort()).toEqual(["orders", "orders (2)"]);
+  });
 });

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -188,10 +188,11 @@ describe("privacy floor — no raw sampleValues persist in artifact DB", () => {
 // createInsight — atomic auto-draft dedup (TOCTOU fix)
 // ---------------------------------------------------------------------------
 //
-// Contract: two concurrent createInsight calls for the same baseTableId and
-// both with empty options (unmodified-draft shape) must converge on exactly
-// ONE insight row in the DB. The check-and-insert runs inside a single
-// transaction, so the dedup decision is atomic with the write.
+// Contract: dedup is opt-in via `reuseUnmodifiedDraft`. When set, two concurrent
+// createInsight calls for the same baseTableId — both unmodified-draft shape —
+// converge on exactly ONE insight row. The check-and-insert runs inside a single
+// transaction, so the dedup decision is atomic with the write. Without the flag,
+// createInsight always inserts a fresh row (explicit-creation intent).
 //
 // PGLite is single-connection: true concurrent writes serialize at the event
 // loop rather than via OS-level locking. The structural fix is therefore
@@ -228,19 +229,19 @@ describe("createInsight — atomic auto-draft dedup", () => {
     return db.select().from(insights);
   }
 
-  it("should return the existing unmodified draft on a second call for the same table", async () => {
+  it("should return the existing unmodified draft on a second reuse call for the same table", async () => {
     const tableId = crypto.randomUUID();
 
     const first = (await call("createInsight", {
       name: "orders",
       baseTableId: tableId,
-      options: { selectedFields: [] },
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
     const second = (await call("createInsight", {
       name: "orders",
       baseTableId: tableId,
-      options: { selectedFields: [] },
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
     // Both calls must return the same id — the second reuses the first draft.
@@ -251,7 +252,7 @@ describe("createInsight — atomic auto-draft dedup", () => {
     expect(rows).toHaveLength(1);
   });
 
-  it("should produce exactly one unmodified draft when two calls fire without awaiting the first (TOCTOU simulation)", async () => {
+  it("should produce exactly one unmodified draft when two reuse calls fire without awaiting the first (TOCTOU simulation)", async () => {
     // Both calls start before either resolves, simulating the race. On PGLite
     // (single-connection WASM) the event loop serializes them, but the FIX is
     // structural: the transaction prevents a second insert after the first
@@ -263,12 +264,12 @@ describe("createInsight — atomic auto-draft dedup", () => {
       call("createInsight", {
         name: "orders",
         baseTableId: tableId,
-        options: { selectedFields: [] },
+        options: { selectedFields: [], reuseUnmodifiedDraft: true },
       }),
       call("createInsight", {
         name: "orders",
         baseTableId: tableId,
-        options: { selectedFields: [] },
+        options: { selectedFields: [], reuseUnmodifiedDraft: true },
       }),
     ])) as [{ id: string }, { id: string }];
 
@@ -282,14 +283,14 @@ describe("createInsight — atomic auto-draft dedup", () => {
 
   it("should still create a new draft when the existing insight has been modified", async () => {
     // A modified insight (selectedFields populated) must NOT be reused as a
-    // draft — createInsight should insert a fresh row.
+    // draft — even a reuse call should insert a fresh row.
     const tableId = crypto.randomUUID();
 
     // First: create a draft and simulate modification by calling updateInsight.
     const { id: draftId } = (await call("createInsight", {
       name: "orders",
       baseTableId: tableId,
-      options: { selectedFields: [] },
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
     await call("updateInsight", {
@@ -301,7 +302,7 @@ describe("createInsight — atomic auto-draft dedup", () => {
     const second = (await call("createInsight", {
       name: "orders (2)",
       baseTableId: tableId,
-      options: { selectedFields: [] },
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
     expect(second.id).not.toBe(draftId);
@@ -310,24 +311,26 @@ describe("createInsight — atomic auto-draft dedup", () => {
     expect(rows).toHaveLength(2);
   });
 
-  it("should always insert when the incoming insight is pre-populated (not a draft)", async () => {
-    // When the caller explicitly passes metrics or selectedFields, the incoming
-    // insight is NOT a draft — even if an unmodified draft already exists, a
-    // fresh row should be created (different intent).
+  it("should always insert when the incoming insight is pre-populated, even with reuse requested", async () => {
+    // When the caller passes selectedFields, the incoming insight is NOT a
+    // draft — even with reuseUnmodifiedDraft set, a fresh row is created.
     const tableId = crypto.randomUUID();
 
     // Create an unmodified draft first.
     const { id: draftId } = (await call("createInsight", {
       name: "orders",
       baseTableId: tableId,
-      options: { selectedFields: [] },
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
     // Create a pre-populated insight — should NOT reuse the draft.
     const prepopulated = (await call("createInsight", {
       name: "orders with fields",
       baseTableId: tableId,
-      options: { selectedFields: ["field-a", "field-b"] },
+      options: {
+        selectedFields: ["field-a", "field-b"],
+        reuseUnmodifiedDraft: true,
+      },
     })) as { id: string };
 
     expect(prepopulated.id).not.toBe(draftId);
@@ -336,24 +339,24 @@ describe("createInsight — atomic auto-draft dedup", () => {
     expect(rows).toHaveLength(2);
   });
 
-  it("should always insert when skipDedup is true, even when an unmodified draft exists", async () => {
-    // createInsightFromInsight passes skipDedup: true so that derived insights
-    // are never silently rerouted to an existing unmodified draft for the same
-    // baseTableId.
+  it("should always insert when reuse is not requested, even when an unmodified draft exists", async () => {
+    // Dedup is opt-in. The derived-insight path (createInsightFromInsight) omits
+    // reuseUnmodifiedDraft, so an empty incoming insight still creates a fresh
+    // row rather than being rerouted to an existing draft.
     const tableId = crypto.randomUUID();
 
-    // Create an unmodified draft first.
+    // Create an unmodified draft via the reuse path.
     const { id: draftId } = (await call("createInsight", {
       name: "orders",
       baseTableId: tableId,
-      options: { selectedFields: [] },
+      options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
-    // A skipDedup call with empty opts must create a new row, not reuse the draft.
+    // An empty call WITHOUT the reuse flag must create a new row.
     const derived = (await call("createInsight", {
       name: "orders (derived)",
       baseTableId: tableId,
-      options: { selectedFields: [], skipDedup: true },
+      options: { selectedFields: [] },
     })) as { id: string };
 
     expect(derived.id).not.toBe(draftId);

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -814,6 +814,15 @@ const createInsight = mutation({
         // so two concurrent auto-draft calls for the same baseTableId converge
         // on a single draft rather than racing into duplicates (TOCTOU).
         //
+        // INVARIANT: this closes the race only while the backend is
+        // single-connection (PGlite, the desktop + `dashframe serve` target),
+        // where transactions serialize at the event loop. A multi-connection
+        // store under READ COMMITTED would let both transactions scan, find no
+        // draft, and both insert — reopening the phantom-read window. Trigger
+        // to revisit if the backend ever becomes multi-connection: add a unique
+        // index on (definition->>'baseTableId') for unmodified drafts, or take
+        // SELECT … FOR UPDATE / serializable isolation here.
+        //
         // NOTE: baseTableId lives inside the `definition` JSONB column, and
         // @wystack/db has no JSONB-path filtering — so the scan is a full table
         // read filtered in JS. Acceptable at current insight-table scale.

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -779,6 +779,25 @@ const getInsight = query({
   },
 });
 
+/**
+ * Returns true when an insight definition has no user modifications: no
+ * selected fields, no metrics, no filters, no sorts, and no joins. These are
+ * auto-drafts that are safe to reuse rather than accumulate as duplicates.
+ *
+ * Mirrors the `isUnmodifiedDraft` predicate in the renderer hook — kept in
+ * sync by contract; the server-side copy is the authoritative dedup gate
+ * (atomic with the insert), the renderer copy is a fast-path UX shortcut.
+ */
+function isUnmodifiedDraft(definition: InsightDefinition): boolean {
+  return (
+    (definition.selectedFields?.length ?? 0) === 0 &&
+    (definition.metrics?.length ?? 0) === 0 &&
+    (definition.filters?.length ?? 0) === 0 &&
+    (definition.sorts?.length ?? 0) === 0 &&
+    (definition.joins?.length ?? 0) === 0
+  );
+}
+
 const createInsight = mutation({
   args: { name: text, baseTableId: uuid, options: jsonb.optional() },
   handler: async (
@@ -788,18 +807,57 @@ const createInsight = mutation({
     const opts = (options ?? {}) as {
       selectedFields?: UUID[];
       metrics?: InsightMetric[];
+      /** When true, skip auto-draft dedup and always insert a new row.
+       *  Used by createInsightFromInsight so derived insights are never
+       *  silently rerouted to an existing unmodified draft. */
+      skipDedup?: boolean;
     };
-    const [row] = (await ctx.db.into(insights).insert({
-      name,
-      definition: insightToDefinition({
-        baseTableId,
-        selectedFields: opts.selectedFields,
-        metrics: opts.metrics,
-      }),
-      createdBy: { kind: "user" },
-    })) as InsightRow[];
-    if (!row) throw new Error("insert returned no row");
-    return { id: row.id };
+
+    // Atomic check-and-create: the dedup decision and the insert run inside one
+    // transaction so two concurrent calls for the same baseTableId converge on
+    // a single unmodified draft rather than producing duplicates.
+    //
+    // The opts passed in are always empty (selectedFields: [], no metrics) for
+    // an auto-draft — the server guards that an unmodified-draft reuse only
+    // fires when the incoming opts are also unmodified. If the caller is
+    // creating an intentionally non-empty insight, the existing-draft check
+    // is skipped and a fresh row is always inserted.
+    return ctx.db.transaction(async (tx) => {
+      // Only attempt dedup when the incoming insight would itself be an
+      // unmodified draft — if the caller is inserting a pre-populated insight
+      // (metrics, fields, etc.) or has opted out via skipDedup, we always
+      // create a new row.
+      const incomingIsUnmodified =
+        !opts.skipDedup &&
+        (opts.selectedFields?.length ?? 0) === 0 &&
+        (opts.metrics?.length ?? 0) === 0;
+
+      if (incomingIsUnmodified) {
+        const rows = (await tx.from(insights).all()) as InsightRow[];
+        const existingDraft = rows
+          .filter(
+            (r) =>
+              (r.definition as InsightDefinition).baseTableId === baseTableId,
+          )
+          .find((r) => isUnmodifiedDraft(r.definition as InsightDefinition));
+
+        if (existingDraft) {
+          return { id: existingDraft.id };
+        }
+      }
+
+      const [row] = (await tx.into(insights).insert({
+        name,
+        definition: insightToDefinition({
+          baseTableId,
+          selectedFields: opts.selectedFields,
+          metrics: opts.metrics,
+        }),
+        createdBy: { kind: "user" },
+      })) as InsightRow[];
+      if (!row) throw new Error("insert returned no row");
+      return { id: row.id };
+    });
   },
 });
 

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -798,9 +798,16 @@ const createInsight = mutation({
     return ctx.db.transaction(async (tx) => {
       // Reuse is opt-in and only applies when the incoming insight is itself an
       // unmodified draft. A pre-populated insight (fields/metrics) or any
-      // non-auto-draft caller always inserts a fresh row.
+      // non-auto-draft caller always inserts a fresh row. Extract the draft
+      // shape explicitly so the predicate reads only the fields it should —
+      // the wider `opts` bag carries the reuse flag itself, which is not part
+      // of the draft definition.
       const shouldReuse =
-        opts.reuseUnmodifiedDraft === true && isUnmodifiedDraft(opts);
+        opts.reuseUnmodifiedDraft === true &&
+        isUnmodifiedDraft({
+          selectedFields: opts.selectedFields,
+          metrics: opts.metrics,
+        });
 
       if (shouldReuse) {
         // Atomic check-and-create: scan-and-decide runs inside the transaction

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -22,7 +22,7 @@ import type {
   VisualizationEncoding,
   VisualizationType,
 } from "@dashframe/types";
-import { stripSampleValues } from "@dashframe/types";
+import { isUnmodifiedDraft, stripSampleValues } from "@dashframe/types";
 import { eq, jsonb, text, uuid } from "@wystack/db";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { isSecretRef } from "@wystack/secret-vault";
@@ -779,25 +779,6 @@ const getInsight = query({
   },
 });
 
-/**
- * Returns true when an insight definition has no user modifications: no
- * selected fields, no metrics, no filters, no sorts, and no joins. These are
- * auto-drafts that are safe to reuse rather than accumulate as duplicates.
- *
- * Mirrors the `isUnmodifiedDraft` predicate in the renderer hook — kept in
- * sync by contract; the server-side copy is the authoritative dedup gate
- * (atomic with the insert), the renderer copy is a fast-path UX shortcut.
- */
-function isUnmodifiedDraft(definition: InsightDefinition): boolean {
-  return (
-    (definition.selectedFields?.length ?? 0) === 0 &&
-    (definition.metrics?.length ?? 0) === 0 &&
-    (definition.filters?.length ?? 0) === 0 &&
-    (definition.sorts?.length ?? 0) === 0 &&
-    (definition.joins?.length ?? 0) === 0
-  );
-}
-
 const createInsight = mutation({
   args: { name: text, baseTableId: uuid, options: jsonb.optional() },
   handler: async (
@@ -807,32 +788,31 @@ const createInsight = mutation({
     const opts = (options ?? {}) as {
       selectedFields?: UUID[];
       metrics?: InsightMetric[];
-      /** When true, skip auto-draft dedup and always insert a new row.
-       *  Used by createInsightFromInsight so derived insights are never
-       *  silently rerouted to an existing unmodified draft. */
-      skipDedup?: boolean;
+      /** Opt-in: when this would be an unmodified draft, reuse an existing
+       *  unmodified draft for the same baseTableId instead of inserting a
+       *  duplicate. The auto-draft entry point sets this; explicit creation
+       *  paths (e.g. deriving from an insight) leave it false. */
+      reuseUnmodifiedDraft?: boolean;
     };
 
-    // Atomic check-and-create: the dedup decision and the insert run inside one
-    // transaction so two concurrent calls for the same baseTableId converge on
-    // a single unmodified draft rather than producing duplicates.
-    //
-    // The opts passed in are always empty (selectedFields: [], no metrics) for
-    // an auto-draft — the server guards that an unmodified-draft reuse only
-    // fires when the incoming opts are also unmodified. If the caller is
-    // creating an intentionally non-empty insight, the existing-draft check
-    // is skipped and a fresh row is always inserted.
     return ctx.db.transaction(async (tx) => {
-      // Only attempt dedup when the incoming insight would itself be an
-      // unmodified draft — if the caller is inserting a pre-populated insight
-      // (metrics, fields, etc.) or has opted out via skipDedup, we always
-      // create a new row.
-      const incomingIsUnmodified =
-        !opts.skipDedup &&
-        (opts.selectedFields?.length ?? 0) === 0 &&
-        (opts.metrics?.length ?? 0) === 0;
+      // Reuse is opt-in and only applies when the incoming insight is itself an
+      // unmodified draft. A pre-populated insight (fields/metrics) or any
+      // non-auto-draft caller always inserts a fresh row.
+      const shouldReuse =
+        opts.reuseUnmodifiedDraft === true && isUnmodifiedDraft(opts);
 
-      if (incomingIsUnmodified) {
+      if (shouldReuse) {
+        // Atomic check-and-create: scan-and-decide runs inside the transaction
+        // so two concurrent auto-draft calls for the same baseTableId converge
+        // on a single draft rather than racing into duplicates (TOCTOU).
+        //
+        // NOTE: baseTableId lives inside the `definition` JSONB column, and
+        // @wystack/db has no JSONB-path filtering — so the scan is a full table
+        // read filtered in JS. Acceptable at current insight-table scale.
+        // Trigger to revisit: when insight count grows enough that this scan
+        // shows up in latency, promote baseTableId to a top-level indexed
+        // column (or add a JSONB expression index) and filter at the DB layer.
         const rows = (await tx.from(insights).all()) as InsightRow[];
         const existingDraft = rows
           .filter(

--- a/packages/app-data/src/insights.ts
+++ b/packages/app-data/src/insights.ts
@@ -36,7 +36,11 @@ export function useInsightMutations(): InsightMutations {
       create: async (
         name: string,
         baseTableId: UUID,
-        options?: { selectedFields?: UUID[]; metrics?: InsightMetric[] },
+        options?: {
+          selectedFields?: UUID[];
+          metrics?: InsightMetric[];
+          skipDedup?: boolean;
+        },
       ): Promise<UUID> => {
         const { id } = await createMutation.mutateAsync(
           loose({ name, baseTableId, options }),

--- a/packages/app-data/src/insights.ts
+++ b/packages/app-data/src/insights.ts
@@ -39,7 +39,7 @@ export function useInsightMutations(): InsightMutations {
         options?: {
           selectedFields?: UUID[];
           metrics?: InsightMetric[];
-          skipDedup?: boolean;
+          reuseUnmodifiedDraft?: boolean;
         },
       ): Promise<UUID> => {
         const { id } = await createMutation.mutateAsync(

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -187,6 +187,10 @@ describe("useCreateInsight", () => {
 
   describe("createInsightFromTable — dedup", () => {
     it("should reuse an existing unmodified draft for the same source table", async () => {
+      // The server handles dedup atomically — the hook always calls createInsight
+      // with the base name (no suffix, because the only same-table insight is
+      // unmodified). The mocked server returns the existing draft's id, mirroring
+      // what the real server does when it finds an unmodified draft.
       const existingDraft = createMockInsight({
         id: "existing-draft",
         name: "orders",
@@ -195,6 +199,8 @@ describe("useCreateInsight", () => {
       });
 
       mockGetAllInsights.mockResolvedValue([existingDraft]);
+      // Server atomically finds the existing draft and returns its id.
+      mockCreateInsight.mockResolvedValue("existing-draft");
 
       const { result } = renderHook(() => useCreateInsight());
 
@@ -206,9 +212,12 @@ describe("useCreateInsight", () => {
         );
       });
 
-      // Must NOT create a new insight
-      expect(mockCreateInsight).not.toHaveBeenCalled();
-      // Must navigate to the existing draft
+      // Hook delegates dedup to the server — createInsight IS called with the
+      // base name (no suffix: only unmodified insights exist for this table).
+      expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
+        selectedFields: [],
+      });
+      // Must navigate to the id the server returned (the existing draft).
       expect(mockPush).toHaveBeenCalledWith("/insights/existing-draft");
       expect(insightId).toBe("existing-draft");
     });
@@ -384,7 +393,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Original Analysis (derived)",
         "table-orders", // Same baseTableId as source
-        { selectedFields: [] },
+        { selectedFields: [], skipDedup: true },
       );
     });
 
@@ -410,7 +419,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Customer Segmentation (derived)",
         "table-customers",
-        { selectedFields: [] },
+        { selectedFields: [], skipDedup: true },
       );
     });
 
@@ -553,7 +562,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Original (derived) (derived)",
         "table-nested",
-        { selectedFields: [] },
+        { selectedFields: [], skipDedup: true },
       );
     });
   });
@@ -576,7 +585,7 @@ describe("useCreateInsight", () => {
       vi.clearAllMocks();
 
       // Second call for the SAME table — the newly created draft now exists
-      // and is still unmodified. The gate should reuse it, not create again.
+      // and is still unmodified. The server returns the existing draft atomically.
       const existingDraft = createMockInsight({
         id: "insight-1",
         name: "Orders",
@@ -584,6 +593,8 @@ describe("useCreateInsight", () => {
         selectedFields: [],
       });
       mockGetAllInsights.mockResolvedValueOnce([existingDraft]);
+      // Mocked server atomically finds the existing draft and returns its id.
+      mockCreateInsight.mockResolvedValueOnce("insight-1");
 
       let secondId: string | null = null;
       await act(async () => {
@@ -593,9 +604,12 @@ describe("useCreateInsight", () => {
         );
       });
 
-      // Must NOT create a second insight
-      expect(mockCreateInsight).not.toHaveBeenCalled();
-      // Must navigate to the existing draft
+      // Hook calls createInsight (server decides dedup) with the base name —
+      // no suffix because the only same-table insight is unmodified.
+      expect(mockCreateInsight).toHaveBeenCalledWith("Orders", "table-shared", {
+        selectedFields: [],
+      });
+      // Must navigate to the id the server returned (the existing draft).
       expect(mockPush).toHaveBeenCalledWith("/insights/insight-1");
       expect(secondId).toBe("insight-1");
     });
@@ -651,6 +665,37 @@ describe("useCreateInsight", () => {
 
       expect(mockCreateInsight).toHaveBeenCalledTimes(3);
       expect(mockPush).toHaveBeenCalledTimes(3);
+    });
+
+    it("should converge on one id for two concurrent calls on the same table (TOCTOU fix)", async () => {
+      // Simulates the TOCTOU race: both calls fire before either resolves,
+      // so both getAllInsights() calls return [] (no existing draft yet).
+      // The server (mocked here) is responsible for dedup — it returns the
+      // same id for both calls, which is what the real server does atomically.
+      // This test pins the hook contract: navigate is called twice with the
+      // same id, and no duplicate draft is created (the server prevents it).
+      mockGetAllInsights.mockResolvedValue([]);
+      // Both calls hit the server; the server's transaction returns the same id.
+      mockCreateInsight.mockResolvedValue("converged-draft");
+
+      const { result } = renderHook(() => useCreateInsight());
+
+      const [id1, id2] = await act(async () => {
+        return Promise.all([
+          result.current.createInsightFromTable("table-orders", "orders"),
+          result.current.createInsightFromTable("table-orders", "orders"),
+        ]);
+      });
+
+      // Both calls should resolve to the same id (server converges them).
+      expect(id1).toBe("converged-draft");
+      expect(id2).toBe("converged-draft");
+      // Both calls made it to the server — dedup is server-side, not skipped.
+      expect(mockCreateInsight).toHaveBeenCalledTimes(2);
+      // Both navigations target the same id.
+      expect(mockPush).toHaveBeenCalledTimes(2);
+      expect(mockPush).toHaveBeenNthCalledWith(1, "/insights/converged-draft");
+      expect(mockPush).toHaveBeenNthCalledWith(2, "/insights/converged-draft");
     });
   });
 

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -84,7 +84,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Sales Data", // name
         "table-abc", // baseTableId
-        { selectedFields: [] }, // Empty for draft state
+        { selectedFields: [], reuseUnmodifiedDraft: true }, // Empty draft, dedup
       );
     });
 
@@ -133,7 +133,10 @@ describe("useCreateInsight", () => {
 
       // Verify the third argument (options) has empty selectedFields
       const callArgs = mockCreateInsight.mock.calls[0];
-      expect(callArgs[2]).toEqual({ selectedFields: [] });
+      expect(callArgs[2]).toEqual({
+        selectedFields: [],
+        reuseUnmodifiedDraft: true,
+      });
     });
 
     it("should handle table names with special characters", async () => {
@@ -151,7 +154,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Sales (2024) - Q1",
         "table-123",
-        { selectedFields: [] },
+        { selectedFields: [], reuseUnmodifiedDraft: true },
       );
     });
 
@@ -166,6 +169,7 @@ describe("useCreateInsight", () => {
 
       expect(mockCreateInsight).toHaveBeenCalledWith("", "table-empty", {
         selectedFields: [],
+        reuseUnmodifiedDraft: true,
       });
     });
 
@@ -213,9 +217,11 @@ describe("useCreateInsight", () => {
       });
 
       // Hook delegates dedup to the server — createInsight IS called with the
-      // base name (no suffix: only unmodified insights exist for this table).
+      // base name (no suffix: only unmodified insights exist for this table)
+      // and the reuse flag so the server returns the existing draft.
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
         selectedFields: [],
+        reuseUnmodifiedDraft: true,
       });
       // Must navigate to the id the server returned (the existing draft).
       expect(mockPush).toHaveBeenCalledWith("/insights/existing-draft");
@@ -234,6 +240,7 @@ describe("useCreateInsight", () => {
 
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
         selectedFields: [],
+        reuseUnmodifiedDraft: true,
       });
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft");
     });
@@ -259,7 +266,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: [] },
+        { selectedFields: [], reuseUnmodifiedDraft: true },
       );
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft-2");
     });
@@ -288,7 +295,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: [] },
+        { selectedFields: [], reuseUnmodifiedDraft: true },
       );
     });
 
@@ -312,6 +319,7 @@ describe("useCreateInsight", () => {
       // The existing draft is for a different table — a new insight is created
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
         selectedFields: [],
+        reuseUnmodifiedDraft: true,
       });
     });
 
@@ -343,7 +351,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)", // gap-free: (2) is missing, not (4)
         "table-orders",
-        { selectedFields: [] },
+        { selectedFields: [], reuseUnmodifiedDraft: true },
       );
     });
   });
@@ -393,7 +401,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Original Analysis (derived)",
         "table-orders", // Same baseTableId as source
-        { selectedFields: [], skipDedup: true },
+        { selectedFields: [] },
       );
     });
 
@@ -419,7 +427,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Customer Segmentation (derived)",
         "table-customers",
-        { selectedFields: [], skipDedup: true },
+        { selectedFields: [] },
       );
     });
 
@@ -562,7 +570,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Original (derived) (derived)",
         "table-nested",
-        { selectedFields: [], skipDedup: true },
+        { selectedFields: [] },
       );
     });
   });
@@ -604,10 +612,12 @@ describe("useCreateInsight", () => {
         );
       });
 
-      // Hook calls createInsight (server decides dedup) with the base name —
-      // no suffix because the only same-table insight is unmodified.
+      // Hook calls createInsight (server decides dedup) with the base name and
+      // the reuse flag — no suffix because the only same-table insight is
+      // unmodified.
       expect(mockCreateInsight).toHaveBeenCalledWith("Orders", "table-shared", {
         selectedFields: [],
+        reuseUnmodifiedDraft: true,
       });
       // Must navigate to the id the server returned (the existing draft).
       expect(mockPush).toHaveBeenCalledWith("/insights/insight-1");

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -262,11 +262,13 @@ describe("useCreateInsight", () => {
         await result.current.createInsightFromTable("table-orders", "orders");
       });
 
-      // A suffix is used rather than prompting — non-blocking, drive-feel
+      // A suffix is used rather than prompting — non-blocking, drive-feel.
+      // The suffix path signals explicit new-draft intent, so reuse is OFF:
+      // the server must create "orders (2)", not reroute to an existing draft.
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: [], reuseUnmodifiedDraft: true },
+        { selectedFields: [], reuseUnmodifiedDraft: false },
       );
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft-2");
     });
@@ -295,7 +297,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: [], reuseUnmodifiedDraft: true },
+        { selectedFields: [], reuseUnmodifiedDraft: false },
       );
     });
 
@@ -351,7 +353,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)", // gap-free: (2) is missing, not (4)
         "table-orders",
-        { selectedFields: [], reuseUnmodifiedDraft: true },
+        { selectedFields: [], reuseUnmodifiedDraft: false },
       );
     });
   });

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -33,8 +33,9 @@ function isUnmodifiedDraft(insight: Insight): boolean {
  * to the insight page (action hub) for further configuration.
  *
  * Auto-draft deduplication (createInsightFromTable only):
- * - If an unmodified draft for the same source table already exists, it is
- *   reused (navigated to) rather than creating a duplicate.
+ * - If an unmodified draft for the same source table already exists, the
+ *   server returns it atomically rather than creating a duplicate. Two
+ *   concurrent calls for the same table converge on one draft (no TOCTOU race).
  * - If the existing insight(s) have been modified/saved, a new draft is
  *   created with a disambiguating numeric suffix, e.g. "orders (2)".
  *   A prompt would be less disruptive but would interrupt a routine action;
@@ -67,24 +68,21 @@ export function useCreateInsight() {
   /**
    * Creates a draft insight from a data table and navigates to it.
    *
-   * Dedup gate: if an unmodified draft for the same source table already
-   * exists, this reuses it instead of creating a new one. If the existing
-   * insight was modified, a new draft is created with a numeric suffix.
+   * Dedup: the server handles unmodified-draft reuse atomically — if a draft
+   * already exists for this table it is returned without a new insert. This
+   * hook reads existing insights only to compute a gap-free numeric suffix
+   * when the user already has modified insights for the same table.
    */
   const createInsightFromTable = useCallback(
     async (tableId: string, tableName: string) => {
-      // --- Dedup gate ---
+      // Read existing insights for UX-only purpose: compute a suffix name when
+      // the user already has modified insights for this table. This read is NOT
+      // the authoritative dedup gate — the server closes the TOCTOU race by
+      // wrapping the check-and-insert in one transaction.
       const allInsights = await getAllInsights();
       const sameTableInsights = allInsights.filter(
         (i) => i.baseTableId === tableId,
       );
-
-      // Reuse an existing unmodified draft rather than accumulating duplicates.
-      const existingDraft = sameTableInsights.find(isUnmodifiedDraft);
-      if (existingDraft) {
-        navigate({ to: `/insights/${existingDraft.id}` } as never);
-        return existingDraft.id;
-      }
 
       // One or more modified insights exist for this table — create a new draft
       // with a numeric suffix so the user can distinguish without a modal prompt.
@@ -94,8 +92,15 @@ export function useCreateInsight() {
       // Use the first gap-free suffix to avoid collisions when insights are
       // deleted and re-created (e.g. "orders (2)" deleted → next should be
       // "orders (2)", not "orders (3)").
+      //
+      // When all existing insights for this table are unmodified drafts (or none
+      // exist), pass the base name — the server will return the existing draft
+      // or create a new one atomically.
       let name = tableName;
-      if (sameTableInsights.length > 0) {
+      const modifiedInsights = sameTableInsights.filter(
+        (i) => !isUnmodifiedDraft(i),
+      );
+      if (modifiedInsights.length > 0) {
         const existingNames = new Set(sameTableInsights.map((i) => i.name));
         let suffix = 2;
         while (existingNames.has(`${tableName} (${suffix})`)) {
@@ -104,7 +109,9 @@ export function useCreateInsight() {
         name = `${tableName} (${suffix})`;
       }
 
-      // Create draft insight with empty fields (shows preview + suggestions)
+      // Create (or reuse) a draft insight with empty fields. The server returns
+      // the existing unmodified draft atomically when one already exists for
+      // this baseTableId — two concurrent calls converge on the same id.
       const insightId = await createInsight(
         name,
         tableId, // baseTableId
@@ -134,11 +141,14 @@ export function useCreateInsight() {
         return null;
       }
 
-      // Create a new insight using the same base table
+      // Create a new insight using the same base table.
+      // skipDedup: true — derived insights must always be a fresh row; without
+      // this flag the server would silently reuse an existing unmodified draft
+      // for the same baseTableId, landing the user on the wrong insight.
       const insightId = await createInsight(
         `${sourceInsightName} (derived)`,
         sourceInsight.baseTableId,
-        { selectedFields: [] }, // Empty for draft state
+        { selectedFields: [], skipDedup: true },
       );
 
       // Navigate to new insight

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -85,7 +85,8 @@ export function useCreateInsight() {
       const modifiedInsights = sameTableInsights.filter(
         (i) => !isUnmodifiedDraft(i),
       );
-      if (modifiedInsights.length > 0) {
+      const hasModifiedInsights = modifiedInsights.length > 0;
+      if (hasModifiedInsights) {
         const existingNames = new Set(sameTableInsights.map((i) => i.name));
         let suffix = 2;
         while (existingNames.has(`${tableName} (${suffix})`)) {
@@ -94,13 +95,19 @@ export function useCreateInsight() {
         name = `${tableName} (${suffix})`;
       }
 
-      // Create (or reuse) a draft insight with empty fields. reuseUnmodifiedDraft
-      // makes the server return an existing unmodified draft for this baseTableId
-      // atomically when one exists — two concurrent calls converge on the same id.
+      // Create (or reuse) a draft insight with empty fields.
+      //
+      // Only opt into reuseUnmodifiedDraft when NO modified insight forces a
+      // suffix. When the suffix path fires, the user is explicitly making a new
+      // distinguishable draft ("orders (2)") — reusing an existing "orders"
+      // draft would discard that name and land them on the wrong insight. With
+      // the flag set, the server returns an existing unmodified draft for this
+      // baseTableId atomically, so two concurrent first-clicks converge on one
+      // draft (no TOCTOU race).
       const insightId = await createInsight(
         name,
         tableId, // baseTableId
-        { selectedFields: [], reuseUnmodifiedDraft: true }, // Empty draft, dedup
+        { selectedFields: [], reuseUnmodifiedDraft: !hasModifiedInsights },
       );
 
       // Navigate to insight page (action hub)

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -87,6 +87,14 @@ export function useCreateInsight() {
       );
       const hasModifiedInsights = modifiedInsights.length > 0;
       if (hasModifiedInsights) {
+        // The suffix is computed from a point-in-time client snapshot and is
+        // NOT race-protected on the server. Two rapid concurrent clicks on a
+        // table that already has a modified insight can both compute the same
+        // suffix ("orders (2)") and insert two same-named rows. This is the
+        // pre-existing suffix-naming behavior (unchanged by the dedup fix);
+        // it's non-destructive (duplicate name, no data loss). Trigger to
+        // address if duplicate-named drafts become a reported problem: move
+        // suffix assignment server-side inside the transaction.
         const existingNames = new Set(sameTableInsights.map((i) => i.name));
         let suffix = 2;
         while (existingNames.has(`${tableName} (${suffix})`)) {

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -3,24 +3,9 @@ import {
   getInsight,
   useInsightMutations,
 } from "@dashframe/core";
-import type { Insight } from "@dashframe/types";
+import { isUnmodifiedDraft } from "@dashframe/types";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
-
-/**
- * Returns true when an insight is an unmodified auto-draft: no fields selected,
- * no metrics, no filters, no sorts, and no joins. These are safe to reuse
- * rather than accumulate as duplicates.
- */
-function isUnmodifiedDraft(insight: Insight): boolean {
-  return (
-    (insight.selectedFields?.length ?? 0) === 0 &&
-    (insight.metrics?.length ?? 0) === 0 &&
-    (insight.filters?.length ?? 0) === 0 &&
-    (insight.sorts?.length ?? 0) === 0 &&
-    (insight.joins?.length ?? 0) === 0
-  );
-}
 
 /**
  * Creates insights and navigates to their pages.
@@ -109,13 +94,13 @@ export function useCreateInsight() {
         name = `${tableName} (${suffix})`;
       }
 
-      // Create (or reuse) a draft insight with empty fields. The server returns
-      // the existing unmodified draft atomically when one already exists for
-      // this baseTableId — two concurrent calls converge on the same id.
+      // Create (or reuse) a draft insight with empty fields. reuseUnmodifiedDraft
+      // makes the server return an existing unmodified draft for this baseTableId
+      // atomically when one exists — two concurrent calls converge on the same id.
       const insightId = await createInsight(
         name,
         tableId, // baseTableId
-        { selectedFields: [] }, // Empty for draft state
+        { selectedFields: [], reuseUnmodifiedDraft: true }, // Empty draft, dedup
       );
 
       // Navigate to insight page (action hub)
@@ -141,14 +126,14 @@ export function useCreateInsight() {
         return null;
       }
 
-      // Create a new insight using the same base table.
-      // skipDedup: true — derived insights must always be a fresh row; without
-      // this flag the server would silently reuse an existing unmodified draft
-      // for the same baseTableId, landing the user on the wrong insight.
+      // Create a new insight using the same base table. Derived insights are an
+      // explicit creation intent, so they don't opt into reuseUnmodifiedDraft —
+      // each call gets a fresh row rather than being rerouted to an existing
+      // unmodified draft for the same baseTableId.
       const insightId = await createInsight(
         `${sourceInsightName} (derived)`,
         sourceInsight.baseTableId,
-        { selectedFields: [], skipDedup: true },
+        { selectedFields: [] },
       );
 
       // Navigate to new insight

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -63,6 +63,7 @@ export type {
 export type {
   CompiledInsight,
   Insight,
+  InsightDraftShape,
   InsightFilter,
   InsightFilterBetweenValue,
   InsightJoinConfig,
@@ -71,6 +72,8 @@ export type {
   UseInsightMutations,
   UseInsights,
 } from "./insights";
+
+export { isUnmodifiedDraft } from "./insights";
 
 export type {
   AxisType,

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -96,6 +96,38 @@ export interface Insight {
 }
 
 /**
+ * The configuration fields that distinguish a user-modified insight from an
+ * unmodified auto-draft. Structural subset satisfied by both {@link Insight}
+ * (renderer) and the server-side insight definition.
+ */
+export interface InsightDraftShape {
+  selectedFields?: UUID[];
+  metrics?: InsightMetric[];
+  filters?: InsightFilter[];
+  sorts?: InsightSort[];
+  joins?: InsightJoinConfig[];
+}
+
+/**
+ * Returns true when an insight has no user modifications: no selected fields,
+ * no metrics, no filters, no sorts, and no joins. These are auto-drafts that
+ * are safe to reuse rather than accumulate as duplicates.
+ *
+ * Single source of truth for the unmodified-draft definition, imported by both
+ * the renderer dedup hook and the server-side dedup gate so the predicate can
+ * never drift between them.
+ */
+export function isUnmodifiedDraft(insight: InsightDraftShape): boolean {
+  return (
+    (insight.selectedFields?.length ?? 0) === 0 &&
+    (insight.metrics?.length ?? 0) === 0 &&
+    (insight.filters?.length ?? 0) === 0 &&
+    (insight.sorts?.length ?? 0) === 0 &&
+    (insight.joins?.length ?? 0) === 0
+  );
+}
+
+/**
  * CompiledInsight - An Insight with all IDs resolved to actual entities.
  *
  * This is a "denormalized" view of an Insight where:
@@ -125,17 +157,22 @@ export interface CompiledInsight {
  * Mutation methods for insights.
  */
 export interface InsightMutations {
-  /** Create a new insight */
+  /** Create a new insight.
+   *
+   *  Inserts a new row by default. The auto-draft entry point (creating an
+   *  insight straight from a table) opts into `reuseUnmodifiedDraft` so a
+   *  rapid second click lands on the existing empty draft for that table
+   *  rather than accumulating duplicates. */
   create: (
     name: string,
     baseTableId: UUID,
     options?: {
       selectedFields?: UUID[];
       metrics?: InsightMetric[];
-      /** When true, bypass auto-draft dedup and always insert a new row.
-       *  Used by createInsightFromInsight so derived insights are never
-       *  silently rerouted to an existing unmodified draft. */
-      skipDedup?: boolean;
+      /** When true, and this would be an unmodified draft, reuse an existing
+       *  unmodified draft for the same `baseTableId` instead of inserting a
+       *  duplicate. Default (false) always inserts a new row. */
+      reuseUnmodifiedDraft?: boolean;
     },
   ) => Promise<UUID>;
 

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -132,6 +132,10 @@ export interface InsightMutations {
     options?: {
       selectedFields?: UUID[];
       metrics?: InsightMetric[];
+      /** When true, bypass auto-draft dedup and always insert a new row.
+       *  Used by createInsightFromInsight so derived insights are never
+       *  silently rerouted to an existing unmodified draft. */
+      skipDedup?: boolean;
     },
   ) => Promise<UUID>;
 


### PR DESCRIPTION
## Summary

- Wraps the `createInsight` check-and-insert in a single `ctx.db.transaction` so two concurrent calls for the same `baseTableId` always converge on one unmodified draft — no TOCTOU window.
- Removes the client-side read-then-write dedup gate (`if existingDraft navigate + return`) from `createInsightFromTable`; the client now reads existing insights only to compute a gap-free numeric suffix for the modified-insight name, then always delegates to the server.
- Adds `skipDedup: true` option for `createInsightFromInsight` callers so derived insights are never silently rerouted to an existing unmodified draft for the same `baseTableId`.

Tracked internally as YW-267.

## Test plan

- [x] `turbo typecheck` — 44/44 tasks pass
- [x] `turbo lint` — clean
- [x] `prettier --check` — clean
- [x] `apps/server` app-artifacts tests — 9/9 pass (4 new dedup contract tests + 1 skipDedup test)
- [x] `packages/app` useCreateInsight tests — 33/33 pass (TOCTOU simulation, derived-insight skipDedup contract)
- [x] Key concurrency test: `Promise.all` fires two `createInsight` calls for the same `baseTableId` without awaiting the first; both resolve to the same `id` and exactly one row in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the TOCTOU race in auto-draft deduplication by moving the check-and-insert into a single server-side `ctx.db.transaction`, and replaces the now-redundant client-side early-return gate with a pure UX read (suffix computation only). The `isUnmodifiedDraft` predicate is extracted to `@dashframe/types` as a single source of truth shared by both the renderer hook and the server gate.

- **Atomic server dedup**: `createInsight` wraps the look-up + insert in one transaction; concurrent auto-draft calls for the same `baseTableId` converge on one row via `reuseUnmodifiedDraft: true` (opt-in, default is always-insert).
- **Client dedup gate removed**: `createInsightFromTable` now reads existing insights only to compute gap-free numeric suffixes for the modified-insight path; it no longer short-circuits before reaching the server.
- **Shared predicate**: `isUnmodifiedDraft` / `InsightDraftShape` moved to `@dashframe/types`, eliminating the previously duplicated client/server logic.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The transaction wrapping is correct for the single-connection PGLite target and the limitations for multi-connection stores are explicitly documented with a revisit trigger.

The change is well-scoped: the server transaction closes the specific TOCTOU window it targets, the client-side gate removal is backed by the server taking over responsibility, the shared isUnmodifiedDraft predicate eliminates the previously noted drift risk, and the opt-in semantics (reuseUnmodifiedDraft defaults to always-insert) mean callers that omit the flag can never accidentally trigger the dedup path. Test coverage is thorough across sequential, concurrent, and edge-case scenarios.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/app-artifacts.ts | Core fix: wraps check-and-insert in a db transaction with opt-in reuseUnmodifiedDraft; includes inline comments for multi-connection and full-scan caveats. |
| packages/types/src/insights.ts | Adds shared InsightDraftShape interface and isUnmodifiedDraft function; adds reuseUnmodifiedDraft opt-in to InsightMutations.create options. |
| packages/app/src/hooks/useCreateInsight.ts | Removes client-side early-return dedup gate; now reads insights only to compute suffix names; delegates all dedup to the server via reuseUnmodifiedDraft. |
| apps/server/src/functions/app-artifacts.test.ts | Adds 6 new dedup-contract tests (sequential reuse, TOCTOU simulation, modified-draft bypass, pre-populated bypass, no-reuse-flag default, explicit reuse=false) using real PGLite. |
| packages/app/src/hooks/useCreateInsight.test.tsx | Updates existing dedup test assertions and adds a TOCTOU concurrent-call convergence test. |
| packages/types/src/index.ts | Exports new InsightDraftShape type and isUnmodifiedDraft function from the types package barrel. |
| packages/app-data/src/insights.ts | Threads reuseUnmodifiedDraft through the useInsightMutations create hook to match the updated InsightMutations interface. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(insight): record single-connection ..."](https://github.com/youhaowei/dashframe/commit/9231c4d771f0f00c06cdc6b4ca4e1a0f36bd8511) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38047325)</sub>

<!-- /greptile_comment -->