### PR TITLE
fix(server): [YW-276] release all credential refs on delete even if one fails

### DIFF
--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -121,12 +121,19 @@ export async function storeCredential(
  *
  * `vault.delete(ref)` is idempotent — a missing ref is a no-op — so calling
  * this on a config with no credential fields is always safe.
+ *
+ * Every ref is attempted (allSettled), not deleted in a short-circuiting
+ * sequence: a sequential `await` loop that threw on the first ref would leave
+ * the remaining refs un-deleted while the row is still slated for deletion —
+ * a partial orphan. Attempting all of them, then throwing an aggregate if any
+ * failed, keeps a single failure from skipping the rest. delete is idempotent,
+ * so a later retry safely re-runs the no-op deletes alongside the failed one.
  */
 export async function releaseCredentialRefs(
   config: DataSourceConfig,
   vault: SecretVault | undefined,
 ): Promise<void> {
-  const refs: string[] = [];
+  const refs: SecretRef[] = [];
   if (isSecretRef(config.apiKey)) refs.push(config.apiKey);
   if (isSecretRef(config.connectionString)) refs.push(config.connectionString);
   if (refs.length === 0) return;
@@ -137,8 +144,17 @@ export async function releaseCredentialRefs(
         "A vault that was present at store time must also be present at delete time.",
     );
   }
-  for (const ref of refs) {
-    await vault.delete(ref as SecretRef);
+  const results = await Promise.allSettled(
+    refs.map((ref) => vault.delete(ref)),
+  );
+  const failures = results.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((f) => f.reason),
+      `[secret-vault] failed to release ${failures.length} of ${refs.length} credential ref(s)`,
+    );
   }
 }
 

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -16,6 +16,7 @@ import { openArtifactDb, schema } from "@dashframe/server-core";
 import {
   InMemoryMappingStore,
   isSecretRef,
+  makeSecretRef,
   SecretRegistry,
   SecretVault,
   TestBackend,
@@ -29,6 +30,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { functions } from "../functions";
 import { cmd } from "./commands";
 import { buildPreviewDiff } from "./preview-diff";
+import { type DataSourceConfig, releaseCredentialRefs } from "./utils";
 
 const { dataSources } = schema;
 
@@ -780,6 +782,65 @@ describe("vault lifecycle — delete releases SecretRefs (DeleteNode)", () => {
     await app.call("createDataSource", { id, type: "csv", name: "No Creds" });
 
     await expect(app.call("deleteNode", { id })).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SecretVault lifecycle coupling — releaseCredentialRefs partial-failure
+// ---------------------------------------------------------------------------
+//
+// Contract: releaseCredentialRefs deletes every ref via Promise.allSettled, NOT
+// a short-circuiting sequential loop. A failure deleting one ref must NOT skip
+// the others (a sequential await loop would leave later refs orphaned while the
+// row is still slated for deletion). All deletes are attempted; any failures
+// surface as an AggregateError so the caller can roll back / retry.
+// ---------------------------------------------------------------------------
+
+describe("releaseCredentialRefs — partial-failure attempts every ref", () => {
+  it("a failing delete on the first ref still attempts the second, then throws AggregateError", async () => {
+    // A source config holding TWO live refs. We make the apiKey delete reject and
+    // record which refs delete() was actually called with.
+    const apiKeyRef = makeSecretRef();
+    const csRef = makeSecretRef();
+    const config: DataSourceConfig = {
+      apiKey: apiKeyRef,
+      connectionString: csRef,
+    };
+    const deletedRefs: string[] = [];
+    const fakeVault = {
+      async delete(ref: string) {
+        deletedRefs.push(ref);
+        // The apiKey ref fails; the connectionString ref succeeds.
+        if (ref === apiKeyRef) {
+          throw new Error("keychain unavailable for apiKey ref");
+        }
+      },
+    } as unknown as SecretVault;
+
+    // A sequential await loop would throw on the first ref and never reach the
+    // second — deletedRefs would have length 1. allSettled attempts both.
+    await expect(
+      releaseCredentialRefs(config, fakeVault),
+    ).rejects.toBeInstanceOf(AggregateError);
+
+    expect(deletedRefs).toContain(apiKeyRef);
+    expect(deletedRefs).toContain(csRef);
+    expect(deletedRefs).toHaveLength(2);
+  });
+
+  it("succeeds silently when every ref deletes cleanly", async () => {
+    const config: DataSourceConfig = {
+      apiKey: makeSecretRef(),
+    };
+    const fakeVault = {
+      async delete() {
+        /* ok */
+      },
+    } as unknown as SecretVault;
+
+    await expect(
+      releaseCredentialRefs(config, fakeVault),
+    ).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What this fixes

`releaseCredentialRefs` (in `apps/server/src/functions/utils.ts`) releases a data source's `SecretRef`s from the vault before its DB row is deleted. The old implementation used a sequential `for...await` loop over `vault.delete(ref)`: if the first ref's delete threw, the remaining refs were never attempted — leaving a partial orphan (the DB row delete is aborted and the row survives, but one ref is already gone from the keychain while a sibling is stranded).

Origin: a Greptile P2 raised on the merged YW-268 PR (#134).

## The change

- Switch the sequential loop to `Promise.allSettled` so **every** ref is attempted regardless of an individual failure, then throw an `AggregateError` carrying all failures if any rejected.
- `vault.delete` is idempotent, so a retry safely re-runs the now-no-op deletes alongside the previously-failed one.
- Type `refs` as `SecretRef[]` (the values are already `isSecretRef`-guarded), removing a redundant `as SecretRef` cast.

Both callers (`removeDataSource` in app-artifacts.ts, `DeleteNode` in commands.ts) just `await` and propagate — neither inspects the error shape, so the `Error → AggregateError` change is transparent to them. The fail-closed contract is preserved: any failure still throws before the row delete, so a partial-failure leaves the row intact and a retry is safe.

## Tests

Adds a focused unit suite (`releaseCredentialRefs — partial-failure attempts every ref`):
- A fake vault whose first ref delete rejects → asserts **both** refs were attempted and an `AggregateError` is thrown. This fails under the old sequential loop (only the first ref is attempted) and passes with `allSettled` — verified by reverting and re-running.
- A clean-path test asserting silent resolution when every ref deletes cleanly.

## Local gate

- `turbo typecheck` (whole graph): PASS — `AggregateError` available (ES2023 lib)
- `lint`: PASS (0 errors; only pre-existing warnings in unrelated files)
- `format:check`: PASS
- `turbo test`: PASS (full suite, 473 app tests)
- `check` (no-ticket-refs): PASS
- code-review (opus): 0 MUST, SHIP
- Greptile (local): 5/5, no comments

---

Tracked internally as YW-276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a partial-orphan bug in `releaseCredentialRefs` where a sequential `for...await` loop would abort on the first failing vault delete, leaving subsequent `SecretRef`s un-released while the DB row was still slated for deletion. The fix replaces the loop with `Promise.allSettled` so every ref is attempted regardless of individual failures, and surfaces all failures together as an `AggregateError`.

- **`utils.ts`**: Replaces the sequential loop with `Promise.allSettled` + `AggregateError` aggregation; tightens `refs` typing from `string[]` to `SecretRef[]`, removing a now-redundant `as SecretRef` cast.
- **`vault-control-plane.test.ts`**: Adds a focused unit suite with a partial-failure test (fake vault rejects the first delete, asserts both refs were attempted and `AggregateError` is thrown) and a clean-path test.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the ref-release loop, the fail-closed contract is preserved, and the new behaviour is directly exercised by the added tests.

The implementation is correct: Promise.allSettled guarantees all deletes are attempted, AggregateError surfaces every failure, and callers that only await/propagate are unaffected by the error-type change. No ticket IDs appear in source, no data-sensitivity paths are touched, and the added unit tests faithfully distinguish the old (sequential) from the new (allSettled) behaviour.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/utils.ts | Switches releaseCredentialRefs from a short-circuiting sequential loop to Promise.allSettled, throwing AggregateError on partial failure; also tightens refs typing from string[] to SecretRef[]. |
| apps/server/src/functions/vault-control-plane.test.ts | Adds two focused unit tests for releaseCredentialRefs: partial-failure (all refs attempted, AggregateError thrown) and happy path (silent resolution). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as removeDataSource / DeleteNode
    participant R as releaseCredentialRefs
    participant V as vault

    Caller->>R: await releaseCredentialRefs(config, vault)
    R->>R: collect refs (apiKey, connectionString)
    par allSettled — every ref attempted
        R->>V: vault.delete(apiKeyRef)
        V-->>R: "fulfilled | rejected"
    and
        R->>V: vault.delete(csRef)
        V-->>R: "fulfilled | rejected"
    end
    alt all fulfilled
        R-->>Caller: resolves void
        Caller->>Caller: proceed to DB row delete
    else any rejected
        R-->>Caller: throws AggregateError(failures)
        Caller->>Caller: propagate — row delete aborted
        note over Caller: retry is safe (vault.delete is idempotent)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as removeDataSource / DeleteNode
    participant R as releaseCredentialRefs
    participant V as vault

    Caller->>R: await releaseCredentialRefs(config, vault)
    R->>R: collect refs (apiKey, connectionString)
    par allSettled — every ref attempted
        R->>V: vault.delete(apiKeyRef)
        V-->>R: "fulfilled | rejected"
    and
        R->>V: vault.delete(csRef)
        V-->>R: "fulfilled | rejected"
    end
    alt all fulfilled
        R-->>Caller: resolves void
        Caller->>Caller: proceed to DB row delete
    else any rejected
        R-->>Caller: throws AggregateError(failures)
        Caller->>Caller: propagate — row delete aborted
        note over Caller: retry is safe (vault.delete is idempotent)
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/7cd02b1ba0121871236f95916b0a2d737a3d4543) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38053897)</sub>

<!-- /greptile_comment -->