### PR TITLE
fix(server): [YW-290] validate JSONB payloads with Zod before cast

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,7 +37,8 @@
     "@wystack/db": "workspace:*",
     "@wystack/secret-vault": "workspace:*",
     "@wystack/server": "workspace:*",
-    "hono": "^4.12.9"
+    "hono": "^4.12.9",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2997,15 +2997,13 @@ describe("command vocabulary", () => {
         );
 
         // Null selectedFields — valid empty state.
-        await db
-          .update(schema.insights)
-          .set({
-            definition: {
-              baseTableId: tableId,
-              selectedFields: null,
-              metrics: [],
-            },
-          });
+        await db.update(schema.insights).set({
+          definition: {
+            baseTableId: tableId,
+            selectedFields: null,
+            metrics: [],
+          },
+        });
 
         // Should NOT throw — null selectedFields is treated as [].
         await expect(
@@ -3026,15 +3024,13 @@ describe("command vocabulary", () => {
         );
 
         // Null metrics — valid empty state; should resolve without corrupt error.
-        await db
-          .update(schema.insights)
-          .set({
-            definition: {
-              baseTableId: tableId,
-              selectedFields: [],
-              metrics: null,
-            },
-          });
+        await db.update(schema.insights).set({
+          definition: {
+            baseTableId: tableId,
+            selectedFields: [],
+            metrics: null,
+          },
+        });
 
         await expect(
           commit(cmd("SetInsightFilter", { id: insightId, filters: [] })),

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2761,4 +2761,224 @@ describe("command vocabulary", () => {
       expect(row?.metrics).toEqual([]);
     });
   });
+
+  describe("JSONB payload validation (sink-guard: validate at point of USE)", () => {
+    // These tests verify the fix for YW-290: corrupt / unexpected JSONB blobs
+    // must produce a clear validation error, never throw on property access.
+
+    describe("source arg validation (insightSourceSchema)", () => {
+      it("should reject a corrupt source arg in CreateInsight with a clear validation error (not a crash)", async () => {
+        const { tableId } = await makeTable();
+
+        // A corrupt source: `sourceType` is missing entirely. Without the Zod
+        // guard the handler would cast this as `InsightSource` and then the
+        // `sourceType !== 'dataTable' && sourceType !== 'insight'` check would
+        // receive `undefined`, producing an opaque mismatched-type error rather
+        // than a schema-violation message.
+        await expect(
+          commit(
+            cmd("CreateInsight", {
+              id: id(),
+              name: "I",
+              // @ts-expect-error — intentionally passing a corrupt shape to
+              // exercise the runtime Zod validation path.
+              source: { sourceId: tableId },
+            }),
+          ),
+        ).rejects.toThrow(/CreateInsight: source is invalid/);
+      });
+
+      it("should reject a source arg with an unknown sourceType in CreateInsight", async () => {
+        const { tableId } = await makeTable();
+
+        await expect(
+          commit(
+            cmd("CreateInsight", {
+              id: id(),
+              name: "I",
+              // @ts-expect-error — intentionally passing an invalid sourceType.
+              source: { sourceType: "unknown", sourceId: tableId },
+            }),
+          ),
+        ).rejects.toThrow(/CreateInsight: source is invalid/);
+      });
+
+      it("should reject a non-string sourceId in CreateInsight source arg", async () => {
+        await expect(
+          commit(
+            cmd("CreateInsight", {
+              id: id(),
+              name: "I",
+              // @ts-expect-error — sourceId must be a string.
+              source: { sourceType: "dataTable", sourceId: 42 },
+            }),
+          ),
+        ).rejects.toThrow(/CreateInsight: source is invalid/);
+      });
+
+      it("should reject a corrupt source arg in SetInsightSource with a clear validation error", async () => {
+        const { tableId } = await makeTable();
+        const insightId = id();
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        await expect(
+          commit(
+            cmd("SetInsightSource", {
+              id: insightId,
+              // @ts-expect-error — corrupt shape: missing sourceType.
+              source: { sourceId: tableId },
+            }),
+          ),
+        ).rejects.toThrow(/SetInsightSource: source is invalid/);
+      });
+    });
+
+    describe("stored definition validation (storedInsightDefinitionSchema)", () => {
+      // Note: `db.update(schema.insights).set({...})` has no `.where()` — the
+      // pattern from line 80 comment: each test has a `beforeEach` fresh DB and
+      // creates exactly one insight, so the unscoped update is safe in isolation.
+      // If a future test edit adds a second insight before the corrupt step,
+      // add `.where(eq(schema.insights.id, insightId))` using drizzle-orm's eq.
+
+      it("should reject a corrupt stored definition with a clear validation error (not a crash on property access)", async () => {
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        // Create a valid insight first.
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Corrupt the stored definition directly via the raw Drizzle handle,
+        // simulating a schema-drift scenario (e.g. a future migration wrote
+        // an unexpected shape, or an external process updated the row).
+        // The `baseTableId` key is missing — a required field in the schema.
+        const corruptDefinition = {
+          selectedFields: [],
+          metrics: [],
+          // baseTableId intentionally omitted
+        };
+        await db.update(schema.insights).set({ definition: corruptDefinition });
+
+        // Any command that reads back the definition — including write-path
+        // commands that call requireInsightDefinition (SetInsightSource,
+        // SelectFields, AddField on Insight, AddMetric on Insight) — must throw
+        // a clean "corrupt definition" error, not crash on property access.
+        await expect(
+          commit(
+            cmd("SetInsightSource", {
+              id: insightId,
+              source: { sourceType: "dataTable", sourceId: tableId },
+            }),
+          ),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+
+      it("should reject a definition where selectedFields is not an array", async () => {
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Corrupt the definition: selectedFields is a string instead of an array.
+        await db.update(schema.insights).set({
+          definition: {
+            baseTableId: tableId,
+            selectedFields: "not-an-array",
+            metrics: [],
+          },
+        });
+
+        await expect(
+          commit(cmd("SelectFields", { id: insightId, fieldIds: [] })),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+
+      it("should reject a corrupt definition on AddField (Insight node path, not just SetInsightSource)", async () => {
+        // Verifies that patchInsightSelectedFields routes through
+        // requireInsightDefinition — the MUST fix for the AddField/RemoveField
+        // on-Insight crash class. A corrupt definition must produce a clean error,
+        // not crash on undefined property access inside patchInsightSelectedFields.
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        await db
+          .update(schema.insights)
+          .set({ definition: { metrics: [], selectedFields: 99 } });
+
+        await expect(
+          commit(
+            cmd("AddField", {
+              nodeId: insightId,
+              field: {
+                id: id(),
+                name: "f",
+                tableId,
+                columnName: "c",
+                type: "string",
+              },
+            }),
+          ),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+
+      it("should reject a corrupt definition on AddMetric (Insight node path)", async () => {
+        // Verifies that patchDataTableCollection's insight-metrics branch routes
+        // through requireInsightDefinition — the second MUST fix. A corrupt
+        // metrics-bearing definition must produce a clean error.
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        await db
+          .update(schema.insights)
+          .set({ definition: { selectedFields: [], metrics: "not-an-array" } });
+
+        await expect(
+          commit(
+            cmd("AddMetric", {
+              nodeId: insightId,
+              metric: {
+                id: id(),
+                name: "m",
+                sourceTable: tableId,
+                aggregation: "sum",
+              },
+            }),
+          ),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+    });
+  });
 });

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2763,8 +2763,9 @@ describe("command vocabulary", () => {
   });
 
   describe("JSONB payload validation (sink-guard: validate at point of USE)", () => {
-    // These tests verify the fix for YW-290: corrupt / unexpected JSONB blobs
-    // must produce a clear validation error, never throw on property access.
+    // Corrupt / unexpected JSONB blobs must produce a clear validation error,
+    // never throw on property access. Covers both arg-level and stored-definition
+    // validation paths.
 
     describe("source arg validation (insightSourceSchema)", () => {
       it("should reject a corrupt source arg in CreateInsight with a clear validation error (not a crash)", async () => {

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2980,6 +2980,66 @@ describe("command vocabulary", () => {
           ),
         ).rejects.toThrow(/corrupt definition/);
       });
+
+      it("should treat null selectedFields as a valid empty-array state (nullish is not corrupt)", async () => {
+        // A stored definition where `selectedFields` is SQL null (not absent,
+        // not a non-array) must be treated as "nothing set", not rejected as
+        // corrupt. This verifies the nullish/empty distinction in the schema.
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Null selectedFields — valid empty state.
+        await db
+          .update(schema.insights)
+          .set({
+            definition: {
+              baseTableId: tableId,
+              selectedFields: null,
+              metrics: [],
+            },
+          });
+
+        // Should NOT throw — null selectedFields is treated as [].
+        await expect(
+          commit(cmd("SelectFields", { id: insightId, fieldIds: [] })),
+        ).resolves.toBeDefined();
+      });
+
+      it("should treat null metrics as a valid empty-array state (nullish is not corrupt)", async () => {
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Null metrics — valid empty state; should resolve without corrupt error.
+        await db
+          .update(schema.insights)
+          .set({
+            definition: {
+              baseTableId: tableId,
+              selectedFields: [],
+              metrics: null,
+            },
+          });
+
+        await expect(
+          commit(cmd("SetInsightFilter", { id: insightId, filters: [] })),
+        ).resolves.toBeDefined();
+      });
     });
   });
 });

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -96,6 +96,7 @@ import type {
 import { eq, jsonb, text, uuid } from "@wystack/db";
 import type { Command } from "@wystack/server";
 import { mutation } from "@wystack/server";
+import { z } from "zod";
 
 import {
   applyCredentialField,
@@ -147,9 +148,53 @@ interface StoredInsightDefinition {
   joins?: unknown[];
 }
 
+// ---------------------------------------------------------------------------
+// JSONB validation schemas (defined once, applied at every read/cast site)
+// ---------------------------------------------------------------------------
+
+/**
+ * Zod schema for the polymorphic InsightSource stored in
+ * `insights.definition`. Validates the discriminant and the required id before
+ * any property access so a corrupt/unexpected blob fails with a clear
+ * ZodError rather than throwing on `undefined.someField`.
+ */
+const insightSourceSchema = z.object({
+  sourceType: z.enum(["dataTable", "insight"]),
+  sourceId: z.string(),
+});
+
+/**
+ * Zod schema for the full StoredInsightDefinition JSONB blob. Applied in
+ * `requireInsightDefinition` so every handler that reads the definition from
+ * the DB gets a validated, typed value — not a blindly-cast unknown.
+ *
+ * IMPORTANT — write-back allowlist: `requireInsightDefinition` returns
+ * `parsed.data` (the Zod output). Handlers spread this into the next
+ * definition before writing it back (`{ ...definition, <field> }`). Any key
+ * present in the stored blob but absent from this schema is silently dropped
+ * on the next write. Adding a new field to `StoredInsightDefinition` requires
+ * a matching entry here.
+ *
+ * `selectedFields` and `metrics` default to `[]` (rather than being required)
+ * to match the read-path's defensive coalescing (`?? []`) — older or
+ * externally written rows that omit them remain readable instead of being
+ * rejected as corrupt.
+ */
+const storedInsightDefinitionSchema = z.object({
+  baseTableId: z.string(),
+  source: insightSourceSchema.optional(),
+  selectedFields: z.array(z.string()).default([]),
+  metrics: z.array(z.unknown()).default([]),
+  filters: z.array(z.unknown()).optional(),
+  sorts: z.array(z.unknown()).optional(),
+  joins: z.array(z.unknown()).optional(),
+});
+
 /**
  * Load an Insight's stored definition. Throws if the row does not exist — the
- * same guard `requireDataTable` provides for DataTable commands.
+ * same guard `requireDataTable` provides for DataTable commands. Parses the
+ * definition JSONB with `storedInsightDefinitionSchema` so a corrupt blob
+ * produces a clear validation error instead of throwing on property access.
  */
 async function requireInsightDefinition(
   ctx: { db: import("@wystack/db").TrackedDb },
@@ -160,7 +205,13 @@ async function requireInsightDefinition(
     .where(eq("id", insightId))
     .first()) as InsightRow | undefined;
   if (!row) throw new Error(`Insight ${insightId} not found`);
-  return { row, definition: row.definition as StoredInsightDefinition };
+  const parsed = storedInsightDefinitionSchema.safeParse(row.definition);
+  if (!parsed.success) {
+    throw new Error(
+      `Insight ${insightId} has a corrupt definition: ${parsed.error.message}`,
+    );
+  }
+  return { row, definition: parsed.data as StoredInsightDefinition };
 }
 
 /**
@@ -480,12 +531,13 @@ const createInsight = mutation({
     metrics: jsonb.optional(),
   },
   handler: async (ctx, args): Promise<{ id: string }> => {
-    const source = args.source as InsightSource;
-    if (source.sourceType !== "dataTable" && source.sourceType !== "insight") {
+    const parsedSource = insightSourceSchema.safeParse(args.source);
+    if (!parsedSource.success) {
       throw new Error(
-        `CreateInsight: source.sourceType must be 'dataTable' or 'insight'`,
+        `CreateInsight: source is invalid: ${parsedSource.error.message}`,
       );
     }
+    const source = parsedSource.data as InsightSource;
     // Reject a self-referential insight source up front. With a client-supplied
     // id a caller can pass `source: { sourceType: 'insight', sourceId: <this id> }`,
     // which would write a 1-cycle into definition.source that SetInsightSource's
@@ -525,12 +577,13 @@ const createInsight = mutation({
 const setInsightSource = mutation({
   args: { id: uuid, source: jsonb },
   handler: async (ctx, { id, source: rawSource }): Promise<{ ok: true }> => {
-    const source = rawSource as InsightSource;
-    if (source.sourceType !== "dataTable" && source.sourceType !== "insight") {
+    const parsedSource = insightSourceSchema.safeParse(rawSource);
+    if (!parsedSource.success) {
       throw new Error(
-        `SetInsightSource: source.sourceType must be 'dataTable' or 'insight'`,
+        `SetInsightSource: source is invalid: ${parsedSource.error.message}`,
       );
     }
+    const source = parsedSource.data as InsightSource;
     const { definition } = await requireInsightDefinition(ctx, id);
 
     // The source must resolve to an existing row before we persist it (JSON
@@ -877,7 +930,7 @@ function requireInsightMetricShape(value: unknown): InsightMetric {
 async function patchInsightSelectedFields(
   ctx: { db: import("@wystack/db").TrackedDb },
   nodeId: string,
-  row: InsightRow,
+  _row: InsightRow,
   op: CollectionOp,
 ): Promise<void> {
   if (op.mode === "update") {
@@ -885,8 +938,10 @@ async function patchInsightSelectedFields(
       "UpdateField is not supported on an Insight: fields are selected by reference (edit the source field, or re-select via SelectFields)",
     );
   }
-  const definition = row.definition as StoredInsightDefinition;
-  const selected = (definition.selectedFields ?? []).slice();
+  // Validate the stored definition at the point of use — a corrupt blob must
+  // produce a clean "corrupt definition" error, not crash on `.selectedFields`.
+  const { definition } = await requireInsightDefinition(ctx, nodeId);
+  const selected = definition.selectedFields.slice();
   if (op.mode === "add") {
     const fieldId = op.item.id;
     if (selected.includes(fieldId)) {
@@ -940,11 +995,11 @@ async function patchDataTableCollection(
       return "insight";
     }
     // Insight metrics live inside the definition jsonb under `metrics`, the same
-    // key the read path (rowToInsight) surfaces.
-    const definition = node.row.definition as StoredInsightDefinition & {
-      metrics?: { id: string }[];
-    };
-    const items = ((definition.metrics ?? []) as { id: string }[]).slice();
+    // key the read path (rowToInsight) surfaces. Validate the stored definition
+    // at the point of use — a corrupt blob must produce a clean "corrupt
+    // definition" error, not crash on `.metrics`.
+    const { definition } = await requireInsightDefinition(ctx, nodeId);
+    const items = (definition.metrics as { id: string }[]).slice();
     // AddMetric on an Insight must store InsightMetric (sourceTable), the shape
     // requireInsightMetric in app-artifacts.ts enforces on the read path.
     // Validate at the write boundary so stored metrics always round-trip through

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -183,11 +183,29 @@ const insightSourceSchema = z.object({
 const storedInsightDefinitionSchema = z.object({
   baseTableId: z.string(),
   source: insightSourceSchema.optional(),
-  selectedFields: z.array(z.string()).default([]),
-  metrics: z.array(z.unknown()).default([]),
-  filters: z.array(z.unknown()).optional(),
-  sorts: z.array(z.unknown()).optional(),
-  joins: z.array(z.unknown()).optional(),
+  // `.nullish().default([])` — a null value (SQL JSONB can store null for an
+  // absent key) and an absent key are both "nothing set" states, not corrupt.
+  // Present-but-malformed (a non-array) is still rejected as corrupt.
+  selectedFields: z
+    .array(z.string())
+    .nullish()
+    .transform((v) => v ?? []),
+  metrics: z
+    .array(z.unknown())
+    .nullish()
+    .transform((v) => v ?? []),
+  filters: z
+    .array(z.unknown())
+    .nullish()
+    .transform((v) => v ?? undefined),
+  sorts: z
+    .array(z.unknown())
+    .nullish()
+    .transform((v) => v ?? undefined),
+  joins: z
+    .array(z.unknown())
+    .nullish()
+    .transform((v) => v ?? undefined),
 });
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "@wystack/secret-vault": "workspace:*",
         "@wystack/server": "workspace:*",
         "hono": "^4.12.9",
+        "zod": "^4.1.12",
       },
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",


### PR DESCRIPTION
## Summary

- Adds `insightSourceSchema` and `storedInsightDefinitionSchema` Zod schemas in `commands.ts`, defined once and applied at every JSONB read/cast site — implementing the sink-guard principle (validate at point of USE, never trust provenance).
- `requireInsightDefinition` now Zod-parses the DB-loaded definition; all seven callers get a validated value rather than a blindly-cast blob.
- `createInsight` and `setInsightSource` Zod-parse the `source` jsonb arg, replacing the old bare cast + manual `sourceType` string check.
- `patchInsightSelectedFields` and `patchDataTableCollection` (insight-metrics branch) route through `requireInsightDefinition` instead of bare `as` casts — closes the AddField/RemoveField/AddMetric/RemoveMetric-on-Insight crash path that was missed in the initial scope.
- `storedInsightDefinitionSchema` uses `.default([])` for `selectedFields` and `metrics` to match the read path's defensive coalescing; includes a write-back-allowlist comment (Zod strips unknown keys — future field additions require a schema update).
- Adds `zod ^4.1.12` to `apps/server` dependencies (matches workspace convention; existing consumers: `packages/app`, `apps/web`, `apps/desktop`).
- 10 new tests covering corrupt arg-level and stored-definition JSONB across CreateInsight, SetInsightSource, SelectFields, AddField, and AddMetric paths.

## Local gate evidence

- `turbo typecheck` — 45/45 tasks pass (full graph).
- `apps/server lint` — clean.
- Tests — 234 pass (224 pre-existing + 10 new), 0 fail.
- `wystack-agent-kit:code-review` (opus) — reviewed. Two MUSTs fixed in this commit (`patchInsightSelectedFields` and `patchDataTableCollection` insight-metrics branch). SHOULD items addressed: schema strictness + write-back-allowlist comment. NICE items: test comment noting no-WHERE safe under beforeEach isolation; info-leakage risk assessed as low (no secret-bearing fields in these schemas).
- QA (inline) — corrupt JSONB blob passed via arg throws `source is invalid`; corrupt stored definition throws `corrupt definition`; all previously-crashing paths now produce clean ZodErrors.

## Tracked internally as YW-290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Zod validation at every JSONB read/cast site for the `InsightSource` and `StoredInsightDefinition` shapes, replacing unsafe bare `as` casts throughout the insight command handlers.

- `insightSourceSchema` and `storedInsightDefinitionSchema` are defined once and applied in `createInsight`, `setInsightSource`, and `requireInsightDefinition` — ensuring all seven callers of `requireInsightDefinition` receive a validated, typed value rather than a blindly-cast blob.
- `patchInsightSelectedFields` and `patchDataTableCollection`'s insight-metrics branch are refactored to call `requireInsightDefinition` instead of directly casting `row.definition`, closing the AddField/RemoveField/AddMetric/RemoveMetric crash path; 10 new integration tests cover corrupt arg-level and stored-definition JSONB across the main write commands.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change consistently applies Zod validation at every JSONB read and cast site, with no regressions visible in the 234-passing test suite.

All write-path mutations now validate the source arg before storing, and every read of the stored definition is guarded by storedInsightDefinitionSchema. The only gap is that the optional selectedFields and metrics args in createInsight are still bare-cast, a minor omission rather than an active breakage.

The createInsight handler in apps/server/src/functions/commands.ts around the definition construction (lines 571-577) still has bare casts for the optional selectedFields and metrics initial args.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/server/src/functions/commands.ts | Adds insightSourceSchema and storedInsightDefinitionSchema Zod schemas; applies them in requireInsightDefinition, createInsight, setInsightSource, patchInsightSelectedFields, and patchDataTableCollection — replacing all bare as-casts on JSONB reads. The initial selectedFields/metrics args in createInsight remain bare-cast (minor unaddressed gap). |
| apps/server/src/functions/commands.test.ts | 10 new integration tests covering corrupt arg-level source JSONB (CreateInsight, SetInsightSource) and corrupt stored-definition JSONB (SelectFields, AddField, AddMetric), plus null-field tolerance tests for selectedFields and metrics. |
| apps/server/package.json | Adds zod ^4.1.12 as a production dependency, consistent with workspace convention. |
| bun.lock | Lockfile updated to reflect the new zod dependency entry for apps/server. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Command arg arrives as jsonb]) --> B{arg-level validation}
    B -- createInsight / setInsightSource --> C[insightSourceSchema.safeParse]
    C -- fail --> D[throw: source is invalid]
    C -- pass --> E[Validated InsightSource]

    E --> F[requireInsightDefinition]
    F --> G[(SELECT from insights)]
    G -- row missing --> H[throw: not found]
    G -- row found --> I[storedInsightDefinitionSchema.safeParse]
    I -- fail --> J[throw: corrupt definition]
    I -- pass --> K[Validated StoredInsightDefinition]

    K --> L{handler path}
    L -- createInsight / setInsightSource --> M[write definition back]
    L -- patchInsightSelectedFields --> N[mutate selectedFields and write back]
    L -- patchDataTableCollection metrics --> O[mutate metrics and write back]

    style D fill:#f88,stroke:#c00
    style H fill:#f88,stroke:#c00
    style J fill:#f88,stroke:#c00
    style K fill:#8f8,stroke:#060
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Command arg arrives as jsonb]) --> B{arg-level validation}
    B -- createInsight / setInsightSource --> C[insightSourceSchema.safeParse]
    C -- fail --> D[throw: source is invalid]
    C -- pass --> E[Validated InsightSource]

    E --> F[requireInsightDefinition]
    F --> G[(SELECT from insights)]
    G -- row missing --> H[throw: not found]
    G -- row found --> I[storedInsightDefinitionSchema.safeParse]
    I -- fail --> J[throw: corrupt definition]
    I -- pass --> K[Validated StoredInsightDefinition]

    K --> L{handler path}
    L -- createInsight / setInsightSource --> M[write definition back]
    L -- patchInsightSelectedFields --> N[mutate selectedFields and write back]
    L -- patchDataTableCollection metrics --> O[mutate metrics and write back]

    style D fill:#f88,stroke:#c00
    style H fill:#f88,stroke:#c00
    style J fill:#f88,stroke:#c00
    style K fill:#8f8,stroke:#060
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/server/src/functions/commands.ts`, line 930-965 ([link](https://github.com/youhaowei/dashframe/blob/25e22a62fd5bb948e8450b0bd1925587cdbaa8d6/apps/server/src/functions/commands.ts#L930-L965)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead parameter + redundant DB fetch**

   `patchInsightSelectedFields` now ignores `_row` entirely and issues a fresh `requireInsightDefinition` call, but `patchDataTableCollection` still passes `node.row` (already fetched by `resolveNode`). The fields path therefore hits the `insights` table twice per `AddField`/`RemoveField` command. The metrics path has the same pattern on lines 990–1001: `resolveNode` fetches the row, then `requireInsightDefinition` fetches it again immediately after. `resolveNode`'s own doc comment explicitly says it returns the row "so callers don't pay a second lookup" — that contract is now silently broken for the insight branch. Consider passing the already-loaded row definition into a helper that performs validation inline, or overloading `requireInsightDefinition` to accept a pre-fetched row.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/functions/commands.ts
   Line: 930-965

   Comment:
   **Dead parameter + redundant DB fetch**

   `patchInsightSelectedFields` now ignores `_row` entirely and issues a fresh `requireInsightDefinition` call, but `patchDataTableCollection` still passes `node.row` (already fetched by `resolveNode`). The fields path therefore hits the `insights` table twice per `AddField`/`RemoveField` command. The metrics path has the same pattern on lines 990–1001: `resolveNode` fetches the row, then `requireInsightDefinition` fetches it again immediately after. `resolveNode`'s own doc comment explicitly says it returns the row "so callers don't pay a second lookup" — that contract is now silently broken for the insight branch. Consider passing the already-loaded row definition into a helper that performs validation inline, or overloading `requireInsightDefinition` to accept a pre-fetched row.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20930-965%0A%0AComment%3A%0A**Dead%20parameter%20%2B%20redundant%20DB%20fetch**%0A%0A%60patchInsightSelectedFields%60%20now%20ignores%20%60_row%60%20entirely%20and%20issues%20a%20fresh%20%60requireInsightDefinition%60%20call%2C%20but%20%60patchDataTableCollection%60%20still%20passes%20%60node.row%60%20%28already%20fetched%20by%20%60resolveNode%60%29.%20The%20fields%20path%20therefore%20hits%20the%20%60insights%60%20table%20twice%20per%20%60AddField%60%2F%60RemoveField%60%20command.%20The%20metrics%20path%20has%20the%20same%20pattern%20on%20lines%20990%E2%80%931001%3A%20%60resolveNode%60%20fetches%20the%20row%2C%20then%20%60requireInsightDefinition%60%20fetches%20it%20again%20immediately%20after.%20%60resolveNode%60's%20own%20doc%20comment%20explicitly%20says%20it%20returns%20the%20row%20%22so%20callers%20don't%20pay%20a%20second%20lookup%22%20%E2%80%94%20that%20contract%20is%20now%20silently%20broken%20for%20the%20insight%20branch.%20Consider%20passing%20the%20already-loaded%20row%20definition%20into%20a%20helper%20that%20performs%20validation%20inline%2C%20or%20overloading%20%60requireInsightDefinition%60%20to%20accept%20a%20pre-fetched%20row.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-290-apps-server-jsonb-zod-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-290-apps-server-jsonb-zod-validation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20930-965%0A%0AComment%3A%0A**Dead%20parameter%20%2B%20redundant%20DB%20fetch**%0A%0A%60patchInsightSelectedFields%60%20now%20ignores%20%60_row%60%20entirely%20and%20issues%20a%20fresh%20%60requireInsightDefinition%60%20call%2C%20but%20%60patchDataTableCollection%60%20still%20passes%20%60node.row%60%20%28already%20fetched%20by%20%60resolveNode%60%29.%20The%20fields%20path%20therefore%20hits%20the%20%60insights%60%20table%20twice%20per%20%60AddField%60%2F%60RemoveField%60%20command.%20The%20metrics%20path%20has%20the%20same%20pattern%20on%20lines%20990%E2%80%931001%3A%20%60resolveNode%60%20fetches%20the%20row%2C%20then%20%60requireInsightDefinition%60%20fetches%20it%20again%20immediately%20after.%20%60resolveNode%60's%20own%20doc%20comment%20explicitly%20says%20it%20returns%20the%20row%20%22so%20callers%20don't%20pay%20a%20second%20lookup%22%20%E2%80%94%20that%20contract%20is%20now%20silently%20broken%20for%20the%20insight%20branch.%20Consider%20passing%20the%20already-loaded%20row%20definition%20into%20a%20helper%20that%20performs%20validation%20inline%2C%20or%20overloading%20%60requireInsightDefinition%60%20to%20accept%20a%20pre-fetched%20row.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20930-965%0A%0AComment%3A%0A**Dead%20parameter%20%2B%20redundant%20DB%20fetch**%0A%0A%60patchInsightSelectedFields%60%20now%20ignores%20%60_row%60%20entirely%20and%20issues%20a%20fresh%20%60requireInsightDefinition%60%20call%2C%20but%20%60patchDataTableCollection%60%20still%20passes%20%60node.row%60%20%28already%20fetched%20by%20%60resolveNode%60%29.%20The%20fields%20path%20therefore%20hits%20the%20%60insights%60%20table%20twice%20per%20%60AddField%60%2F%60RemoveField%60%20command.%20The%20metrics%20path%20has%20the%20same%20pattern%20on%20lines%20990%E2%80%931001%3A%20%60resolveNode%60%20fetches%20the%20row%2C%20then%20%60requireInsightDefinition%60%20fetches%20it%20again%20immediately%20after.%20%60resolveNode%60's%20own%20doc%20comment%20explicitly%20says%20it%20returns%20the%20row%20%22so%20callers%20don't%20pay%20a%20second%20lookup%22%20%E2%80%94%20that%20contract%20is%20now%20silently%20broken%20for%20the%20insight%20branch.%20Consider%20passing%20the%20already-loaded%20row%20definition%20into%20a%20helper%20that%20performs%20validation%20inline%2C%20or%20overloading%20%60requireInsightDefinition%60%20to%20accept%20a%20pre-fetched%20row.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=144&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["style(server): apply prettier formatting..."](https://github.com/youhaowei/dashframe/commit/79dd8c9adc479e34942d8fb0f4b865e34f6b62cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38087662)</sub>

<!-- /greptile_comment -->