### PR TITLE
feat(assistant): [YW-277] OAuth credential lifecycle + token refresh

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -26,6 +26,7 @@
     "check": "bun run typecheck && bun run lint"
   },
   "dependencies": {
+    "@dashframe/assistant": "workspace:*",
     "@dashframe/connector-notion": "workspace:*",
     "@dashframe/engine": "workspace:*",
     "@dashframe/engine-server": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "dashframe": "src/index.ts",
       },
       "dependencies": {
+        "@dashframe/assistant": "workspace:*",
         "@dashframe/connector-notion": "workspace:*",
         "@dashframe/engine": "workspace:*",
         "@dashframe/engine-server": "workspace:*",
@@ -456,7 +457,7 @@
     },
     "packages/assistant": {
       "name": "@dashframe/assistant",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.79.6",
         "@earendil-works/pi-ai": "0.79.6",
@@ -464,6 +465,7 @@
       },
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
+        "@types/bun": "^1.2.0",
         "typescript": "5.7.2",
         "vitest": "^4.1.6",
       },

--- a/packages/assistant/eslint.config.mjs
+++ b/packages/assistant/eslint.config.mjs
@@ -1,0 +1,3 @@
+import sharedConfig from "@dashframe/eslint-config";
+
+export default [...sharedConfig];

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@dashframe/assistant",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "description": "OAuth credential lifecycle and tool-layer helper for the DashFrame assistant",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
@@ -13,9 +14,9 @@
   },
   "scripts": {
     "clean": "node -e \"require('node:fs/promises').rm('dist',{recursive:true,force:true})\"",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint src",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "eslint src",
     "check": "bun run typecheck && bun run lint && bun run test"
   },
   "dependencies": {
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
+    "@types/bun": "^1.2.0",
     "typescript": "5.7.2",
     "vitest": "^4.1.6"
   }

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -1,10 +1,16 @@
 /**
  * @dashframe/assistant — agentic report harness substrate.
  *
- * Loop, tools, and UI land in follow-up implementation work.
+ * OAuth credential lifecycle: read the Claude Code subscription token from
+ * the OS keychain at runtime; refresh in-memory when expired; never write
+ * back. Fail closed on dead credentials.
+ *
+ * Typed tool-layer helper: the seam all assistant mutation and read tools
+ * build through.
  */
 
-export const ASSISTANT_VERSION = "0.0.0" as const;
+// OAuth credential lifecycle
+export * from "./oauth/index.js";
 
 // Typed tool-layer helper — the seam all assistant mutation and read tools build through.
 export {

--- a/packages/assistant/src/oauth/index.ts
+++ b/packages/assistant/src/oauth/index.ts
@@ -1,0 +1,4 @@
+export { readKeychainOAuth } from "./keychain.js";
+export type { KeychainOAuth } from "./keychain.js";
+export { OAuthTokenExpiredError, getOAuthToken } from "./token-provider.js";
+export type { TokenProviderOptions } from "./token-provider.js";

--- a/packages/assistant/src/oauth/index.ts
+++ b/packages/assistant/src/oauth/index.ts
@@ -1,4 +1,6 @@
 export { readKeychainOAuth } from "./keychain.js";
 export type { KeychainOAuth } from "./keychain.js";
+export { refreshAccessToken } from "./refresh.js";
+export type { RefreshedCredentials } from "./refresh.js";
 export { OAuthTokenExpiredError, getOAuthToken } from "./token-provider.js";
 export type { TokenProviderOptions } from "./token-provider.js";

--- a/packages/assistant/src/oauth/keychain.ts
+++ b/packages/assistant/src/oauth/keychain.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface KeychainOAuth {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+}
+
+/**
+ * Reads the Claude Code OAuth credentials from the macOS keychain.
+ * Parses the JSON blob and returns the claudeAiOauth sub-object.
+ *
+ * Throws with a clear message if the credential is missing or malformed.
+ *
+ * Uses the async execFile to avoid blocking the event loop — keychain reads
+ * are typically fast but can stall on wake-from-sleep or when the keychain
+ * is locked; blocking the event loop during those waits is undesirable.
+ */
+export async function readKeychainOAuth(): Promise<KeychainOAuth> {
+  let raw: string;
+  try {
+    // Use the absolute path — avoids PATH-injection risk (sonarjs/no-os-command-from-path).
+    // /usr/bin/security is the macOS keychain CLI; this is macOS-only.
+    // Interpolate .message only, never the full error object (which can attach
+    // stdout/stderr that might contain sensitive output on some error paths).
+    const { stdout } = await execFileAsync(
+      "/usr/bin/security",
+      [
+        "find-generic-password",
+        "-s",
+        "Claude Code-credentials",
+        "-a",
+        "root",
+        "-w",
+      ],
+      { encoding: "utf-8" },
+    );
+    raw = stdout.trim();
+  } catch (err) {
+    throw new Error(
+      `Failed to read Claude Code credentials from keychain: ${(err as Error).message}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "Claude Code keychain entry is not valid JSON — credential may be corrupted",
+    );
+  }
+
+  const oauth = (parsed as Record<string, unknown>)?.claudeAiOauth as
+    | KeychainOAuth
+    | undefined;
+  if (!oauth) {
+    throw new Error(
+      "no claudeAiOauth block found in Claude Code keychain entry",
+    );
+  }
+
+  return oauth;
+}

--- a/packages/assistant/src/oauth/keychain.ts
+++ b/packages/assistant/src/oauth/keychain.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { userInfo } from "node:os";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -18,6 +19,11 @@ export interface KeychainOAuth {
  * Uses the async execFile to avoid blocking the event loop — keychain reads
  * are typically fast but can stall on wake-from-sleep or when the keychain
  * is locked; blocking the event loop during those waits is undesirable.
+ *
+ * Account lookup: Claude Code stores the credential under the signed-in user's
+ * account, not under "root". We pass `-a <current-user>` so the lookup matches
+ * on any standard macOS installation. `userInfo().username` is the POSIX user
+ * running the process — the same account Claude Code uses when writing the item.
  */
 export async function readKeychainOAuth(): Promise<KeychainOAuth> {
   let raw: string;
@@ -26,6 +32,7 @@ export async function readKeychainOAuth(): Promise<KeychainOAuth> {
     // /usr/bin/security is the macOS keychain CLI; this is macOS-only.
     // Interpolate .message only, never the full error object (which can attach
     // stdout/stderr that might contain sensitive output on some error paths).
+    const username = userInfo().username;
     const { stdout } = await execFileAsync(
       "/usr/bin/security",
       [
@@ -33,7 +40,7 @@ export async function readKeychainOAuth(): Promise<KeychainOAuth> {
         "-s",
         "Claude Code-credentials",
         "-a",
-        "root",
+        username,
         "-w",
       ],
       { encoding: "utf-8" },

--- a/packages/assistant/src/oauth/refresh.ts
+++ b/packages/assistant/src/oauth/refresh.ts
@@ -1,0 +1,69 @@
+/**
+ * Owns the token refresh leg inline.
+ *
+ * FINDING (pi packaging gap): pi DOES implement refreshAnthropicToken and its
+ * .d.ts re-exports it from the package root — but the runtime `exports` map
+ * does NOT, and there is no subpath for the oauth utils. It is UNREACHABLE at
+ * runtime. We own the refresh here, against the same Claude Code OAuth endpoint
+ * pi uses. CLIENT_ID is Claude Code's public client_id (not a secret).
+ *
+ * NEVER import { refreshAnthropicToken } from "@earendil-works/pi-ai" — it
+ * will throw SyntaxError: Export named 'refreshAnthropicToken' not found.
+ */
+
+const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+
+/**
+ * Refreshes the Claude Code OAuth access token in-memory.
+ *
+ * - Never writes the refreshed token back to the keychain (would race Claude
+ *   Code's own refresher and mutate the user's real credentials).
+ * - Returns the new access token string in-memory only.
+ *
+ * @throws if the refresh endpoint returns a non-2xx response.
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<string> {
+  const res = await fetchFn(CLAUDE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      client_id: CLAUDE_CODE_CLIENT_ID,
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!res.ok) {
+    // Parse structured OAuth error when possible; otherwise cap the raw body to
+    // avoid surfacing attacker-influenced or credential-echoing server text in
+    // exception messages that callers will log.
+    const rawBody = await res.text().catch(() => "(unreadable body)");
+    let detail: string;
+    try {
+      const parsed = JSON.parse(rawBody) as {
+        error?: unknown;
+        error_description?: unknown;
+      };
+      const code = typeof parsed.error === "string" ? parsed.error : null;
+      const desc =
+        typeof parsed.error_description === "string"
+          ? parsed.error_description
+          : null;
+      detail = [code, desc].filter(Boolean).join(": ") || `HTTP ${res.status}`;
+    } catch {
+      // Non-JSON error body — surface HTTP status only (never raw body text).
+      detail = `HTTP ${res.status}`;
+    }
+    throw new Error(`token refresh failed: ${detail}`);
+  }
+
+  const data = (await res.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error("refresh response had no access_token field");
+  }
+  return data.access_token;
+}

--- a/packages/assistant/src/oauth/refresh.ts
+++ b/packages/assistant/src/oauth/refresh.ts
@@ -15,18 +15,38 @@ const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 
 /**
+ * The full rotated credential set returned by a successful token refresh.
+ *
+ * Claude Code ROTATES the refresh token on every successful refresh call —
+ * the old refresh token becomes dead immediately after the response. Callers
+ * MUST hold `refreshToken` in-memory for the next cycle; re-reading the
+ * keychain after a refresh will return the now-dead original token.
+ *
+ * `expiresIn` is seconds from now (standard OAuth2 `expires_in` field).
+ * May be absent if the server omits it; callers should treat absent as "unknown
+ * expiry" and attempt a refresh on the next use rather than serving a token
+ * whose freshness is unknowable.
+ */
+export interface RefreshedCredentials {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+}
+
+/**
  * Refreshes the Claude Code OAuth access token in-memory.
  *
- * - Never writes the refreshed token back to the keychain (would race Claude
- *   Code's own refresher and mutate the user's real credentials).
- * - Returns the new access token string in-memory only.
+ * - Returns the full rotated credential set (accessToken + rotated refreshToken
+ *   + expiresIn) so callers can track the new refresh token for the next cycle.
+ * - Never writes the refreshed credentials back to the keychain (would race
+ *   Claude Code's own refresher and mutate the user's real credentials).
  *
  * @throws if the refresh endpoint returns a non-2xx response.
  */
 export async function refreshAccessToken(
   refreshToken: string,
   fetchFn: typeof fetch = fetch,
-): Promise<string> {
+): Promise<RefreshedCredentials> {
   const res = await fetchFn(CLAUDE_OAUTH_TOKEN_URL, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -61,9 +81,25 @@ export async function refreshAccessToken(
     throw new Error(`token refresh failed: ${detail}`);
   }
 
-  const data = (await res.json()) as { access_token?: string };
+  const data = (await res.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: unknown;
+  };
   if (!data.access_token) {
     throw new Error("refresh response had no access_token field");
   }
-  return data.access_token;
+
+  return {
+    accessToken: data.access_token,
+    // Claude Code rotates the refresh token on each successful refresh.
+    // Preserve it in-memory so the next expiry cycle uses the live token.
+    refreshToken:
+      typeof data.refresh_token === "string" ? data.refresh_token : undefined,
+    // Standard OAuth2 expires_in is seconds; validate it's a positive number.
+    expiresIn:
+      typeof data.expires_in === "number" && data.expires_in > 0
+        ? data.expires_in
+        : undefined,
+  };
 }

--- a/packages/assistant/src/oauth/token-provider.test.ts
+++ b/packages/assistant/src/oauth/token-provider.test.ts
@@ -1,10 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { KeychainOAuth } from "./keychain.js";
-import { getOAuthToken, OAuthTokenExpiredError } from "./token-provider.js";
+import type { RefreshedCredentials } from "./refresh.js";
+import {
+  _resetInMemoryCredentials,
+  getOAuthToken,
+  OAuthTokenExpiredError,
+} from "./token-provider.js";
 
 const FUTURE = Date.now() + 3_600_000; // 1h from now — fresh
 const PAST = Date.now() - 3_600_000; // 1h ago — expired
+/** Just beyond the 60s safety margin — treated as fresh. */
+const NEAR_FUTURE = Date.now() + 61_000;
+/** Just within the 60s safety margin — treated as expiring/stale. */
+const EXPIRING_SOON = Date.now() + 59_000;
 
 function makeKeychain(overrides: Partial<KeychainOAuth> = {}): KeychainOAuth {
   return {
@@ -14,6 +23,22 @@ function makeKeychain(overrides: Partial<KeychainOAuth> = {}): KeychainOAuth {
     ...overrides,
   };
 }
+
+function makeRotated(
+  overrides: Partial<RefreshedCredentials> = {},
+): RefreshedCredentials {
+  return {
+    accessToken: "sk-ant-oat-mock-rotated-access-token",
+    refreshToken: "mock-rotated-refresh-token",
+    expiresIn: 3600,
+    ...overrides,
+  };
+}
+
+// Reset in-memory slot between tests so they are isolated.
+beforeEach(() => {
+  _resetInMemoryCredentials();
+});
 
 // ---------------------------------------------------------------------------
 // Security: token-never-logged invariant
@@ -74,7 +99,9 @@ describe("getOAuthToken — security invariant", () => {
     });
     const mockReadKeychain = vi.fn(async () => mockKeychain);
     const freshToken = "sk-ant-oat-mock-fresh-access-token";
-    const mockFetchRefresh = vi.fn(async (_rt: string) => freshToken);
+    const mockFetchRefresh = vi.fn(async (_rt: string) =>
+      makeRotated({ accessToken: freshToken }),
+    );
 
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];
@@ -139,10 +166,86 @@ describe("getOAuthToken — fresh token path", () => {
     expect(token).toBe("sk-ant-oat-mock-access-token");
     expect(mockFetchRefresh).not.toHaveBeenCalled();
   });
+
+  it("returns fresh token when expiresAt is just beyond the 60s safety margin", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: NEAR_FUTURE }),
+    );
+    const mockFetchRefresh = vi.fn();
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe("sk-ant-oat-mock-access-token");
+    expect(mockFetchRefresh).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
-// Expired token → refresh
+// Expiry safety margin
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — 60s expiry safety margin", () => {
+  it("proactively refreshes when token expires within 60s", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: EXPIRING_SOON }),
+    );
+    const rotated = makeRotated();
+    const mockFetchRefresh = vi.fn(async (_rt: string) => rotated);
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe(rotated.accessToken);
+    expect(mockFetchRefresh).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// String expiresAt (ISO timestamp)
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — string expiresAt", () => {
+  it("accepts a future ISO timestamp string as fresh", async () => {
+    const futureIso = new Date(Date.now() + 3_600_000).toISOString();
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: futureIso as unknown as number }),
+    );
+    const mockFetchRefresh = vi.fn();
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe("sk-ant-oat-mock-access-token");
+    expect(mockFetchRefresh).not.toHaveBeenCalled();
+  });
+
+  it("treats a past ISO timestamp string as expired — falls to refresh path", async () => {
+    const pastIso = new Date(Date.now() - 3_600_000).toISOString();
+    const rotated = makeRotated();
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: pastIso as unknown as number }),
+    );
+    const mockFetchRefresh = vi.fn(async (_rt: string) => rotated);
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe(rotated.accessToken);
+    expect(mockFetchRefresh).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expired token → refresh + token rotation
 // ---------------------------------------------------------------------------
 
 describe("getOAuthToken — expired token refresh", () => {
@@ -150,15 +253,15 @@ describe("getOAuthToken — expired token refresh", () => {
     const mockReadKeychain = vi.fn(async () =>
       makeKeychain({ expiresAt: PAST }),
     );
-    const refreshed = "sk-ant-oat-mock-refreshed-token";
-    const mockFetchRefresh = vi.fn(async (_rt: string) => refreshed);
+    const rotated = makeRotated();
+    const mockFetchRefresh = vi.fn(async (_rt: string) => rotated);
 
     const token = await getOAuthToken({
       readKeychain: mockReadKeychain,
       fetchRefresh: mockFetchRefresh,
     });
 
-    expect(token).toBe(refreshed);
+    expect(token).toBe(rotated.accessToken);
     expect(mockFetchRefresh).toHaveBeenCalledOnce();
     expect(mockFetchRefresh).toHaveBeenCalledWith("mock-refresh-token");
   });
@@ -193,6 +296,131 @@ describe("getOAuthToken — expired token refresh", () => {
         fetchRefresh: mockFetchRefresh,
       }),
     ).rejects.toThrow(/token refresh failed: 400/);
+  });
+
+  it("uses the rotated refresh token on the second expiry cycle (token rotation)", async () => {
+    // First call: keychain has original tokens, access token is expired.
+    // Refresh returns a rotated credential set.
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: PAST }),
+    );
+    const firstRotated: RefreshedCredentials = {
+      accessToken: "sk-ant-oat-first-rotated-access",
+      refreshToken: "first-rotated-refresh-token",
+      expiresIn: 1, // 1 second — will expire almost immediately
+    };
+    const secondRotated: RefreshedCredentials = {
+      accessToken: "sk-ant-oat-second-rotated-access",
+      refreshToken: "second-rotated-refresh-token",
+      expiresIn: 3600,
+    };
+    const mockFetchRefresh = vi
+      .fn()
+      .mockResolvedValueOnce(firstRotated)
+      .mockResolvedValueOnce(secondRotated);
+
+    // First call — triggers refresh, gets firstRotated
+    const token1 = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+    expect(token1).toBe(firstRotated.accessToken);
+
+    // Make the in-memory slot appear expired by backdating it.
+    // We reset and call again with an already-expired expiresIn.
+    // The second refresh must use firstRotated.refreshToken, NOT the original
+    // "mock-refresh-token" from the keychain (which is dead after rotation).
+    _resetInMemoryCredentials();
+
+    // Simulate: in-memory slot was populated by first call but now expired.
+    // We do this by calling again with readKeychain returning expired + rotated
+    // refresh token already used — the implementation should use in-memory slot.
+    // Instead, test directly: call again with the firstRotated refresh token
+    // as the in-memory state by setting up a second expired scenario.
+    //
+    // Re-run from scratch: first call populates in-memory with firstRotated.
+    // Then immediately simulate expiry by re-entering with expired in-memory slot.
+    _resetInMemoryCredentials();
+
+    // Rebuild: first call populates in-memory slot with firstRotated.
+    await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+    // mockFetchRefresh.calls[0] used "mock-refresh-token" (original from keychain)
+    // mockFetchRefresh.calls[1] used "first-rotated-refresh-token" (from in-memory)
+    // But in-memory slot has expiresIn=1 → already expired for a second call.
+    // Force the second call through by resetting ONLY the in-memory slot's token
+    // as expired — but we can't do that without a clock mock. Instead, test
+    // the invariant directly: verify the second fetchRefresh call used the
+    // rotated token, not the original keychain one.
+
+    // At this point mockFetchRefresh has been called twice (once from reset+first,
+    // once from the second attempt above). Verify the first call used the
+    // original refresh token.
+    const firstCallArg = mockFetchRefresh.mock.calls[0]?.[0];
+    expect(firstCallArg).toBe("mock-refresh-token");
+  });
+
+  it("second getOAuthToken call uses rotated refresh token (not dead keychain original)", async () => {
+    // Simulate token rotation correctly using a very short expiresIn so the
+    // in-memory slot is already expired on the second call.
+    // We use a mock that can control "now" via Date.now overriding.
+
+    const originalDateNow = Date.now;
+    let fakeNow = originalDateNow();
+
+    // Monkey-patch Date.now for this test
+    Date.now = () => fakeNow;
+
+    try {
+      const expiredAt = fakeNow - 100; // Already expired
+      const mockReadKeychain = vi.fn(async () =>
+        makeKeychain({ expiresAt: expiredAt }),
+      );
+
+      const firstRotated: RefreshedCredentials = {
+        accessToken: "sk-ant-oat-first-rotated-access",
+        refreshToken: "rotated-refresh-token-v2",
+        expiresIn: 60, // 60s from "now"
+      };
+      const secondRotated: RefreshedCredentials = {
+        accessToken: "sk-ant-oat-second-rotated-access",
+        refreshToken: "rotated-refresh-token-v3",
+        expiresIn: 3600,
+      };
+      const mockFetchRefresh = vi
+        .fn()
+        .mockResolvedValueOnce(firstRotated)
+        .mockResolvedValueOnce(secondRotated);
+
+      // First call — triggers refresh
+      const token1 = await getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      });
+      expect(token1).toBe(firstRotated.accessToken);
+      expect(mockFetchRefresh).toHaveBeenCalledTimes(1);
+      const call0Arg = mockFetchRefresh.mock.calls[0]?.[0];
+      expect(call0Arg).toBe("mock-refresh-token");
+
+      // Advance time past the in-memory token's expiry (60s + 61s safety margin)
+      fakeNow += (60 + 61) * 1000;
+
+      // Second call — in-memory slot is expired, must use rotated refresh token
+      const token2 = await getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      });
+      expect(token2).toBe(secondRotated.accessToken);
+      expect(mockFetchRefresh).toHaveBeenCalledTimes(2);
+      // CRITICAL: second call must use the rotated refresh token, NOT the original
+      const call1Arg = mockFetchRefresh.mock.calls[1]?.[0];
+      expect(call1Arg).toBe(firstRotated.refreshToken);
+      expect(call1Arg).not.toBe("mock-refresh-token");
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 });
 
@@ -244,18 +472,20 @@ describe("getOAuthToken — missing credentials", () => {
     // Intentional policy: when expiresAt is absent we cannot assert freshness,
     // so we attempt an in-memory refresh. This avoids silently serving a
     // potentially-stale token at the cost of an extra network call.
-    const refreshed = "sk-ant-oat-mock-refreshed-no-expiry";
+    const rotated = makeRotated({
+      accessToken: "sk-ant-oat-mock-refreshed-no-expiry",
+    });
     const mockReadKeychain = vi.fn(async () =>
       makeKeychain({ expiresAt: undefined }),
     );
-    const mockFetchRefresh = vi.fn(async (_rt: string) => refreshed);
+    const mockFetchRefresh = vi.fn(async (_rt: string) => rotated);
 
     const token = await getOAuthToken({
       readKeychain: mockReadKeychain,
       fetchRefresh: mockFetchRefresh,
     });
 
-    expect(token).toBe(refreshed);
+    expect(token).toBe(rotated.accessToken);
     expect(mockFetchRefresh).toHaveBeenCalledOnce();
   });
 
@@ -273,5 +503,41 @@ describe("getOAuthToken — missing credentials", () => {
     await expect(
       getOAuthToken({ readKeychain: mockReadKeychain }),
     ).rejects.toThrow("Failed to read Claude Code credentials from keychain");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-memory credential slot: isolation + reset
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — in-memory credential slot", () => {
+  it("_resetInMemoryCredentials clears state so next call re-reads the keychain", async () => {
+    // Populate the in-memory slot via a first refresh.
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: PAST }),
+    );
+    const rotated = makeRotated();
+    const mockFetchRefresh = vi.fn(async (_rt: string) => rotated);
+
+    await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+    expect(mockFetchRefresh).toHaveBeenCalledTimes(1);
+
+    // Reset slot — next call must re-read keychain.
+    _resetInMemoryCredentials();
+
+    // Provide a fresh keychain entry — should not need to refresh.
+    const freshKeychain = makeKeychain({ expiresAt: FUTURE });
+    const mockReadKeychain2 = vi.fn(async () => freshKeychain);
+    const mockFetchRefresh2 = vi.fn();
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain2,
+      fetchRefresh: mockFetchRefresh2,
+    });
+    expect(token).toBe(freshKeychain.accessToken);
+    expect(mockFetchRefresh2).not.toHaveBeenCalled();
   });
 });

--- a/packages/assistant/src/oauth/token-provider.test.ts
+++ b/packages/assistant/src/oauth/token-provider.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { KeychainOAuth } from "./keychain.js";
+import { getOAuthToken, OAuthTokenExpiredError } from "./token-provider.js";
+
+const FUTURE = Date.now() + 3_600_000; // 1h from now — fresh
+const PAST = Date.now() - 3_600_000; // 1h ago — expired
+
+function makeKeychain(overrides: Partial<KeychainOAuth> = {}): KeychainOAuth {
+  return {
+    accessToken: "sk-ant-oat-mock-access-token",
+    refreshToken: "mock-refresh-token",
+    expiresAt: FUTURE,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Security: token-never-logged invariant
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — security invariant", () => {
+  it("should never log the access token to stdout or stderr", async () => {
+    const mockKeychain = makeKeychain({ expiresAt: FUTURE });
+    const mockReadKeychain = vi.fn(async () => mockKeychain);
+
+    // intercept raw stream writes
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const origStdout = process.stdout.write.bind(process.stdout);
+    const origStderr = process.stderr.write.bind(process.stderr);
+
+    process.stdout.write = (chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return origStdout(chunk as Parameters<typeof origStdout>[0]);
+    };
+    process.stderr.write = (chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return origStderr(chunk as Parameters<typeof origStderr>[0]);
+    };
+
+    // Also spy on console.* — Vitest can buffer these separately from raw
+    // stream writes, so a naive process.stderr.write intercept won't catch
+    // console.error(token). Any console.* call with the token is a leak.
+    const consoleSpy = {
+      log: vi.spyOn(console, "log").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
+      warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+      debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+    };
+
+    try {
+      const token = await getOAuthToken({ readKeychain: mockReadKeychain });
+      const allOutput = [...stdoutChunks, ...stderrChunks].join("\n");
+      expect(allOutput).not.toContain(token);
+
+      // Assert console.* never received the token as any argument
+      for (const spy of Object.values(consoleSpy)) {
+        const allArgs = spy.mock.calls.flat().map(String).join("\n");
+        expect(allArgs).not.toContain(token);
+      }
+    } finally {
+      process.stdout.write = origStdout;
+      process.stderr.write = origStderr;
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("should never log the refreshed access token to stdout or stderr", async () => {
+    const mockKeychain = makeKeychain({
+      expiresAt: PAST,
+      accessToken: "sk-ant-oat-mock-stale-access-token",
+      refreshToken: "mock-refresh-token",
+    });
+    const mockReadKeychain = vi.fn(async () => mockKeychain);
+    const freshToken = "sk-ant-oat-mock-fresh-access-token";
+    const mockFetchRefresh = vi.fn(async (_rt: string) => freshToken);
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const origStdout = process.stdout.write.bind(process.stdout);
+    const origStderr = process.stderr.write.bind(process.stderr);
+
+    process.stdout.write = (chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return origStdout(chunk as Parameters<typeof origStdout>[0]);
+    };
+    process.stderr.write = (chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return origStderr(chunk as Parameters<typeof origStderr>[0]);
+    };
+
+    // Also spy on console.* — same reasoning as above
+    const consoleSpy = {
+      log: vi.spyOn(console, "log").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
+      warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+      debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+    };
+
+    try {
+      const token = await getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      });
+      const allOutput = [...stdoutChunks, ...stderrChunks].join("\n");
+      expect(allOutput).not.toContain(token);
+      expect(token).toBe(freshToken);
+
+      // Assert console.* never received the token as any argument
+      for (const spy of Object.values(consoleSpy)) {
+        const allArgs = spy.mock.calls.flat().map(String).join("\n");
+        expect(allArgs).not.toContain(token);
+      }
+    } finally {
+      process.stdout.write = origStdout;
+      process.stderr.write = origStderr;
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy paths
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — fresh token path", () => {
+  it("returns the access token directly when expiresAt is in the future", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: FUTURE }),
+    );
+    const mockFetchRefresh = vi.fn();
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe("sk-ant-oat-mock-access-token");
+    expect(mockFetchRefresh).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expired token → refresh
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — expired token refresh", () => {
+  it("calls refresh when access token is expired and returns refreshed token", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: PAST }),
+    );
+    const refreshed = "sk-ant-oat-mock-refreshed-token";
+    const mockFetchRefresh = vi.fn(async (_rt: string) => refreshed);
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe(refreshed);
+    expect(mockFetchRefresh).toHaveBeenCalledOnce();
+    expect(mockFetchRefresh).toHaveBeenCalledWith("mock-refresh-token");
+  });
+
+  it("throws OAuthTokenExpiredError when refresh returns 400 (dead refresh token)", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: PAST }),
+    );
+    const mockFetchRefresh = vi.fn(async (_rt: string) => {
+      throw new Error("token refresh failed: 400 Bad Request");
+    });
+
+    await expect(
+      getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      }),
+    ).rejects.toThrow(OAuthTokenExpiredError);
+  });
+
+  it("OAuthTokenExpiredError message includes cause when refresh fails", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: PAST }),
+    );
+    const mockFetchRefresh = vi.fn(async (_rt: string) => {
+      throw new Error("token refresh failed: 400 Bad Request");
+    });
+
+    await expect(
+      getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      }),
+    ).rejects.toThrow(/token refresh failed: 400/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing / no-credential cases
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — missing credentials", () => {
+  it("throws OAuthTokenExpiredError when no claudeAiOauth block found (missing both tokens)", async () => {
+    const mockReadKeychain = vi.fn(async () => ({}) as KeychainOAuth);
+
+    await expect(
+      getOAuthToken({ readKeychain: mockReadKeychain }),
+    ).rejects.toThrow(OAuthTokenExpiredError);
+  });
+
+  it("OAuthTokenExpiredError message mentions 'missing' when no credential", async () => {
+    const mockReadKeychain = vi.fn(async () => ({}) as KeychainOAuth);
+
+    await expect(
+      getOAuthToken({ readKeychain: mockReadKeychain }),
+    ).rejects.toThrow(/missing accessToken and refreshToken/);
+  });
+
+  it("throws OAuthTokenExpiredError when accessToken expired and no refreshToken", async () => {
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({
+        expiresAt: PAST,
+        refreshToken: undefined,
+      }),
+    );
+
+    await expect(
+      getOAuthToken({ readKeychain: mockReadKeychain }),
+    ).rejects.toThrow(OAuthTokenExpiredError);
+  });
+
+  it("OAuthTokenExpiredError is an instanceof Error", async () => {
+    const mockReadKeychain = vi.fn(async () => ({}) as KeychainOAuth);
+
+    const err = await getOAuthToken({ readKeychain: mockReadKeychain }).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(OAuthTokenExpiredError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("treats accessToken present with undefined expiresAt as expired — falls to refresh path", async () => {
+    // Intentional policy: when expiresAt is absent we cannot assert freshness,
+    // so we attempt an in-memory refresh. This avoids silently serving a
+    // potentially-stale token at the cost of an extra network call.
+    const refreshed = "sk-ant-oat-mock-refreshed-no-expiry";
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: undefined }),
+    );
+    const mockFetchRefresh = vi.fn(async (_rt: string) => refreshed);
+
+    const token = await getOAuthToken({
+      readKeychain: mockReadKeychain,
+      fetchRefresh: mockFetchRefresh,
+    });
+
+    expect(token).toBe(refreshed);
+    expect(mockFetchRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("propagates a raw Error (not OAuthTokenExpiredError) when the keychain reader throws — callers receive a clear failure", async () => {
+    // readKeychainOAuth throws a plain Error (e.g. OS keychain unavailable).
+    // This is intentionally NOT wrapped in OAuthTokenExpiredError — it's an
+    // infrastructure failure, not an expired-credential case. The error still
+    // satisfies "fail-closed": it throws, never silently falls back.
+    const mockReadKeychain = vi.fn(async () => {
+      throw new Error(
+        "Failed to read Claude Code credentials from keychain: the tool exited with status 44",
+      );
+    });
+
+    await expect(
+      getOAuthToken({ readKeychain: mockReadKeychain }),
+    ).rejects.toThrow("Failed to read Claude Code credentials from keychain");
+  });
+});

--- a/packages/assistant/src/oauth/token-provider.test.ts
+++ b/packages/assistant/src/oauth/token-provider.test.ts
@@ -298,70 +298,6 @@ describe("getOAuthToken — expired token refresh", () => {
     ).rejects.toThrow(/token refresh failed: 400/);
   });
 
-  it("uses the rotated refresh token on the second expiry cycle (token rotation)", async () => {
-    // First call: keychain has original tokens, access token is expired.
-    // Refresh returns a rotated credential set.
-    const mockReadKeychain = vi.fn(async () =>
-      makeKeychain({ expiresAt: PAST }),
-    );
-    const firstRotated: RefreshedCredentials = {
-      accessToken: "sk-ant-oat-first-rotated-access",
-      refreshToken: "first-rotated-refresh-token",
-      expiresIn: 1, // 1 second — will expire almost immediately
-    };
-    const secondRotated: RefreshedCredentials = {
-      accessToken: "sk-ant-oat-second-rotated-access",
-      refreshToken: "second-rotated-refresh-token",
-      expiresIn: 3600,
-    };
-    const mockFetchRefresh = vi
-      .fn()
-      .mockResolvedValueOnce(firstRotated)
-      .mockResolvedValueOnce(secondRotated);
-
-    // First call — triggers refresh, gets firstRotated
-    const token1 = await getOAuthToken({
-      readKeychain: mockReadKeychain,
-      fetchRefresh: mockFetchRefresh,
-    });
-    expect(token1).toBe(firstRotated.accessToken);
-
-    // Make the in-memory slot appear expired by backdating it.
-    // We reset and call again with an already-expired expiresIn.
-    // The second refresh must use firstRotated.refreshToken, NOT the original
-    // "mock-refresh-token" from the keychain (which is dead after rotation).
-    _resetInMemoryCredentials();
-
-    // Simulate: in-memory slot was populated by first call but now expired.
-    // We do this by calling again with readKeychain returning expired + rotated
-    // refresh token already used — the implementation should use in-memory slot.
-    // Instead, test directly: call again with the firstRotated refresh token
-    // as the in-memory state by setting up a second expired scenario.
-    //
-    // Re-run from scratch: first call populates in-memory with firstRotated.
-    // Then immediately simulate expiry by re-entering with expired in-memory slot.
-    _resetInMemoryCredentials();
-
-    // Rebuild: first call populates in-memory slot with firstRotated.
-    await getOAuthToken({
-      readKeychain: mockReadKeychain,
-      fetchRefresh: mockFetchRefresh,
-    });
-    // mockFetchRefresh.calls[0] used "mock-refresh-token" (original from keychain)
-    // mockFetchRefresh.calls[1] used "first-rotated-refresh-token" (from in-memory)
-    // But in-memory slot has expiresIn=1 → already expired for a second call.
-    // Force the second call through by resetting ONLY the in-memory slot's token
-    // as expired — but we can't do that without a clock mock. Instead, test
-    // the invariant directly: verify the second fetchRefresh call used the
-    // rotated token, not the original keychain one.
-
-    // At this point mockFetchRefresh has been called twice (once from reset+first,
-    // once from the second attempt above). Verify the first call used the
-    // original refresh token.
-    const firstCallArg = mockFetchRefresh.mock.calls[0]?.[0];
-    expect(firstCallArg).toBe("mock-refresh-token");
-  });
-
   it("second getOAuthToken call uses rotated refresh token (not dead keychain original)", async () => {
     // Simulate token rotation correctly using a very short expiresIn so the
     // in-memory slot is already expired on the second call.
@@ -539,5 +475,52 @@ describe("getOAuthToken — in-memory credential slot", () => {
     });
     expect(token).toBe(freshKeychain.accessToken);
     expect(mockFetchRefresh2).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent refresh — single-flight dedup
+// ---------------------------------------------------------------------------
+
+describe("getOAuthToken — concurrent refresh dedup (single-flight)", () => {
+  it("fires the refresh exactly once when two concurrent calls race on an expired token", async () => {
+    // Both calls arrive with an expired in-memory state. Without single-flight
+    // dedup, both would call refresher() — the second sends the now-dead
+    // (rotated) original refresh token → 400 on Claude's server.
+    const mockReadKeychain = vi.fn(async () =>
+      makeKeychain({ expiresAt: PAST }),
+    );
+
+    let resolveRefresh!: (v: RefreshedCredentials) => void;
+    const refreshPromise = new Promise<RefreshedCredentials>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const mockFetchRefresh = vi.fn(() => refreshPromise);
+
+    // Fire two concurrent calls before the refresh resolves.
+    const [p1, p2] = [
+      getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      }),
+      getOAuthToken({
+        readKeychain: mockReadKeychain,
+        fetchRefresh: mockFetchRefresh,
+      }),
+    ];
+
+    // Resolve the refresh now — both callers should get the same token.
+    const rotated = makeRotated({
+      accessToken: "sk-ant-oat-single-flight-token",
+    });
+    resolveRefresh(rotated);
+
+    const [t1, t2] = await Promise.all([p1, p2]);
+
+    // Both callers receive the refreshed token.
+    expect(t1).toBe(rotated.accessToken);
+    expect(t2).toBe(rotated.accessToken);
+    // The refresh was only called once — no rotation-invalidating second call.
+    expect(mockFetchRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/assistant/src/oauth/token-provider.ts
+++ b/packages/assistant/src/oauth/token-provider.ts
@@ -1,0 +1,100 @@
+import type { KeychainOAuth } from "./keychain.js";
+import { readKeychainOAuth } from "./keychain.js";
+import { refreshAccessToken } from "./refresh.js";
+
+/**
+ * Thrown when the keychain access token is expired AND the refresh token is
+ * also dead (or absent). Fail-closed: never silently falls back to an
+ * unauthenticated state.
+ */
+export class OAuthTokenExpiredError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "OAuthTokenExpiredError";
+  }
+}
+
+export interface TokenProviderOptions {
+  /**
+   * Injectable keychain reader for testing.
+   * Defaults to the real macOS keychain read via `security`.
+   */
+  readKeychain?: () => KeychainOAuth | Promise<KeychainOAuth>;
+
+  /**
+   * Injectable fetch for token refresh, for testing.
+   * Defaults to the real global `fetch`.
+   */
+  fetchRefresh?: (refreshToken: string) => Promise<string>;
+}
+
+/**
+ * Returns a live Claude Code OAuth access token (sk-ant-oat…).
+ *
+ * Strategy:
+ * 1. Read the credential from the macOS keychain.
+ * 2. If the stored access token is fresh (expiresAt in the future) → return it.
+ * 3. If the access token is expired → refresh in-memory via the OAuth endpoint.
+ * 4. If both are dead → throw OAuthTokenExpiredError (fail-closed).
+ *
+ * Security invariants:
+ * - Token is never written to console.log, process.stdout, or process.stderr.
+ * - Token is never written to disk.
+ * - Refreshed token is never written back to the keychain.
+ * - Token is returned by value for the caller's use; callers must not log it.
+ *
+ * Note on SecretVault: the token is returned as a bare string (not wrapped in
+ * a SecretVault ref / withSecret lease) because pi's `getApiKey` hook expects
+ * a plain string. A withSecret-style opaque holder would require pi to be
+ * vault-aware, which it is not. The trust boundary is at the process level:
+ * the token exists in-memory for the duration of the agent turn. Callers
+ * MUST NOT log or persist the returned value.
+ */
+export async function getOAuthToken(
+  options: TokenProviderOptions = {},
+): Promise<string> {
+  const keychainReader = options.readKeychain ?? readKeychainOAuth;
+  const refresher = options.fetchRefresh ?? refreshAccessToken;
+
+  const kc = await keychainReader();
+
+  if (!kc.accessToken && !kc.refreshToken) {
+    throw new OAuthTokenExpiredError(
+      "no claudeAiOauth credentials found in keychain (missing accessToken and refreshToken)",
+    );
+  }
+
+  // Conservative freshness: if expiresAt is absent or non-numeric, we cannot
+  // assert the token is still valid, so we fall to the refresh path. This
+  // avoids silently serving a potentially-stale token at the cost of an extra
+  // network call. Callers that prefer returning an existing token when expiresAt
+  // is absent can set a permissive readKeychain mock.
+  const isFresh = typeof kc.expiresAt === "number" && Date.now() < kc.expiresAt;
+
+  if (isFresh && kc.accessToken) {
+    return kc.accessToken;
+  }
+
+  // Access token is expired or missing. Try the refresh path.
+  if (!kc.refreshToken) {
+    throw new OAuthTokenExpiredError(
+      "keychain access token is expired and no refreshToken is present — re-authenticate with Claude Code",
+    );
+  }
+
+  // Perform the in-memory refresh. If this throws (e.g. 400/401 from server),
+  // we surface it as OAuthTokenExpiredError so callers get a typed sentinel.
+  try {
+    process.stderr.write(
+      `[assistant/oauth] keychain access token expired (expiresAt=${kc.expiresAt ?? "none"}); refreshing in-memory…\n`,
+    );
+    const freshToken = await refresher(kc.refreshToken);
+    return freshToken;
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new OAuthTokenExpiredError(
+      `OAuth refresh failed — re-authenticate with Claude Code. Cause: ${cause}`,
+      { cause: err },
+    );
+  }
+}

--- a/packages/assistant/src/oauth/token-provider.ts
+++ b/packages/assistant/src/oauth/token-provider.ts
@@ -104,7 +104,19 @@ let inMemoryCredentials: {
   expiresAtMs: number | undefined;
 } | null = null;
 
-export async function getOAuthToken(
+/**
+ * In-flight refresh Promise (single-flight dedup).
+ *
+ * When a refresh is already in progress, concurrent callers await the same
+ * Promise rather than issuing parallel refresh requests. This is critical for
+ * token rotation: Claude Code rotates the refresh token on every successful
+ * refresh, so a second parallel refresh would send a token the first call just
+ * invalidated → 400 error + corrupted in-memory slot. The Promise is cleared
+ * (set to null) when the refresh settles, regardless of outcome.
+ */
+let inFlightRefresh: Promise<string> | null = null;
+
+export function getOAuthToken(
   options: TokenProviderOptions = {},
 ): Promise<string> {
   const keychainReader = options.readKeychain ?? readKeychainOAuth;
@@ -119,93 +131,124 @@ export async function getOAuthToken(
     const isFresh =
       typeof expiresAtMs === "number" &&
       Date.now() + EXPIRY_MARGIN_MS < expiresAtMs;
-    if (isFresh) return accessToken;
+    if (isFresh) return Promise.resolve(accessToken);
     // In-memory slot is stale — fall through to refresh using the in-memory
     // refresh token (which may be rotated from the keychain's original).
   }
 
   // ------------------------------------------------------------------
-  // 2. Read from keychain (first call, or in-memory slot exhausted before
-  //    we had a chance to refresh it).
+  // 2. Single-flight dedup: if a refresh is already in flight, join it.
+  //
+  //    This check is synchronous — before any await — so concurrent callers
+  //    that enter this function while a refresh is in progress will see the
+  //    live `inFlightRefresh` Promise and await it rather than issuing a
+  //    second (rotation-invalidating) refresh call.
+  //
+  //    The `inFlightRefresh` Promise is set below (step 4) synchronously
+  //    before any await, so the first caller to reach step 4 wins the
+  //    lock and all later callers that reach THIS check (steps 1–2) see
+  //    the live Promise immediately.
   // ------------------------------------------------------------------
-  const kc = await keychainReader();
-
-  if (!kc.accessToken && !kc.refreshToken) {
-    throw new OAuthTokenExpiredError(
-      "no claudeAiOauth credentials found in keychain (missing accessToken and refreshToken)",
-    );
-  }
-
-  // Resolve expiresAt — keychain may store numeric ms or ISO string.
-  const expiresAtMs = parseExpiresAt(
-    kc.expiresAt as number | string | undefined,
-  );
-
-  // Conservative freshness: if expiresAt is absent or unparseable, we cannot
-  // assert the token is still valid, so we fall to the refresh path. This
-  // avoids silently serving a potentially-stale token at the cost of an extra
-  // network call. Apply a 60s safety margin so tokens expiring imminently
-  // are proactively refreshed before they actually expire.
-  const isFresh =
-    typeof expiresAtMs === "number" &&
-    Date.now() + EXPIRY_MARGIN_MS < expiresAtMs;
-
-  if (isFresh && kc.accessToken) {
-    return kc.accessToken;
+  if (inFlightRefresh) {
+    return inFlightRefresh;
   }
 
   // ------------------------------------------------------------------
-  // 3. Access token is expired or expiring. Determine which refresh token
-  //    to use: prefer the in-memory (potentially rotated) token over the
-  //    keychain's original, which may be dead after a prior rotation.
+  // 3. No in-flight refresh yet. Register the guard Promise synchronously
+  //    before any await so concurrent callers see it at step 2.
   // ------------------------------------------------------------------
-  const refreshToken = inMemoryCredentials?.refreshToken ?? kc.refreshToken;
+  inFlightRefresh = (async (): Promise<string> => {
+    try {
+      // Read from keychain (first call, or in-memory slot exhausted before
+      // we had a chance to refresh it).
+      const kc = await keychainReader();
 
-  if (!refreshToken) {
-    throw new OAuthTokenExpiredError(
-      "keychain access token is expired and no refreshToken is present — re-authenticate with Claude Code",
-    );
-  }
+      if (!kc.accessToken && !kc.refreshToken) {
+        throw new OAuthTokenExpiredError(
+          "no claudeAiOauth credentials found in keychain (missing accessToken and refreshToken)",
+        );
+      }
 
-  // Perform the in-memory refresh. If this throws (e.g. 400/401 from server),
-  // we surface it as OAuthTokenExpiredError so callers get a typed sentinel.
-  try {
-    process.stderr.write(
-      `[assistant/oauth] keychain access token expired (expiresAt=${kc.expiresAt ?? "none"}); refreshing in-memory…\n`,
-    );
-    const rotated: RefreshedCredentials = await refresher(refreshToken);
+      // Resolve expiresAt — keychain may store numeric ms or ISO string.
+      const expiresAtMs = parseExpiresAt(
+        kc.expiresAt as number | string | undefined,
+      );
 
-    // ------------------------------------------------------------------
-    // 4. Update the in-memory credential slot with the rotated values.
-    //    Claude Code rotates the refresh token on every successful refresh —
-    //    the old token is dead. We hold the new token in-memory; the keychain
-    //    entry is NOT written back (would race Claude Code's own refresher).
-    // ------------------------------------------------------------------
-    const newExpiresAtMs =
-      typeof rotated.expiresIn === "number"
-        ? Date.now() + rotated.expiresIn * 1000
-        : undefined;
+      // Conservative freshness: if expiresAt is absent or unparseable, we cannot
+      // assert the token is still valid, so we fall to the refresh path. This
+      // avoids silently serving a potentially-stale token at the cost of an extra
+      // network call. Apply a 60s safety margin so tokens expiring imminently
+      // are proactively refreshed before they actually expire.
+      const isFresh =
+        typeof expiresAtMs === "number" &&
+        Date.now() + EXPIRY_MARGIN_MS < expiresAtMs;
 
-    inMemoryCredentials = {
-      accessToken: rotated.accessToken,
-      // If the server didn't return a new refresh token (non-rotating server),
-      // keep the one we just used so the next cycle still has a token to try.
-      refreshToken: rotated.refreshToken ?? refreshToken,
-      expiresAtMs: newExpiresAtMs,
-    };
+      if (isFresh && kc.accessToken) {
+        return kc.accessToken;
+      }
 
-    return rotated.accessToken;
-  } catch (err) {
-    const cause = err instanceof Error ? err.message : String(err);
-    throw new OAuthTokenExpiredError(
-      `OAuth refresh failed — re-authenticate with Claude Code. Cause: ${cause}`,
-      { cause: err },
-    );
-  }
+      // ------------------------------------------------------------------
+      // Determine which refresh token to use: prefer the in-memory
+      // (potentially rotated) token over the keychain's original, which may
+      // be dead after a prior rotation.
+      // ------------------------------------------------------------------
+      const refreshToken = inMemoryCredentials?.refreshToken ?? kc.refreshToken;
+
+      if (!refreshToken) {
+        throw new OAuthTokenExpiredError(
+          "keychain access token is expired and no refreshToken is present — re-authenticate with Claude Code",
+        );
+      }
+
+      // ------------------------------------------------------------------
+      // Perform the in-memory refresh.
+      // NOTE: expiresAt is a timestamp — never the token itself — so
+      // interpolating it here is safe.
+      // ------------------------------------------------------------------
+      process.stderr.write(
+        `[assistant/oauth] keychain access token expired (expiresAt=${kc.expiresAt ?? "none"}); refreshing in-memory…\n`,
+      );
+      const rotated: RefreshedCredentials = await refresher(refreshToken);
+
+      // ------------------------------------------------------------------
+      // Update the in-memory credential slot with the rotated values.
+      // Claude Code rotates the refresh token on every successful refresh —
+      // the old token is dead. We hold the new token in-memory; the keychain
+      // entry is NOT written back (would race Claude Code's own refresher).
+      // ------------------------------------------------------------------
+      const newExpiresAtMs =
+        typeof rotated.expiresIn === "number"
+          ? Date.now() + rotated.expiresIn * 1000
+          : undefined;
+
+      inMemoryCredentials = {
+        accessToken: rotated.accessToken,
+        // If the server didn't return a new refresh token (non-rotating server),
+        // keep the one we just used so the next cycle still has a token to try.
+        refreshToken: rotated.refreshToken ?? refreshToken,
+        expiresAtMs: newExpiresAtMs,
+      };
+
+      return rotated.accessToken;
+    } catch (err) {
+      if (err instanceof OAuthTokenExpiredError) throw err;
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new OAuthTokenExpiredError(
+        `OAuth refresh failed — re-authenticate with Claude Code. Cause: ${cause}`,
+        { cause: err },
+      );
+    } finally {
+      // Clear the in-flight guard regardless of outcome so subsequent calls
+      // (after this one settles) can initiate a new refresh if needed.
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
 }
 
 /**
- * Resets the in-memory credential slot.
+ * Resets the in-memory credential slot and in-flight refresh guard.
  *
  * Exposed for testing only — allows tests to clear module-level state between
  * cases without reimporting. NOT part of the public API surface.
@@ -214,4 +257,5 @@ export async function getOAuthToken(
  */
 export function _resetInMemoryCredentials(): void {
   inMemoryCredentials = null;
+  inFlightRefresh = null;
 }

--- a/packages/assistant/src/oauth/token-provider.ts
+++ b/packages/assistant/src/oauth/token-provider.ts
@@ -1,5 +1,6 @@
 import type { KeychainOAuth } from "./keychain.js";
 import { readKeychainOAuth } from "./keychain.js";
+import type { RefreshedCredentials } from "./refresh.js";
 import { refreshAccessToken } from "./refresh.js";
 
 /**
@@ -24,8 +25,28 @@ export interface TokenProviderOptions {
   /**
    * Injectable fetch for token refresh, for testing.
    * Defaults to the real global `fetch`.
+   *
+   * Returns the full rotated credential set so the caller can track the new
+   * refresh token for the next cycle (Claude Code rotates it on every call).
    */
-  fetchRefresh?: (refreshToken: string) => Promise<string>;
+  fetchRefresh?: (refreshToken: string) => Promise<RefreshedCredentials>;
+}
+
+/**
+ * Parses `expiresAt` to a Unix-ms timestamp, accepting both numeric ms values
+ * and ISO-8601 strings. Returns `undefined` when the value is absent or
+ * unparseable — callers treat absent expiry as "unknown, must refresh."
+ *
+ * Claude Code stores `expiresAt` as either a numeric milliseconds value or an
+ * ISO timestamp string, depending on the version that wrote the keychain entry.
+ */
+function parseExpiresAt(raw: number | string | undefined): number | undefined {
+  if (typeof raw === "number") return raw > 0 ? raw : undefined;
+  if (typeof raw === "string") {
+    const ms = Date.parse(raw);
+    return isNaN(ms) ? undefined : ms;
+  }
+  return undefined;
 }
 
 /**
@@ -33,9 +54,11 @@ export interface TokenProviderOptions {
  *
  * Strategy:
  * 1. Read the credential from the macOS keychain.
- * 2. If the stored access token is fresh (expiresAt in the future) → return it.
+ * 2. If the stored access token is fresh (expiresAt > now + 60s) → return it.
  * 3. If the access token is expired → refresh in-memory via the OAuth endpoint.
- * 4. If both are dead → throw OAuthTokenExpiredError (fail-closed).
+ * 4. Hold the rotated refresh token + new expiry in-memory for the session so
+ *    subsequent calls use the live token, not the dead original in the keychain.
+ * 5. If both are dead → throw OAuthTokenExpiredError (fail-closed).
  *
  * Security invariants:
  * - Token is never written to console.log, process.stdout, or process.stderr.
@@ -43,19 +66,68 @@ export interface TokenProviderOptions {
  * - Refreshed token is never written back to the keychain.
  * - Token is returned by value for the caller's use; callers must not log it.
  *
+ * Token rotation:
+ * - Claude Code ROTATES the refresh token on every successful refresh response.
+ * - The in-memory credential slot is updated after each refresh so the next
+ *   expiry cycle uses the live (rotated) refresh token, not the dead original.
+ * - The keychain entry is NOT updated; it remains the original and becomes stale
+ *   after the first rotation. Re-reading the keychain after a rotation would
+ *   yield a dead refresh token — hence the in-memory slot.
+ *
  * Note on SecretVault: the token is returned as a bare string (not wrapped in
  * a SecretVault ref / withSecret lease) because pi's `getApiKey` hook expects
  * a plain string. A withSecret-style opaque holder would require pi to be
  * vault-aware, which it is not. The trust boundary is at the process level:
  * the token exists in-memory for the duration of the agent turn. Callers
  * MUST NOT log or persist the returned value.
+ *
+ * Expiry safety margin:
+ * - A 60-second safety margin is applied so that a token expiring imminently
+ *   triggers a refresh before it actually expires rather than after. This avoids
+ *   in-flight race conditions where the token expires mid-request.
  */
+
+/** Seconds before expiry at which we proactively refresh. */
+const EXPIRY_MARGIN_MS = 60_000;
+
+/**
+ * In-memory credential slot updated after each successful refresh.
+ * Tracks the rotated refresh token and new expiry so subsequent calls within
+ * the same process do not re-read a stale keychain entry.
+ *
+ * Module-level state is intentional: a single process runs one agent turn;
+ * there is no multi-tenant concern. The slot holds secrets only in-memory.
+ */
+let inMemoryCredentials: {
+  accessToken: string;
+  refreshToken: string;
+  expiresAtMs: number | undefined;
+} | null = null;
+
 export async function getOAuthToken(
   options: TokenProviderOptions = {},
 ): Promise<string> {
   const keychainReader = options.readKeychain ?? readKeychainOAuth;
   const refresher = options.fetchRefresh ?? refreshAccessToken;
 
+  // ------------------------------------------------------------------
+  // 1. Check the in-memory credential slot first (populated after first
+  //    successful in-memory refresh — holds the rotated refresh token).
+  // ------------------------------------------------------------------
+  if (inMemoryCredentials) {
+    const { accessToken, expiresAtMs } = inMemoryCredentials;
+    const isFresh =
+      typeof expiresAtMs === "number" &&
+      Date.now() + EXPIRY_MARGIN_MS < expiresAtMs;
+    if (isFresh) return accessToken;
+    // In-memory slot is stale — fall through to refresh using the in-memory
+    // refresh token (which may be rotated from the keychain's original).
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Read from keychain (first call, or in-memory slot exhausted before
+  //    we had a chance to refresh it).
+  // ------------------------------------------------------------------
   const kc = await keychainReader();
 
   if (!kc.accessToken && !kc.refreshToken) {
@@ -64,19 +136,32 @@ export async function getOAuthToken(
     );
   }
 
-  // Conservative freshness: if expiresAt is absent or non-numeric, we cannot
+  // Resolve expiresAt — keychain may store numeric ms or ISO string.
+  const expiresAtMs = parseExpiresAt(
+    kc.expiresAt as number | string | undefined,
+  );
+
+  // Conservative freshness: if expiresAt is absent or unparseable, we cannot
   // assert the token is still valid, so we fall to the refresh path. This
   // avoids silently serving a potentially-stale token at the cost of an extra
-  // network call. Callers that prefer returning an existing token when expiresAt
-  // is absent can set a permissive readKeychain mock.
-  const isFresh = typeof kc.expiresAt === "number" && Date.now() < kc.expiresAt;
+  // network call. Apply a 60s safety margin so tokens expiring imminently
+  // are proactively refreshed before they actually expire.
+  const isFresh =
+    typeof expiresAtMs === "number" &&
+    Date.now() + EXPIRY_MARGIN_MS < expiresAtMs;
 
   if (isFresh && kc.accessToken) {
     return kc.accessToken;
   }
 
-  // Access token is expired or missing. Try the refresh path.
-  if (!kc.refreshToken) {
+  // ------------------------------------------------------------------
+  // 3. Access token is expired or expiring. Determine which refresh token
+  //    to use: prefer the in-memory (potentially rotated) token over the
+  //    keychain's original, which may be dead after a prior rotation.
+  // ------------------------------------------------------------------
+  const refreshToken = inMemoryCredentials?.refreshToken ?? kc.refreshToken;
+
+  if (!refreshToken) {
     throw new OAuthTokenExpiredError(
       "keychain access token is expired and no refreshToken is present — re-authenticate with Claude Code",
     );
@@ -88,8 +173,28 @@ export async function getOAuthToken(
     process.stderr.write(
       `[assistant/oauth] keychain access token expired (expiresAt=${kc.expiresAt ?? "none"}); refreshing in-memory…\n`,
     );
-    const freshToken = await refresher(kc.refreshToken);
-    return freshToken;
+    const rotated: RefreshedCredentials = await refresher(refreshToken);
+
+    // ------------------------------------------------------------------
+    // 4. Update the in-memory credential slot with the rotated values.
+    //    Claude Code rotates the refresh token on every successful refresh —
+    //    the old token is dead. We hold the new token in-memory; the keychain
+    //    entry is NOT written back (would race Claude Code's own refresher).
+    // ------------------------------------------------------------------
+    const newExpiresAtMs =
+      typeof rotated.expiresIn === "number"
+        ? Date.now() + rotated.expiresIn * 1000
+        : undefined;
+
+    inMemoryCredentials = {
+      accessToken: rotated.accessToken,
+      // If the server didn't return a new refresh token (non-rotating server),
+      // keep the one we just used so the next cycle still has a token to try.
+      refreshToken: rotated.refreshToken ?? refreshToken,
+      expiresAtMs: newExpiresAtMs,
+    };
+
+    return rotated.accessToken;
   } catch (err) {
     const cause = err instanceof Error ? err.message : String(err);
     throw new OAuthTokenExpiredError(
@@ -97,4 +202,16 @@ export async function getOAuthToken(
       { cause: err },
     );
   }
+}
+
+/**
+ * Resets the in-memory credential slot.
+ *
+ * Exposed for testing only — allows tests to clear module-level state between
+ * cases without reimporting. NOT part of the public API surface.
+ *
+ * @internal
+ */
+export function _resetInMemoryCredentials(): void {
+  inMemoryCredentials = null;
 }

--- a/packages/assistant/tsconfig.json
+++ b/packages/assistant/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
   "compilerOptions": {
-    "rootDir": "src",
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
+    "types": ["bun"]
+  }
 }

--- a/packages/assistant/vitest.config.ts
+++ b/packages/assistant/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary

- Adds `@dashframe/assistant` OAuth credential lifecycle: reads the Claude Code subscription token (`sk-ant-oat…`) from the macOS keychain at runtime, refreshes it in-memory when expired, and fails closed on dead credentials — token never persisted, logged, or written back to the keychain.
- Owns the OAuth refresh leg inline (pi's `refreshAnthropicToken` is in the `.d.ts` but unreachable at runtime — no `./oauth` export subpath in pi's `exports` map). Refreshes via POST to `https://platform.claude.com/v1/oauth/token` using Claude Code's public client_id.
- Typed `OAuthTokenExpiredError` sentinel for expired/dead-credential failures so callers get a discriminable, typed error, not a generic crash.
- 30 tests: token-never-logged invariant (intercepts `process.stdout/stderr.write` + spies on `console.*`), fresh/expired/dead-refresh paths, `expiresAt`-absent policy, raw keychain error propagation.

## Tracked internally as YW-277

## Security invariants (all hold, tested)
- Token never written to `process.stdout`, `process.stderr`, or any `console.*` channel — proven by test.
- Token never written to disk or back to keychain.
- Refresh token never echoed in error messages — raw server body sanitized to structured `error`/`error_description` fields.
- Fail-closed: dead credentials → `OAuthTokenExpiredError`, no silent fallback.

## Local review gate evidence
- `turbo typecheck --filter=@dashframe/assistant`: 2 tasks successful, 0 errors.
- `turbo lint --filter=@dashframe/assistant`: 1 task successful, 0 errors.
- `bun run test --cwd packages/assistant`: 30/30 tests pass (3 test files).
- `wystack-agent-kit:code-review --effort high`: 3 MUSTs applied (refresh error body sanitized, unused dep removed + deliberate bare-string return documented, `console.*` spies added to token-never-logged tests), 2 SUGGESTs resolved (expiresAt-absent policy documented + tested, keychain-error propagation tested).

## LATER findings (not blocking)
- Security: consider an HTTPS URL assertion at module load for `CLAUDE_OAUTH_TOKEN_URL` (defense-in-depth, not a current risk).
- Security: the `(err as Error).message` interpolation in `keychain.ts` is correct but a comment pinning "never interpolate the full error object" would prevent future widening.

## Test plan
- [ ] All 30 tests pass: `bun run test --cwd packages/assistant`
- [ ] Typecheck green: `turbo typecheck --filter=@dashframe/assistant`
- [ ] Lint green: `turbo lint --filter=@dashframe/assistant`
- [ ] Token-never-logged: the two security invariant tests in `token-provider.test.ts` assert the token is absent from all stdout/stderr/console.* output
- [ ] Live token path (YW-282): run `getOAuthToken()` with a fresh interactive Claude Code login to confirm the non-expired path; run after token expires to confirm in-memory refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a complete OAuth credential lifecycle to `@dashframe/assistant`: reads the Claude Code subscription token from the macOS keychain at runtime, applies a 60s safety margin, and refreshes in-memory when expired — with token rotation and single-flight dedup to prevent concurrent refresh invalidation.

- **`token-provider.ts`**: Core orchestrator with module-level `inMemoryCredentials` and `inFlightRefresh` slots; handles fresh-keychain, stale-with-rotation, and dead-credential paths; single-flight Promise dedup prevents parallel refresh calls that would invalidate each other's tokens.
- **`keychain.ts`** / **`refresh.ts`**: Async keychain read via `execFileAsync` (avoids event-loop blocking) and an inlined OAuth refresh call against `platform.claude.com` (pi's `refreshAnthropicToken` is `.d.ts`-visible but unreachable at runtime).
- **30 tests** cover security invariants (token-never-logged via `process.stdout/stderr` intercepts + `console.*` spies), the 60s margin, ISO vs numeric `expiresAt`, single-flight concurrency, and dead-credential fail-closed behaviour.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the credential lifecycle is correctly implemented with no logic errors or security regressions introduced by this PR.

The single-flight dedup is synchronous and correctly prevents concurrent refresh calls from burning a rotated refresh token. Token rotation (preferring inMemoryCredentials.refreshToken over the stale keychain original) is handled correctly on every re-entry path. The fail-closed invariant — OAuthTokenExpiredError on dead credentials, no silent fallback — holds across all branches and is backed by tests. Security invariants (token never reaching stdout/stderr/console.*) are verified at the test layer. All previously raised concerns from earlier review rounds have been addressed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/src/oauth/token-provider.ts | Core credential orchestrator: in-memory slot + single-flight dedup + 60s safety margin all implemented correctly; token rotation (using inMemoryCredentials.refreshToken over the dead keychain original) is sound; fail-closed on dead credentials. |
| packages/assistant/src/oauth/keychain.ts | Switched from execFileSync to async execFileAsync (addresses previous blocking-event-loop concern); absolute path to /usr/bin/security avoids PATH injection; error path interpolates only .message, never the full error object. |
| packages/assistant/src/oauth/refresh.ts | Error body is sanitized to structured {error, error_description} fields only; non-JSON bodies surface HTTP status only; access_token and refresh_token presence validated before returning; expiresIn validated as positive number. |
| packages/assistant/src/oauth/token-provider.test.ts | 30 tests covering security invariants (process.stdout/stderr intercepts + console.* spies), fresh/expired/dead paths, 60s margin, ISO vs numeric expiresAt, token rotation, single-flight concurrency, and keychain error propagation. |
| packages/assistant/src/oauth/index.ts | Re-exports public types and functions; _resetInMemoryCredentials is intentionally omitted from the public API surface. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant getOAuthToken
    participant inMemoryCredentials
    participant inFlightRefresh
    participant Keychain as /usr/bin/security
    participant OAuthEndpoint as platform.claude.com

    Caller->>getOAuthToken: getOAuthToken()

    alt "inMemoryCredentials fresh (expiresAtMs > now+60s)"
        getOAuthToken->>inMemoryCredentials: check expiresAtMs
        inMemoryCredentials-->>getOAuthToken: fresh
        getOAuthToken-->>Caller: accessToken (no I/O)

    else inFlightRefresh already set (concurrent caller)
        getOAuthToken->>inFlightRefresh: join existing Promise
        inFlightRefresh-->>getOAuthToken: accessToken
        getOAuthToken-->>Caller: accessToken

    else no in-flight — start IIFE
        getOAuthToken->>inFlightRefresh: set guard (synchronous)
        getOAuthToken->>Keychain: execFileAsync security find-generic-password
        Keychain-->>getOAuthToken: JSON blob (claudeAiOauth)

        alt "keychain token fresh (expiresAt > now+60s)"
            getOAuthToken-->>Caller: kc.accessToken
        else keychain token expired or expiresAt absent
            getOAuthToken->>OAuthEndpoint: POST /v1/oauth/token (refresh_token)
            OAuthEndpoint-->>getOAuthToken: "{access_token, refresh_token, expires_in}"
            getOAuthToken->>inMemoryCredentials: "update {accessToken, rotatedRefreshToken, expiresAtMs}"
            getOAuthToken-->>Caller: rotated accessToken
        else refresh fails (400 / dead token)
            getOAuthToken-->>Caller: throw OAuthTokenExpiredError (fail-closed)
        end
        getOAuthToken->>inFlightRefresh: clear (finally)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant getOAuthToken
    participant inMemoryCredentials
    participant inFlightRefresh
    participant Keychain as /usr/bin/security
    participant OAuthEndpoint as platform.claude.com

    Caller->>getOAuthToken: getOAuthToken()

    alt "inMemoryCredentials fresh (expiresAtMs > now+60s)"
        getOAuthToken->>inMemoryCredentials: check expiresAtMs
        inMemoryCredentials-->>getOAuthToken: fresh
        getOAuthToken-->>Caller: accessToken (no I/O)

    else inFlightRefresh already set (concurrent caller)
        getOAuthToken->>inFlightRefresh: join existing Promise
        inFlightRefresh-->>getOAuthToken: accessToken
        getOAuthToken-->>Caller: accessToken

    else no in-flight — start IIFE
        getOAuthToken->>inFlightRefresh: set guard (synchronous)
        getOAuthToken->>Keychain: execFileAsync security find-generic-password
        Keychain-->>getOAuthToken: JSON blob (claudeAiOauth)

        alt "keychain token fresh (expiresAt > now+60s)"
            getOAuthToken-->>Caller: kc.accessToken
        else keychain token expired or expiresAt absent
            getOAuthToken->>OAuthEndpoint: POST /v1/oauth/token (refresh_token)
            OAuthEndpoint-->>getOAuthToken: "{access_token, refresh_token, expires_in}"
            getOAuthToken->>inMemoryCredentials: "update {accessToken, rotatedRefreshToken, expiresAtMs}"
            getOAuthToken-->>Caller: rotated accessToken
        else refresh fails (400 / dead token)
            getOAuthToken-->>Caller: throw OAuthTokenExpiredError (fail-closed)
        end
        getOAuthToken->>inFlightRefresh: clear (finally)
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(assistant): \[YW-277\] guard concurren..."](https://github.com/youhaowei/dashframe/commit/b609bc5bd9ac2b669605bb6b8bdb566d84ec520e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38088532)</sub>

<!-- /greptile_comment -->