### PR TITLE
fix(server,server-core): [YW-268] SecretVault lifecycle coupling — release on delete, preview-safe store

### DIFF
--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -33,6 +33,7 @@ import {
   applyCredentialField,
   type DataSourceConfig,
   isRecord,
+  modeFromCtx,
   releaseCredentialRefs,
   requireRecordWithId,
   vaultFromCtx,
@@ -499,8 +500,11 @@ const removeDataSource = mutation({
     // Fetch the source config BEFORE deleting so we can release its SecretRefs.
     // vault-absent-with-a-ref is an error (fail-closed symmetry): a ref can only
     // exist because vault.store() succeeded, which requires a vault to be present.
+    // In preview mode vault.delete() is skipped — like vault.store(), it is a
+    // keychain side-effect outside the DB transaction. A preview executes then
+    // rolls back: the row (with its refs) survives, so its credential must too.
     const source = await ctx.db.from(dataSources).where(eq("id", id)).first();
-    if (source) {
+    if (source && modeFromCtx(ctx) !== "preview") {
       await releaseCredentialRefs(
         (source.config ?? {}) as DataSourceConfig,
         vaultFromCtx(ctx),

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -33,6 +33,7 @@ import {
   applyCredentialField,
   type DataSourceConfig,
   isRecord,
+  releaseCredentialRefs,
   requireRecordWithId,
   vaultFromCtx,
 } from "./utils";
@@ -495,6 +496,16 @@ const updateDataSource = mutation({
 const removeDataSource = mutation({
   args: { id: uuid },
   handler: async (ctx, { id }): Promise<{ ok: true }> => {
+    // Fetch the source config BEFORE deleting so we can release its SecretRefs.
+    // vault-absent-with-a-ref is an error (fail-closed symmetry): a ref can only
+    // exist because vault.store() succeeded, which requires a vault to be present.
+    const source = await ctx.db.from(dataSources).where(eq("id", id)).first();
+    if (source) {
+      await releaseCredentialRefs(
+        (source.config ?? {}) as DataSourceConfig,
+        vaultFromCtx(ctx),
+      );
+    }
     await ctx.db.from(dataTables).where(eq("dataSourceId", id)).delete();
     await ctx.db.from(dataSources).where(eq("id", id)).delete();
     return { ok: true };

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -101,6 +101,8 @@ import {
   applyCredentialField,
   type DataSourceConfig,
   isRecord,
+  modeFromCtx,
+  releaseCredentialRefs,
   requireRecordWithId,
   vaultFromCtx,
 } from "./utils";
@@ -278,16 +280,28 @@ const createDataSource = mutation({
     { id, type, name, apiKey, connectionString },
   ): Promise<{ id: string }> => {
     const vault = vaultFromCtx(ctx);
+    const preview = modeFromCtx(ctx) === "preview";
     const config: DataSourceConfig = {};
     // store non-empty / skip-on-empty (applyCredentialField). On a fresh config an
     // empty string is a no-op. A real store fails closed when no vault is injected.
-    await applyCredentialField(config, "apiKey", apiKey, vault, `apiKey-${id}`);
+    // In preview mode the vault write is skipped — the DB transaction rolls back
+    // anyway, but vault.store() is a keychain side-effect outside the transaction
+    // that would survive the rollback and permanently orphan a secret.
+    await applyCredentialField(
+      config,
+      "apiKey",
+      apiKey,
+      vault,
+      `apiKey-${id}`,
+      preview,
+    );
     await applyCredentialField(
       config,
       "connectionString",
       connectionString,
       vault,
       `connectionString-${id}`,
+      preview,
     );
     const [row] = (await ctx.db.into(dataSources).insert({
       id,
@@ -318,6 +332,7 @@ const setDataSourceConfig = mutation({
     { id, apiKey, connectionString },
   ): Promise<{ ok: true }> => {
     const vault = vaultFromCtx(ctx);
+    const preview = modeFromCtx(ctx) === "preview";
     const current = (await ctx.db
       .from(dataSources)
       .where(eq("id", id))
@@ -331,13 +346,22 @@ const setDataSourceConfig = mutation({
     // from the vault here — the same deferred cleanup as rotation; the locator is
     // dropped from config so the data-plane resolver stops using it, and the
     // plaintext-never-at-rest invariant is unaffected.
-    await applyCredentialField(config, "apiKey", apiKey, vault, `apiKey-${id}`);
+    // In preview mode vault writes are skipped (keychain is not transactional).
+    await applyCredentialField(
+      config,
+      "apiKey",
+      apiKey,
+      vault,
+      `apiKey-${id}`,
+      preview,
+    );
     await applyCredentialField(
       config,
       "connectionString",
       connectionString,
       vault,
       `connectionString-${id}`,
+      preview,
     );
     await ctx.db.from(dataSources).where(eq("id", id)).update({ config });
     return { ok: true };
@@ -1721,6 +1745,14 @@ const deleteNode = mutation({
         .where(eq("dataSourceId", id))
         .all()) as (typeof dataTables.$inferSelect)[];
       const orphanedNodes = await deleteDataSourceDependents(ctx, ownedTables);
+      // Release any SecretRefs in the config BEFORE deleting the row so the
+      // mapping row + backend blob are not permanently orphaned in the OS keychain.
+      // vault-absent-with-a-ref is treated as an error (fail-closed symmetry):
+      // a ref can only exist if vault.store() was called, which requires a vault.
+      await releaseCredentialRefs(
+        (source.config ?? {}) as DataSourceConfig,
+        vaultFromCtx(ctx),
+      );
       // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
       return { ok: true, deleted: { kind: "dataSource", id }, orphanedNodes };

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1749,10 +1749,16 @@ const deleteNode = mutation({
       // mapping row + backend blob are not permanently orphaned in the OS keychain.
       // vault-absent-with-a-ref is treated as an error (fail-closed symmetry):
       // a ref can only exist if vault.store() was called, which requires a vault.
-      await releaseCredentialRefs(
-        (source.config ?? {}) as DataSourceConfig,
-        vaultFromCtx(ctx),
-      );
+      // In preview mode vault.delete() is skipped — like vault.store(), it is a
+      // keychain side-effect outside the DB transaction. A preview executes then
+      // rolls back: the DataSource row (with its refs) survives, so its credential
+      // must survive too. Releasing here would orphan the surviving row's refs.
+      if (modeFromCtx(ctx) !== "preview") {
+        await releaseCredentialRefs(
+          (source.config ?? {}) as DataSourceConfig,
+          vaultFromCtx(ctx),
+        );
+      }
       // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
       return { ok: true, deleted: { kind: "dataSource", id }, orphanedNodes };

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -464,6 +464,15 @@ export async function buildPreviewDiff(
   // credential-free batches.
   context: Record<string, unknown> = {},
 ): Promise<PreviewDiff> {
+  // Merge `mode: "preview"` into the context bag so every handler can read it
+  // via `modeFromCtx(ctx)` and skip vault writes (keychain side-effects that
+  // survive the DB rollback). The `context` object spread into FunctionContext
+  // by `runHandler`, so `ctx.mode` is available to all handlers in this preview.
+  const previewContext: Record<string, unknown> = {
+    ...context,
+    mode: "preview",
+  };
+
   // 1. Execute-then-rollback the full batch to learn what happens and collect
   //    handler results for polymorphic-command resolution (RenameNode etc. report
   //    the resolved kind on result.value — public issue #64). On success the
@@ -476,7 +485,7 @@ export async function buildPreviewDiff(
   try {
     const result = await applyCommands(app, batch, {
       mode: "preview",
-      context,
+      context: previewContext,
     });
     prefixResults = result.results;
     tablesWritten = [...result.tablesWritten];
@@ -489,14 +498,14 @@ export async function buildPreviewDiff(
       app,
       batch,
       fallback,
-      context,
+      previewContext,
     );
     error = { commandIndex: failureIndex, message };
 
     // The pre-failure prefix is commands 0..failureIndex-1. Run it to build nodes.
     prefixBatch = batch.slice(0, failureIndex);
     if (prefixBatch.length > 0) {
-      const prefix = await runPrefixSafe(app, prefixBatch, context);
+      const prefix = await runPrefixSafe(app, prefixBatch, previewContext);
       prefixBatch = prefix.safeBatch;
       prefixResults = prefix.results;
       tablesWritten = prefix.tablesWritten;

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -4,6 +4,7 @@
  * (transition window while legacy coarse handlers and the command vocabulary coexist).
  */
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
+import { isSecretRef } from "@wystack/secret-vault";
 import type { FunctionContext } from "@wystack/server";
 
 /**
@@ -34,6 +35,26 @@ export function vaultFromCtx(ctx: FunctionContext): SecretVault | undefined {
 }
 
 /**
+ * Extract the execution `mode` flag that `buildPreviewDiff` threads into the
+ * handler context via the `context` bag on `applyCommands`.
+ *
+ * When `mode === "preview"` the handler is running inside an
+ * execute-then-rollback preview transaction. Vault writes (keychain blobs +
+ * mapping rows) are NOT part of that transaction and therefore survive the
+ * rollback — any `vault.store()` call in preview mode mints a permanently
+ * orphaned secret. Callers must skip vault writes when this returns `"preview"`.
+ *
+ * Returns `"commit"` (or `undefined`) for normal mutations.
+ */
+export function modeFromCtx(
+  ctx: FunctionContext,
+): "commit" | "preview" | undefined {
+  const m = ctx.mode;
+  if (m === "preview" || m === "commit") return m;
+  return undefined;
+}
+
+/**
  * Store one connector credential and return its `SecretRef`.
  *
  * The server's contract: a credential can only be persisted as a vault ref. No
@@ -49,16 +70,34 @@ export function vaultFromCtx(ctx: FunctionContext): SecretVault | undefined {
  * composed the server; it knows only "vault present → store ref" / "vault
  * absent → throw".
  *
+ * **Preview mode:** when `preview` is `true` the handler is running inside an
+ * execute-then-rollback transaction. `vault.store()` is a keychain side-effect
+ * that survives the DB rollback, so calling it would permanently orphan a
+ * secret for every preview invocation. Instead, synthesise a throwaway
+ * placeholder ref — the string `"secret:preview-noop"`. It is recognisably
+ * non-canonical (a real ref is a UUID), so it cannot be confused with a real
+ * secret, and it is never written to the mapping store or keychain backend.
+ * The diff produced by preview still type-checks and renders; it just must not
+ * touch the vault.
+ *
  * @param vault     The vault from {@link vaultFromCtx}, or `undefined`.
  * @param plaintext The raw credential to store.
  * @param locatorHint A human-readable hint for the backend's locator.
- * @throws when `vault` is `undefined` — the write must abort, persisting nothing.
+ * @param preview   When `true`, skip the vault write and return a no-op ref.
+ * @throws when `vault` is `undefined` and `preview` is false — the write must
+ *   abort, persisting nothing.
  */
 export async function storeCredential(
   vault: SecretVault | undefined,
   plaintext: string,
   locatorHint: string,
+  preview = false,
 ): Promise<SecretRef> {
+  if (preview) {
+    // Preview mode: return a non-canonical placeholder. Real refs are UUIDs;
+    // this sentinel is intentionally recognisable and never stored.
+    return "secret:preview-noop" as SecretRef;
+  }
   if (vault == null) {
     throw new Error(
       "[secret-vault] cannot store a credential: this server has no vault " +
@@ -66,6 +105,41 @@ export async function storeCredential(
     );
   }
   return vault.store(plaintext, { class: "connector-key", locatorHint });
+}
+
+/**
+ * Release every `SecretRef` present in a `DataSourceConfig` from the vault.
+ * Called before a data-source row is deleted so the mapping row and backend
+ * blob do not accumulate as permanent orphans in the OS keychain.
+ *
+ * **Vault-absent policy (fail-closed consistency):** `storeCredential` throws
+ * when no vault is injected, so a config holding a real `SecretRef` could only
+ * have been written with a vault present. If that same vault is absent at
+ * delete time — which would be a server mis-configuration — we throw rather
+ * than silently leaving an orphan. This keeps the invariant symmetric: the
+ * fail-closed store implies a fail-closed delete.
+ *
+ * `vault.delete(ref)` is idempotent — a missing ref is a no-op — so calling
+ * this on a config with no credential fields is always safe.
+ */
+export async function releaseCredentialRefs(
+  config: DataSourceConfig,
+  vault: SecretVault | undefined,
+): Promise<void> {
+  const refs: string[] = [];
+  if (isSecretRef(config.apiKey)) refs.push(config.apiKey);
+  if (isSecretRef(config.connectionString)) refs.push(config.connectionString);
+  if (refs.length === 0) return;
+  if (vault == null) {
+    throw new Error(
+      "[secret-vault] cannot release credential refs: this server has no vault " +
+        "injected, but the data-source config holds live SecretRefs. " +
+        "A vault that was present at store time must also be present at delete time.",
+    );
+  }
+  for (const ref of refs) {
+    await vault.delete(ref as SecretRef);
+  }
 }
 
 /**
@@ -80,6 +154,9 @@ export async function storeCredential(
  *
  * The vault-absent refusal lives in {@link storeCredential}, so a clear (`""`) or
  * an untouched field (`undefined`) does NOT require a vault — only a real store does.
+ *
+ * @param preview When `true` (preview-mode execution) the vault write is skipped
+ *   and a no-op placeholder ref is stored instead. See {@link storeCredential}.
  */
 export async function applyCredentialField(
   config: DataSourceConfig,
@@ -87,13 +164,14 @@ export async function applyCredentialField(
   value: string | undefined,
   vault: SecretVault | undefined,
   locatorHint: string,
+  preview = false,
 ): Promise<void> {
   if (value === undefined) return; // not part of this write
   if (value.length === 0) {
     delete config[field]; // explicit clear
     return;
   }
-  config[field] = await storeCredential(vault, value, locatorHint);
+  config[field] = await storeCredential(vault, value, locatorHint, preview);
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -568,7 +568,7 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
 });
 
 // ---------------------------------------------------------------------------
-// YW-268: SecretVault lifecycle coupling — delete releases SecretRefs
+// SecretVault lifecycle coupling — delete releases SecretRefs
 // ---------------------------------------------------------------------------
 //
 // Contract: when a data-source that holds SecretRefs is deleted (by either
@@ -784,7 +784,7 @@ describe("vault lifecycle — delete releases SecretRefs (DeleteNode)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// YW-268: SecretVault lifecycle coupling — preview mode skips vault store
+// SecretVault lifecycle coupling — preview mode skips vault store
 // ---------------------------------------------------------------------------
 //
 // Contract: when `buildPreviewDiff` runs a credential-bearing batch (e.g.
@@ -889,6 +889,65 @@ describe("vault lifecycle — preview mode skips vault store", () => {
     expect(storeCallCount).toBe(0);
   });
 
+  it("preview mode — DeleteNode for a credential-bearing DataSource does NOT call vault.delete() (refs survive rollback)", async () => {
+    // Arrange: create a real source with a credential (commit mode, separate
+    // vault-injected app so the ref is live and verifiable via vault.has()).
+    const setupDir = mkdtempSync(join(tmpdir(), "dashframe-vault-del-setup-"));
+    const setupDb = await openArtifactDb({
+      path: join(setupDir, "artifacts.db"),
+    });
+    const rawSetupApp = await createWyStack({ db: setupDb, functions });
+    const setupApp: WyStackApp = {
+      ...rawSetupApp,
+      async call(path, args, ctx) {
+        return rawSetupApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawSetupApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+    const sourceId = crypto.randomUUID();
+    await setupApp.call("createDataSource", {
+      id: sourceId,
+      type: "notion",
+      name: "To Preview Delete",
+      apiKey: "live-key",
+    });
+    const rows = await setupDb.select().from(dataSources);
+    const apiKeyRef = (
+      rows.find((r) => r.id === sourceId)!.config as Record<string, string>
+    )["apiKey"];
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    // Confirm the ref is live before the preview.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: preview a DeleteNode on the SAME db (the source row is visible to
+    // the handler inside the preview transaction).
+    await buildPreviewDiff(
+      setupApp,
+      setupDb,
+      [cmd("DeleteNode", { id: sourceId })],
+      { vault },
+    );
+
+    // Assert: the vault entry MUST still be live after the preview.
+    // The preview rolled back the DB delete, so the source row (and its ref)
+    // survived. If vault.delete() had fired — which it must not — the ref
+    // would be gone and the source would have an unresolvable credential.
+    // The modeFromCtx(ctx) !== "preview" guard in deleteNode prevents this.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    await setupDb.$client.close();
+    rmSync(setupDir, { recursive: true, force: true });
+  });
+
   it("preview mode — storeCallCount is 0 but would be >0 in a real commit (spy confirms the guard fires)", async () => {
     // This test acts as a calibration: it shows that the spy is functional
     // (a real commit path DOES increment storeCallCount) so the 0-assertions
@@ -928,5 +987,133 @@ describe("vault lifecycle — preview mode skips vault store", () => {
 
     await commitDb.$client.close();
     rmSync(commitDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SecretVault lifecycle coupling — preview mode skips vault delete
+// ---------------------------------------------------------------------------
+//
+// Mirror of the preview-safe-store invariant on the DELETE side. A preview is
+// execute-then-rollback: the DB transaction is undone, so a previewed
+// `DeleteNode` (or `removeDataSource`) leaves the data-source row — and its
+// SecretRefs — intact in the canonical DB. vault.delete() is a keychain
+// side-effect OUTSIDE that transaction; if it fired during a preview, it would
+// permanently orphan the surviving row's refs (vault.has(ref) → false while the
+// row still references it). The handlers detect `ctx.mode === "preview"` via
+// modeFromCtx() and skip releaseCredentialRefs entirely.
+//
+// Witness: a spy on vault.delete() that must stay at 0 during a previewed
+// delete, plus a calibration showing a REAL commit delete DOES release the ref.
+// ---------------------------------------------------------------------------
+
+describe("vault lifecycle — preview mode skips vault delete", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let commitApp: WyStackApp;
+  let previewApp: WyStackApp;
+  let vault: SecretVault;
+  let deleteCallCount: number;
+
+  function wrapWithVault(rawApp: WyStackApp): WyStackApp {
+    return {
+      ...rawApp,
+      async call(path, args, ctx) {
+        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+  }
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-vault-del-preview-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault } = makeTestVault());
+    deleteCallCount = 0;
+
+    // Spy on vault.delete() — the only direct witness that the preview guard
+    // fires. A previewed delete must never reach it.
+    const realDelete = vault.delete.bind(vault);
+    vault.delete = async (...args: Parameters<typeof vault.delete>) => {
+      deleteCallCount++;
+      return realDelete(...args);
+    };
+
+    const rawApp = await createWyStack({ db, functions });
+    // commitApp threads the vault via a wrapper (commit-mode call path).
+    commitApp = wrapWithVault(rawApp);
+    // previewApp runs DeleteNode through buildPreviewDiff, which threads the
+    // vault via the context arg it passes to applyCommands — the production seam.
+    previewApp = rawApp;
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("preview mode — previewing a DeleteNode never calls vault.delete() and the ref survives", async () => {
+    // Arrange: commit a credentialed source so a real SecretRef is live.
+    const id = crypto.randomUUID();
+    await commitApp.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Keep My Creds",
+      apiKey: "do-not-orphan-me",
+    });
+    const config = await readConfig(db, id);
+    const apiKeyRef = config!["apiKey"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    const deleteCountBefore = deleteCallCount;
+
+    // Act: preview a DeleteNode of that source (execute-then-rollback).
+    await buildPreviewDiff(previewApp, db, [cmd("DeleteNode", { id })], {
+      vault,
+    });
+
+    // Assert: the guard fired — vault.delete() was never called during preview.
+    expect(deleteCallCount).toBe(deleteCountBefore);
+    // The canonical row survived the rollback...
+    const rows = await db.select().from(dataSources);
+    expect(rows.find((r) => r.id === id)).toBeDefined();
+    // ...and its credential is still resolvable (NOT orphaned by the preview).
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+  });
+
+  it("commit mode — a real DeleteNode DOES call vault.delete() and releases the ref (calibration)", async () => {
+    // Calibration: proves the spy + release path are wired, so the preview
+    // 0-assertion above is meaningful, not trivially green.
+    const id = crypto.randomUUID();
+    await commitApp.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Delete For Real",
+      apiKey: "release-me",
+    });
+    const config = await readConfig(db, id);
+    const apiKeyRef = config!["apiKey"] as string;
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    const deleteCountBefore = deleteCallCount;
+
+    // Act: a real (commit-mode) deleteNode.
+    await commitApp.call("deleteNode", { id });
+
+    // Assert: vault.delete() fired and the ref is gone.
+    expect(deleteCallCount).toBeGreaterThan(deleteCountBefore);
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
   });
 });

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -27,6 +27,8 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { functions } from "../functions";
+import { cmd } from "./commands";
+import { buildPreviewDiff } from "./preview-diff";
 
 const { dataSources } = schema;
 
@@ -562,5 +564,369 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
         tableId: crypto.randomUUID(),
       }),
     ).rejects.toThrow(/not a notion source/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// YW-268: SecretVault lifecycle coupling — delete releases SecretRefs
+// ---------------------------------------------------------------------------
+//
+// Contract: when a data-source that holds SecretRefs is deleted (by either
+// path — removeDataSource handler or deleteNode command), the refs are removed
+// from the vault BEFORE the row is dropped. After the delete, vault.has(ref)
+// must return false for every ref that was stored on that source.
+//
+// Both handlers route through releaseCredentialRefs() in utils.ts, which calls
+// vault.delete(ref) for each live ref in the config jsonb. The tests below pin
+// that end-to-end invariant: vault presence is verifiable via vault.has() (a
+// non-decrypting call that reads the mapping store + backend presence index).
+//
+// A source with NO credential fields must not cause any error during delete
+// (releaseCredentialRefs early-returns when the config has no live refs).
+// ---------------------------------------------------------------------------
+
+describe("vault lifecycle — delete releases SecretRefs (removeDataSource)", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  let vault: SecretVault;
+  let backend: TestBackend;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-vault-rm-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault, backend } = makeTestVault());
+    const rawApp = await createWyStack({ db, functions });
+    app = {
+      ...rawApp,
+      async call(path, args, ctx) {
+        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("removeDataSource — vault.has(apiKeyRef) is false after deleting a source that had an apiKey", async () => {
+    // Arrange: create a source with an apiKey so a SecretRef is minted and stored.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Cred Source",
+      apiKey: "secret-api-key",
+    });
+    // Capture the ref from the config jsonb before deletion.
+    const config = await readConfig(db, id);
+    const apiKeyRef = config!["apiKey"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    // Confirm the secret is live before we delete.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: delete the source via the removeDataSource handler.
+    await app.call("removeDataSource", { id });
+
+    // Assert: the vault no longer holds the ref.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+  });
+
+  it("removeDataSource — vault.has(apiKeyRef) and vault.has(csRef) are false after deleting a source with both credentials", async () => {
+    // Arrange: source with both credential fields.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "postgres",
+      name: "Full Cred Source",
+      apiKey: "ak",
+      connectionString: "postgresql://u:p@h/db",
+    });
+    const config = await readConfig(db, id);
+    const apiKeyRef = config!["apiKey"] as string;
+    const csRef = config!["connectionString"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    expect(isSecretRef(csRef)).toBe(true);
+
+    // Act.
+    await app.call("removeDataSource", { id });
+
+    // Assert: both refs are gone from the vault.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+    expect(await vault.has(csRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+  });
+
+  it("removeDataSource — deleting a no-credential source succeeds without touching the vault", async () => {
+    // Arrange: source with no credentials.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "csv",
+      name: "Clean Source",
+    });
+    const resolveCountBefore = backend.resolveCallCount;
+    const hasCountBefore = backend.hasCallCount;
+
+    // Act: must not throw.
+    await expect(app.call("removeDataSource", { id })).resolves.toBeDefined();
+
+    // Assert: vault was not consulted for resolve or has (no refs to check).
+    expect(backend.resolveCallCount).toBe(resolveCountBefore);
+    expect(backend.hasCallCount).toBe(hasCountBefore);
+  });
+});
+
+describe("vault lifecycle — delete releases SecretRefs (DeleteNode)", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  let vault: SecretVault;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-vault-del-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault } = makeTestVault());
+    const rawApp = await createWyStack({ db, functions });
+    app = {
+      ...rawApp,
+      async call(path, args, ctx) {
+        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("deleteNode (DataSource) — vault.has(apiKeyRef) is false after the delete command", async () => {
+    // Arrange: mint a source with an apiKey through the command vocabulary.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "To Delete",
+      apiKey: "delete-me",
+    });
+    const config = await readConfig(db, id);
+    const apiKeyRef = config!["apiKey"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: delete via the deleteNode command path (commands.ts ~L1738).
+    await app.call("deleteNode", { id });
+
+    // Assert: the SecretRef was released from the vault before the row dropped.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+  });
+
+  it("deleteNode (DataSource) — both credential refs are released when source has apiKey + connectionString", async () => {
+    // Arrange.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "postgres",
+      name: "PG Source",
+      apiKey: "ak",
+      connectionString: "postgresql://u:p@h/db",
+    });
+    const config = await readConfig(db, id);
+    const apiKeyRef = config!["apiKey"] as string;
+    const csRef = config!["connectionString"] as string;
+
+    // Act.
+    await app.call("deleteNode", { id });
+
+    // Assert: both refs are gone.
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+    expect(await vault.has(csRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+  });
+
+  it("deleteNode (DataSource) — no-credential source delete succeeds without error", async () => {
+    // A source without any credential fields must be deletable via deleteNode
+    // without the vault being involved (releaseCredentialRefs is a no-op when
+    // the config carries no SecretRefs).
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", { id, type: "csv", name: "No Creds" });
+
+    await expect(app.call("deleteNode", { id })).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// YW-268: SecretVault lifecycle coupling — preview mode skips vault store
+// ---------------------------------------------------------------------------
+//
+// Contract: when `buildPreviewDiff` runs a credential-bearing batch (e.g.
+// CreateDataSource with an apiKey), the handlers detect `ctx.mode === "preview"`
+// via `modeFromCtx()` and call `storeCredential(..., preview=true)`. In that
+// branch, `storeCredential` returns the sentinel `"secret:preview-noop"` without
+// ever calling `vault.store()`. This means the backend receives no `store()` call
+// and its presence index remains empty for the whole preview.
+//
+// The canonical DB row is also absent (the preview transaction rolled back), so
+// after a preview run: no vault entry exists, no data-source row persists.
+// ---------------------------------------------------------------------------
+
+describe("vault lifecycle — preview mode skips vault store", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  let vault: SecretVault;
+  let storeCallCount: number;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-vault-preview-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault } = makeTestVault());
+    storeCallCount = 0;
+
+    // Wrap vault.store() with a spy so we can assert it was NEVER called
+    // during a preview dispatch. This is the only direct witness for the
+    // "preview-safe store" invariant: storeCredential(preview=true) returns
+    // the sentinel WITHOUT calling vault.store(). backend.hasCallCount is
+    // not a reliable witness because nothing in the preview path calls
+    // vault.has() (no getDataSource in the batch), so it stays 0 regardless.
+    const realStore = vault.store.bind(vault);
+    vault.store = async (...args: Parameters<typeof vault.store>) => {
+      storeCallCount++;
+      return realStore(...args);
+    };
+
+    // No vault wrapper on the raw app: buildPreviewDiff threads the vault through
+    // the `context` arg it passes to applyCommands, so the handlers receive it
+    // via ctx — the same path as the production seam.
+    app = await createWyStack({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("preview mode — CreateDataSource with apiKey never calls vault.store()", async () => {
+    // Arrange: a credential-bearing CreateDataSource in a preview batch.
+    const sourceId = crypto.randomUUID();
+
+    // Baseline: store has not been called yet.
+    expect(storeCallCount).toBe(0);
+
+    // Act: run preview (execute-then-rollback) with vault injected in context.
+    await buildPreviewDiff(
+      app,
+      db,
+      [
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "Preview Src",
+          apiKey: "secret-key",
+        }),
+      ],
+      { vault },
+    );
+
+    // Assert: storeCredential(preview=true) returns "secret:preview-noop"
+    // without calling vault.store(). The spy confirms no call was made.
+    expect(storeCallCount).toBe(0);
+  });
+
+  it("preview mode — CreateDataSource + SetDataSourceConfig leave canonical DB with no data-source row and make zero vault.store() calls", async () => {
+    // Arrange: two credential-bearing commands targeting the same source.
+    const sourceId = crypto.randomUUID();
+
+    // Act: preview the create-then-configure sequence.
+    await buildPreviewDiff(
+      app,
+      db,
+      [
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "Preview Src",
+          apiKey: "key-v1",
+        }),
+        cmd("SetDataSourceConfig", { id: sourceId, apiKey: "key-v2" }),
+      ],
+      { vault },
+    );
+
+    // Assert — canonical DB is untouched (the preview transaction rolled back).
+    const rows = await db.select().from(dataSources);
+    expect(rows.find((r) => r.id === sourceId)).toBeUndefined();
+    // Both createDataSource and setDataSourceConfig called storeCredential with
+    // preview=true; neither should have reached vault.store().
+    expect(storeCallCount).toBe(0);
+  });
+
+  it("preview mode — storeCallCount is 0 but would be >0 in a real commit (spy confirms the guard fires)", async () => {
+    // This test acts as a calibration: it shows that the spy is functional
+    // (a real commit path DOES increment storeCallCount) so the 0-assertions
+    // above are meaningful, not trivially satisfied by a broken spy.
+    //
+    // We compose a separate vault-injected app (same pattern as the delete
+    // tests' beforeEach) and call createDataSource via commit — not preview.
+    const commitDir = mkdtempSync(
+      join(tmpdir(), "dashframe-vault-commit-cal-"),
+    );
+    const commitDb = await openArtifactDb({
+      path: join(commitDir, "artifacts.db"),
+    });
+    const rawApp = await createWyStack({ db: commitDb, functions });
+    const commitApp: WyStackApp = {
+      ...rawApp,
+      async call(path, args, ctx) {
+        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+
+    await commitApp.call("createDataSource", {
+      id: crypto.randomUUID(),
+      type: "notion",
+      name: "Commit Source",
+      apiKey: "real-key",
+    });
+
+    // The commit path must have called vault.store() — spy confirms it.
+    expect(storeCallCount).toBeGreaterThan(0);
+
+    await commitDb.$client.close();
+    rmSync(commitDir, { recursive: true, force: true });
   });
 });

--- a/packages/server-core/src/db.test.ts
+++ b/packages/server-core/src/db.test.ts
@@ -119,61 +119,6 @@ describe("openArtifactDb", () => {
     ]);
   });
 
-  test("should enforce cascade delete from data_sources to secrets", async () => {
-    const db = await openTestArtifactDb();
-
-    const [source] = await db
-      .insert(schema.dataSources)
-      .values({
-        name: "csv-test",
-        kind: "csv",
-        storage: "parquet",
-        config: { originalPath: "./fixtures/test.csv" },
-        createdBy: userProvenance,
-      })
-      .returning();
-
-    await db.insert(schema.secrets).values({
-      sourceId: source!.id,
-      secretName: "notion_token",
-      ciphertext: new Uint8Array([1, 2, 3, 4]),
-    });
-
-    expect(await db.select().from(schema.secrets)).toHaveLength(1);
-
-    await db.delete(schema.dataSources);
-
-    expect(await db.select().from(schema.secrets)).toHaveLength(0);
-  });
-
-  test("should reject duplicate (sourceId, secretName) on secrets", async () => {
-    const db = await openTestArtifactDb();
-    const [source] = await db
-      .insert(schema.dataSources)
-      .values({
-        name: "csv-test",
-        kind: "csv",
-        storage: "parquet",
-        config: {},
-        createdBy: userProvenance,
-      })
-      .returning();
-
-    await db.insert(schema.secrets).values({
-      sourceId: source!.id,
-      secretName: "notion_token",
-      ciphertext: new Uint8Array([1, 2, 3]),
-    });
-
-    await expect(
-      db.insert(schema.secrets).values({
-        sourceId: source!.id,
-        secretName: "notion_token",
-        ciphertext: new Uint8Array([4, 5, 6]),
-      }),
-    ).rejects.toThrow();
-  });
-
   test("should declare required artifact provenance fields and parent indexes", async () => {
     const db = await openTestArtifactDb();
 

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -8,19 +8,15 @@
  * The actual secrets live in the OS keychain via the SecretVault substrate; the
  * `secret_mappings` table persists the ref → backend/locator binding so refs
  * stay resolvable across restarts.
- * The `secrets` table below was an earlier design artifact and is retained in
- * the schema but unused by the current vault implementation.
  */
 
 import {
-  customType,
   index,
   integer,
   jsonb,
   pgTable,
   text,
   timestamp,
-  unique,
   uuid,
 } from "drizzle-orm/pg-core";
 
@@ -32,13 +28,6 @@ export interface ArtifactProvenance {
   id?: string;
   runId?: string;
 }
-
-// bytea isn't a first-class column type in drizzle-orm/pg-core yet; wrap it.
-const bytea = customType<{ data: Uint8Array; notNull: false; default: false }>({
-  dataType() {
-    return "bytea";
-  },
-});
 
 // project_meta — exactly one row per project. Holds version + identity.
 export const projectMeta = pgTable("project_meta", {
@@ -223,25 +212,6 @@ export const secretMappings = pgTable("secret_mappings", {
     .defaultNow(),
 });
 
-// secrets — encrypted API keys / passwords keyed by source + name.
-// ciphertext format: [nonce(12B) | ciphertext | tag(16B)] under AES-256-GCM.
-// The encryption key is NOT stored here — see SecretVault docs.
-export const secrets = pgTable(
-  "secrets",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    sourceId: uuid("source_id")
-      .notNull()
-      .references(() => dataSources.id, { onDelete: "cascade" }),
-    secretName: text("secret_name").notNull(),
-    ciphertext: bytea("ciphertext").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-  },
-  (t) => [unique("secrets_source_name_unique").on(t.sourceId, t.secretName)],
-);
-
 export const schema = {
   projectMeta,
   dataSources,
@@ -250,7 +220,6 @@ export const schema = {
   insights,
   visualizations,
   dashboards,
-  secrets,
   secretMappings,
 } as const;
 


### PR DESCRIPTION
## Summary

- **Delete-path release (both handlers):** `releaseCredentialRefs()` is called before any data-source row deletion. Both paths are covered:
  - `removeDataSource` (app-artifacts.ts) — fetches config before delete, calls `releaseCredentialRefs`
  - `deleteNode` DataSource case (commands.ts) — calls `releaseCredentialRefs` before `db.delete`. This is the Gap A fix: the `DeleteNode` path was the key missing coverage.
- **Preview-safe store:** `modeFromCtx(ctx)` reads `mode: "preview"` from the context bag threaded by `buildPreviewDiff` into every handler. `createDataSource` and `setDataSourceConfig` pass `preview=true` to `storeCredential`, which returns the sentinel `"secret:preview-noop"` instead of calling `vault.store()`. Vault writes are keychain side-effects outside the DB transaction; without this guard every diff preview would permanently orphan a keychain entry.
- **Dead `secrets` table removed:** The `secrets` table in `server-core/schema.ts` (superseded by the SecretVault control plane in YW-264) is fully removed along with its `bytea`/`unique` helpers and the two now-dead `db.test.ts` tests for it.
- **DataSourceConfig type:** `DataSourceConfig` is defined once in `apps/server/src/functions/utils.ts` — no duplication found in `project.ts`. Gap C is a non-issue.
- **9 new vault lifecycle tests** in `vault-control-plane.test.ts`:
  - 3 for `removeDataSource` delete-release (single ref, dual ref, no-credential no-op)
  - 3 for `deleteNode` delete-release (same coverage)
  - 3 for preview-safe store: spy wrapper on `vault.store()` confirms zero calls in preview; calibration test proves the spy is live by showing a real commit path increments the count

## DeleteNode coverage confirmation

`deleteNode` at `commands.ts` line 1738 calls `releaseCredentialRefs((source.config ?? {}) as DataSourceConfig, vaultFromCtx(ctx))` before `db.delete`. Both the test and code review confirmed this path. No delete path skips the release for a found DataSource.

## Dup-type decision

`DataSourceConfig` exists only in `apps/server/src/functions/utils.ts`. No duplicate in `packages/server-core/src/project.ts`. Gap C is resolved as a non-issue — no consolidation needed.

Tracked internally as YW-268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two classes of SecretVault lifecycle bugs: orphaned vault entries on data-source deletion (both `removeDataSource` and the previously uncovered `deleteNode` path), and permanently orphaned keychain entries from execute-then-rollback preview transactions.

- **Delete-path release:** `releaseCredentialRefs()` is called before the DB row is dropped in both `removeDataSource` (app-artifacts.ts) and the `DeleteNode` command handler (commands.ts), with a preview-mode guard in each to prevent `vault.delete()` firing during a rolled-back preview.
- **Preview-safe store:** `buildPreviewDiff` now merges `mode: \"preview\"` into the context bag threaded to `applyCommands`; `storeCredential` returns the `\"secret:preview-noop\"` sentinel and `releaseCredentialRefs` is skipped, keeping the OS keychain clean across every preview dispatch.
- **Dead schema removed:** The legacy `secrets` table is dropped from `schema.ts` and its two stale tests removed; 9 new vault lifecycle tests with calibration probes are added.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both delete paths correctly release vault refs before the DB row is dropped, all preview dispatches skip vault side-effects, and the new tests include calibration proofs confirming the spy wiring is live

The vault lifecycle logic is correct on all happy paths, preview guards are consistently applied across every call site in buildPreviewDiff, and the 9 new tests pin the end-to-end invariants for both commit and preview legs. The only open concern is a minor edge case: a mid-loop vault.delete() failure leaves one ref dead while the row survives, but this is a known limitation of the non-transactional vault design and recovery is possible on the next attempt.

No files require special attention; the partial-release edge case in releaseCredentialRefs (utils.ts) is low-probability and inherent to the non-transactional vault design
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/utils.ts | Adds modeFromCtx, preview parameter to storeCredential/applyCredentialField, and new releaseCredentialRefs — all three helpers are cleanly implemented with correct fail-closed behavior |
| apps/server/src/functions/commands.ts | Adds preview flag to createDataSource and setDataSourceConfig credential stores, and adds the critical releaseCredentialRefs call before deleteNode's DB row deletion with a correct preview guard |
| apps/server/src/functions/app-artifacts.ts | Adds vault release before row deletion in removeDataSource, guarded by modeFromCtx to skip in preview — ordering (release then delete) is correct |
| apps/server/src/functions/preview-diff.ts | buildPreviewDiff now merges mode:"preview" into a previewContext consistently threaded to all three applyCommands call-sites (main run, probeBatchFailure, runPrefixSafe) |
| apps/server/src/functions/vault-control-plane.test.ts | Nine new lifecycle tests covering commit-mode delete release for both handler paths, preview-mode store bypass, and preview-mode delete bypass — each block includes a calibration test proving the spy is live |
| packages/server-core/src/db.test.ts | Removes two now-dead tests for the deleted secrets table; remaining tests are unaffected |
| packages/server-core/src/schema.ts | Removes the unused secrets table definition (bytea type helper, unique constraint, and export) — syncSchema uses CREATE TABLE IF NOT EXISTS so the physical table in existing DBs is left in place but unreferenced |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant BD as buildPreviewDiff
    participant AC as applyCommands
    participant H as Handler
    participant V as SecretVault
    participant DB as Database

    Note over C,DB: Commit mode
    C->>H: call(deleteNode / createDataSource)
    H->>H: modeFromCtx → undefined
    H->>V: vault.delete(ref) / vault.store(plaintext)
    V-->>H: ok / SecretRef
    H->>DB: db.delete / db.insert
    DB-->>H: committed

    Note over C,DB: Preview mode
    C->>BD: "buildPreviewDiff(app, db, batch, {vault})"
    BD->>BD: "previewContext = {...ctx, mode:preview}"
    BD->>AC: applyCommands(mode:preview, context:previewContext)
    AC->>H: "runHandler — ctx.mode === preview"
    H->>H: modeFromCtx → preview — vault skipped
    H->>DB: db.insert / db.delete (inside TX)
    AC->>DB: ROLLBACK
    DB-->>AC: row restored
    AC-->>BD: results
    BD-->>C: PreviewDiff (vault untouched)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant BD as buildPreviewDiff
    participant AC as applyCommands
    participant H as Handler
    participant V as SecretVault
    participant DB as Database

    Note over C,DB: Commit mode
    C->>H: call(deleteNode / createDataSource)
    H->>H: modeFromCtx → undefined
    H->>V: vault.delete(ref) / vault.store(plaintext)
    V-->>H: ok / SecretRef
    H->>DB: db.delete / db.insert
    DB-->>H: committed

    Note over C,DB: Preview mode
    C->>BD: "buildPreviewDiff(app, db, batch, {vault})"
    BD->>BD: "previewContext = {...ctx, mode:preview}"
    BD->>AC: applyCommands(mode:preview, context:previewContext)
    AC->>H: "runHandler — ctx.mode === preview"
    H->>H: modeFromCtx → preview — vault skipped
    H->>DB: db.insert / db.delete (inside TX)
    AC->>DB: ROLLBACK
    DB-->>AC: row restored
    AC-->>BD: results
    BD-->>C: PreviewDiff (vault untouched)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): guard vault.delete against ..."](https://github.com/youhaowei/dashframe/commit/80c12e4232ba2b033b20d5cc0c276fb502f97d98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38048343)</sub>

<!-- /greptile_comment -->