### PR TITLE
feat(assistant): [YW-278] typed tool-layer helper over pi's unknown-args AgentTool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -460,6 +460,7 @@
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.79.6",
         "@earendil-works/pi-ai": "0.79.6",
+        "typebox": "1.1.38",
       },
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.79.6",
-    "@earendil-works/pi-ai": "0.79.6"
+    "@earendil-works/pi-ai": "0.79.6",
+    "typebox": "1.1.38"
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -9,6 +9,7 @@ export const ASSISTANT_VERSION = "0.0.0" as const;
 // Typed tool-layer helper — the seam all assistant mutation and read tools build through.
 export {
   Check,
+  Convert,
   Errors,
   Type,
   defineToolHandler,

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -5,3 +5,18 @@
  */
 
 export const ASSISTANT_VERSION = "0.0.0" as const;
+
+// Typed tool-layer helper — the seam mutation (YW-279) and read (YW-280) tools build through.
+export {
+  Check,
+  Errors,
+  ToolExecutionError,
+  Type,
+  defineToolHandler,
+  isValidationError,
+  type Static,
+  type TSchema,
+  type ToolArgValidationError,
+  type ToolHandlerConfig,
+  type ToolHandlerErrorDetails,
+} from "./tool.js";

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -6,7 +6,7 @@
 
 export const ASSISTANT_VERSION = "0.0.0" as const;
 
-// Typed tool-layer helper — the seam mutation (YW-279) and read (YW-280) tools build through.
+// Typed tool-layer helper — the seam all assistant mutation and read tools build through.
 export {
   Check,
   Errors,

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -10,10 +10,10 @@ export const ASSISTANT_VERSION = "0.0.0" as const;
 export {
   Check,
   Errors,
-  ToolExecutionError,
   Type,
   defineToolHandler,
   isValidationError,
+  validateToolArgs,
   type Static,
   type TSchema,
   type ToolArgValidationError,

--- a/packages/assistant/src/tool.test.ts
+++ b/packages/assistant/src/tool.test.ts
@@ -134,10 +134,52 @@ describe("validateToolArgs — valid args", () => {
   });
 });
 
-describe("validateToolArgs — invalid args", () => {
-  it("returns ok: false with a structured validation_error when args fail the schema", () => {
+describe("validateToolArgs — coercion mirrors pi's Convert-then-Check", () => {
+  // Pi's prepareToolCall runs Value.Convert THEN Check. Models routinely emit
+  // numbers as strings (`"10"`), so a tool pre-validated here must coerce
+  // identically to the live agent loop — otherwise the seam diverges from pi.
+  it('coerces a string limit to a number (model emits "10")', () => {
     const result = validateToolArgs(QuerySchema, {
-      tableId: 42, // should be string
+      tableId: "orders",
+      limit: "10", // model-emitted string
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Coerced to the schema type — not left as a string.
+      expect(result.value.limit).toBe(10);
+      expect(typeof result.value.limit).toBe("number");
+    }
+  });
+
+  it("coerces a numeric tableId to a string", () => {
+    const result = validateToolArgs(QuerySchema, {
+      tableId: 42, // number where a string is expected
+      limit: 5,
+    });
+
+    // Convert coerces 42 -> "42" (string-typed field), so this is now VALID —
+    // exactly as pi would handle it before calling execute.
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.tableId).toBe("42");
+      expect(typeof result.value.tableId).toBe("string");
+    }
+  });
+
+  it("does not mutate the caller's input object", () => {
+    const raw = { tableId: "orders", limit: "10" };
+    validateToolArgs(QuerySchema, raw);
+    // raw.limit must still be the original string — Convert ran on a clone.
+    expect(raw.limit).toBe("10");
+  });
+});
+
+describe("validateToolArgs — invalid args", () => {
+  it("returns ok: false with a structured validation_error when coercion can't satisfy the schema", () => {
+    const result = validateToolArgs(QuerySchema, {
+      tableId: "orders",
+      limit: "not-a-number", // cannot coerce to number
     });
 
     expect(result.ok).toBe(false);
@@ -146,19 +188,20 @@ describe("validateToolArgs — invalid args", () => {
       expect(result.error.kind).toBe("validation_error");
       expect(result.error.message).toMatch(/Tool argument validation failed/);
       expect(result.error.errors.length).toBeGreaterThan(0);
+      // Error points at the offending field, not a useless root path.
+      expect(result.error.errors[0]?.path).toBe("/limit");
     }
   });
 
-  it("collects errors for all failing fields", () => {
+  it("reports a missing required field after coercion", () => {
     const result = validateToolArgs(QuerySchema, {
-      tableId: 99,
-      limit: "not-a-number",
+      tableId: "orders",
+      // limit omitted entirely
     });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.errors.length).toBeGreaterThan(0);
-      // Every error carries a path and a message
       for (const e of result.error.errors) {
         expect(typeof e.path).toBe("string");
         expect(typeof e.message).toBe("string");
@@ -214,5 +257,34 @@ describe("defineToolHandler — AgentTool shape", () => {
     expect(tool.label).toBe("No-op");
     expect(tool.parameters).toBeDefined();
     expect(typeof tool.execute).toBe("function");
+  });
+
+  it("forwards executionMode so mutating tools can serialise against the batch", () => {
+    const mutating = defineToolHandler({
+      name: "apply_command",
+      description: "Mutates the report",
+      label: "Apply Command",
+      executionMode: "sequential",
+      parameters: Type.Object({ command: Type.String() }),
+      async execute(_id, _params) {
+        return { content: [], details: null };
+      },
+    });
+
+    expect(mutating.executionMode).toBe("sequential");
+  });
+
+  it("omits executionMode when not specified (uses pi's loop default)", () => {
+    const readonly = defineToolHandler({
+      name: "read_table",
+      description: "Reads a table",
+      label: "Read Table",
+      parameters: Type.Object({ id: Type.String() }),
+      async execute(_id, _params) {
+        return { content: [], details: null };
+      },
+    });
+
+    expect("executionMode" in readonly).toBe(false);
   });
 });

--- a/packages/assistant/src/tool.test.ts
+++ b/packages/assistant/src/tool.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  defineToolHandler,
+  isValidationError,
+  ToolExecutionError,
+  Type,
+} from "./tool.js";
+
+// ---------------------------------------------------------------------------
+// Shared schema used across tests
+// ---------------------------------------------------------------------------
+
+const QuerySchema = Type.Object({
+  tableId: Type.String(),
+  limit: Type.Number({ minimum: 1, maximum: 1000 }),
+});
+
+// ---------------------------------------------------------------------------
+// Valid args → typed params, success envelope
+// ---------------------------------------------------------------------------
+
+describe("defineToolHandler — valid args", () => {
+  it("produces an AgentTool that executes when args match the schema", async () => {
+    const tool = defineToolHandler({
+      name: "query_table",
+      description: "Query a table",
+      label: "Query Table",
+      parameters: QuerySchema,
+      async execute(_callId, params) {
+        // params is fully typed here — no `as` casts
+        const tableId: string = params.tableId;
+        const limit: number = params.limit;
+        return {
+          content: [{ type: "text", text: `queried ${tableId}` }],
+          details: { rowCount: limit },
+        };
+      },
+    });
+
+    const result = await tool.execute("call-1", {
+      tableId: "orders",
+      limit: 10,
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "queried orders" }]);
+    expect(result.details).toEqual({ rowCount: 10 });
+    expect(isValidationError(result.details)).toBe(false);
+  });
+
+  it("passes toolCallId and abort signal through to execute", async () => {
+    let receivedId: string | undefined;
+    let receivedSignal: AbortSignal | undefined;
+
+    const tool = defineToolHandler({
+      name: "identity",
+      description: "Identity",
+      label: "Identity",
+      parameters: Type.Object({ value: Type.String() }),
+      async execute(toolCallId, params, signal) {
+        receivedId = toolCallId;
+        receivedSignal = signal;
+        return { content: [{ type: "text", text: params.value }], details: {} };
+      },
+    });
+
+    const controller = new AbortController();
+    await tool.execute("abc-123", { value: "hello" }, controller.signal);
+
+    expect(receivedId).toBe("abc-123");
+    expect(receivedSignal).toBe(controller.signal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid args → clean error shape, not a crash
+// ---------------------------------------------------------------------------
+
+describe("defineToolHandler — invalid args", () => {
+  it("returns a validation_error result when args fail schema check", async () => {
+    const tool = defineToolHandler({
+      name: "query_table",
+      description: "Query a table",
+      label: "Query Table",
+      parameters: QuerySchema,
+      async execute(_callId, _params) {
+        // should NOT be reached
+        throw new Error("execute should not be called with invalid args");
+      },
+    });
+
+    // Missing `limit`, wrong type for `tableId`
+    const result = await tool.execute("call-bad", {
+      tableId: 42, // should be string
+    } as unknown as { tableId: string; limit: number });
+
+    expect(isValidationError(result.details)).toBe(true);
+    expect(result.content[0]).toMatchObject({ type: "text" });
+    // Error message must be a non-empty string
+    const first = result.content[0];
+    if (first?.type === "text") {
+      expect(first.text.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("reports all validation errors when multiple fields are wrong", async () => {
+    const tool = defineToolHandler({
+      name: "query_table",
+      description: "Query a table",
+      label: "Query Table",
+      parameters: QuerySchema,
+      async execute(_callId, _params) {
+        throw new Error("should not be reached");
+      },
+    });
+
+    const result = await tool.execute("call-multi-err", {
+      tableId: 99,
+      limit: "not-a-number",
+    } as unknown as { tableId: string; limit: number });
+
+    expect(isValidationError(result.details)).toBe(true);
+    if (isValidationError(result.details)) {
+      expect(result.details.kind).toBe("validation_error");
+      expect(result.details.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("throws ToolExecutionError when execute throws, so pi marks result isError", async () => {
+    const tool = defineToolHandler({
+      name: "boom",
+      description: "Always throws",
+      label: "Boom",
+      parameters: Type.Object({ x: Type.String() }),
+      async execute() {
+        throw new Error("kaboom");
+      },
+    });
+
+    await expect(
+      tool.execute("call-throw", { x: "ok" }),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+
+    await expect(tool.execute("call-throw", { x: "ok" })).rejects.toThrow(
+      "kaboom",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Envelope shape — details always present
+// ---------------------------------------------------------------------------
+
+describe("defineToolHandler — result envelope", () => {
+  it("always produces a details field in the result", async () => {
+    const tool = defineToolHandler({
+      name: "greet",
+      description: "Greet",
+      label: "Greet",
+      parameters: Type.Object({ name: Type.String() }),
+      async execute(_id, params) {
+        return {
+          content: [{ type: "text", text: `Hello ${params.name}` }],
+          details: { greeted: params.name },
+        };
+      },
+    });
+
+    const ok = await tool.execute("c1", { name: "world" });
+    expect("details" in ok).toBe(true);
+    expect(ok.details).toEqual({ greeted: "world" });
+
+    // Validation-error path also always has details
+    const err = await tool.execute("c2", { notAField: true } as unknown as {
+      name: string;
+    });
+    expect("details" in err).toBe(true);
+    expect(err.details).toBeDefined();
+    expect(isValidationError(err.details)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool metadata is preserved on the returned AgentTool
+// ---------------------------------------------------------------------------
+
+describe("defineToolHandler — AgentTool shape", () => {
+  it("exposes name, description, label, and parameters on the returned tool", () => {
+    const tool = defineToolHandler({
+      name: "noop",
+      description: "A no-op tool",
+      label: "No-op",
+      parameters: Type.Object({ value: Type.Number() }),
+      async execute(_id, _params) {
+        return { content: [], details: null };
+      },
+    });
+
+    expect(tool.name).toBe("noop");
+    expect(tool.description).toBe("A no-op tool");
+    expect(tool.label).toBe("No-op");
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe("function");
+  });
+});

--- a/packages/assistant/src/tool.test.ts
+++ b/packages/assistant/src/tool.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   defineToolHandler,
   isValidationError,
-  ToolExecutionError,
   Type,
+  validateToolArgs,
 } from "./tool.js";
 
 // ---------------------------------------------------------------------------
@@ -16,18 +16,19 @@ const QuerySchema = Type.Object({
 });
 
 // ---------------------------------------------------------------------------
-// Valid args → typed params, success envelope
+// defineToolHandler — valid args → typed params, no casts
 // ---------------------------------------------------------------------------
 
 describe("defineToolHandler — valid args", () => {
-  it("produces an AgentTool that executes when args match the schema", async () => {
+  it("executes with typed params — no `as` casts in the body", async () => {
     const tool = defineToolHandler({
       name: "query_table",
       description: "Query a table",
       label: "Query Table",
       parameters: QuerySchema,
       async execute(_callId, params) {
-        // params is fully typed here — no `as` casts
+        // These assignments would fail to compile if params were `unknown`.
+        // The test is executable proof that types are narrowed correctly.
         const tableId: string = params.tableId;
         const limit: number = params.limit;
         return {
@@ -44,7 +45,6 @@ describe("defineToolHandler — valid args", () => {
 
     expect(result.content).toEqual([{ type: "text", text: "queried orders" }]);
     expect(result.details).toEqual({ rowCount: 10 });
-    expect(isValidationError(result.details)).toBe(false);
   });
 
   it("passes toolCallId and abort signal through to execute", async () => {
@@ -69,89 +69,8 @@ describe("defineToolHandler — valid args", () => {
     expect(receivedId).toBe("abc-123");
     expect(receivedSignal).toBe(controller.signal);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Invalid args → clean error shape, not a crash
-// ---------------------------------------------------------------------------
-
-describe("defineToolHandler — invalid args", () => {
-  it("returns a validation_error result when args fail schema check", async () => {
-    const tool = defineToolHandler({
-      name: "query_table",
-      description: "Query a table",
-      label: "Query Table",
-      parameters: QuerySchema,
-      async execute(_callId, _params) {
-        // should NOT be reached
-        throw new Error("execute should not be called with invalid args");
-      },
-    });
-
-    // Missing `limit`, wrong type for `tableId`
-    const result = await tool.execute("call-bad", {
-      tableId: 42, // should be string
-    } as unknown as { tableId: string; limit: number });
-
-    expect(isValidationError(result.details)).toBe(true);
-    expect(result.content[0]).toMatchObject({ type: "text" });
-    // Error message must be a non-empty string
-    const first = result.content[0];
-    if (first?.type === "text") {
-      expect(first.text.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("reports all validation errors when multiple fields are wrong", async () => {
-    const tool = defineToolHandler({
-      name: "query_table",
-      description: "Query a table",
-      label: "Query Table",
-      parameters: QuerySchema,
-      async execute(_callId, _params) {
-        throw new Error("should not be reached");
-      },
-    });
-
-    const result = await tool.execute("call-multi-err", {
-      tableId: 99,
-      limit: "not-a-number",
-    } as unknown as { tableId: string; limit: number });
-
-    expect(isValidationError(result.details)).toBe(true);
-    if (isValidationError(result.details)) {
-      expect(result.details.kind).toBe("validation_error");
-      expect(result.details.errors.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("throws ToolExecutionError when execute throws, so pi marks result isError", async () => {
-    const tool = defineToolHandler({
-      name: "boom",
-      description: "Always throws",
-      label: "Boom",
-      parameters: Type.Object({ x: Type.String() }),
-      async execute() {
-        throw new Error("kaboom");
-      },
-    });
-
-    await expect(
-      tool.execute("call-throw", { x: "ok" }),
-    ).rejects.toBeInstanceOf(ToolExecutionError);
-
-    await expect(tool.execute("call-throw", { x: "ok" })).rejects.toThrow(
-      "kaboom",
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Envelope shape — details always present
-// ---------------------------------------------------------------------------
-
-describe("defineToolHandler — result envelope", () => {
-  it("always produces a details field in the result", async () => {
+  it("result envelope always includes a details field", async () => {
     const tool = defineToolHandler({
       name: "greet",
       description: "Greet",
@@ -165,26 +84,121 @@ describe("defineToolHandler — result envelope", () => {
       },
     });
 
-    const ok = await tool.execute("c1", { name: "world" });
-    expect("details" in ok).toBe(true);
-    expect(ok.details).toEqual({ greeted: "world" });
-
-    // Validation-error path also always has details
-    const err = await tool.execute("c2", { notAField: true } as unknown as {
-      name: string;
-    });
-    expect("details" in err).toBe(true);
-    expect(err.details).toBeDefined();
-    expect(isValidationError(err.details)).toBe(true);
+    const result = await tool.execute("c1", { name: "world" });
+    expect("details" in result).toBe(true);
+    expect(result.details).toEqual({ greeted: "world" });
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tool metadata is preserved on the returned AgentTool
+// defineToolHandler — execute errors propagate (pi catches and marks isError)
+// ---------------------------------------------------------------------------
+
+describe("defineToolHandler — execute errors", () => {
+  it("propagates thrown errors so pi can mark the result isError: true", async () => {
+    const tool = defineToolHandler({
+      name: "boom",
+      description: "Always throws",
+      label: "Boom",
+      parameters: Type.Object({ x: Type.String() }),
+      async execute() {
+        throw new Error("kaboom");
+      },
+    });
+
+    await expect(tool.execute("call-throw", { x: "ok" })).rejects.toThrow(
+      "kaboom",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateToolArgs — the TypeBox boundary check for test/integration use
+// ---------------------------------------------------------------------------
+
+describe("validateToolArgs — valid args", () => {
+  it("returns ok: true and narrows the type", () => {
+    const result = validateToolArgs(QuerySchema, {
+      tableId: "orders",
+      limit: 10,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Type-check: the compiler allows these assignments only because result.value
+      // is Static<typeof QuerySchema>, not `unknown`.
+      const tableId: string = result.value.tableId;
+      const limit: number = result.value.limit;
+      expect(tableId).toBe("orders");
+      expect(limit).toBe(10);
+    }
+  });
+});
+
+describe("validateToolArgs — invalid args", () => {
+  it("returns ok: false with a structured validation_error when args fail the schema", () => {
+    const result = validateToolArgs(QuerySchema, {
+      tableId: 42, // should be string
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(isValidationError(result.error)).toBe(true);
+      expect(result.error.kind).toBe("validation_error");
+      expect(result.error.message).toMatch(/Tool argument validation failed/);
+      expect(result.error.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("collects errors for all failing fields", () => {
+    const result = validateToolArgs(QuerySchema, {
+      tableId: 99,
+      limit: "not-a-number",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.errors.length).toBeGreaterThan(0);
+      // Every error carries a path and a message
+      for (const e of result.error.errors) {
+        expect(typeof e.path).toBe("string");
+        expect(typeof e.message).toBe("string");
+      }
+    }
+  });
+
+  it("returns ok: false (not a crash) when value is the wrong root type", () => {
+    const result = validateToolArgs(QuerySchema, null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(isValidationError(result.error)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidationError — type guard
+// ---------------------------------------------------------------------------
+
+describe("isValidationError", () => {
+  it("returns true for a ToolArgValidationError shaped object", () => {
+    expect(
+      isValidationError({ kind: "validation_error", message: "x", errors: [] }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-error shapes", () => {
+    expect(isValidationError(null)).toBe(false);
+    expect(isValidationError({ kind: "something_else" })).toBe(false);
+    expect(isValidationError({ rowCount: 10 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTool shape — metadata is preserved
 // ---------------------------------------------------------------------------
 
 describe("defineToolHandler — AgentTool shape", () => {
-  it("exposes name, description, label, and parameters on the returned tool", () => {
+  it("exposes name, description, label, parameters, and execute on the returned tool", () => {
     const tool = defineToolHandler({
       name: "noop",
       description: "A no-op tool",

--- a/packages/assistant/src/tool.ts
+++ b/packages/assistant/src/tool.ts
@@ -14,14 +14,24 @@
  *      execute are passed through to pi unchanged (same pi behavior).
  *
  * Guard the sink, not provenance: the TypeBox schema passed to defineToolHandler
- * IS the validation gate. Pi's prepareToolCall runs Value.Convert + Check against
- * the schema before execute is invoked — validate here (the schema declaration),
- * trust the typed params pi delivers.
+ * IS the validation gate. Pi's prepareToolCall runs `Value.Convert` THEN `Check`
+ * against the schema before execute is invoked — validate here (the schema
+ * declaration), trust the typed params pi delivers.
+ *
+ * `validateToolArgs` (below) mirrors that exact order — Convert-then-Check — so a
+ * tool pre-validated through this helper sees the same coercion pi applies at
+ * runtime (e.g. a model emitting `"10"` for a numeric param). Mirroring matters:
+ * this is the seam every assistant tool builds on, so any divergence from pi's
+ * native arg handling would propagate to every tool.
  */
 
-import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import type {
+  AgentTool,
+  AgentToolResult,
+  ToolExecutionMode,
+} from "@earendil-works/pi-agent-core";
 import { Type, type Static, type TSchema } from "typebox";
-import { Check, Errors } from "typebox/value";
+import { Check, Convert, Errors } from "typebox/value";
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -68,10 +78,17 @@ export interface ToolHandlerConfig<TParams extends TSchema, TDetails> {
   label: string;
   /**
    * TypeBox schema for the tool's parameters.
-   * Pi validates args against this schema before calling execute — type-safe
-   * params arrive already checked; no double-validation inside the execute body.
+   * Pi validates (Convert then Check) args against this schema before calling
+   * execute — type-safe params arrive already checked and coerced; no
+   * double-validation inside the execute body.
    */
   parameters: TParams;
+  /**
+   * Per-tool execution mode. Mutating tools (e.g. apply-command) should declare
+   * `"sequential"` so pi serialises them against other tool calls in the same
+   * batch; read-only tools can stay `"parallel"`. Omit to use pi's loop default.
+   */
+  executionMode?: ToolExecutionMode;
   /**
    * The tool body. Receives fully-typed, validated params — no `as` casts needed.
    *
@@ -115,7 +132,7 @@ export interface ToolHandlerConfig<TParams extends TSchema, TDetails> {
 export function defineToolHandler<TParams extends TSchema, TDetails>(
   config: ToolHandlerConfig<TParams, TDetails>,
 ): AgentTool<TParams, TDetails> {
-  return {
+  const tool: AgentTool<TParams, TDetails> = {
     name: config.name,
     description: config.description,
     label: config.label,
@@ -126,11 +143,17 @@ export function defineToolHandler<TParams extends TSchema, TDetails>(
       params,
       signal,
     ): Promise<AgentToolResult<TDetails>> => {
-      // params: Static<TParams> — pi validated before calling us.
+      // params: Static<TParams> — pi validated (Convert+Check) before calling us.
       // Throw to signal runtime errors (pi catches, marks isError: true).
       return config.execute(toolCallId, params, signal);
     },
   };
+
+  if (config.executionMode !== undefined) {
+    tool.executionMode = config.executionMode;
+  }
+
+  return tool;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,9 +161,17 @@ export function defineToolHandler<TParams extends TSchema, TDetails>(
 // ---------------------------------------------------------------------------
 
 /**
- * Run TypeBox validation and return structured errors.
- * Useful in tests and integration harnesses that need to pre-validate args
- * before passing them to a tool (e.g., before calling tool.execute directly).
+ * Validate raw args against a TypeBox schema, mirroring pi's runtime handling:
+ * `Value.Convert` (coercion) THEN `Value.Check`. Returns the coerced, narrowed
+ * value on success or a structured error on failure.
+ *
+ * Useful in tests and integration harnesses that pre-validate args before
+ * calling `tool.execute` directly — using this keeps the coercion behavior
+ * identical to pi's `prepareToolCall`, so direct-execute tests match the live
+ * agent loop (a model emitting `"10"` for a numeric param coerces to `10` here
+ * exactly as it would inside pi).
+ *
+ * The input is cloned before coercion, so `raw` is never mutated.
  */
 export function validateToolArgs<TParams extends TSchema>(
   schema: TParams,
@@ -148,13 +179,17 @@ export function validateToolArgs<TParams extends TSchema>(
 ):
   | { ok: true; value: Static<TParams> }
   | { ok: false; error: ToolArgValidationError } {
-  if (Check(schema, raw)) {
-    return { ok: true, value: raw };
+  // Convert mutates in place and returns the coerced value — clone first so the
+  // caller's input is untouched, matching pi's structuredClone in validateToolArguments.
+  const coerced = Convert(schema, structuredClone(raw));
+
+  if (Check(schema, coerced)) {
+    return { ok: true, value: coerced };
   }
 
-  const errorList = Errors(schema, raw).map((e) => ({
-    path: e.instancePath ?? "/",
-    message: e.message ?? "invalid value",
+  const errorList = [...Errors(schema, coerced)].map((e) => ({
+    path: e.instancePath,
+    message: e.message,
   }));
 
   const parts = errorList.map((e) => `${e.path} ${e.message}`).join("; ");
@@ -171,4 +206,4 @@ export function validateToolArgs<TParams extends TSchema>(
 // ---------------------------------------------------------------------------
 // Re-export TypeBox primitives so tool authors don't need a separate import
 // ---------------------------------------------------------------------------
-export { Check, Errors, Type, type Static, type TSchema };
+export { Check, Convert, Errors, Type, type Static, type TSchema };

--- a/packages/assistant/src/tool.ts
+++ b/packages/assistant/src/tool.ts
@@ -79,7 +79,7 @@ export interface ToolHandlerConfig<TParams extends TSchema, TDetails> {
    * thrown errors and marks the ToolResultMessage as isError: true.
    *
    * Note: pi's prepareToolCall passes an onUpdate streaming callback as the 4th
-   * argument. This helper omits it because YW-279/YW-280 tools are atomic; add
+   * argument. This helper omits it because assistant tools are currently atomic; add
    * onUpdate to the signature if incremental progress becomes needed.
    */
   execute: (

--- a/packages/assistant/src/tool.ts
+++ b/packages/assistant/src/tool.ts
@@ -5,20 +5,18 @@
  * `beforeToolCall.args` arrives as `unknown`. Every DashFrame tool built
  * through this helper gets:
  *
- *   1. Validated params — `unknown` → `Static<TSchema>` at the boundary,
- *      once, via TypeBox. Tool bodies receive fully-typed params.
+ *   1. Typed params — pi validates args against the TypeBox schema before
+ *      calling execute; the helper surface exposes a fully-typed execute
+ *      callback, so tool bodies never see `unknown` or need `as` casts.
  *   2. Standardised result envelope — `details` is always present.
- *   3. Consistent error shaping on validation failure and thrown execute errors.
+ *   3. Consistent error shaping — validation failures are handled by pi
+ *      (isError: true on the ToolResultMessage); runtime errors thrown from
+ *      execute are passed through to pi unchanged (same pi behavior).
  *
- * Guard the sink, not provenance: validate at the point of use (here),
- * never rely on "the caller passed safe values already".
- *
- * Error signaling note: per pi's AgentTool contract, execute should throw to
- * signal failure. The helper does so for execute-thrown errors (re-throws
- * with a structured ToolExecutionError). For validation errors the helper
- * returns a result with `details.kind === "validation_error"` — the tool did
- * not even begin executing, so a clean informative return is more appropriate
- * than a throw that looks like a runtime crash to the model.
+ * Guard the sink, not provenance: the TypeBox schema passed to defineToolHandler
+ * IS the validation gate. Pi's prepareToolCall runs Value.Convert + Check against
+ * the schema before execute is invoked — validate here (the schema declaration),
+ * trust the typed params pi delivers.
  */
 
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
@@ -29,25 +27,16 @@ import { Check, Errors } from "typebox/value";
 // Error types
 // ---------------------------------------------------------------------------
 
-/** Structured payload carried in the result envelope on validation failure. */
+/** Structured validation-error detail for programmatic inspection. */
 export interface ToolArgValidationError {
   kind: "validation_error";
   message: string;
-  /** Path → message pairs from TypeBox; empty when the root value is wrong type. */
+  /** Path → message pairs from TypeBox. */
   errors: Array<{ path: string; message: string }>;
 }
 
-/** Error thrown from executeWithDetails when the tool body throws. */
-export class ToolExecutionError extends Error {
-  readonly kind = "execution_error" as const;
-  constructor(
-    message: string,
-    override readonly cause?: unknown,
-  ) {
-    super(message);
-    this.name = "ToolExecutionError";
-  }
-}
+/** Union of error detail shapes produced by defineToolHandler. */
+export type ToolHandlerErrorDetails = ToolArgValidationError;
 
 /** Discriminant for checking the details payload on a validation-failure result. */
 export function isValidationError(
@@ -59,9 +48,6 @@ export function isValidationError(
     (details as ToolArgValidationError).kind === "validation_error"
   );
 }
-
-/** Union of error detail shapes produced by defineToolHandler. */
-export type ToolHandlerErrorDetails = ToolArgValidationError;
 
 // ---------------------------------------------------------------------------
 // defineToolHandler config
@@ -82,52 +68,25 @@ export interface ToolHandlerConfig<TParams extends TSchema, TDetails> {
   label: string;
   /**
    * TypeBox schema for the tool's parameters.
-   * Validation runs here, once, before the execute body receives typed params.
+   * Pi validates args against this schema before calling execute — type-safe
+   * params arrive already checked; no double-validation inside the execute body.
    */
   parameters: TParams;
   /**
-   * The tool body. Receives fully-typed, validated params.
+   * The tool body. Receives fully-typed, validated params — no `as` casts needed.
    *
-   * Per pi's AgentTool contract, throw to signal runtime failure — the agent
-   * loop catches it and marks the tool result as an error in the conversation.
-   * The helper re-throws with a ToolExecutionError wrapper for structured detail.
+   * Per pi's AgentTool contract, throw to signal runtime failure. Pi catches
+   * thrown errors and marks the ToolResultMessage as isError: true.
+   *
+   * Note: pi's prepareToolCall passes an onUpdate streaming callback as the 4th
+   * argument. This helper omits it because YW-279/YW-280 tools are atomic; add
+   * onUpdate to the signature if incremental progress becomes needed.
    */
   execute: (
     toolCallId: string,
     params: Static<TParams>,
     signal?: AbortSignal,
   ) => Promise<AgentToolResult<TDetails>>;
-}
-
-// ---------------------------------------------------------------------------
-// Validation helpers
-// ---------------------------------------------------------------------------
-
-/** Validate raw args against a TypeBox schema and narrow the type. */
-function validateArgs<TParams extends TSchema>(
-  schema: TParams,
-  raw: unknown,
-):
-  | { ok: true; value: Static<TParams> }
-  | { ok: false; error: ToolArgValidationError } {
-  if (Check(schema, raw)) {
-    return { ok: true, value: raw };
-  }
-
-  const errorList = Errors(schema, raw).map((e) => ({
-    path: e.instancePath ?? "/",
-    message: e.message ?? "invalid value",
-  }));
-
-  const parts = errorList.map((e) => `${e.path} ${e.message}`).join("; ");
-  return {
-    ok: false,
-    error: {
-      kind: "validation_error",
-      message: `Tool argument validation failed: ${parts}`,
-      errors: errorList,
-    },
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +114,7 @@ function validateArgs<TParams extends TSchema>(
  */
 export function defineToolHandler<TParams extends TSchema, TDetails>(
   config: ToolHandlerConfig<TParams, TDetails>,
-): AgentTool<TParams, TDetails | ToolArgValidationError> {
+): AgentTool<TParams, TDetails> {
   return {
     name: config.name,
     description: config.description,
@@ -166,32 +125,45 @@ export function defineToolHandler<TParams extends TSchema, TDetails>(
       toolCallId,
       params,
       signal,
-    ): Promise<AgentToolResult<TDetails | ToolArgValidationError>> => {
-      // The execute callback from pi already receives Static<TParams>-typed params
-      // because AgentTool<TParams> wires that up. We add a runtime validation
-      // guard here regardless — trust the schema, not the caller.
-      const validated = validateArgs(config.parameters, params);
-      if (!validated.ok) {
-        const { error } = validated;
-        // Return (not throw) a clean error result; the model sees the message,
-        // downstream code reads details.kind to distinguish from success.
-        return {
-          content: [{ type: "text", text: error.message }],
-          details: error,
-        };
-      }
+    ): Promise<AgentToolResult<TDetails>> => {
+      // params: Static<TParams> — pi validated before calling us.
+      // Throw to signal runtime errors (pi catches, marks isError: true).
+      return config.execute(toolCallId, params, signal);
+    },
+  };
+}
 
-      // For execute errors, re-throw as ToolExecutionError so pi marks the
-      // ToolResultMessage as isError: true (pi's convention: throw = error).
-      try {
-        return await config.execute(toolCallId, validated.value, signal);
-      } catch (err) {
-        const message =
-          err instanceof Error
-            ? err.message
-            : `Tool execution error: ${String(err)}`;
-        throw new ToolExecutionError(message, err);
-      }
+// ---------------------------------------------------------------------------
+// Validation utilities — exported for test/integration use
+// ---------------------------------------------------------------------------
+
+/**
+ * Run TypeBox validation and return structured errors.
+ * Useful in tests and integration harnesses that need to pre-validate args
+ * before passing them to a tool (e.g., before calling tool.execute directly).
+ */
+export function validateToolArgs<TParams extends TSchema>(
+  schema: TParams,
+  raw: unknown,
+):
+  | { ok: true; value: Static<TParams> }
+  | { ok: false; error: ToolArgValidationError } {
+  if (Check(schema, raw)) {
+    return { ok: true, value: raw };
+  }
+
+  const errorList = Errors(schema, raw).map((e) => ({
+    path: e.instancePath ?? "/",
+    message: e.message ?? "invalid value",
+  }));
+
+  const parts = errorList.map((e) => `${e.path} ${e.message}`).join("; ");
+  return {
+    ok: false,
+    error: {
+      kind: "validation_error",
+      message: `Tool argument validation failed: ${parts}`,
+      errors: errorList,
     },
   };
 }

--- a/packages/assistant/src/tool.ts
+++ b/packages/assistant/src/tool.ts
@@ -1,0 +1,202 @@
+/**
+ * Typed tool-layer helper for DashFrame assistant tools.
+ *
+ * Pi's AgentTool interface is deliberately untyped at the args boundary —
+ * `beforeToolCall.args` arrives as `unknown`. Every DashFrame tool built
+ * through this helper gets:
+ *
+ *   1. Validated params — `unknown` → `Static<TSchema>` at the boundary,
+ *      once, via TypeBox. Tool bodies receive fully-typed params.
+ *   2. Standardised result envelope — `details` is always present.
+ *   3. Consistent error shaping on validation failure and thrown execute errors.
+ *
+ * Guard the sink, not provenance: validate at the point of use (here),
+ * never rely on "the caller passed safe values already".
+ *
+ * Error signaling note: per pi's AgentTool contract, execute should throw to
+ * signal failure. The helper does so for execute-thrown errors (re-throws
+ * with a structured ToolExecutionError). For validation errors the helper
+ * returns a result with `details.kind === "validation_error"` — the tool did
+ * not even begin executing, so a clean informative return is more appropriate
+ * than a throw that looks like a runtime crash to the model.
+ */
+
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import { Type, type Static, type TSchema } from "typebox";
+import { Check, Errors } from "typebox/value";
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/** Structured payload carried in the result envelope on validation failure. */
+export interface ToolArgValidationError {
+  kind: "validation_error";
+  message: string;
+  /** Path → message pairs from TypeBox; empty when the root value is wrong type. */
+  errors: Array<{ path: string; message: string }>;
+}
+
+/** Error thrown from executeWithDetails when the tool body throws. */
+export class ToolExecutionError extends Error {
+  readonly kind = "execution_error" as const;
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "ToolExecutionError";
+  }
+}
+
+/** Discriminant for checking the details payload on a validation-failure result. */
+export function isValidationError(
+  details: unknown,
+): details is ToolArgValidationError {
+  return (
+    typeof details === "object" &&
+    details !== null &&
+    (details as ToolArgValidationError).kind === "validation_error"
+  );
+}
+
+/** Union of error detail shapes produced by defineToolHandler. */
+export type ToolHandlerErrorDetails = ToolArgValidationError;
+
+// ---------------------------------------------------------------------------
+// defineToolHandler config
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration passed to `defineToolHandler`.
+ *
+ * @typeParam TParams  - TypeBox schema describing the tool's parameters.
+ * @typeParam TDetails - Type of the `details` field in a successful result.
+ */
+export interface ToolHandlerConfig<TParams extends TSchema, TDetails> {
+  /** Tool name (must be unique within an agent). */
+  name: string;
+  /** Human-readable description sent to the model. */
+  description: string;
+  /** Human-readable label for UI display. */
+  label: string;
+  /**
+   * TypeBox schema for the tool's parameters.
+   * Validation runs here, once, before the execute body receives typed params.
+   */
+  parameters: TParams;
+  /**
+   * The tool body. Receives fully-typed, validated params.
+   *
+   * Per pi's AgentTool contract, throw to signal runtime failure — the agent
+   * loop catches it and marks the tool result as an error in the conversation.
+   * The helper re-throws with a ToolExecutionError wrapper for structured detail.
+   */
+  execute: (
+    toolCallId: string,
+    params: Static<TParams>,
+    signal?: AbortSignal,
+  ) => Promise<AgentToolResult<TDetails>>;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/** Validate raw args against a TypeBox schema and narrow the type. */
+function validateArgs<TParams extends TSchema>(
+  schema: TParams,
+  raw: unknown,
+):
+  | { ok: true; value: Static<TParams> }
+  | { ok: false; error: ToolArgValidationError } {
+  if (Check(schema, raw)) {
+    return { ok: true, value: raw };
+  }
+
+  const errorList = Errors(schema, raw).map((e) => ({
+    path: e.instancePath ?? "/",
+    message: e.message ?? "invalid value",
+  }));
+
+  const parts = errorList.map((e) => `${e.path} ${e.message}`).join("; ");
+  return {
+    ok: false,
+    error: {
+      kind: "validation_error",
+      message: `Tool argument validation failed: ${parts}`,
+      errors: errorList,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Define a DashFrame assistant tool with typed params and a standardised result envelope.
+ *
+ * Usage:
+ * ```ts
+ * const myTool = defineToolHandler({
+ *   name: "my_tool",
+ *   description: "Does something",
+ *   label: "My tool",
+ *   parameters: Type.Object({ id: Type.String() }),
+ *   async execute(_callId, params) {
+ *     // `params.id` is `string` — no casts needed
+ *     return { content: [{ type: "text", text: params.id }], details: { id: params.id } };
+ *   },
+ * });
+ * ```
+ *
+ * @returns A pi `AgentTool` ready to pass to `agent.state.tools`.
+ */
+export function defineToolHandler<TParams extends TSchema, TDetails>(
+  config: ToolHandlerConfig<TParams, TDetails>,
+): AgentTool<TParams, TDetails | ToolArgValidationError> {
+  return {
+    name: config.name,
+    description: config.description,
+    label: config.label,
+    parameters: config.parameters,
+
+    execute: async (
+      toolCallId,
+      params,
+      signal,
+    ): Promise<AgentToolResult<TDetails | ToolArgValidationError>> => {
+      // The execute callback from pi already receives Static<TParams>-typed params
+      // because AgentTool<TParams> wires that up. We add a runtime validation
+      // guard here regardless — trust the schema, not the caller.
+      const validated = validateArgs(config.parameters, params);
+      if (!validated.ok) {
+        const { error } = validated;
+        // Return (not throw) a clean error result; the model sees the message,
+        // downstream code reads details.kind to distinguish from success.
+        return {
+          content: [{ type: "text", text: error.message }],
+          details: error,
+        };
+      }
+
+      // For execute errors, re-throw as ToolExecutionError so pi marks the
+      // ToolResultMessage as isError: true (pi's convention: throw = error).
+      try {
+        return await config.execute(toolCallId, validated.value, signal);
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : `Tool execution error: ${String(err)}`;
+        throw new ToolExecutionError(message, err);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Re-export TypeBox primitives so tool authors don't need a separate import
+// ---------------------------------------------------------------------------
+export { Check, Errors, Type, type Static, type TSchema };


### PR DESCRIPTION
## Summary

- Adds `defineToolHandler` to `@dashframe/assistant` — the typed factory every DashFrame assistant tool (YW-279 mutation, YW-280 read) builds through
- The TypeBox schema passed to `defineToolHandler` IS the validation gate: pi's `prepareToolCall` runs `Value.Convert + Check` against it before `execute` is ever invoked, so tool bodies receive `Static<TParams>` params with zero `as` casts
- Adds `validateToolArgs()` — standalone TypeBox boundary check for test and integration callers that need to pre-validate before calling `tool.execute` directly
- Adds `isValidationError()` type guard for discriminant checks on details payloads
- Adds `typebox@1.1.38` as a direct dep (matching pi-agent-core's transitive pin)
- Result envelope: `details` is always present; execute errors propagate to pi unchanged (pi catches and marks `ToolResultMessage.isError: true`)

## Design notes (for reviewers of YW-279/YW-280)

Pi's `AgentTool.execute` already receives `Static<TParams>` — it's typed at the schema level. The helper surface makes this explicit and enforces it consistently. Tool bodies need no casts:

```ts
const myTool = defineToolHandler({
  name: "my_tool",
  description: "Does something",
  label: "My tool",
  parameters: Type.Object({ id: Type.String() }),
  async execute(_callId, params) {
    const id: string = params.id; // typed, no `as`
    return { content: [{ type: "text", text: id }], details: { id } };
  },
});
```

The `onUpdate` streaming callback (pi's 4th execute arg) is intentionally omitted — YW-279/280 tools are atomic. Add it to `ToolHandlerConfig.execute` when incremental progress is needed.

## Review gate
- turbo typecheck: 45/45 pass
- lint: clean
- tests: 13/13 pass (2 test files)
- code-review (opus): 2 MUSTs found and fixed (dead double-validation path removed; ToolExecutionError wrapper dropped — pi silently discards structured detail)
- clawpatch: no features touched by diff
- greptile: 2 P1s were false positives (Errors() returns Array in this TypeBox version, instancePath is the correct field name per d.mts) — confirmed by passing tests

## LATER findings (no blocking issues)

- **onUpdate streaming** — pi's 4th execute arg is omitted (atomic tools, documented in-source). Trigger: first tool needing incremental progress.
- **Integration test through pi's prepareToolCall** — tests call `tool.execute` directly; an integration test through pi's real `validateToolArguments` would catch any future TypeBox API drift. Low priority given tests + greptile false-positive confirms the current behavior is correct.

Tracked internally as YW-278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `defineToolHandler`, a typed factory that wraps pi's loosely-typed `AgentTool` interface so every DashFrame assistant tool receives fully-typed, coercion-validated params without `as` casts. It also ships `validateToolArgs` (a `Convert`-then-`Check` boundary check matching pi's `prepareToolCall` order) and `isValidationError` for discriminant inspection of error details.

- **`defineToolHandler`** wires a TypeBox schema to a typed `execute` callback; the async wrapper absorbs pi's optional 4th `onUpdate` arg so tool bodies remain 3-arity and atomic.
- **`validateToolArgs`** clones the raw input before calling `Value.Convert` (matching pi's `structuredClone` in `validateToolArguments`), coerces, then checks — tests verify string→number coercion, no mutation of the caller's object, and graceful handling of null/wrong-root-type inputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a net-new typed abstraction with no changes to existing runtime paths.

The change is entirely additive: a new module, its tests, and package.json/lock updates. The critical design decisions (Convert-then-Check ordering, structuredClone before mutation, async wrapper absorbing onUpdate) are all correct and covered by passing tests. Previously flagged ticket-ID references have been removed. No existing code is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/src/tool.ts | New core module — clean implementation of defineToolHandler, validateToolArgs, and isValidationError with thorough JSDoc; no ticket IDs, no YW references, correct Convert→Check ordering, structuredClone before mutation. |
| packages/assistant/src/tool.test.ts | Comprehensive test suite covering coercion parity with pi, mutation safety, null/wrong-type inputs, typed params, error structure, AgentTool shape, and executionMode forwarding — 13 tests across 7 describe blocks. |
| packages/assistant/src/index.ts | Re-exports defineToolHandler, validateToolArgs, isValidationError, and TypeBox primitives (Check, Convert, Errors, Type) as intentional package surface for tool authors. |
| packages/assistant/package.json | Adds typebox@1.1.38 as a direct dep, pinned to match pi-agent-core's transitive version. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Model as LLM Model
    participant Pi as pi prepareToolCall
    participant DFT as defineToolHandler(AgentTool)
    participant Exec as tool.execute callback

    Model->>Pi: raw args (unknown JSON)
    Pi->>Pi: structuredClone(args)
    Pi->>Pi: Value.Convert(schema, clone)
    Pi->>Pi: Value.Check(schema, coerced)
    alt Check fails
        Pi-->>Model: ToolResultMessage (isError: true)
    else Check passes
        Pi->>DFT: "execute(callId, Static<TParams>, signal, onUpdate?)"
        DFT->>Exec: config.execute(callId, params, signal)
        note over DFT,Exec: onUpdate 4th arg absorbed by wrapper
        alt execute throws
            Exec-->>Pi: thrown Error
            Pi-->>Model: ToolResultMessage (isError: true)
        else execute succeeds
            Exec-->>DFT: "AgentToolResult<TDetails>"
            DFT-->>Pi: "AgentToolResult<TDetails>"
            Pi-->>Model: ToolResultMessage (isError: false)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Model as LLM Model
    participant Pi as pi prepareToolCall
    participant DFT as defineToolHandler(AgentTool)
    participant Exec as tool.execute callback

    Model->>Pi: raw args (unknown JSON)
    Pi->>Pi: structuredClone(args)
    Pi->>Pi: Value.Convert(schema, clone)
    Pi->>Pi: Value.Check(schema, coerced)
    alt Check fails
        Pi-->>Model: ToolResultMessage (isError: true)
    else Check passes
        Pi->>DFT: "execute(callId, Static<TParams>, signal, onUpdate?)"
        DFT->>Exec: config.execute(callId, params, signal)
        note over DFT,Exec: onUpdate 4th arg absorbed by wrapper
        alt execute throws
            Exec-->>Pi: thrown Error
            Pi-->>Model: ToolResultMessage (isError: true)
        else execute succeeds
            Exec-->>DFT: "AgentToolResult<TDetails>"
            DFT-->>Pi: "AgentToolResult<TDetails>"
            Pi-->>Model: ToolResultMessage (isError: false)
        end
    end
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(assistant): mirror pi&#39;s Convert-then..."](https://github.com/youhaowei/dashframe/commit/ac169a0dff75425c43fa5da18522e8ba8f66e616) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38076540)</sub>

<!-- /greptile_comment -->