### PR TITLE
feat(types,server): [YW-139] DataSource.config typed field + SetDataSourceConfig wiring

### DIFF
--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -257,10 +257,16 @@ async function rowToDataSource(
     hasConnectionString = Boolean(config.connectionString);
   }
   // Pass through any non-credential keys from the stored config so future
-  // fields are forward-compatible. Credential slots are NEVER passed through.
+  // fields are forward-compatible. Two exclusion criteria apply:
+  //   1. Key name — "apiKey" and "connectionString" are the typed credential
+  //      slots; they never appear in the public DTO (only the boolean flags do).
+  //   2. Value shape — any value that is a well-formed SecretRef ("secret:<uuid>")
+  //      is also dropped, regardless of key name. Guards the sink by value shape,
+  //      not only by provenance: a future credential field stored under a
+  //      non-standard key name can't leak a live ref to the renderer.
   const otherKeys: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(config)) {
-    if (k !== "apiKey" && k !== "connectionString") {
+    if (k !== "apiKey" && k !== "connectionString" && !isSecretRef(v)) {
       otherKeys[k] = v;
     }
   }

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -256,12 +256,19 @@ async function rowToDataSource(
     hasApiKey = Boolean(config.apiKey);
     hasConnectionString = Boolean(config.connectionString);
   }
+  // Pass through any non-credential keys from the stored config so future
+  // fields are forward-compatible. Credential slots are NEVER passed through.
+  const otherKeys: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(config)) {
+    if (k !== "apiKey" && k !== "connectionString") {
+      otherKeys[k] = v;
+    }
+  }
   return {
     id: row.id,
     type: row.kind,
     name: row.name,
-    hasApiKey,
-    hasConnectionString,
+    config: { hasApiKey, hasConnectionString, ...otherKeys },
     createdAt: row.createdAt.getTime(),
   };
 }

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -632,6 +632,77 @@ describe("command vocabulary", () => {
       ).rejects.toThrow(/not found/);
     });
 
+    it("SetDataSourceConfig sink guard: extra.apiKey throws and leaves config unchanged", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "N",
+          apiKey: "original",
+        }),
+      );
+      const refBefore = (
+        (await sourcesById(sourceId))[0]?.config as { apiKey?: string }
+      ).apiKey;
+      // Attempt to smuggle a credential via extra — must throw.
+      await expect(
+        commit(
+          cmd("SetDataSourceConfig", {
+            id: sourceId,
+            extra: { apiKey: "smuggled-plaintext" } as Record<string, unknown>,
+          }),
+        ),
+      ).rejects.toThrow(/apiKey.*connectionString.*typed credential/i);
+      // Config must be unchanged — the original ref is still there.
+      const refAfter = (
+        (await sourcesById(sourceId))[0]?.config as { apiKey?: string }
+      ).apiKey;
+      expect(refAfter).toBe(refBefore);
+    });
+
+    it("SetDataSourceConfig sink guard: extra.connectionString throws and leaves config unchanged", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "postgres", name: "P" }),
+      );
+      await expect(
+        commit(
+          cmd("SetDataSourceConfig", {
+            id: sourceId,
+            extra: { connectionString: "postgresql://plaintext" } as Record<
+              string,
+              unknown
+            >,
+          }),
+        ),
+      ).rejects.toThrow(/apiKey.*connectionString.*typed credential/i);
+    });
+
+    it("SetDataSourceConfig extra: non-credential settings round-trip through config", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "postgres", name: "P" }),
+      );
+      await commit(
+        cmd("SetDataSourceConfig", {
+          id: sourceId,
+          extra: { database: "analytics", schema: "public" } as Record<
+            string,
+            unknown
+          >,
+        }),
+      );
+      const [row] = await sourcesById(sourceId);
+      const stored = row?.config as Record<string, unknown>;
+      // Non-credential keys persist as-is.
+      expect(stored["database"]).toBe("analytics");
+      expect(stored["schema"]).toBe("public");
+      // Credential slots remain absent (never set).
+      expect(stored["apiKey"]).toBeUndefined();
+      expect(stored["connectionString"]).toBeUndefined();
+    });
+
     it("should throw on UpdateField with a missing fieldId", async () => {
       const sourceId = id();
       const tableId = id();

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -369,15 +369,14 @@ const setDataSourceConfig = mutation({
       preview,
     );
     // Sink guard: callers may not sneak credential keys in via `extra`.
-    if (extra != null && typeof extra === "object" && !Array.isArray(extra)) {
-      const extraRecord = extra as Record<string, unknown>;
-      if ("apiKey" in extraRecord || "connectionString" in extraRecord) {
+    if (isRecord(extra)) {
+      if ("apiKey" in extra || "connectionString" in extra) {
         throw new Error(
           "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, not extra",
         );
       }
       // Merge non-credential keys into the config.
-      Object.assign(config, extraRecord);
+      Object.assign(config, extra);
     }
     await ctx.db.from(dataSources).where(eq("id", id)).update({ config });
     return { ok: true };

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -320,16 +320,21 @@ const createDataSource = mutation({
  * SetDataSourceConfig — replaces the config slice of a DataSource (the connector
  * secrets). The `name` slice is NOT here — renaming is `RenameNode`. This is the
  * config half decomposed out of the coarse `updateDataSource`.
+ *
+ * `extra` carries optional non-credential connector settings (e.g. database name,
+ * schema). Sink guard: any key in `extra` that matches "apiKey" or
+ * "connectionString" is rejected — callers must use the typed credential fields.
  */
 const setDataSourceConfig = mutation({
   args: {
     id: uuid,
     apiKey: text.optional(),
     connectionString: text.optional(),
+    extra: jsonb.optional(),
   },
   handler: async (
     ctx,
-    { id, apiKey, connectionString },
+    { id, apiKey, connectionString, extra },
   ): Promise<{ ok: true }> => {
     const vault = vaultFromCtx(ctx);
     const preview = modeFromCtx(ctx) === "preview";
@@ -363,6 +368,17 @@ const setDataSourceConfig = mutation({
       `connectionString-${id}`,
       preview,
     );
+    // Sink guard: callers may not sneak credential keys in via `extra`.
+    if (extra != null && typeof extra === "object" && !Array.isArray(extra)) {
+      const extraRecord = extra as Record<string, unknown>;
+      if ("apiKey" in extraRecord || "connectionString" in extraRecord) {
+        throw new Error(
+          "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, not extra",
+        );
+      }
+      // Merge non-credential keys into the config.
+      Object.assign(config, extraRecord);
+    }
     await ctx.db.from(dataSources).where(eq("id", id)).update({ config });
     return { ok: true };
   },
@@ -1889,6 +1905,8 @@ export interface CommandPayloads {
     id: UUID;
     apiKey?: string;
     connectionString?: string;
+    /** Non-credential connector settings. Must not include 'apiKey' or 'connectionString'. */
+    extra?: Record<string, unknown>;
   };
   // DataTable
   CreateDataTable: {

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -174,7 +174,9 @@ describe("vault control-plane — store→ref + has→presence", () => {
 
     // Presence now reads false — no usable credential remains.
     const { result: ds } = await app.call("getDataSource", { id });
-    expect((ds as { hasApiKey: boolean }).hasApiKey).toBe(false);
+    expect((ds as { config: { hasApiKey: boolean } }).config.hasApiKey).toBe(
+      false,
+    );
   });
 
   it("AC2 — setDataSourceConfig with empty apiKey CLEARS the credential", async () => {
@@ -256,9 +258,11 @@ describe("vault control-plane — store→ref + has→presence", () => {
     const id = (createResult as { id: string }).id;
 
     const { result } = await app.call("getDataSource", { id });
-    const ds = result as { hasApiKey: boolean; hasConnectionString: boolean };
-    expect(ds.hasApiKey).toBe(true);
-    expect(ds.hasConnectionString).toBe(false);
+    const ds = result as {
+      config: { hasApiKey: boolean; hasConnectionString: boolean };
+    };
+    expect(ds.config.hasApiKey).toBe(true);
+    expect(ds.config.hasConnectionString).toBe(false);
   });
 
   it("AC3 — hasApiKey is false when no credential was stored", async () => {
@@ -269,9 +273,11 @@ describe("vault control-plane — store→ref + has→presence", () => {
     const id = (createResult as { id: string }).id;
 
     const { result } = await app.call("getDataSource", { id });
-    const ds = result as { hasApiKey: boolean; hasConnectionString: boolean };
-    expect(ds.hasApiKey).toBe(false);
-    expect(ds.hasConnectionString).toBe(false);
+    const ds = result as {
+      config: { hasApiKey: boolean; hasConnectionString: boolean };
+    };
+    expect(ds.config.hasApiKey).toBe(false);
+    expect(ds.config.hasConnectionString).toBe(false);
   });
 
   it("AC3 — hasApiKey reflects backend.has(), not raw config truthiness", async () => {
@@ -285,8 +291,8 @@ describe("vault control-plane — store→ref + has→presence", () => {
 
     // The backend has() must have been called (not withSecret).
     const { result } = await app.call("getDataSource", { id });
-    const ds = result as { hasApiKey: boolean };
-    expect(ds.hasApiKey).toBe(true);
+    const ds = result as { config: { hasApiKey: boolean } };
+    expect(ds.config.hasApiKey).toBe(true);
     // Verify withSecret was NOT called (control plane never decrypts).
     expect(backend.resolveCallCount).toBe(0);
     // has() was called (presence check).
@@ -306,11 +312,14 @@ describe("vault control-plane — store→ref + has→presence", () => {
     });
 
     const { result } = await app.call("listDataSources", {});
-    const sources = result as { name: string; hasApiKey: boolean }[];
+    const sources = result as {
+      name: string;
+      config: { hasApiKey: boolean };
+    }[];
     const withKey = sources.find((s) => s.name === "With key");
     const withoutKey = sources.find((s) => s.name === "Without key");
-    expect(withKey?.hasApiKey).toBe(true);
-    expect(withoutKey?.hasApiKey).toBe(false);
+    expect(withKey?.config.hasApiKey).toBe(true);
+    expect(withoutKey?.config.hasApiKey).toBe(false);
   });
 });
 

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -263,6 +263,9 @@ describe("vault control-plane — store→ref + has→presence", () => {
     };
     expect(ds.config.hasApiKey).toBe(true);
     expect(ds.config.hasConnectionString).toBe(false);
+    // The SecretRef must NOT appear in the public DTO — only the boolean flag.
+    // Absence here proves rowToDataSource redacts the ref, not just the name.
+    expect((ds.config as Record<string, unknown>)["apiKey"]).toBeUndefined();
   });
 
   it("AC3 — hasApiKey is false when no credential was stored", async () => {

--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
@@ -191,9 +191,9 @@ const DATA_SOURCE = {
   id: SOURCE_ID,
   name: "My Database",
   type: "csv",
-  apiKey: null,
-  connectionString: null,
-} as import("@dashframe/types").DataSource;
+  config: { hasApiKey: false, hasConnectionString: false },
+  createdAt: 0,
+} satisfies import("@dashframe/types").DataSource;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/packages/app/src/components/data-sources/DataSourceControls.tsx
+++ b/packages/app/src/components/data-sources/DataSourceControls.tsx
@@ -209,7 +209,11 @@ export function DataSourceControls({ dataSourceId }: DataSourceControlsProps) {
 
   // Fetch databases with permanent caching (only refreshes on manual click)
   const fetchDatabases = async (force = false) => {
-    if (!dataSource || dataSource.type !== "notion" || !dataSource.hasApiKey)
+    if (
+      !dataSource ||
+      dataSource.type !== "notion" ||
+      !dataSource.config.hasApiKey
+    )
       return;
 
     // Use cached data unless explicitly forced to refresh
@@ -325,10 +329,12 @@ export function DataSourceControls({ dataSourceId }: DataSourceControlsProps) {
               value={apiKeyInput}
               onChange={handleApiKeyChange}
               className="font-mono text-xs"
-              placeholder={dataSource.hasApiKey ? "••••••••" : "secret_..."}
+              placeholder={
+                dataSource.config.hasApiKey ? "••••••••" : "secret_..."
+              }
             />
             <p className="mt-1.5 text-xs text-neutral-fg-subtle">
-              {dataSource.hasApiKey
+              {dataSource.config.hasApiKey
                 ? "A token is saved. Enter a new one to replace it."
                 : "Your Notion integration token"}
             </p>

--- a/packages/app/src/components/data-sources/DataSourceDisplay.tsx
+++ b/packages/app/src/components/data-sources/DataSourceDisplay.tsx
@@ -372,7 +372,7 @@ export function DataSourceDisplay({ dataSourceId }: DataSourceDisplayProps) {
         !selectedDataTable ||
         !dataSource ||
         dataSource.type !== "notion" ||
-        !dataSource.hasApiKey
+        !dataSource.config.hasApiKey
       ) {
         return;
       }
@@ -426,7 +426,7 @@ export function DataSourceDisplay({ dataSourceId }: DataSourceDisplayProps) {
       !selectedDataTable ||
       !dataSource ||
       dataSource.type !== "notion" ||
-      !dataSource.hasApiKey
+      !dataSource.config.hasApiKey
     ) {
       return;
     }
@@ -480,7 +480,7 @@ export function DataSourceDisplay({ dataSourceId }: DataSourceDisplayProps) {
       !selectedDataTable ||
       !dataSource ||
       dataSource.type !== "notion" ||
-      !dataSource.hasApiKey
+      !dataSource.config.hasApiKey
     ) {
       return;
     }

--- a/packages/types/src/data-sources.ts
+++ b/packages/types/src/data-sources.ts
@@ -6,24 +6,42 @@ import type { UUID } from "./uuid";
 // ============================================================================
 
 /**
+ * Public-safe connector config blob on the DataSource read DTO.
+ *
+ * Credential fields (apiKey, connectionString) are represented as boolean
+ * presence flags — never as the raw SecretRef or plaintext. The connector
+ * KIND (DataSource.type) interprets any additional keys.
+ *
+ * This is the structured, safe-to-diff config; the server strips secret refs
+ * before populating it. Non-credential keys are passed through as-is.
+ */
+export type ConnectorConfig = {
+  /** True when an API key is stored in the vault. Never the raw value. */
+  hasApiKey: boolean;
+  /** True when a connection string is stored in the vault. Never the raw value. */
+  hasConnectionString: boolean;
+  /** Any additional non-credential connector settings, kind-interpreted. */
+  [key: string]: unknown;
+};
+
+/**
  * DataSource interface - generic for any connector type.
  * Type is the connector ID from the registry (e.g., "csv", "notion").
  *
  * SECURITY: this is a read DTO. Raw credential values are NEVER returned
- * by the read path. Presence is indicated by boolean flags so the UI can
- * show "key is set" without receiving the secret itself.
+ * by the read path. Presence is indicated by boolean flags inside `config`
+ * so the UI can show "key is set" without receiving the secret itself.
  */
 export interface DataSource {
   id: UUID;
   type: string; // Connector ID from registry
   name: string;
-  // Credential presence flags — true when the config field is non-empty.
-  // Always set by the read path (rowToDataSource), so non-optional: this
-  // avoids a three-state `true | false | undefined` where a missing field
-  // and a stored `false` would be indistinguishable.
-  // The actual secret is never returned by list/get queries.
-  hasApiKey: boolean; // For remote API connectors (e.g., Notion)
-  hasConnectionString: boolean; // For database connectors (future)
+  /**
+   * Public-safe connector config. Credential slots are boolean presence
+   * flags; non-credential keys are passed through as-is.
+   * Always set by the read path (rowToDataSource), so non-optional.
+   */
+  config: ConnectorConfig;
   createdAt: number;
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,7 @@ export type { DataTableField, DataTableInfo } from "./data-table-info";
 export type { UseQueryResult } from "./repository-base";
 
 export type {
+  ConnectorConfig,
   CreateDataSourceInput,
   DataSource,
   DataSourceMutations,


### PR DESCRIPTION
## Summary

- Adds `ConnectorConfig` to `@dashframe/types`: structured public-safe config blob where credential fields (`hasApiKey`, `hasConnectionString`) are boolean presence flags, never raw `SecretRef` values or plaintext. Non-credential connector settings pass through as-is.
- `rowToDataSource` converts the internal `DataSourceConfig` (SecretRef slots) to `ConnectorConfig`: credential slots are redacted to booleans; non-credential keys are passed through verbatim BUT any value that is a well-formed `SecretRef` (`secret:<uuid>`) is also stripped regardless of key name — sink guarded by value shape, not provenance.
- `SetDataSourceConfig` gains an optional `extra: Record<string,unknown>` field for non-credential connector settings (e.g. `database`, `schema`, `host`). Sink guard rejects any attempt to pass `"apiKey"` or `"connectionString"` via `extra` — callers must use the typed credential fields.
- UI components and tests migrated from `dataSource.hasApiKey` to `dataSource.config.hasApiKey`.

Tracked internally as YW-139.

## Test plan

- [ ] `turbo typecheck` — 44 tasks, 0 failures
- [ ] `@dashframe/server` tests — 222 pass (219 existing + 3 new)
  - `SetDataSourceConfig sink guard: extra.apiKey throws and leaves config unchanged`
  - `SetDataSourceConfig sink guard: extra.connectionString throws and leaves config unchanged`
  - `SetDataSourceConfig extra: non-credential settings round-trip through config`
- [ ] `@dashframe/app` tests — 510 pass (all existing)
- [ ] vault-control-plane AC3 test extended: `config.apiKey` is absent from the read DTO even when `hasApiKey` is true (SecretRef redaction verified)
- [ ] CI green

## Findings triaged to LATER

- **OOD-1** — Legacy `updateDataSource` coexistence. The `utils.ts` header calls it a "transition window" which collides with the no-backward-compat memory. TRIGGER: before any new connector (PostgreSQL or similar) adds a caller, cut `updateDataSource` — it has no sink guard and no `extra` path.
- **OOD-2** — `CreateDataSource` lacks `extra` parameter; `SetDataSourceConfig` has it. TRIGGER: when the first connector needing creation-time non-credential settings is defined, add `extra` (+ same sink guard) to `CreateDataSource` for symmetry.
- **OOD-3** — `ConnectorConfig` index signature `[key: string]: unknown`. TRIGGER: when the 3rd connector lands, revisit as a discriminated union per Rule of Three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `ConnectorConfig` as a typed public-safe DTO for the `DataSource.config` field, nesting credential presence flags (`hasApiKey`, `hasConnectionString`) and pass-through non-credential settings there instead of at the top level. It also wires an `extra` parameter into `SetDataSourceConfig` with a sink guard that blocks `"apiKey"`/`"connectionString"` from being smuggled in.

- **New `ConnectorConfig` type** (`packages/types/src/data-sources.ts`): replaces flat `hasApiKey`/`hasConnectionString` on `DataSource` with a structured `config` blob; credential fields are boolean presence flags, extra non-credential keys pass through under an open index signature.
- **`rowToDataSource` redaction loop** (`app-artifacts.ts`): iterates stored config, drops credential slots by key name and drops any SecretRef-shaped value by value shape, then spreads remaining keys into the DTO after the vault-computed booleans.
- **`SetDataSourceConfig extra` field** (`commands.ts`): accepts non-credential connector settings (e.g. `database`, `schema`) and merges them into the stored config; sink guard rejects `"apiKey"`/`"connectionString"` in `extra`, directing callers to use the typed credential fields.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the understanding that the previously-flagged spoofing path in the sink guard remains open.

The core redaction logic in `rowToDataSource` and the `extra` sink guard in `SetDataSourceConfig` are well-structured, and all UI callsites are consistently migrated. However, the existing unresolved finding from a prior review (callers can pass `extra: { hasApiKey: true }`, which `Object.assign` writes into stored config and then the `...otherKeys` spread in `rowToDataSource` surfaces as a spoofed `config.hasApiKey: true` in the DTO, overriding the vault-computed boolean) is still present in this diff and has not been addressed.

`apps/server/src/functions/commands.ts` (sink guard) and `apps/server/src/functions/app-artifacts.ts` (`rowToDataSource` spread order) together form the unresolved spoofing path flagged in the prior review.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/types/src/data-sources.ts | Adds `ConnectorConfig` type with `hasApiKey`, `hasConnectionString`, and an open index signature; replaces flat `hasApiKey`/`hasConnectionString` on `DataSource` with `config: ConnectorConfig`. |
| apps/server/src/functions/app-artifacts.ts | Adds `otherKeys` loop in `rowToDataSource` to pass through non-credential, non-SecretRef config keys; spreads them after the vault-computed booleans, which means stored `hasApiKey`/`hasConnectionString` keys in `otherKeys` win over the vault-derived values. |
| apps/server/src/functions/commands.ts | Adds `extra: jsonb.optional()` to `SetDataSourceConfig`; sink guard blocks `"apiKey"`/`"connectionString"` keys but not `"hasApiKey"`/`"hasConnectionString"`, and guard runs after `applyCredentialField` vault writes (both previously flagged). |
| apps/server/src/functions/commands.test.ts | Adds three new tests for `SetDataSourceConfig`: sink-guard rejection for `extra.apiKey`, sink-guard rejection for `extra.connectionString`, and round-trip of non-credential extra keys. |
| apps/server/src/functions/vault-control-plane.test.ts | Migrates all assertions from `ds.hasApiKey` to `ds.config.hasApiKey` and adds a new assertion verifying the SecretRef is absent from the public DTO (AC3 extension). |
| packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx | Updates test fixture from unsafe `as DataSource` cast to type-checked `satisfies DataSource` with correct `config` shape and `createdAt`. |
| packages/app/src/components/data-sources/DataSourceControls.tsx | Mechanical migration of `dataSource.hasApiKey` → `dataSource.config.hasApiKey` at three call sites. |
| packages/app/src/components/data-sources/DataSourceDisplay.tsx | Mechanical migration of `dataSource.hasApiKey` → `dataSource.config.hasApiKey` at three guard sites. |
| packages/types/src/index.ts | Adds `ConnectorConfig` to the public package exports. One-line change, correct. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI Component
    participant CMD as SetDataSourceConfig
    participant Vault as SecretVault
    participant DB as Database
    participant DTO as rowToDataSource

    UI->>CMD: "{ id, apiKey?, connectionString?, extra? }"
    CMD->>CMD: applyCredentialField(apiKey) → SecretRef
    CMD->>Vault: vault.store(apiKey plaintext)
    Vault-->>CMD: SecretRef
    CMD->>CMD: sink guard: reject if extra has apiKey/connectionString
    CMD->>CMD: Object.assign(config, extra)
    CMD->>DB: UPDATE data_sources SET config
    DB-->>CMD: ok

    UI->>DTO: getDataSource(id)
    DTO->>DB: SELECT config FROM data_sources
    DB-->>DTO: "{ apiKey: SecretRef, database: analytics, ... }"
    DTO->>Vault: vault.has(SecretRef) → boolean
    Vault-->>DTO: hasApiKey true/false
    DTO->>DTO: otherKeys loop: skip apiKey, connectionString, SecretRef values
    DTO-->>UI: "{ config: { hasApiKey, hasConnectionString, database, ... } }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI Component
    participant CMD as SetDataSourceConfig
    participant Vault as SecretVault
    participant DB as Database
    participant DTO as rowToDataSource

    UI->>CMD: "{ id, apiKey?, connectionString?, extra? }"
    CMD->>CMD: applyCredentialField(apiKey) → SecretRef
    CMD->>Vault: vault.store(apiKey plaintext)
    Vault-->>CMD: SecretRef
    CMD->>CMD: sink guard: reject if extra has apiKey/connectionString
    CMD->>CMD: Object.assign(config, extra)
    CMD->>DB: UPDATE data_sources SET config
    DB-->>CMD: ok

    UI->>DTO: getDataSource(id)
    DTO->>DB: SELECT config FROM data_sources
    DB-->>DTO: "{ apiKey: SecretRef, database: analytics, ... }"
    DTO->>Vault: vault.has(SecretRef) → boolean
    Vault-->>DTO: hasApiKey true/false
    DTO->>DTO: otherKeys loop: skip apiKey, connectionString, SecretRef values
    DTO-->>UI: "{ config: { hasApiKey, hasConnectionString, database, ... } }"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/server/src/functions/commands.ts`, line 355-380 ([link](https://github.com/youhaowei/dashframe/blob/e596efaf5a417bd9d01cf005badd6a228128a79b/apps/server/src/functions/commands.ts#L355-L380)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Sink guard runs after vault writes — unnecessary vault-ref orphaning on rejection**

   `applyCredentialField` is called before the `extra` sink guard. If a caller supplies both a non-empty `apiKey` and `extra: { apiKey: "x" }`, the vault write for `apiKey` completes (and a new `SecretRef` is generated) before the guard throws and aborts the DB update. The orphaned ref is benign per the deferred-cleanup design, but the guard should be hoisted above the `applyCredentialField` calls so rejections fail before touching the vault at all.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/functions/commands.ts
   Line: 355-380

   Comment:
   **Sink guard runs after vault writes — unnecessary vault-ref orphaning on rejection**

   `applyCredentialField` is called before the `extra` sink guard. If a caller supplies both a non-empty `apiKey` and `extra: { apiKey: "x" }`, the vault write for `apiKey` completes (and a new `SecretRef` is generated) before the guard throws and aborts the DB update. The orphaned ref is benign per the deferred-cleanup design, but the guard should be hoisted above the `applyCredentialField` calls so rejections fail before touching the vault at all.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20355-380%0A%0AComment%3A%0A**Sink%20guard%20runs%20after%20vault%20writes%20%E2%80%94%20unnecessary%20vault-ref%20orphaning%20on%20rejection**%0A%0A%60applyCredentialField%60%20is%20called%20before%20the%20%60extra%60%20sink%20guard.%20If%20a%20caller%20supplies%20both%20a%20non-empty%20%60apiKey%60%20and%20%60extra%3A%20%7B%20apiKey%3A%20%22x%22%20%7D%60%2C%20the%20vault%20write%20for%20%60apiKey%60%20completes%20%28and%20a%20new%20%60SecretRef%60%20is%20generated%29%20before%20the%20guard%20throws%20and%20aborts%20the%20DB%20update.%20The%20orphaned%20ref%20is%20benign%20per%20the%20deferred-cleanup%20design%2C%20but%20the%20guard%20should%20be%20hoisted%20above%20the%20%60applyCredentialField%60%20calls%20so%20rejections%20fail%20before%20touching%20the%20vault%20at%20all.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-139-datasourceconfig-typed-field-setdatasourceconfig-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-139-datasourceconfig-typed-field-setdatasourceconfig-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20355-380%0A%0AComment%3A%0A**Sink%20guard%20runs%20after%20vault%20writes%20%E2%80%94%20unnecessary%20vault-ref%20orphaning%20on%20rejection**%0A%0A%60applyCredentialField%60%20is%20called%20before%20the%20%60extra%60%20sink%20guard.%20If%20a%20caller%20supplies%20both%20a%20non-empty%20%60apiKey%60%20and%20%60extra%3A%20%7B%20apiKey%3A%20%22x%22%20%7D%60%2C%20the%20vault%20write%20for%20%60apiKey%60%20completes%20%28and%20a%20new%20%60SecretRef%60%20is%20generated%29%20before%20the%20guard%20throws%20and%20aborts%20the%20DB%20update.%20The%20orphaned%20ref%20is%20benign%20per%20the%20deferred-cleanup%20design%2C%20but%20the%20guard%20should%20be%20hoisted%20above%20the%20%60applyCredentialField%60%20calls%20so%20rejections%20fail%20before%20touching%20the%20vault%20at%20all.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20355-380%0A%0AComment%3A%0A**Sink%20guard%20runs%20after%20vault%20writes%20%E2%80%94%20unnecessary%20vault-ref%20orphaning%20on%20rejection**%0A%0A%60applyCredentialField%60%20is%20called%20before%20the%20%60extra%60%20sink%20guard.%20If%20a%20caller%20supplies%20both%20a%20non-empty%20%60apiKey%60%20and%20%60extra%3A%20%7B%20apiKey%3A%20%22x%22%20%7D%60%2C%20the%20vault%20write%20for%20%60apiKey%60%20completes%20%28and%20a%20new%20%60SecretRef%60%20is%20generated%29%20before%20the%20guard%20throws%20and%20aborts%20the%20DB%20update.%20The%20orphaned%20ref%20is%20benign%20per%20the%20deferred-cleanup%20design%2C%20but%20the%20guard%20should%20be%20hoisted%20above%20the%20%60applyCredentialField%60%20calls%20so%20rejections%20fail%20before%20touching%20the%20vault%20at%20all.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(server): harden SetDataSourceConfig ..."](https://github.com/youhaowei/dashframe/commit/1aac07031d5c3caf4564eff321997516fa6757cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38073036)</sub>

<!-- /greptile_comment -->