### PR TITLE
test: [YW-266] stabilize native-DB-concurrency test flakes (WsManager + mapping-store)

### DIFF
--- a/packages/server-core/vitest.config.ts
+++ b/packages/server-core/vitest.config.ts
@@ -12,5 +12,15 @@ export default defineConfig({
     // tolerates a slow runner without masking a genuine hang.
     testTimeout: 60_000,
     include: ["**/*.test.{ts,tsx}"],
+    // All five test files in this package use PGlite (WASM Postgres). Running
+    // them in parallel forks causes simultaneous WASM cold-starts that contend
+    // for file descriptors and memory on a loaded CI runner — the first test in
+    // each file (mapping-store: "get returns the record written by set") was the
+    // most common victim because it runs before any warm-up query. Serialising
+    // to a single fork eliminates the cold-start race at the cost of slightly
+    // longer wall-clock time (the tests are I/O-bound, not CPU-bound, so the
+    // loss is small).
+    maxWorkers: 1,
+    minWorkers: 1,
   },
 });


### PR DESCRIPTION
## Problem

Two native-DB (PGlite/WASM) test races ate CI re-runs across **unrelated** PRs this cycle (e.g. #138 hit the mapping-store flake despite touching zero server-core files). They are a class, not one test:

1. `@wystack/client` `WsManager > does not reconnect on close code 4001` — original report.
2. `@wystack/server-core` `mapping-store.test.ts > DrizzleMappingStore > get returns the record written by set` — flaked on a PR touching zero server-core files; 53s file duration = native-DB timing contention.

Both are test-setup races, fixed at the mechanism level — **no `test.retry()`, no bare timeout bumps to mask the race.**

## Fixes

### server-core — `vitest.config.ts` (this repo)
vitest 4.x runs all five server-core test files in **parallel forks**. Every file spins up PGlite (WASM Postgres), so they cold-start the WASM module simultaneously and contend for FDs/memory on a loaded runner. The first test in each file runs before any warm-up query, so it's the victim. Serialize the suite (`maxWorkers: 1` / `minWorkers: 1`) so files cold-start one at a time. Tests are I/O-bound — small wall-clock cost.

### client / WsManager — wystack submodule bump
`ws.test.ts` leaked ~12 PGlite WASM instances (sync `afterEach` never closed them), squeezing the 2500ms-sleep no-reconnect tests against the 5s bun timeout. The submodule commit adds a tracked-handle registry drained in an **async** `afterEach`, plus timeout headroom. Detail in [youhaowei/wystack#46](https://github.com/youhaowei/wystack/pull/46).

## Verification

De-flake proven by **looped** local runs (a single green run does not prove a flake fixed):
- `mapping-store.test.ts`: **20/20 pass, 0 fail**
- `ws.test.ts` (submodule): **20/20 pass, 0 fail**
- Full server-core suite (`maxWorkers:1`): 70 passed, 1 todo
- typecheck + lint clean (DashFrame + wystack)

## Submodule sequencing

The `libs/wystack` pointer references the **YW-266 branch commit** so CI runs green against the fix now. **Re-point to the merged wystack main commit before merging this PR** (depends on youhaowei/wystack#46).

Tracked internally as YW-266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes two recurring CI flakes caused by PGlite/WASM test-setup races — no retries or timeout masking. Both fixes target the mechanism: serializing the server-core vitest worker pool so five PGlite files no longer cold-start simultaneously, and bumping the wystack submodule to pick up an async `afterEach` that properly drains leaked WASM handles in `ws.test.ts`.

- `packages/server-core/vitest.config.ts`: adds `maxWorkers: 1` / `minWorkers: 1` with a detailed comment; forces sequential file execution and eliminates the FD/memory contention that caused the first test in each file to be the flake victim.
- `libs/wystack`: advances the submodule pointer to the wystack YW-266 branch commit (4bed431) which adds a tracked-handle registry drained via async `afterEach`; the PR description explicitly notes this must be re-pointed to the merged main SHA before merging.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge once the wystack submodule is re-pointed to the merged main commit as documented.

Both changes are targeted and low-risk: the vitest config serializes existing test files (no production code touched), and the submodule bump only affects test infrastructure. The pre-merge gate (re-pointing the submodule to wystack main after wystack#46 merges) is clearly documented in the PR description and acknowledged by the author.

No files require special attention beyond the documented pre-merge step of re-pointing libs/wystack to the merged wystack main SHA.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server-core/vitest.config.ts | Adds maxWorkers: 1 / minWorkers: 1 to serialize PGlite-based test files and eliminate WASM cold-start contention; well-commented and correct. |
| libs/wystack | Submodule pointer bumped from 6b5f7c1 to 4bed431 (wystack YW-266 branch) to pick up the async afterEach PGlite handle drain fix; intentionally on a pre-merge branch SHA per PR description. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: server-core test run] --> B{Before fix\nmaxWorkers default}
    B --> C[Fork 1: mapping-store.test.ts\nPGlite WASM cold-start]
    B --> D[Fork 2: other.test.ts\nPGlite WASM cold-start]
    B --> E[Fork 3: ...\nPGlite WASM cold-start]
    C & D & E --> F[Contend for FDs/memory\non loaded CI runner]
    F --> G[First test in each file\nflakes / times out]
    A2[CI: server-core test run] --> B2{After fix\nmaxWorkers: 1}
    B2 --> H[Fork 1: mapping-store.test.ts\nPGlite WASM cold-start]
    H --> I[Fork 1 done]
    I --> J[Fork 2: other.test.ts\nPGlite WASM cold-start]
    J --> K[... sequential ...]
    K --> L[All tests pass]
    style G fill:#f88,stroke:#c00
    style L fill:#8f8,stroke:#0c0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CI: server-core test run] --> B{Before fix\nmaxWorkers default}
    B --> C[Fork 1: mapping-store.test.ts\nPGlite WASM cold-start]
    B --> D[Fork 2: other.test.ts\nPGlite WASM cold-start]
    B --> E[Fork 3: ...\nPGlite WASM cold-start]
    C & D & E --> F[Contend for FDs/memory\non loaded CI runner]
    F --> G[First test in each file\nflakes / times out]
    A2[CI: server-core test run] --> B2{After fix\nmaxWorkers: 1}
    B2 --> H[Fork 1: mapping-store.test.ts\nPGlite WASM cold-start]
    H --> I[Fork 1 done]
    I --> J[Fork 2: other.test.ts\nPGlite WASM cold-start]
    J --> K[... sequential ...]
    K --> L[All tests pass]
    style G fill:#f88,stroke:#c00
    style L fill:#8f8,stroke:#0c0
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: re-point libs/wystack to main (YW..."](https://github.com/youhaowei/dashframe/commit/da15cc484f3ddc48debb448bdbf4b58b3478850e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38148035)</sub>

<!-- /greptile_comment -->