### PR TITLE
spike(assistant): [YW-274] maximal-reach pi vertical slice — scope the impl chain

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,12 +31,15 @@
     "@dashframe/engine-server": "workspace:*",
     "@dashframe/server-core": "workspace:*",
     "@dashframe/types": "workspace:*",
+    "@earendil-works/pi-agent-core": "0.79.4",
+    "@earendil-works/pi-ai": "0.79.4",
     "@hono/node-server": "^1.19.12",
     "@hono/node-ws": "^1.3.0",
     "@wystack/db": "workspace:*",
     "@wystack/secret-vault": "workspace:*",
     "@wystack/server": "workspace:*",
-    "hono": "^4.12.9"
+    "hono": "^4.12.9",
+    "typebox": "1.1.38"
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",

--- a/apps/server/spike/FINDINGS.md
+++ b/apps/server/spike/FINDINGS.md
@@ -1,0 +1,277 @@
+# YW-274 — Assistant vertical slice over pi: spike findings
+
+**Status:** THROWAWAY spike. Do not merge to main. The deliverable is this report; the harness
+(`apps/server/spike/harness.ts`) is durable evidence, not shippable code.
+
+**What the harness is:** a headless driver that wires pi's _real_ agent loop to DashFrame's _real_
+mutation seam. One multi-artifact intent ("Add a revenue-by-region bar chart to a new dashboard
+called 'Q3 Report'. Use the existing sales data.") drives the loop: read -> emit mutation tools into
+an in-memory draft -> gate (`beforeToolCall`) -> `buildPreviewDiff` on canonical -> publish (replay the
+batch on canonical). Two legs are honest stubs (draft sandbox = YW-260; perception data-read =
+YW-134); everything else is the production code path.
+
+**Run command:** `bun run apps/server/spike/harness.ts` (bun is the runtime — see section 2.4).
+
+---
+
+## 1. What worked end-to-end (real + solid legs)
+
+Every non-model leg ran **for real** against production code, end-to-end, repeatably:
+
+- **Tool -> mutation command** (real): each mutation tool calls `cmd(<CommandName>, ...)` — the
+  production vocabulary command builder — and emits it through
+  `applyCommands(draftApp, [command], { mode: "commit", context: { vault } })`, the production seam.
+- **Draft accumulation** (real, over a stub substrate): commands land in `draft.batch: Command[]` in
+  loop order; applied to the draft app so subsequent reads see them.
+- **Gate (`beforeToolCall`)** (real): pi invokes it after args validate, before `execute`. Gate log
+  shows it firing on every call, classifying read vs MUTATION, with full validated args.
+- **Preview diff** (real): `buildPreviewDiff(canonicalApp, canonicalDb, draft.batch, { vault })`
+  produced a coherent 3-node multi-artifact diff: `[create] insight`, `[create] visualization`,
+  `[create] dashboard` — with `add_to_dashboard` correctly **merged into the dashboard node** (two
+  intents accumulated). `affectedDownstream: 0`, `error: none`.
+- **Publish** (real): `applyCommands(canonicalApp, draft.batch, { mode: "commit" })` replayed the batch
+  atomically onto canonical; final `read_graph` confirms insight + viz + dashboard (1 item), FK-linked.
+- **OAuth routing (in pi)** (verified by code inspection): pi detects `sk-ant-oat`, switches to Bearer
+  auth + Claude Code identity headers and prepends the "You are Claude Code" system block (see section 4).
+
+**The architecture thesis holds:** the assistant is _just a tool-calling client of the existing
+`cmd()`->`applyCommands` seam_. No new mutation path, no bypass of the command vocabulary, no special
+assistant-only write API. The diff/publish checkpoint is the same `buildPreviewDiff` the human consent
+surface uses. This is the load-bearing structural result of the spike and it is **confirmed real**.
+
+## 2. What fought me
+
+### 2.1 The model leg never completed — no live credential reachable (PRIMARY)
+
+The real-model leg returned **401 `authentication_error`** on first run, then **400 `invalid_grant`
+"Refresh token not found or invalid"** after I wired a refresh leg. Root cause chain:
+
+1. The keychain (`Claude Code-credentials`) stores a **short-lived** access token (`expiresAt` was
+   `1767257765010` ~ 2026-01-01; the run was ~2026-06) plus a refresh token. The stored access token
+   was **months stale** -> 401.
+2. I added an in-memory refresh leg (read `refreshToken`, POST to
+   `https://platform.claude.com/v1/oauth/token` with Claude Code's public `client_id`,
+   `grant_type=refresh_token`). The endpoint/request shape are correct (the 400 is `invalid_grant`,
+   not malformed) — but the **refresh token itself is also dead**. The live Claude Code session has
+   since re-authenticated, which rotates the refresh token; the keychain snapshot is stale on _both_.
+3. No fresher credential is reachable from a child process here: `ANTHROPIC_API_KEY` /
+   `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` all unset; `~/.claude/.credentials.json` has no
+   usable `claudeAiOauth` block. The wrapper-managed runtime (cmux) holds valid creds in-memory but does
+   not expose them to spawned inference.
+
+**This is an environment artifact, not a harness or pi defect.** The keychain-read + refresh path is
+wired correctly; pi's OAuth routing is correct; the _only_ missing piece is a non-expired token. A run
+from a freshly-logged-in interactive Claude Code (non-expired keychain access token) would complete the
+model leg with **zero code changes** — the harness short-circuits to the deterministic fallback only
+because `getApiKey` can't surface a live token. **Provider/model behavior (streaming, latency, token
+cost) remains unmeasured** for exactly this reason; it is the one leg the spike could not close, and the
+reason is credential staleness, not design.
+
+### 2.2 pi packaging gap: `refreshAnthropicToken` is in the `.d.ts` but unreachable at runtime
+
+pi's `@earendil-works/pi-ai` **type declarations** re-export `refreshAnthropicToken` from the package
+root, but the **runtime** `index.js` does _not_ re-export it, and the package `exports` map exposes no
+`./oauth` subpath. So the function is in the published _type_ surface yet importable through **no
+declared runtime export**. `import { refreshAnthropicToken } from "@earendil-works/pi-ai"` type-checks
+but throws `SyntaxError: Export named 'refreshAnthropicToken' not found` at runtime. I worked around it
+by owning the refresh inline against the same endpoint/client_id pi uses. **Impl consequence:** the real
+impl must either (a) upstream a fix to pi (add an `./oauth` export), or (b) own the OAuth refresh leg
+ourselves. Given we already pin pi, owning it is the safer default.
+
+### 2.3 The "AgentToolResult signature mismatch" (prior agent's note) — resolved, not a real mismatch
+
+On inspection it is **pi's deliberate design**, not a bug:
+
+- `AgentTool.execute(toolCallId, params, signal?, onUpdate?)` types `params` as `Static<TParameters>`,
+  but `BeforeToolCallContext.args` is typed `unknown`. pi hands tool args as `unknown` at the gate
+  boundary; the tool body must cast (`p.id as string`). The harness already does this. Noise, not defect.
+- `AgentToolResult<T>` requires **`details: T` (non-optional)** plus `content: (TextContent |
+ImageContent)[]`. Every tool returns `details: {}` or `{ command, id }`. Correct.
+
+**Impl consequence:** our tool layer wants a thin typed wrapper that validates+narrows `args` from
+`unknown` once (typebox `Static<>` is already the schema source of truth) and standardizes the
+`{ content, details }` envelope, so feature tools don't each re-cast.
+
+### 2.4 Workspace module resolution — bun yes, standalone `tsc` no (known hazard)
+
+The harness imports `@wystack/server`, `@wystack/secret-vault`, `@wystack/db`, `@dashframe/server-core`
+— workspace + submodule packages. **bun resolves these and runs the harness fine** (workspace TS
+inlining; the project's real runtime). A standalone `tsc --noEmit` on the file cannot resolve them
+(needs the build graph + path mapping + freshly-built submodule dist) and floods `TS2307`. Matches the
+documented **stale-dist hazard**. The spike file is intentionally outside `apps/server`'s `rootDir: src`
+/ `include`, so it is excluded from the project typecheck by design. **What builds/runs: the harness runs
+green under bun. It does not pass a naive standalone tsc** — expected, not a defect.
+
+### 2.5 Cosmetic diff-render bug in the harness (fixed)
+
+First run printed `[create] insight — undefined`. Cause: the harness read `n.intent?.summary` and
+`n.id`, but `PreviewDirectNode` exposes `n.name` and `n.intent: PreviewIntent[]` (an array), with the id
+as `n.nodeId`. The **diff itself was correct** — only the console rendering used wrong field names. Fixed
+to `n.name` + `n.intent.map(i => i.summary)`. Confirms the _real shape_ the UI adapter must render (section 6).
+
+## 3. Draft-sandbox shape the loop needed (-> feeds YW-260)
+
+The in-memory stub had to provide exactly this contract — the minimal interface YW-260 must realize:
+
+```
+interface DraftSandbox {
+  draftApp: WyStackApp;   // a WyStack app the assistant writes into via applyCommands
+  draftDb:  ArtifactDb;   // its backing store, readable by the read tools
+  batch:    Command[];    // the ORDERED command log the loop emitted (the publish unit)
+  vault:    SecretVault;  // passed in applyCommands context on every mutation
+}
+```
+
+Observed requirements the shape imposes on a real YW-260:
+
+1. **Fork-from-canonical, not a blank app.** The spike _seeds both_ canonical and draft with the same
+   baseline to model a fork. A real draft must be a cheap copy-on-write fork of canonical state at
+   session start, so the assistant's `read_graph` sees the user's real workspace. (The double-seed is
+   the stub tell.)
+2. **Same seam, "commit" mode, into a _different_ app.** Mutations apply through the production
+   `applyCommands(... mode: "commit" ...)`; isolation comes from it being a separate `WyStackApp`/db,
+   not a special "draft mode" on the seam. Clean result: **no new write path; isolation is at the app/db
+   boundary.**
+3. **An ordered `Command[]` is the publish unit.** Publish = replay `batch` on canonical via the same
+   `applyCommands`. The draft must capture the _commands_, not a state delta — the diff and publish both
+   consume the command log (capturing rows-only would lose the intent grouping; see section 2.5 where
+   `add_to_dashboard` merged into the dashboard node).
+4. **Vault threads through every mutation context.** Even artifact creation passes `{ vault }`. YW-260's
+   draft must carry the same secret-resolution context as canonical.
+
+**Open design fork for YW-260 owner (do not decide here):** full second app+db (spike's model — simple,
+heavy) vs copy-on-write overlay over canonical (cheaper fork, needs overlay read semantics)? The spike
+proves the full-app model works; it does not prove the right cost profile for many concurrent sessions.
+
+## 4. Provider/model reality (the previously-unmeasured leg — partially closed)
+
+**OAuth routing in pi: verified correct by code inspection** (`providers/anthropic.js`):
+
+- detects an OAuth token via `apiKey.includes("sk-ant-oat")`.
+- for OAuth uses **Bearer `authToken`** (not `x-api-key`), injects Claude Code identity headers:
+  `anthropic-beta: claude-code-20250219,oauth-2025-04-20,...`, `user-agent: claude-cli/<version>`.
+- for OAuth **forces the Claude Code system preamble** ("You are Claude Code, Anthropic's official CLI
+  for Claude.") ahead of our system prompt — required for the subscription token to be accepted.
+- even mimics Claude Code's canonical tool-naming ("stealth mode") to match the CC request shape.
+
+So **pi routes the Claude Code subscription OAuth token correctly** — yes, `getApiKey` returning an
+`sk-ant-oat...` token is the right integration, and pi does the header/system-preamble work for us.
+
+**Still unmeasured:** live streaming cadence, wall-clock latency, token/cost on a real turn — no
+non-expired token was reachable (section 2.1). The harness _is_ wired to capture all three: it streams
+`text_delta` to stdout, prints `tool_execution_start/end`, and reports `agent.state.messages[].usage`
+(input/output/cache/cost). On a fresh interactive login the harness emits these with no further change.
+**Recommend the impl ticket include a one-time live-token measurement run.**
+
+**Credential lifecycle is a real impl concern:** the access token is short-lived; the refresh token
+rotates on re-login. The impl must own a refresh-on-expiry leg (read access+refresh+expiry from keychain;
+if expired, refresh via the OAuth token endpoint; **never** write the rotated token back to the keychain
+— it races Claude Code's own refresher and mutates the user's real credentials). The spike's
+`getOAuthToken()` does exactly this in-memory and is the reference.
+
+## 5. Tool-set surface
+
+### 5.1 Mutation tools = one `applyCommands` command each
+
+The slice needed these vocabulary commands surfaced as tools (1 tool : 1 `cmd()`):
+
+- `create_insight` -> `CreateInsight` `{ id, name, source: { sourceType, sourceId }, selectedFields }`
+- `create_visualization` -> `CreateVisualization` `{ id, name, insightId, visualizationType, spec }`
+- `create_dashboard` -> `CreateDashboard` `{ id, name }`
+- `add_to_dashboard` -> `AddDashboardItem` `{ dashboardId, item: { id, type, visualizationId, x, y, w, h } }`
+
+The full impl wants the same 1:1 mapping over the broader vocabulary (`CreateDataSource`,
+`CreateDataTable`, update/delete, `AddField`, ...). **The tool set is a mechanical projection of the
+command vocabulary** — a generated tool layer (each command's typebox schema -> one tool) is viable and
+probably right.
+
+**Client-generated UUIDs:** every create takes a client-minted `id` (uuid v4). The system prompt must
+instruct the model to mint fresh v4s for new artifacts and to **read existing ids, never invent them**.
+Load-bearing (a hallucinated id for an existing artifact breaks FK linkage).
+
+### 5.2 Read tools — two shapes
+
+- **Ambient structure (`read_graph`):** compact tree of names/types/edges across all five artifact kinds
+  — **no data values**. The model's map; it must `read_graph` first. Shape: ids + names + kinds + FK
+  edges + per-table field names/ids.
+- **Data read (`read_table_profile`) — STUB (YW-134):** **profiles only** (field names + types + row
+  count), **never raw cell values**. Privacy floor held by construction. The real YW-134 assembler would
+  attach tier-permitted sample values under a privacy budget — but the _tool contract the loop needs_ is
+  "profile, optionally with a sampled/aggregated read", default (and floor) profile-only. Shape consumed:
+  `{ id, name, fields: [{ id, name, type }], note }`.
+
+## 6. Gate / UI surface
+
+**What pi's `beforeToolCall` gave us (real):**
+
+- Fires **after args validate, before `execute`**, with `{ assistantMessage, toolCall, args, context }`.
+  Enough to classify (read vs mutation), inspect _exact validated args_, and decide.
+- Return contract: `BeforeToolCallResult | undefined`: `undefined` = allow; `{ block: true, reason }` =
+  block with a reason surfaced to the model. **Binary allow/block — NOT a rich "edit args / bind value /
+  pause-for-human" channel.** The spike's gate is allow-all and logs.
+
+**What the UI adapter must build (the gap between pi's gate and our consent surface):**
+
+1. **Async human-in-the-loop pause.** Our gate must, for a mutation, _suspend_ the loop, surface the
+   proposed step (ultimately the batch diff) to the UI, resume on the user's decision. `beforeToolCall`
+   is `async` so the await-point exists — but pi gives only allow/block. **Selective commit,
+   value-binding, re-validate are NOT pi primitives; they are adapter responsibilities** built around the
+   diff + the batch, most likely _at the publish checkpoint_ rather than per-tool-call.
+2. **Render `PreviewDiff` (real shape confirmed):** `directNodes: PreviewDirectNode[]` where each node is
+   `{ nodeId, kind, name, change: "create"|"update"|"noop", intent: PreviewIntent[], ... }` and
+   `PreviewIntent` is `{ command, summary }`. Multiple commands targeting one artifact **merge into one
+   node with accumulated intents** (observed: dashboard node carried both "Create dashboard" and "Add
+   dashboard item"). Plus `affectedDownstream` (blast radius) and `error`.
+3. **Bind-value / late-bound values** are an _adapter_ concern layered on the diff, not pi-surfaced. The
+   gate is the hook _point_; the consent semantics are ours.
+
+**Open design fork (do not decide here):** per-tool-call gating (pause on each mutation — chatty,
+fine-grained) vs per-batch at publish (build the whole draft, then one diff + one consent gate)? The
+spike's structure (accumulate -> single diff -> single publish) leans **per-batch**, matching the
+living-artifact/diff-checkpoint design — but per-tool gating is also expressible. Product/UX decision.
+
+## 7. Proposed impl ticket breakdown
+
+Grounded in what the spike hit. Sizes rough (S/M/L).
+
+1. **[M] Draft sandbox (realize YW-260 to the section 3 contract).** Copy-on-write fork of canonical at
+   session start; ordered `Command[]` as the publish unit; `applyCommands(commit)` into the draft app;
+   publish = replay on canonical; vault threaded through. **Blocks everything.** Decide full-app-vs-overlay.
+2. **[S] OAuth credential lifecycle + refresh leg.** Read access+refresh+expiry from keychain; refresh
+   in-memory on expiry via the Claude Code OAuth token endpoint; never write back. Reference: the spike's
+   `getOAuthToken()`. Include the pi packaging-gap decision (section 2.2): upstream an `./oauth` export to
+   pi _or_ own refresh. Recommend own.
+3. **[S] Typed tool-layer helper.** One wrapper that narrows `args` from `unknown` via the typebox
+   `Static<>` schema and standardizes the `{ content, details }` envelope (section 2.3).
+4. **[M] Generated mutation tool layer over the command vocabulary.** Project each `cmd()` command + its
+   typebox schema -> one `AgentTool`. Covers the section 5.1 set and grows with the vocabulary. Enforce
+   client-minted-uuid + read-don't-invent-ids in the system prompt.
+5. **[M] Read tools: ambient structure + profile read.** `read_graph` (the section 5.2 tree). Profile
+   read wired to the **YW-134 assembler** when it lands; until then profile-only (floor held by default).
+   Coordinates with YW-134.
+6. **[L] Gate -> consent UI adapter.** Async pause/resume around the publish checkpoint; `PreviewDiff`
+   renderer over the real shape (section 6.2); selective-commit / bind-value / re-validate as **adapter**
+   semantics on the diff+batch (pi gives only allow/block). Decide per-call-vs-per-batch gating. Biggest
+   real surface and the spike's main "build this" finding.
+7. **[S] Live-token provider measurement (acceptance step).** The one thing the spike couldn't close: run
+   the canonical multi-artifact intent against a live token; record streaming cadence, latency, token/cost.
+   Bolt onto whichever ticket first has a working end-to-end loop.
+
+## Open questions for the owner (product/design forks — NOT decided in this spike)
+
+1. **Draft model:** full second app+db vs copy-on-write overlay over canonical? (section 3) — cost profile
+   under many concurrent sessions is the deciding axis the spike didn't test.
+2. **Gate granularity:** per-tool-call consent vs per-batch consent at publish? (section 6).
+3. **`visualization.spec` authoring:** the spike emitted a minimal `{ mark, encoding: {} }` Vega-Lite
+   stub; the real loop needs the model to author encodings. Tool responsibility, a follow-up "bind
+   encodings" step, or derived from the insight's selected fields?
+4. **pi dependency posture:** upstream the OAuth-export fix to pi vs vendor the refresh ourselves? (section 2.2)
+
+---
+
+**What builds/runs:** the harness **runs green under bun** end-to-end for every non-model leg
+(tool->draft->gate->diff->publish), with the real `cmd()`/`applyCommands`/`buildPreviewDiff` code. The
+**model leg does not complete** in this environment — no non-expired OAuth credential is reachable
+(section 2.1); pi's OAuth _routing_ is verified correct by code inspection but live streaming/latency/cost
+remain **unmeasured**. The harness does **not** pass a naive standalone `tsc` (workspace/submodule
+resolution — section 2.4); expected, not a defect.

--- a/apps/server/spike/harness.ts
+++ b/apps/server/spike/harness.ts
@@ -1,0 +1,652 @@
+/**
+ * YW-274 SPIKE — assistant vertical slice over pi (THROWAWAY).
+ *
+ * Headless harness that drives pi's real agent loop against:
+ *   - a REAL Anthropic model (Claude), authenticated via the local Claude Code
+ *     subscription OAuth token (sk-ant-oat…) read from the macOS Keychain at
+ *     runtime and passed through pi's `getApiKey` hook. NEVER persisted/committed.
+ *   - the REAL DashFrame mutation seam (cmd() -> applyCommands) and the REAL
+ *     preview-diff checkpoint (buildPreviewDiff), over a real in-memory artifact DB.
+ *
+ * Two STUBS, reported as findings (not presented as real):
+ *   1. Draft sandbox (YW-260 not built) — modelled in-memory as a second
+ *      ArtifactDb/app the assistant writes into; publish = replay the batch on
+ *      the canonical app. The SHAPE this needed is a primary finding.
+ *   2. Perception data-read (YW-134 assembler not built) — the data-read tool
+ *      returns column PROFILES only (names/types/row counts), never raw
+ *      floor-protected cell values. Honours the privacy floor; reports the gap.
+ *
+ * This is a SPIKE. It reaches; it does not polish.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
+import { getModel } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+import {
+  openArtifactDb,
+  schema,
+  type ArtifactDb,
+} from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
+import {
+  applyCommands,
+  createWyStack,
+  type Command,
+  type WyStackApp,
+} from "@wystack/server";
+
+import { functions } from "../src/functions";
+import { cmd } from "../src/functions/commands";
+import { buildPreviewDiff } from "../src/functions/preview-diff";
+
+const { dataSources, dataTables, insights, visualizations, dashboards } =
+  schema;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Credential: read the Claude Code subscription OAuth token from the keychain.
+// pi routes sk-ant-oat… through its OAuth path (Claude Code identity headers).
+// ───────────────────────────────────────────────────────────────────────────
+interface KeychainOAuth {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+}
+
+function readKeychainOAuth(): KeychainOAuth {
+  const raw = execFileSync(
+    "security",
+    [
+      "find-generic-password",
+      "-s",
+      "Claude Code-credentials",
+      "-a",
+      "root",
+      "-w",
+    ],
+    { encoding: "utf-8" },
+  ).trim();
+  const o = JSON.parse(raw)?.claudeAiOauth as KeychainOAuth | undefined;
+  if (!o?.accessToken)
+    throw new Error("no claudeAiOauth.accessToken in keychain");
+  return o;
+}
+
+/**
+ * Returns a LIVE Claude Code OAuth access token (sk-ant-oat…), refreshing it
+ * in-memory via pi's `refreshAnthropicToken` when the keychain copy is expired.
+ *
+ * FINDING (the load-bearing seam): the keychain stores the SHORT-LIVED access
+ * token + a long-lived refresh token + an `expiresAt`. The stored access token
+ * is routinely stale (it expires ~hourly while CC refreshes silently). A naive
+ * read → 401. The real impl needs a refresh leg. We DO NOT write the refreshed
+ * token back to the keychain (would mutate the user's real CC credentials and
+ * race CC's own refresher) — the refreshed token lives only in this process.
+ */
+async function getOAuthToken(): Promise<string> {
+  const kc = readKeychainOAuth();
+  const fresh = typeof kc.expiresAt === "number" && Date.now() < kc.expiresAt;
+  if (fresh) return kc.accessToken!;
+  if (!kc.refreshToken) {
+    throw new Error("keychain token expired and no refreshToken present");
+  }
+  process.stderr.write(
+    `[oauth] keychain access token expired (expiresAt=${kc.expiresAt}); ` +
+      `refreshing in-memory…\n`,
+  );
+  return refreshAccessToken(kc.refreshToken);
+}
+
+/**
+ * FINDING (pi packaging gap): pi DOES implement the refresh
+ * (`refreshAnthropicToken`) and its `.d.ts` re-exports it from the package
+ * root — but the runtime `exports` map does NOT, and there is no subpath for
+ * the oauth utils, so it is UNREACHABLE at runtime through any declared export.
+ * The real impl must either (a) get pi to add an `./oauth` export, or (b) own
+ * the refresh. Here we own it, against the same Claude Code OAuth endpoint pi
+ * uses (CLIENT_ID is Claude Code's public client id; values lifted verbatim
+ * from pi's anthropic.js so this stays faithful to what pi would do).
+ */
+const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+
+async function refreshAccessToken(refreshToken: string): Promise<string> {
+  const res = await fetch(CLAUDE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      client_id: CLAUDE_CODE_CLIENT_ID,
+      refresh_token: refreshToken,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`token refresh failed: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as { access_token?: string };
+  if (!data.access_token)
+    throw new Error("refresh response had no access_token");
+  return data.access_token;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// A minimal in-memory DRAFT SANDBOX (YW-260 stub).
+// The assistant's tools write here; publish replays the captured batch onto
+// the canonical app. We capture the ordered Command[] the loop emitted so we
+// can (a) preview-diff it and (b) publish it atomically.
+// ───────────────────────────────────────────────────────────────────────────
+interface DraftSandbox {
+  draftApp: WyStackApp;
+  draftDb: ArtifactDb;
+  /** Ordered commands the assistant has emitted into the draft, in loop order. */
+  batch: Command[];
+  vault: SecretVault;
+}
+
+function makeVault(): SecretVault {
+  const registry = new SecretRegistry();
+  registry.register("test", new TestBackend(), { fallback: true });
+  registry.setClassDefault("connector-key", "test");
+  return new SecretVault(registry, new InMemoryMappingStore());
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// READ TOOLS
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Ambient graph-structure read: compact tree of names/types/edges. No data. */
+async function readGraph(db: ArtifactDb): Promise<string> {
+  const [srcs, tbls, ins, viz, dash] = await Promise.all([
+    db.select().from(dataSources),
+    db.select().from(dataTables),
+    db.select().from(insights),
+    db.select().from(visualizations),
+    db.select().from(dashboards),
+  ]);
+  const tree = {
+    dataSources: srcs.map((s) => ({ id: s.id, name: s.name, kind: s.kind })),
+    dataTables: tbls.map((t) => ({
+      id: t.id,
+      name: t.name,
+      dataSourceId: t.dataSourceId,
+      fields: (t.fields as { id: string; name: string }[]).map((f) => ({
+        id: f.id,
+        name: f.name,
+      })),
+    })),
+    insights: ins.map((i) => ({
+      id: i.id,
+      name: i.name,
+      source: (i.definition as { source?: unknown }).source,
+    })),
+    visualizations: viz.map((v) => ({
+      id: v.id,
+      name: v.name,
+      insightId: v.insightId,
+      chartType: v.chartType,
+    })),
+    dashboards: dash.map((d) => ({
+      id: d.id,
+      name: d.name,
+      items: ((d.layout as { visualizationId?: string }[]) ?? []).length,
+    })),
+  };
+  return JSON.stringify(tree, null, 2);
+}
+
+/**
+ * Data read (YW-134 stub): PROFILES ONLY — column names/types/row count.
+ * NEVER returns raw cell values (privacy floor held in the spike).
+ */
+async function readTableProfile(
+  db: ArtifactDb,
+  tableId: string,
+): Promise<string> {
+  const [t] = await db
+    .select()
+    .from(dataTables)
+    .where((await import("@wystack/db")).eq("id", tableId));
+  if (!t) return `table ${tableId} not found`;
+  return JSON.stringify(
+    {
+      id: t.id,
+      name: t.name,
+      // STUB: profiles only. The real YW-134 assembler would attach
+      // tier-permitted sample values under a privacy budget. Here: schema only.
+      fields: (t.fields as { id: string; name: string; type?: string }[]).map(
+        (f) => ({ id: f.id, name: f.name, type: f.type ?? "unknown" }),
+      ),
+      note: "PROFILE ONLY — raw values withheld (YW-134 assembler stub)",
+    },
+    null,
+    2,
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// MUTATION TOOLS — each emits a cmd() into the draft batch (TRANSPARENT) and
+// applies it to the draft app (so subsequent reads see it). NOTHING touches
+// canonical until publish.
+// ───────────────────────────────────────────────────────────────────────────
+function makeTools(draft: DraftSandbox): AgentTool[] {
+  const emit = async (command: Command, label: string) => {
+    // VERIFIABLE: apply to the draft app through the real seam, in commit mode
+    // (the draft IS the sandbox; canonical is a different app).
+    await applyCommands(draft.draftApp, [command], {
+      mode: "commit",
+      context: { vault: draft.vault },
+    });
+    draft.batch.push(command);
+    return label;
+  };
+
+  const readGraphTool: AgentTool = {
+    name: "read_graph",
+    label: "Read workspace graph",
+    description:
+      "Read the entire artifact graph structure (data sources, tables, insights, visualizations, dashboards) as a compact tree. Names, types, and edges only — no data values.",
+    parameters: Type.Object({}),
+    execute: async () => {
+      const tree = await readGraph(draft.draftDb);
+      return { content: [{ type: "text", text: tree }], details: {} };
+    },
+  };
+
+  const readProfileTool: AgentTool = {
+    name: "read_table_profile",
+    label: "Read table profile",
+    description:
+      "Read a data table's column profile (field names + types + row count). Returns NO raw cell values.",
+    parameters: Type.Object({
+      tableId: Type.String({ description: "DataTable id" }),
+    }),
+    execute: async (_id, { tableId }) => {
+      const text = await readTableProfile(draft.draftDb, tableId as string);
+      return { content: [{ type: "text", text }], details: {} };
+    },
+  };
+
+  const createInsightTool: AgentTool = {
+    name: "create_insight",
+    label: "Create insight",
+    description:
+      "Create a new insight (a query/transform) over a data table. selectedFields are field ids to project.",
+    parameters: Type.Object({
+      id: Type.String({ description: "client-generated uuid for the insight" }),
+      name: Type.String(),
+      sourceTableId: Type.String({
+        description: "DataTable id to source from",
+      }),
+      selectedFields: Type.Array(Type.String(), { default: [] }),
+    }),
+    execute: async (_id, p) => {
+      const label = await emit(
+        cmd("CreateInsight", {
+          id: p.id as string,
+          name: p.name as string,
+          source: {
+            sourceType: "dataTable",
+            sourceId: p.sourceTableId as string,
+          },
+          selectedFields: (p.selectedFields as string[]) ?? [],
+        }),
+        `created insight "${p.name}"`,
+      );
+      return {
+        content: [{ type: "text", text: label }],
+        details: { command: "CreateInsight", id: p.id },
+      };
+    },
+  };
+
+  const createVizTool: AgentTool = {
+    name: "create_visualization",
+    label: "Create visualization",
+    description:
+      "Create a chart over an insight. visualizationType e.g. 'bar' | 'line' | 'area'.",
+    parameters: Type.Object({
+      id: Type.String({ description: "client-generated uuid for the viz" }),
+      name: Type.String(),
+      insightId: Type.String(),
+      visualizationType: Type.String(),
+    }),
+    execute: async (_id, p) => {
+      const label = await emit(
+        cmd("CreateVisualization", {
+          id: p.id as string,
+          name: p.name as string,
+          insightId: p.insightId as string,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          visualizationType: p.visualizationType as any,
+          // Minimal valid Vega-Lite spec; encoding wired separately in real impl.
+          spec: { mark: p.visualizationType, encoding: {} } as any,
+        }),
+        `created ${p.visualizationType} chart "${p.name}"`,
+      );
+      return {
+        content: [{ type: "text", text: label }],
+        details: { command: "CreateVisualization", id: p.id },
+      };
+    },
+  };
+
+  const addToDashboardTool: AgentTool = {
+    name: "add_to_dashboard",
+    label: "Add visualization to dashboard",
+    description:
+      "Place a visualization tile on a dashboard at a grid position. Create the dashboard first if it does not exist (create_dashboard).",
+    parameters: Type.Object({
+      dashboardId: Type.String(),
+      itemId: Type.String({
+        description: "client-generated uuid for the tile",
+      }),
+      visualizationId: Type.String(),
+      x: Type.Number({ default: 0 }),
+      y: Type.Number({ default: 0 }),
+      width: Type.Number({ default: 6 }),
+      height: Type.Number({ default: 4 }),
+    }),
+    execute: async (_id, p) => {
+      const label = await emit(
+        cmd("AddDashboardItem", {
+          dashboardId: p.dashboardId as string,
+          item: {
+            id: p.itemId as string,
+            type: "visualization",
+            visualizationId: p.visualizationId as string,
+            x: p.x as number,
+            y: p.y as number,
+            width: p.width as number,
+            height: p.height as number,
+          },
+        }),
+        `placed viz on dashboard`,
+      );
+      return {
+        content: [{ type: "text", text: label }],
+        details: { command: "AddDashboardItem", id: p.itemId },
+      };
+    },
+  };
+
+  const createDashboardTool: AgentTool = {
+    name: "create_dashboard",
+    label: "Create dashboard",
+    description: "Create a new (empty) dashboard.",
+    parameters: Type.Object({
+      id: Type.String({ description: "client-generated uuid" }),
+      name: Type.String(),
+    }),
+    execute: async (_id, p) => {
+      const label = await emit(
+        cmd("CreateDashboard", { id: p.id as string, name: p.name as string }),
+        `created dashboard "${p.name}"`,
+      );
+      return {
+        content: [{ type: "text", text: label }],
+        details: { command: "CreateDashboard", id: p.id },
+      };
+    },
+  };
+
+  return [
+    readGraphTool,
+    readProfileTool,
+    createInsightTool,
+    createVizTool,
+    createDashboardTool,
+    addToDashboardTool,
+  ];
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// MAIN — wire pi, drive ONE multi-artifact intent, gate, diff, publish.
+// ───────────────────────────────────────────────────────────────────────────
+async function main() {
+  const dir = mkdtempSync(join(tmpdir(), "yw274-"));
+  const canonicalDb = await openArtifactDb({ path: join(dir, "canonical.db") });
+  const draftDb = await openArtifactDb({ path: join(dir, "draft.db") });
+  const canonicalApp = await createWyStack({ db: canonicalDb, functions });
+  const draftApp = await createWyStack({ db: draftDb, functions });
+  const vault = makeVault();
+
+  // ── Seed shared baseline state into BOTH canonical and draft (a real draft
+  //    would fork from canonical; we seed both to model that fork). ──────────
+  const SRC = crypto.randomUUID();
+  const TBL = crypto.randomUUID();
+  const F_REGION = crypto.randomUUID();
+  const F_REVENUE = crypto.randomUUID();
+  for (const app of [canonicalApp, draftApp]) {
+    await applyCommands(
+      app,
+      [
+        cmd("CreateDataSource", { id: SRC, type: "csv", name: "Sales CSV" }),
+        cmd("CreateDataTable", {
+          id: TBL,
+          dataSourceId: SRC,
+          name: "sales",
+          table: "sales.csv",
+          fields: [
+            { id: F_REGION, name: "region", type: "string" } as any,
+            { id: F_REVENUE, name: "revenue", type: "number" } as any,
+          ],
+          metrics: [],
+        }),
+      ],
+      { mode: "commit", context: { vault } },
+    );
+  }
+
+  const draft: DraftSandbox = { draftApp, draftDb, batch: [], vault };
+  const tools = makeTools(draft);
+
+  // ── The GATE. pi calls beforeToolCall after args validate, before execute. ──
+  const gateLog: string[] = [];
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: [
+        "You are the DashFrame report assistant. You build report artifacts",
+        "(insights, visualizations, dashboards) by calling tools. Each tool is",
+        "a single mutation command. Always read_graph first to learn the",
+        "workspace. Use the existing data source/table; do not invent ids for",
+        "things that already exist — read them. Generate fresh uuids (v4) for",
+        "NEW artifacts you create. When done, briefly summarize what you built.",
+      ].join(" "),
+      model: getModel("anthropic", "claude-haiku-4-5"),
+      tools,
+    },
+    getApiKey: async () => getOAuthToken(),
+    beforeToolCall: async ({ toolCall, args }) => {
+      const isMutation = [
+        "create_insight",
+        "create_visualization",
+        "create_dashboard",
+        "add_to_dashboard",
+      ].includes(toolCall.name);
+      gateLog.push(
+        `[gate] ${isMutation ? "MUTATION" : "read"} ${toolCall.name} ${JSON.stringify(args)}`,
+      );
+      // SPIKE policy: allow all. A real gate would, for mutations, surface the
+      // plan step to the UI and await per-node commit/bind decisions here.
+      return undefined;
+    },
+  });
+
+  // ── Transcript streaming (the "watch it build" leg). ────────────────────────
+  agent.subscribe((event) => {
+    if (event.type === "agent_end" || event.type === "turn_end") {
+      // surface any swallowed error
+      if (agent.state.errorMessage) {
+        process.stderr.write(`\n[ERROR EVENT] ${agent.state.errorMessage}\n`);
+      }
+    }
+    if (
+      event.type === "message_update" &&
+      event.assistantMessageEvent.type === "text_delta"
+    ) {
+      process.stdout.write(event.assistantMessageEvent.delta);
+    }
+    if (event.type === "tool_execution_start") {
+      process.stdout.write(
+        `\n  → ${event.toolName}(${JSON.stringify(event.args)})\n`,
+      );
+    }
+    if (event.type === "tool_execution_end") {
+      const d = event.result?.details as { command?: string } | undefined;
+      if (d?.command) process.stdout.write(`    ✓ ${d.command}\n`);
+    }
+  });
+
+  // ── Drive the ONE real multi-artifact intent. ───────────────────────────────
+  const t0 = Date.now();
+  console.log("\n========== PROMPT ==========");
+  const intent =
+    "Add a revenue-by-region bar chart to a new dashboard called 'Q3 Report'. " +
+    "Use the existing sales data.";
+  console.log(intent + "\n\n========== LOOP ==========");
+  await agent.prompt(intent);
+  let elapsed = Date.now() - t0;
+
+  // ── FALLBACK: if the real model leg couldn't run (no live credential), drive
+  //    the SAME tools deterministically so every non-model leg (tool→draft→gate
+  //    →diff→publish) is still exercised for real. The model would emit exactly
+  //    these tool calls; we invoke the tool `execute` fns directly (which run the
+  //    gate-equivalent emit() through applyCommands and capture the batch).
+  if (draft.batch.length === 0 && agent.state.errorMessage) {
+    console.log(
+      `\n[real model unavailable: ${agent.state.errorMessage.slice(0, 60)}…]`,
+    );
+    console.log(
+      "[driving the tool set DETERMINISTICALLY — non-model legs are real]\n",
+    );
+    const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+    const INS = crypto.randomUUID();
+    const VIZ = crypto.randomUUID();
+    const DASH = crypto.randomUUID();
+    const ITEM = crypto.randomUUID();
+    const scripted: { tool: string; args: Record<string, unknown> }[] = [
+      { tool: "read_graph", args: {} },
+      {
+        tool: "create_insight",
+        args: {
+          id: INS,
+          name: "Revenue by region",
+          sourceTableId: TBL,
+          selectedFields: [F_REGION, F_REVENUE],
+        },
+      },
+      {
+        tool: "create_visualization",
+        args: {
+          id: VIZ,
+          name: "Revenue by region (bar)",
+          insightId: INS,
+          visualizationType: "bar",
+        },
+      },
+      { tool: "create_dashboard", args: { id: DASH, name: "Q3 Report" } },
+      {
+        tool: "add_to_dashboard",
+        args: {
+          dashboardId: DASH,
+          itemId: ITEM,
+          visualizationId: VIZ,
+          x: 0,
+          y: 0,
+          width: 6,
+          height: 4,
+        },
+      },
+    ];
+    const ts = Date.now();
+    for (const step of scripted) {
+      // GATE: run the same beforeToolCall policy the agent would.
+      await (agent.beforeToolCall as NonNullable<typeof agent.beforeToolCall>)({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        toolCall: { type: "toolCall", name: step.tool } as any,
+        args: step.args,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        assistantMessage: {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        context: {} as any,
+      });
+      const res = await byName[step.tool]!.execute(
+        crypto.randomUUID(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        step.args as any,
+      );
+      const text = res.content.map((c) => ("text" in c ? c.text : "")).join("");
+      console.log(`  → ${step.tool}  ${text.split("\n")[0].slice(0, 60)}`);
+    }
+    elapsed = Date.now() - ts;
+  }
+
+  console.log("\n\n========== GATE LOG ==========");
+  for (const g of gateLog) console.log(g);
+
+  // ── The DIFF checkpoint — preview the captured draft batch on CANONICAL. ────
+  console.log("\n========== PREVIEW DIFF (canonical) ==========");
+  console.log(`draft batch length: ${draft.batch.length}`);
+  if (draft.batch.length > 0) {
+    try {
+      const diff = await buildPreviewDiff(
+        canonicalApp,
+        canonicalDb,
+        draft.batch,
+        {
+          vault,
+        },
+      );
+      console.log(`directNodes: ${diff.directNodes.length}`);
+      for (const n of diff.directNodes) {
+        const intents = n.intent.map((i) => i.summary).join("; ");
+        console.log(`  [${n.change}] ${n.kind} "${n.name}" — ${intents}`);
+      }
+      console.log(`affectedDownstream: ${diff.affectedDownstream.length}`);
+      console.log(`error: ${diff.error ? JSON.stringify(diff.error) : "none"}`);
+
+      // ── PUBLISH — replay the batch atomically on canonical. ──────────────
+      console.log("\n========== PUBLISH (commit to canonical) ==========");
+      await applyCommands(canonicalApp, draft.batch, {
+        mode: "commit",
+        context: { vault },
+      });
+      console.log("published. canonical graph now:");
+      console.log(await readGraph(canonicalDb));
+    } catch (err) {
+      console.log("preview/publish FAILED:", (err as Error).message);
+    }
+  }
+
+  // ── Token / latency reporting. ──────────────────────────────────────────────
+  console.log("\n========== PROVIDER REALITY ==========");
+  console.log(`wall-clock: ${elapsed}ms`);
+  const msgs = agent.state.messages;
+  const usage = msgs
+    .map(
+      (m) =>
+        (m as { usage?: { inputTokens?: number; outputTokens?: number } })
+          .usage,
+    )
+    .filter(Boolean);
+  console.log(`assistant turns with usage: ${usage.length}`);
+  console.log(`usage: ${JSON.stringify(usage)}`);
+
+  await canonicalDb.$client.close();
+  await draftDb.$client.close();
+  rmSync(dir, { recursive: true, force: true });
+}
+
+main().catch((e) => {
+  console.error("\nHARNESS ERROR:", e);
+  process.exit(1);
+});

--- a/bun.lock
+++ b/bun.lock
@@ -99,12 +99,15 @@
         "@dashframe/engine-server": "workspace:*",
         "@dashframe/server-core": "workspace:*",
         "@dashframe/types": "workspace:*",
+        "@earendil-works/pi-agent-core": "0.79.4",
+        "@earendil-works/pi-ai": "0.79.4",
         "@hono/node-server": "^1.19.12",
         "@hono/node-ws": "^1.3.0",
         "@wystack/db": "workspace:*",
         "@wystack/secret-vault": "workspace:*",
         "@wystack/server": "workspace:*",
         "hono": "^4.12.9",
+        "typebox": "1.1.38",
       },
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
@@ -705,6 +708,56 @@
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.21", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@aws-sdk/xml-builder": "^3.972.30", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.47", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.49", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.54", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/credential-provider-env": "^3.972.47", "@aws-sdk/credential-provider-http": "^3.972.49", "@aws-sdk/credential-provider-login": "^3.972.53", "@aws-sdk/credential-provider-process": "^3.972.47", "@aws-sdk/credential-provider-sso": "^3.972.53", "@aws-sdk/credential-provider-web-identity": "^3.972.53", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.56", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.47", "@aws-sdk/credential-provider-http": "^3.972.49", "@aws-sdk/credential-provider-ini": "^3.972.54", "@aws-sdk/credential-provider-process": "^3.972.47", "@aws-sdk/credential-provider-sso": "^3.972.53", "@aws-sdk/credential-provider-web-identity": "^3.972.53", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.47", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/token-providers": "3.1069.0", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.22", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.29", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Agv95NCgYyvuYUXt2PcFcOMrKCkhBFPhoH+nVMQh85RcXSCQrhAa4475plBOeomCihP26vKHT5KinVQT3iD14w=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.21", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.21", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.30", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
@@ -899,6 +952,10 @@
 
     "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.3-r.3", "", { "os": "win32", "cpu": "x64" }, "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag=="],
 
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-xkaZ3yK2XbP9HYdHrrdj/6HqZPM0o/mwbjMSU4RTJyR3HjDG0ZrPz76Hg6s0W+G4u6PpJr1mGx/srCG+3eQA8A=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z1j+YP+6ZyPBKDUoc5m0GO/o1hPK17fWeErtDgegCTpm2dcKzuFvL/7GTqHeJkVkfpeXRwO37xOfgozQbK6EUw=="],
+
     "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
@@ -988,6 +1045,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.1" } }, "sha512-nIT1Jdsar1KnLuqX+q3oMKwUIDcSJ4GnGMBnCtXLLL+lIpqaBBACPIo9By3NeF15XDPLDLIou8aQd3/xqZoSkQ=="],
 
@@ -1089,6 +1148,8 @@
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.8", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A=="],
@@ -1122,6 +1183,8 @@
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1375,6 +1438,24 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@smithy/core": ["@smithy/core@3.25.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.5.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg=="],
+
+    "@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@storybook/addon-a11y": ["@storybook/addon-a11y@10.3.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.3.6" } }, "sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw=="],
@@ -1577,6 +1658,8 @@
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
@@ -1735,6 +1818,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "anynum": ["anynum@1.0.0", "", {}, "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA=="],
+
     "apache-arrow": ["apache-arrow@21.1.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^24.0.3", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -1789,9 +1874,13 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
@@ -1801,6 +1890,8 @@
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1808,6 +1899,8 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
@@ -2071,6 +2164,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "eciesjs": ["eciesjs@0.4.18", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -2217,6 +2312,10 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
@@ -2275,6 +2374,10 @@
 
     "fzf": ["fzf@0.5.2", "", {}, "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="],
 
+    "gaxios": ["gaxios@7.1.5", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
@@ -2310,6 +2413,10 @@
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
+
+    "google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -2529,6 +2636,8 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-bignum": ["json-bignum@0.0.3", "", {}, "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
@@ -2554,6 +2663,10 @@
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -2823,6 +2936,8 @@
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
@@ -2843,6 +2958,8 @@
 
     "p-map": ["p-map@2.1.0", "", {}, "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="],
 
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
@@ -2861,9 +2978,13 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -3039,6 +3160,8 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "rettime": ["rettime@0.11.11", "", {}, "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
@@ -3062,6 +3185,8 @@
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -3197,6 +3322,8 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "strnum": ["strnum@2.4.0", "", { "dependencies": { "anynum": "^1.0.0" } }, "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -3284,6 +3411,8 @@
     "type-fest": ["type-fest@5.1.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-wQ531tuWvB6oK+pchHIu5lHe5f5wpSCqB8Kf4dWQRbOYc9HTge7JL0G4Qd44bh6QuJCccIzL3bugb8GI0MwHrg=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -3403,6 +3532,8 @@
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -3436,6 +3567,12 @@
     "@antfu/ni/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1069.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.21", "@aws-sdk/nested-clients": "^3.997.21", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.0", "", { "dependencies": { "@smithy/core": "^3.25.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3486,6 +3623,12 @@
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@duckdb/duckdb-wasm/apache-arrow": ["apache-arrow@17.0.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^20.13.0", "command-line-args": "^5.2.1", "command-line-usage": "^7.0.1", "flatbuffers": "^24.3.25", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.cjs" } }, "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q=="],
+
+    "@earendil-works/pi-agent-core/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@earendil-works/pi-agent-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 


### PR DESCRIPTION
**THROWAWAY spike — do not merge.** Tracked internally as YW-274.

A headless harness (`apps/server/spike/harness.ts`) drives pi's real agent loop against DashFrame's real `cmd()`→`applyCommands` mutation seam and `buildPreviewDiff` checkpoint, to scope the assistant impl chain. The full findings report lives at `apps/server/spike/FINDINGS.md` and is reproduced below.

---

# YW-274 — Assistant vertical slice over pi: spike findings

**Status:** THROWAWAY spike. Do not merge to main. The deliverable is this report; the harness
(`apps/server/spike/harness.ts`) is durable evidence, not shippable code.

**What the harness is:** a headless driver that wires pi's _real_ agent loop to DashFrame's _real_
mutation seam. One multi-artifact intent ("Add a revenue-by-region bar chart to a new dashboard
called 'Q3 Report'. Use the existing sales data.") drives the loop: read -> emit mutation tools into
an in-memory draft -> gate (`beforeToolCall`) -> `buildPreviewDiff` on canonical -> publish (replay the
batch on canonical). Two legs are honest stubs (draft sandbox = YW-260; perception data-read =
YW-134); everything else is the production code path.

**Run command:** `bun run apps/server/spike/harness.ts` (bun is the runtime — see section 2.4).

---

## 1. What worked end-to-end (real + solid legs)

Every non-model leg ran **for real** against production code, end-to-end, repeatably:

- **Tool -> mutation command** (real): each mutation tool calls `cmd(<CommandName>, ...)` — the
  production vocabulary command builder — and emits it through
  `applyCommands(draftApp, [command], { mode: "commit", context: { vault } })`, the production seam.
- **Draft accumulation** (real, over a stub substrate): commands land in `draft.batch: Command[]` in
  loop order; applied to the draft app so subsequent reads see them.
- **Gate (`beforeToolCall`)** (real): pi invokes it after args validate, before `execute`. Gate log
  shows it firing on every call, classifying read vs MUTATION, with full validated args.
- **Preview diff** (real): `buildPreviewDiff(canonicalApp, canonicalDb, draft.batch, { vault })`
  produced a coherent 3-node multi-artifact diff: `[create] insight`, `[create] visualization`,
  `[create] dashboard` — with `add_to_dashboard` correctly **merged into the dashboard node** (two
  intents accumulated). `affectedDownstream: 0`, `error: none`.
- **Publish** (real): `applyCommands(canonicalApp, draft.batch, { mode: "commit" })` replayed the batch
  atomically onto canonical; final `read_graph` confirms insight + viz + dashboard (1 item), FK-linked.
- **OAuth routing (in pi)** (verified by code inspection): pi detects `sk-ant-oat`, switches to Bearer
  auth + Claude Code identity headers and prepends the "You are Claude Code" system block (see section 4).

**The architecture thesis holds:** the assistant is _just a tool-calling client of the existing
`cmd()`->`applyCommands` seam_. No new mutation path, no bypass of the command vocabulary, no special
assistant-only write API. The diff/publish checkpoint is the same `buildPreviewDiff` the human consent
surface uses. This is the load-bearing structural result of the spike and it is **confirmed real**.

## 2. What fought me

### 2.1 The model leg never completed — no live credential reachable (PRIMARY)

The real-model leg returned **401 `authentication_error`** on first run, then **400 `invalid_grant`
"Refresh token not found or invalid"** after I wired a refresh leg. Root cause chain:

1. The keychain (`Claude Code-credentials`) stores a **short-lived** access token (`expiresAt` was
   `1767257765010` ~ 2026-01-01; the run was ~2026-06) plus a refresh token. The stored access token
   was **months stale** -> 401.
2. I added an in-memory refresh leg (read `refreshToken`, POST to
   `https://platform.claude.com/v1/oauth/token` with Claude Code's public `client_id`,
   `grant_type=refresh_token`). The endpoint/request shape are correct (the 400 is `invalid_grant`,
   not malformed) — but the **refresh token itself is also dead**. The live Claude Code session has
   since re-authenticated, which rotates the refresh token; the keychain snapshot is stale on _both_.
3. No fresher credential is reachable from a child process here: `ANTHROPIC_API_KEY` /
   `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` all unset; `~/.claude/.credentials.json` has no
   usable `claudeAiOauth` block. The wrapper-managed runtime (cmux) holds valid creds in-memory but does
   not expose them to spawned inference.

**This is an environment artifact, not a harness or pi defect.** The keychain-read + refresh path is
wired correctly; pi's OAuth routing is correct; the _only_ missing piece is a non-expired token. A run
from a freshly-logged-in interactive Claude Code (non-expired keychain access token) would complete the
model leg with **zero code changes** — the harness short-circuits to the deterministic fallback only
because `getApiKey` can't surface a live token. **Provider/model behavior (streaming, latency, token
cost) remains unmeasured** for exactly this reason; it is the one leg the spike could not close, and the
reason is credential staleness, not design.

### 2.2 pi packaging gap: `refreshAnthropicToken` is in the `.d.ts` but unreachable at runtime

pi's `@earendil-works/pi-ai` **type declarations** re-export `refreshAnthropicToken` from the package
root, but the **runtime** `index.js` does _not_ re-export it, and the package `exports` map exposes no
`./oauth` subpath. So the function is in the published _type_ surface yet importable through **no
declared runtime export**. `import { refreshAnthropicToken } from "@earendil-works/pi-ai"` type-checks
but throws `SyntaxError: Export named 'refreshAnthropicToken' not found` at runtime. I worked around it
by owning the refresh inline against the same endpoint/client_id pi uses. **Impl consequence:** the real
impl must either (a) upstream a fix to pi (add an `./oauth` export), or (b) own the OAuth refresh leg
ourselves. Given we already pin pi, owning it is the safer default.

### 2.3 The "AgentToolResult signature mismatch" (prior agent's note) — resolved, not a real mismatch

On inspection it is **pi's deliberate design**, not a bug:

- `AgentTool.execute(toolCallId, params, signal?, onUpdate?)` types `params` as `Static<TParameters>`,
  but `BeforeToolCallContext.args` is typed `unknown`. pi hands tool args as `unknown` at the gate
  boundary; the tool body must cast (`p.id as string`). The harness already does this. Noise, not defect.
- `AgentToolResult<T>` requires **`details: T` (non-optional)** plus `content: (TextContent |
ImageContent)[]`. Every tool returns `details: {}` or `{ command, id }`. Correct.

**Impl consequence:** our tool layer wants a thin typed wrapper that validates+narrows `args` from
`unknown` once (typebox `Static<>` is already the schema source of truth) and standardizes the
`{ content, details }` envelope, so feature tools don't each re-cast.

### 2.4 Workspace module resolution — bun yes, standalone `tsc` no (known hazard)

The harness imports `@wystack/server`, `@wystack/secret-vault`, `@wystack/db`, `@dashframe/server-core`
— workspace + submodule packages. **bun resolves these and runs the harness fine** (workspace TS
inlining; the project's real runtime). A standalone `tsc --noEmit` on the file cannot resolve them
(needs the build graph + path mapping + freshly-built submodule dist) and floods `TS2307`. Matches the
documented **stale-dist hazard**. The spike file is intentionally outside `apps/server`'s `rootDir: src`
/ `include`, so it is excluded from the project typecheck by design. **What builds/runs: the harness runs
green under bun. It does not pass a naive standalone tsc** — expected, not a defect.

### 2.5 Cosmetic diff-render bug in the harness (fixed)

First run printed `[create] insight — undefined`. Cause: the harness read `n.intent?.summary` and
`n.id`, but `PreviewDirectNode` exposes `n.name` and `n.intent: PreviewIntent[]` (an array), with the id
as `n.nodeId`. The **diff itself was correct** — only the console rendering used wrong field names. Fixed
to `n.name` + `n.intent.map(i => i.summary)`. Confirms the _real shape_ the UI adapter must render (section 6).

## 3. Draft-sandbox shape the loop needed (-> feeds YW-260)

The in-memory stub had to provide exactly this contract — the minimal interface YW-260 must realize:

```
interface DraftSandbox {
  draftApp: WyStackApp;   // a WyStack app the assistant writes into via applyCommands
  draftDb:  ArtifactDb;   // its backing store, readable by the read tools
  batch:    Command[];    // the ORDERED command log the loop emitted (the publish unit)
  vault:    SecretVault;  // passed in applyCommands context on every mutation
}
```

Observed requirements the shape imposes on a real YW-260:

1. **Fork-from-canonical, not a blank app.** The spike _seeds both_ canonical and draft with the same
   baseline to model a fork. A real draft must be a cheap copy-on-write fork of canonical state at
   session start, so the assistant's `read_graph` sees the user's real workspace. (The double-seed is
   the stub tell.)
2. **Same seam, "commit" mode, into a _different_ app.** Mutations apply through the production
   `applyCommands(... mode: "commit" ...)`; isolation comes from it being a separate `WyStackApp`/db,
   not a special "draft mode" on the seam. Clean result: **no new write path; isolation is at the app/db
   boundary.**
3. **An ordered `Command[]` is the publish unit.** Publish = replay `batch` on canonical via the same
   `applyCommands`. The draft must capture the _commands_, not a state delta — the diff and publish both
   consume the command log (capturing rows-only would lose the intent grouping; see section 2.5 where
   `add_to_dashboard` merged into the dashboard node).
4. **Vault threads through every mutation context.** Even artifact creation passes `{ vault }`. YW-260's
   draft must carry the same secret-resolution context as canonical.

**Open design fork for YW-260 owner (do not decide here):** full second app+db (spike's model — simple,
heavy) vs copy-on-write overlay over canonical (cheaper fork, needs overlay read semantics)? The spike
proves the full-app model works; it does not prove the right cost profile for many concurrent sessions.

## 4. Provider/model reality (the previously-unmeasured leg — partially closed)

**OAuth routing in pi: verified correct by code inspection** (`providers/anthropic.js`):

- detects an OAuth token via `apiKey.includes("sk-ant-oat")`.
- for OAuth uses **Bearer `authToken`** (not `x-api-key`), injects Claude Code identity headers:
  `anthropic-beta: claude-code-20250219,oauth-2025-04-20,...`, `user-agent: claude-cli/<version>`.
- for OAuth **forces the Claude Code system preamble** ("You are Claude Code, Anthropic's official CLI
  for Claude.") ahead of our system prompt — required for the subscription token to be accepted.
- even mimics Claude Code's canonical tool-naming ("stealth mode") to match the CC request shape.

So **pi routes the Claude Code subscription OAuth token correctly** — yes, `getApiKey` returning an
`sk-ant-oat...` token is the right integration, and pi does the header/system-preamble work for us.

**Still unmeasured:** live streaming cadence, wall-clock latency, token/cost on a real turn — no
non-expired token was reachable (section 2.1). The harness _is_ wired to capture all three: it streams
`text_delta` to stdout, prints `tool_execution_start/end`, and reports `agent.state.messages[].usage`
(input/output/cache/cost). On a fresh interactive login the harness emits these with no further change.
**Recommend the impl ticket include a one-time live-token measurement run.**

**Credential lifecycle is a real impl concern:** the access token is short-lived; the refresh token
rotates on re-login. The impl must own a refresh-on-expiry leg (read access+refresh+expiry from keychain;
if expired, refresh via the OAuth token endpoint; **never** write the rotated token back to the keychain
— it races Claude Code's own refresher and mutates the user's real credentials). The spike's
`getOAuthToken()` does exactly this in-memory and is the reference.

## 5. Tool-set surface

### 5.1 Mutation tools = one `applyCommands` command each

The slice needed these vocabulary commands surfaced as tools (1 tool : 1 `cmd()`):

- `create_insight` -> `CreateInsight` `{ id, name, source: { sourceType, sourceId }, selectedFields }`
- `create_visualization` -> `CreateVisualization` `{ id, name, insightId, visualizationType, spec }`
- `create_dashboard` -> `CreateDashboard` `{ id, name }`
- `add_to_dashboard` -> `AddDashboardItem` `{ dashboardId, item: { id, type, visualizationId, x, y, w, h } }`

The full impl wants the same 1:1 mapping over the broader vocabulary (`CreateDataSource`,
`CreateDataTable`, update/delete, `AddField`, ...). **The tool set is a mechanical projection of the
command vocabulary** — a generated tool layer (each command's typebox schema -> one tool) is viable and
probably right.

**Client-generated UUIDs:** every create takes a client-minted `id` (uuid v4). The system prompt must
instruct the model to mint fresh v4s for new artifacts and to **read existing ids, never invent them**.
Load-bearing (a hallucinated id for an existing artifact breaks FK linkage).

### 5.2 Read tools — two shapes

- **Ambient structure (`read_graph`):** compact tree of names/types/edges across all five artifact kinds
  — **no data values**. The model's map; it must `read_graph` first. Shape: ids + names + kinds + FK
  edges + per-table field names/ids.
- **Data read (`read_table_profile`) — STUB (YW-134):** **profiles only** (field names + types + row
  count), **never raw cell values**. Privacy floor held by construction. The real YW-134 assembler would
  attach tier-permitted sample values under a privacy budget — but the _tool contract the loop needs_ is
  "profile, optionally with a sampled/aggregated read", default (and floor) profile-only. Shape consumed:
  `{ id, name, fields: [{ id, name, type }], note }`.

## 6. Gate / UI surface

**What pi's `beforeToolCall` gave us (real):**

- Fires **after args validate, before `execute`**, with `{ assistantMessage, toolCall, args, context }`.
  Enough to classify (read vs mutation), inspect _exact validated args_, and decide.
- Return contract: `BeforeToolCallResult | undefined`: `undefined` = allow; `{ block: true, reason }` =
  block with a reason surfaced to the model. **Binary allow/block — NOT a rich "edit args / bind value /
  pause-for-human" channel.** The spike's gate is allow-all and logs.

**What the UI adapter must build (the gap between pi's gate and our consent surface):**

1. **Async human-in-the-loop pause.** Our gate must, for a mutation, _suspend_ the loop, surface the
   proposed step (ultimately the batch diff) to the UI, resume on the user's decision. `beforeToolCall`
   is `async` so the await-point exists — but pi gives only allow/block. **Selective commit,
   value-binding, re-validate are NOT pi primitives; they are adapter responsibilities** built around the
   diff + the batch, most likely _at the publish checkpoint_ rather than per-tool-call.
2. **Render `PreviewDiff` (real shape confirmed):** `directNodes: PreviewDirectNode[]` where each node is
   `{ nodeId, kind, name, change: "create"|"update"|"noop", intent: PreviewIntent[], ... }` and
   `PreviewIntent` is `{ command, summary }`. Multiple commands targeting one artifact **merge into one
   node with accumulated intents** (observed: dashboard node carried both "Create dashboard" and "Add
   dashboard item"). Plus `affectedDownstream` (blast radius) and `error`.
3. **Bind-value / late-bound values** are an _adapter_ concern layered on the diff, not pi-surfaced. The
   gate is the hook _point_; the consent semantics are ours.

**Open design fork (do not decide here):** per-tool-call gating (pause on each mutation — chatty,
fine-grained) vs per-batch at publish (build the whole draft, then one diff + one consent gate)? The
spike's structure (accumulate -> single diff -> single publish) leans **per-batch**, matching the
living-artifact/diff-checkpoint design — but per-tool gating is also expressible. Product/UX decision.

## 7. Proposed impl ticket breakdown

Grounded in what the spike hit. Sizes rough (S/M/L).

1. **[M] Draft sandbox (realize YW-260 to the section 3 contract).** Copy-on-write fork of canonical at
   session start; ordered `Command[]` as the publish unit; `applyCommands(commit)` into the draft app;
   publish = replay on canonical; vault threaded through. **Blocks everything.** Decide full-app-vs-overlay.
2. **[S] OAuth credential lifecycle + refresh leg.** Read access+refresh+expiry from keychain; refresh
   in-memory on expiry via the Claude Code OAuth token endpoint; never write back. Reference: the spike's
   `getOAuthToken()`. Include the pi packaging-gap decision (section 2.2): upstream an `./oauth` export to
   pi _or_ own refresh. Recommend own.
3. **[S] Typed tool-layer helper.** One wrapper that narrows `args` from `unknown` via the typebox
   `Static<>` schema and standardizes the `{ content, details }` envelope (section 2.3).
4. **[M] Generated mutation tool layer over the command vocabulary.** Project each `cmd()` command + its
   typebox schema -> one `AgentTool`. Covers the section 5.1 set and grows with the vocabulary. Enforce
   client-minted-uuid + read-don't-invent-ids in the system prompt.
5. **[M] Read tools: ambient structure + profile read.** `read_graph` (the section 5.2 tree). Profile
   read wired to the **YW-134 assembler** when it lands; until then profile-only (floor held by default).
   Coordinates with YW-134.
6. **[L] Gate -> consent UI adapter.** Async pause/resume around the publish checkpoint; `PreviewDiff`
   renderer over the real shape (section 6.2); selective-commit / bind-value / re-validate as **adapter**
   semantics on the diff+batch (pi gives only allow/block). Decide per-call-vs-per-batch gating. Biggest
   real surface and the spike's main "build this" finding.
7. **[S] Live-token provider measurement (acceptance step).** The one thing the spike couldn't close: run
   the canonical multi-artifact intent against a live token; record streaming cadence, latency, token/cost.
   Bolt onto whichever ticket first has a working end-to-end loop.

## Open questions for the owner (product/design forks — NOT decided in this spike)

1. **Draft model:** full second app+db vs copy-on-write overlay over canonical? (section 3) — cost profile
   under many concurrent sessions is the deciding axis the spike didn't test.
2. **Gate granularity:** per-tool-call consent vs per-batch consent at publish? (section 6).
3. **`visualization.spec` authoring:** the spike emitted a minimal `{ mark, encoding: {} }` Vega-Lite
   stub; the real loop needs the model to author encodings. Tool responsibility, a follow-up "bind
   encodings" step, or derived from the insight's selected fields?
4. **pi dependency posture:** upstream the OAuth-export fix to pi vs vendor the refresh ourselves? (section 2.2)

---

**What builds/runs:** the harness **runs green under bun** end-to-end for every non-model leg
(tool->draft->gate->diff->publish), with the real `cmd()`/`applyCommands`/`buildPreviewDiff` code. The
**model leg does not complete** in this environment — no non-expired OAuth credential is reachable
(section 2.1); pi's OAuth _routing_ is verified correct by code inspection but live streaming/latency/cost
remain **unmeasured**. The harness does **not** pass a naive standalone `tsc` (workspace/submodule
resolution — section 2.4); expected, not a defect.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a throwaway spike (`apps/server/spike/`) that wires pi's agent loop to DashFrame's real `cmd()`→`applyCommands`/`buildPreviewDiff` seam to scope the assistant implementation chain. The deliverable is `FINDINGS.md`; the harness is durable evidence, not shippable code.

- **Spike harness** (`harness.ts`): drives a multi-artifact intent end-to-end through read tools, draft sandbox, gate (`beforeToolCall`), preview diff, and canonical publish — the model leg stubs out due to a stale keychain credential, but all other legs run against real production code.
- **New packages** (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, `typebox`) are added to the **production `dependencies`** in `apps/server/package.json` instead of `devDependencies`, which would bundle them into every production install even though no production code uses them.
- **Multiple `YW-` ticket identifiers** appear in `harness.ts` source comments (and the tmpdir prefix on line 415), violating the CI-enforced `check-no-ticket-refs.mjs` rule that requires public GitHub issue numbers (`#nn`) instead.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The spike files themselves are low-risk throwaway code, but the package.json change ships spike-only dependencies into production `dependencies`, and the harness embeds ticket IDs that would trip the repo's CI enforcement script.

Two concrete problems in the changed files: spike packages land in production `dependencies` (not `devDependencies`), which affects every install and deployment of `apps/server`; and CI's `check-no-ticket-refs.mjs` would fire on the `YW-` identifiers that appear in harness.ts source comments and in the runtime tmpdir prefix. Both need to be fixed before this could merge — the PR's own description says not to merge it, so these likely won't reach main, but they should be corrected before the harness is promoted to durable evidence.

apps/server/package.json — spike packages in the wrong dependency section
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/package.json | Adds three spike-only packages (@earendil-works/pi-agent-core, @earendil-works/pi-ai, typebox) to production `dependencies` instead of `devDependencies`; these will be included in all production installs. |
| apps/server/spike/harness.ts | Throwaway spike harness driving pi's agent loop end-to-end; multiple CI-enforced YW- ticket ID references in source comments, the data-read stub correctly withholds raw cell values honouring the privacy floor. |
| apps/server/spike/FINDINGS.md | Spike findings report — documentation-only file; contains YW- identifiers in titles and throughout the prose (expected for a findings doc but check CI scope). |
| bun.lock | Lockfile updated with resolved entries for the three new spike packages; auto-generated, no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant H as harness.ts
    participant A as pi Agent
    participant G as beforeToolCall gate
    participant DT as Draft (stub WyStackApp)
    participant C as Canonical WyStackApp
    participant PD as buildPreviewDiff

    H->>A: agent.prompt(intent)
    A->>G: beforeToolCall(read_graph)
    G-->>A: allow
    A->>DT: readGraph(draftDb)
    A->>G: beforeToolCall(create_insight)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([CreateInsight])
    A->>G: beforeToolCall(create_visualization)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([CreateVisualization])
    A->>G: beforeToolCall(create_dashboard)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([CreateDashboard])
    A->>G: beforeToolCall(add_to_dashboard)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([AddDashboardItem])
    A-->>H: "agent done (draft.batch = [4 commands])"
    H->>PD: buildPreviewDiff(canonicalApp, canonicalDb, draft.batch)
    PD-->>H: directNodes: [create insight, create viz, create dashboard+item]
    H->>C: "applyCommands(draft.batch, mode=commit)"
    C-->>H: published — canonical graph updated
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant H as harness.ts
    participant A as pi Agent
    participant G as beforeToolCall gate
    participant DT as Draft (stub WyStackApp)
    participant C as Canonical WyStackApp
    participant PD as buildPreviewDiff

    H->>A: agent.prompt(intent)
    A->>G: beforeToolCall(read_graph)
    G-->>A: allow
    A->>DT: readGraph(draftDb)
    A->>G: beforeToolCall(create_insight)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([CreateInsight])
    A->>G: beforeToolCall(create_visualization)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([CreateVisualization])
    A->>G: beforeToolCall(create_dashboard)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([CreateDashboard])
    A->>G: beforeToolCall(add_to_dashboard)
    G-->>A: allow (log MUTATION)
    A->>DT: applyCommands([AddDashboardItem])
    A-->>H: "agent done (draft.batch = [4 commands])"
    H->>PD: buildPreviewDiff(canonicalApp, canonicalDb, draft.batch)
    PD-->>H: directNodes: [create insight, create viz, create dashboard+item]
    H->>C: "applyCommands(draft.batch, mode=commit)"
    C-->>H: published — canonical graph updated
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fserver%2Fpackage.json%3A33-36%0A**Spike%20packages%20in%20production%20%60dependencies%60**%0A%0A%60%40earendil-works%2Fpi-agent-core%60%2C%20%60%40earendil-works%2Fpi-ai%60%2C%20and%20%60typebox%60%20are%20added%20to%20the%20runtime%20%60dependencies%60%20section%2C%20not%20%60devDependencies%60.%20These%20packages%20are%20only%20consumed%20by%20%60spike%2Fharness.ts%60%20%E2%80%94%20a%20file%20that%20is%20explicitly%20out-of-scope%20for%20the%20project%20%60rootDir%60%2F%60include%60%20%28per%20the%20FINDINGS%20report%20itself%29.%20Landing%20them%20in%20%60dependencies%60%20means%20they%20will%20be%20pulled%20into%20every%20production%20install%20and%20deployment%20bundle%20for%20%60apps%2Fserver%60%2C%20even%20though%20no%20production%20code%20path%20imports%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fserver%2Fspike%2Fharness.ts%3A1-19%0A**YW-%20ticket%20IDs%20in%20source%20%E2%80%94%20CI-enforced%20rule**%0A%0AThe%20file%20header%20and%20inline%20comments%20contain%20multiple%20%60YW-274%60%2C%20%60YW-260%60%2C%20and%20%60YW-134%60%20identifiers.%20The%20repo's%20CI%20check%20%28%60scripts%2Fcheck-no-ticket-refs.mjs%60%29%20enforces%20that%20source%20code%20and%20comments%20must%20never%20contain%20%60YW-%60%2F%60TASK-%60%20identifiers%3B%20the%20rule%20requires%20using%20the%20public%20GitHub%20issue%20number%20%28%60%23nn%60%29%20instead.%20This%20pattern%20repeats%20throughout%20the%20file%20%28lines%20~14%2C%2016%2C%20141%2C%20208%2C%20228%2C%20and%20the%20%60tmpdir%60%20prefix%20on%20line%20415%20which%20embeds%20%60%22yw274-%22%60%20directly%20into%20a%20filesystem%20path%20at%20runtime%29.%20%60apps%2Fserver%2Fspike%2FFINDINGS.md%60%20similarly%20contains%20%60YW-%60%20identifiers%20throughout%20its%20content.%0A%0A&repo=youhaowei%2Fdashframe&pr=136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-274-spike-assistant-vertical-slice%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-274-spike-assistant-vertical-slice%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fserver%2Fpackage.json%3A33-36%0A**Spike%20packages%20in%20production%20%60dependencies%60**%0A%0A%60%40earendil-works%2Fpi-agent-core%60%2C%20%60%40earendil-works%2Fpi-ai%60%2C%20and%20%60typebox%60%20are%20added%20to%20the%20runtime%20%60dependencies%60%20section%2C%20not%20%60devDependencies%60.%20These%20packages%20are%20only%20consumed%20by%20%60spike%2Fharness.ts%60%20%E2%80%94%20a%20file%20that%20is%20explicitly%20out-of-scope%20for%20the%20project%20%60rootDir%60%2F%60include%60%20%28per%20the%20FINDINGS%20report%20itself%29.%20Landing%20them%20in%20%60dependencies%60%20means%20they%20will%20be%20pulled%20into%20every%20production%20install%20and%20deployment%20bundle%20for%20%60apps%2Fserver%60%2C%20even%20though%20no%20production%20code%20path%20imports%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fserver%2Fspike%2Fharness.ts%3A1-19%0A**YW-%20ticket%20IDs%20in%20source%20%E2%80%94%20CI-enforced%20rule**%0A%0AThe%20file%20header%20and%20inline%20comments%20contain%20multiple%20%60YW-274%60%2C%20%60YW-260%60%2C%20and%20%60YW-134%60%20identifiers.%20The%20repo's%20CI%20check%20%28%60scripts%2Fcheck-no-ticket-refs.mjs%60%29%20enforces%20that%20source%20code%20and%20comments%20must%20never%20contain%20%60YW-%60%2F%60TASK-%60%20identifiers%3B%20the%20rule%20requires%20using%20the%20public%20GitHub%20issue%20number%20%28%60%23nn%60%29%20instead.%20This%20pattern%20repeats%20throughout%20the%20file%20%28lines%20~14%2C%2016%2C%20141%2C%20208%2C%20228%2C%20and%20the%20%60tmpdir%60%20prefix%20on%20line%20415%20which%20embeds%20%60%22yw274-%22%60%20directly%20into%20a%20filesystem%20path%20at%20runtime%29.%20%60apps%2Fserver%2Fspike%2FFINDINGS.md%60%20similarly%20contains%20%60YW-%60%20identifiers%20throughout%20its%20content.%0A%0A&repo=youhaowei%2Fdashframe&pr=136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fserver%2Fpackage.json%3A33-36%0A**Spike%20packages%20in%20production%20%60dependencies%60**%0A%0A%60%40earendil-works%2Fpi-agent-core%60%2C%20%60%40earendil-works%2Fpi-ai%60%2C%20and%20%60typebox%60%20are%20added%20to%20the%20runtime%20%60dependencies%60%20section%2C%20not%20%60devDependencies%60.%20These%20packages%20are%20only%20consumed%20by%20%60spike%2Fharness.ts%60%20%E2%80%94%20a%20file%20that%20is%20explicitly%20out-of-scope%20for%20the%20project%20%60rootDir%60%2F%60include%60%20%28per%20the%20FINDINGS%20report%20itself%29.%20Landing%20them%20in%20%60dependencies%60%20means%20they%20will%20be%20pulled%20into%20every%20production%20install%20and%20deployment%20bundle%20for%20%60apps%2Fserver%60%2C%20even%20though%20no%20production%20code%20path%20imports%20them.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fserver%2Fspike%2Fharness.ts%3A1-19%0A**YW-%20ticket%20IDs%20in%20source%20%E2%80%94%20CI-enforced%20rule**%0A%0AThe%20file%20header%20and%20inline%20comments%20contain%20multiple%20%60YW-274%60%2C%20%60YW-260%60%2C%20and%20%60YW-134%60%20identifiers.%20The%20repo's%20CI%20check%20%28%60scripts%2Fcheck-no-ticket-refs.mjs%60%29%20enforces%20that%20source%20code%20and%20comments%20must%20never%20contain%20%60YW-%60%2F%60TASK-%60%20identifiers%3B%20the%20rule%20requires%20using%20the%20public%20GitHub%20issue%20number%20%28%60%23nn%60%29%20instead.%20This%20pattern%20repeats%20throughout%20the%20file%20%28lines%20~14%2C%2016%2C%20141%2C%20208%2C%20228%2C%20and%20the%20%60tmpdir%60%20prefix%20on%20line%20415%20which%20embeds%20%60%22yw274-%22%60%20directly%20into%20a%20filesystem%20path%20at%20runtime%29.%20%60apps%2Fserver%2Fspike%2FFINDINGS.md%60%20similarly%20contains%20%60YW-%60%20identifiers%20throughout%20its%20content.%0A%0A&pr=136&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/server/package.json:33-36
**Spike packages in production `dependencies`**

`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `typebox` are added to the runtime `dependencies` section, not `devDependencies`. These packages are only consumed by `spike/harness.ts` — a file that is explicitly out-of-scope for the project `rootDir`/`include` (per the FINDINGS report itself). Landing them in `dependencies` means they will be pulled into every production install and deployment bundle for `apps/server`, even though no production code path imports them.

### Issue 2 of 2
apps/server/spike/harness.ts:1-19
**YW- ticket IDs in source — CI-enforced rule**

The file header and inline comments contain multiple `YW-274`, `YW-260`, and `YW-134` identifiers. The repo's CI check (`scripts/check-no-ticket-refs.mjs`) enforces that source code and comments must never contain `YW-`/`TASK-` identifiers; the rule requires using the public GitHub issue number (`#nn`) instead. This pattern repeats throughout the file (lines ~14, 16, 141, 208, 228, and the `tmpdir` prefix on line 415 which embeds `"yw274-"` directly into a filesystem path at runtime). `apps/server/spike/FINDINGS.md` similarly contains `YW-` identifiers throughout its content.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["spike(assistant): maximal-reach pi verti..."](https://github.com/youhaowei/dashframe/commit/7a16e2557b13100fd038a4f8e3d80f2d683f644b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38054329)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - NO TICKET IDS IN SOURCE (CI-enforced). Source code... ([source](greptile.json))

<!-- /greptile_comment -->