### PR TITLE
feat(engine): [YW-140] generic declarative RestConnector (HTTP/JSON any-source)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -501,6 +501,20 @@
         "vitest": "^4.0.16",
       },
     },
+    "packages/connector-rest": {
+      "name": "@dashframe/connector-rest",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dashframe/engine": "workspace:*",
+        "@wystack/secret-vault": "workspace:*",
+        "apache-arrow": "^21.1.0",
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.0.16",
+        "typescript": "^5.6.0",
+        "vitest": "^4.0.16",
+      },
+    },
     "packages/core": {
       "name": "@dashframe/core",
       "version": "0.1.0",
@@ -897,6 +911,8 @@
     "@dashframe/connector-local": ["@dashframe/connector-local@workspace:packages/connector-local"],
 
     "@dashframe/connector-notion": ["@dashframe/connector-notion@workspace:packages/connector-notion"],
+
+    "@dashframe/connector-rest": ["@dashframe/connector-rest@workspace:packages/connector-rest"],
 
     "@dashframe/core": ["@dashframe/core@workspace:packages/core"],
 
@@ -3597,6 +3613,8 @@
     "@dashframe/connector-local/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@dashframe/connector-notion/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@dashframe/connector-rest/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@dashframe/core/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/packages/connector-rest/package.json
+++ b/packages/connector-rest/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dashframe/connector-rest",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc -w -p tsconfig.json --preserveWatchOutput",
+    "lint": "eslint src",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@dashframe/engine": "workspace:*",
+    "@wystack/secret-vault": "workspace:*",
+    "apache-arrow": "^21.1.0"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.16",
+    "typescript": "^5.6.0",
+    "vitest": "^4.0.16"
+  }
+}

--- a/packages/connector-rest/src/connector.test.ts
+++ b/packages/connector-rest/src/connector.test.ts
@@ -436,7 +436,7 @@ describe("RestConnector", () => {
   // -------------------------------------------------------------------------
 
   describe("noopResolver for public endpoints", () => {
-    it("calls fetch with empty Authorization header for public endpoints", async () => {
+    it("calls fetch without Authorization header for public endpoints", async () => {
       let capturedHeaders: Record<string, string> = {};
       const mockFetch = vi
         .fn()
@@ -452,8 +452,8 @@ describe("RestConnector", () => {
       await c.query("db", crypto.randomUUID());
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      // noopResolver passes empty string as token → "Bearer "
-      expect(capturedHeaders["Authorization"]).toBe("Bearer ");
+      // noopResolver passes empty string as token → no Authorization header sent
+      expect(capturedHeaders["Authorization"]).toBeUndefined();
     });
   });
 });

--- a/packages/connector-rest/src/connector.test.ts
+++ b/packages/connector-rest/src/connector.test.ts
@@ -1,0 +1,459 @@
+/**
+ * RestConnector tests
+ *
+ * Pattern: makeRestConnector(auth, config) — the connector is auth-blind.
+ * For tests that need real vault resolution, we build a TestBackend vault and
+ * mint a bound resolver. For tests without auth, we use noopResolver.
+ *
+ * WARNING: TestBackend / InMemoryMappingStore / SecretRegistry / SecretVault
+ * are CI/dev-only doubles — NEVER import these in production or renderer code.
+ */
+
+import type { SecretResolver } from "@dashframe/engine";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RestConnector,
+  applyFieldMap,
+  extractRows,
+  makeRestConnector,
+  noopResolver,
+} from "./connector.js";
+
+// ---------------------------------------------------------------------------
+// Vault factory
+// ---------------------------------------------------------------------------
+
+async function makeTestVaultWithSecret(plaintext: string) {
+  const backend = new TestBackend();
+  const registry = new SecretRegistry();
+  registry.register("test", backend, { fallback: true });
+  registry.setClassDefault("connector-key", "test");
+  const vault = new SecretVault(registry, new InMemoryMappingStore());
+  const ref = await vault.store(plaintext, { class: "connector-key" });
+  return { vault, ref };
+}
+
+/**
+ * Mint a bound SecretResolver from a vault + ref, matching how the
+ * server-layer connector factory works.
+ */
+function makeBoundResolver(
+  vault: SecretVault,
+  ref: Awaited<ReturnType<SecretVault["store"]>>,
+): SecretResolver {
+  return (use) => vault.withSecret(ref, use);
+}
+
+// ---------------------------------------------------------------------------
+// Mock fetch helper
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Response-like object for vi.stubGlobal('fetch', ...) */
+function makeResponse(
+  body: unknown,
+  opts: { ok?: boolean; status?: number; linkHeader?: string } = {},
+): Response {
+  const ok = opts.ok ?? true;
+  const status = opts.status ?? 200;
+  const headers = new Map<string, string>();
+  if (opts.linkHeader) {
+    headers.set("link", opts.linkHeader);
+  }
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: async () => body,
+    headers: {
+      get: (key: string) => headers.get(key.toLowerCase()) ?? null,
+    },
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Unit: extractRows
+// ---------------------------------------------------------------------------
+
+describe("extractRows", () => {
+  it("returns root array when no rowPath", () => {
+    expect(extractRows([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("returns [] for non-array root with no rowPath", () => {
+    expect(extractRows({ items: [1] })).toEqual([]);
+  });
+
+  it("resolves a dot-path to the array", () => {
+    expect(extractRows({ data: { items: [{ id: 1 }] } }, "data.items")).toEqual(
+      [{ id: 1 }],
+    );
+  });
+
+  it("returns [] when dot-path resolves to a non-array", () => {
+    expect(extractRows({ data: "not-array" }, "data")).toEqual([]);
+  });
+
+  it("returns [] when dot-path is missing", () => {
+    expect(extractRows({ a: 1 }, "a.b.c")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: applyFieldMap
+// ---------------------------------------------------------------------------
+
+describe("applyFieldMap", () => {
+  it("returns row as-is when no fieldMap", () => {
+    const row = { id: 1, name: "Alice" };
+    expect(applyFieldMap(row)).toEqual({ id: 1, name: "Alice" });
+  });
+
+  it("renames mapped keys and passes through unmapped ones", () => {
+    const row = { full_name: "Alice", age: 30 };
+    expect(applyFieldMap(row, { full_name: "name" })).toEqual({
+      name: "Alice",
+      age: 30,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: RestConnector
+// ---------------------------------------------------------------------------
+
+describe("RestConnector", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Static properties
+  // -------------------------------------------------------------------------
+
+  it("has id = 'rest'", () => {
+    const c = makeRestConnector(noopResolver, {
+      endpoint: "https://api.example.com/data",
+    });
+    expect(c.id).toBe("rest");
+  });
+
+  it("has sourceType = 'remote-api'", () => {
+    const c = makeRestConnector(noopResolver, {
+      endpoint: "https://api.example.com/data",
+    });
+    expect(c.sourceType).toBe("remote-api");
+  });
+
+  it("is an instance of RestConnector", () => {
+    const c = makeRestConnector(noopResolver, {
+      endpoint: "https://api.example.com/data",
+    });
+    expect(c).toBeInstanceOf(RestConnector);
+  });
+
+  it("getFormFields returns at least endpoint field", () => {
+    const c = makeRestConnector(noopResolver, {
+      endpoint: "https://api.example.com/data",
+    });
+    const fields = c.getFormFields();
+    expect(fields.some((f) => f.name === "endpoint")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // validate()
+  // -------------------------------------------------------------------------
+
+  describe("validate()", () => {
+    const c = makeRestConnector(noopResolver, {
+      endpoint: "https://api.example.com/data",
+    });
+
+    it("fails when endpoint is missing", () => {
+      const result = c.validate({});
+      expect(result.valid).toBe(false);
+      expect(result.errors?.["endpoint"]).toBeTruthy();
+    });
+
+    it("fails when endpoint is not a valid URL", () => {
+      const result = c.validate({ endpoint: "not-a-url" });
+      expect(result.valid).toBe(false);
+    });
+
+    it("passes for a valid URL", () => {
+      const result = c.validate({ endpoint: "https://api.example.com/data" });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Offset pagination
+  // -------------------------------------------------------------------------
+
+  describe("offset pagination", () => {
+    it("collects rows from both pages and stops when page is empty", async () => {
+      const page1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      const page2: unknown[] = [];
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse(page1))
+        .mockResolvedValueOnce(makeResponse(page2));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "offset",
+        paginationParams: { pageSize: 3 },
+      });
+      const result = await c.query("db", tableId);
+
+      expect(result.fields.length).toBeGreaterThan(0);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // First call: offset=0, limit=3
+      expect(mockFetch.mock.calls[0]?.[0]).toContain("offset=0");
+      expect(mockFetch.mock.calls[0]?.[0]).toContain("limit=3");
+      // Second call: offset=3
+      expect(mockFetch.mock.calls[1]?.[0]).toContain("offset=3");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Cursor pagination
+  // -------------------------------------------------------------------------
+
+  describe("cursor pagination", () => {
+    it("follows next_cursor until absent", async () => {
+      const page1 = { data: [{ id: 1 }], next_cursor: "cursor-abc" };
+      const page2 = { data: [{ id: 2 }] };
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse(page1))
+        .mockResolvedValueOnce(makeResponse(page2));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "cursor",
+        rowPath: "data",
+      });
+      const result = await c.query("db", tableId);
+
+      expect(result.fields.length).toBeGreaterThan(0);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Second call should include cursor=cursor-abc
+      expect(mockFetch.mock.calls[1]?.[0]).toContain("cursor=cursor-abc");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Page-number pagination
+  // -------------------------------------------------------------------------
+
+  describe("page-number pagination", () => {
+    it("fetches page 1 then page 2, stops when page 2 has fewer than pageSize rows", async () => {
+      const page1 = [{ id: 1 }, { id: 2 }];
+      const page2 = [{ id: 3 }]; // < pageSize=2 → stop
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse(page1))
+        .mockResolvedValueOnce(makeResponse(page2));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "page-number",
+        paginationParams: { pageSize: 2 },
+      });
+      await c.query("db", tableId);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0]?.[0]).toContain("page=1");
+      expect(mockFetch.mock.calls[1]?.[0]).toContain("page=2");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Link-header pagination
+  // -------------------------------------------------------------------------
+
+  describe("link-header pagination", () => {
+    it("follows Link: rel=next header, stops when absent", async () => {
+      const page1Rows = [{ id: 1 }];
+      const page2Rows = [{ id: 2 }];
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeResponse(page1Rows, {
+            linkHeader: '<https://api.example.com/data?page=2>; rel="next"',
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse(page2Rows));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "link-header",
+      });
+      await c.query("db", tableId);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]?.[0]).toBe(
+        "https://api.example.com/data?page=2",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. rowPath + fieldMap
+  // -------------------------------------------------------------------------
+
+  describe("rowPath + fieldMap", () => {
+    it("extracts nested rows and renames keys", async () => {
+      const body = { results: [{ id: 1, full_name: "Alice" }] };
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(makeResponse(body)));
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        rowPath: "results",
+        fieldMap: { full_name: "name" },
+      });
+      const result = await c.query("db", tableId);
+
+      // Fields should include "name" but not "full_name"
+      const fieldNames = result.fields.map((f) => f.name);
+      expect(fieldNames).toContain("name");
+      expect(fieldNames).not.toContain("full_name");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. authRef vault resolution
+  // -------------------------------------------------------------------------
+
+  describe("authRef vault resolution", () => {
+    it("resolves the token from vault and passes it as Bearer auth header", async () => {
+      const { vault, ref } = await makeTestVaultWithSecret("my-api-token");
+      const auth = makeBoundResolver(vault, ref);
+
+      let capturedHeaders: Record<string, string> = {};
+      const mockFetch = vi
+        .fn()
+        .mockImplementation((_url: string, opts: RequestInit) => {
+          capturedHeaders = (opts.headers ?? {}) as Record<string, string>;
+          return Promise.resolve(makeResponse([{ id: 1 }]));
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(auth, {
+        endpoint: "https://api.example.com/data",
+      });
+      await c.query("db", tableId);
+
+      expect(capturedHeaders["Authorization"]).toBe("Bearer my-api-token");
+      // Plaintext never appears in the config or connector's public interface
+    });
+
+    it("resolves the token during connect()", async () => {
+      const { vault, ref } = await makeTestVaultWithSecret("connect-token");
+      const auth = makeBoundResolver(vault, ref);
+
+      let capturedHeaders: Record<string, string> = {};
+      const mockFetch = vi
+        .fn()
+        .mockImplementation((_url: string, opts: RequestInit) => {
+          capturedHeaders = (opts.headers ?? {}) as Record<string, string>;
+          return Promise.resolve(makeResponse([{ id: 1 }]));
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(auth, {
+        endpoint: "https://api.example.com/data",
+      });
+      const result = await c.connect();
+
+      expect(capturedHeaders["Authorization"]).toBe("Bearer connect-token");
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe("https://api.example.com/data");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Fail-closed: resolver throws → no fetch called
+  // -------------------------------------------------------------------------
+
+  describe("fail-closed: resolver failure", () => {
+    it("throws before calling fetch when the SecretResolver rejects", async () => {
+      const failResolver: SecretResolver = async (_use) => {
+        throw new Error("No secret available — vault missing or ref invalid");
+      };
+
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const tableId = crypto.randomUUID();
+      const c = makeRestConnector(failResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+
+      await expect(c.query("db", tableId)).rejects.toThrow(
+        /No secret available|vault/i,
+      );
+
+      // fetch must NOT have been called — resolver failed before fetch
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("throws before calling fetch in connect() when resolver rejects", async () => {
+      const failResolver: SecretResolver = async (_use) => {
+        throw new Error("No secret available");
+      };
+
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(failResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+
+      await expect(c.connect()).rejects.toThrow(/No secret available/i);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. noopResolver — public endpoint (no auth)
+  // -------------------------------------------------------------------------
+
+  describe("noopResolver for public endpoints", () => {
+    it("calls fetch with empty Authorization header for public endpoints", async () => {
+      let capturedHeaders: Record<string, string> = {};
+      const mockFetch = vi
+        .fn()
+        .mockImplementation((_url: string, opts: RequestInit) => {
+          capturedHeaders = (opts.headers ?? {}) as Record<string, string>;
+          return Promise.resolve(makeResponse([{ id: 1 }]));
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/public",
+      });
+      await c.query("db", crypto.randomUUID());
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // noopResolver passes empty string as token → "Bearer "
+      expect(capturedHeaders["Authorization"]).toBe("Bearer ");
+    });
+  });
+});

--- a/packages/connector-rest/src/connector.test.ts
+++ b/packages/connector-rest/src/connector.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   RestConnector,
   applyFieldMap,
+  assertFieldMapNoCollision,
   extractRows,
   makeRestConnector,
   noopResolver,
@@ -454,6 +455,403 @@ describe("RestConnector", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       // noopResolver passes empty string as token → no Authorization header sent
       expect(capturedHeaders["Authorization"]).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SECURITY 1. SSRF / credential leak — cross-origin next-link gets NO token
+  // -------------------------------------------------------------------------
+
+  describe("SSRF guard: cross-origin Link rel=next does NOT receive the token", () => {
+    it("stops pagination and never sends the Bearer token off-origin", async () => {
+      const { vault, ref } = await makeTestVaultWithSecret("secret-token");
+      const auth = makeBoundResolver(vault, ref);
+
+      const seenRequests: { url: string; auth: string | undefined }[] = [];
+      const mockFetch = vi
+        .fn()
+        .mockImplementationOnce((url: string, opts: RequestInit) => {
+          const h = (opts.headers ?? {}) as Record<string, string>;
+          seenRequests.push({ url, auth: h["Authorization"] });
+          // First (same-origin) page returns a CROSS-ORIGIN next-link.
+          return Promise.resolve(
+            makeResponse([{ id: 1 }], {
+              linkHeader: '<https://attacker.example/harvest>; rel="next"',
+            }),
+          );
+        })
+        .mockImplementation((url: string, opts: RequestInit) => {
+          const h = (opts.headers ?? {}) as Record<string, string>;
+          seenRequests.push({ url, auth: h["Authorization"] });
+          return Promise.resolve(makeResponse([{ id: 2 }]));
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(auth, {
+        endpoint: "https://api.example.com/data",
+        authRef: "secret:placeholder",
+        pagination: "link-header",
+      });
+      await c.query("db", crypto.randomUUID());
+
+      // Only the first (same-origin) request was made; pagination stopped.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // The attacker host NEVER received any request — token not forwarded.
+      expect(seenRequests.some((r) => r.url.includes("attacker.example"))).toBe(
+        false,
+      );
+      // The same-origin request did carry the token (sanity: auth was wired).
+      expect(seenRequests[0]?.auth).toBe("Bearer secret-token");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SECURITY 2. Fail-closed — authRef set but resolver yields no token
+  // -------------------------------------------------------------------------
+
+  describe("fail-closed: authRef set but no token resolved", () => {
+    it("throws BEFORE fetch when authRef is configured and the token is empty", async () => {
+      // A resolver that yields an empty token (miswired factory / deleted secret).
+      const emptyTokenResolver: SecretResolver = (use) => use("");
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(emptyTokenResolver, {
+        endpoint: "https://api.example.com/data",
+        authRef: "secret:configured-but-unresolvable",
+      });
+
+      await expect(c.query("db", crypto.randomUUID())).rejects.toThrow(
+        /authRef.*no token|fail-closed/i,
+      );
+      // No request was issued — fail-closed before any network side-effect.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("throws BEFORE fetch in connect() when authRef set and token empty", async () => {
+      const emptyTokenResolver: SecretResolver = (use) => use("");
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(emptyTokenResolver, {
+        endpoint: "https://api.example.com/data",
+        authRef: "secret:configured-but-unresolvable",
+      });
+
+      await expect(c.connect()).rejects.toThrow(
+        /authRef.*no token|fail-closed/i,
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SECURITY 3. Prototype pollution — __proto__ response key is data, not proto
+  // -------------------------------------------------------------------------
+
+  describe("prototype pollution: __proto__ response key does not pollute", () => {
+    it("drops the __proto__ column and does not pollute Object.prototype", async () => {
+      // A response row with an own `__proto__` key. JSON.parse produces an own
+      // property, so this models a real malicious/edge API.
+      const malicious = JSON.parse(
+        '[{"id": 1, "__proto__": "evil", "constructor": "bad"}]',
+      );
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValueOnce(makeResponse(malicious)),
+      );
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+      const result = await c.query("db", crypto.randomUUID());
+
+      // The reserved keys are dropped — never become columns (they cannot be
+      // legitimate data and would crash the Arrow build). `id` remains.
+      expect(result.fields.some((f) => f.name === "id")).toBe(true);
+      expect(result.fields.some((f) => f.name === "__proto__")).toBe(false);
+      expect(result.fields.some((f) => f.name === "constructor")).toBe(false);
+      // fieldIds and fields stay aligned (no phantom dropped column).
+      expect(result.fieldIds).toHaveLength(result.fields.length);
+      // Object.prototype was NOT polluted.
+      expect(({} as Record<string, unknown>)["evil"]).toBeUndefined();
+      expect(Object.prototype).not.toHaveProperty("evil");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Honor query limit BEFORE fetching all pages (limit pushdown)
+  // -------------------------------------------------------------------------
+
+  describe("limit pushdown: stops paginating once the budget is met", () => {
+    it("does not fetch further pages once offset+limit rows are collected", async () => {
+      // Each page returns a full page of 100 rows; the API would keep going.
+      const fullPage = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+      const mockFetch = vi.fn().mockResolvedValue(makeResponse(fullPage));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "offset",
+        paginationParams: { pageSize: 100 },
+      });
+      // Request only 10 rows — one page (100) already satisfies the budget.
+      await c.query("db", crypto.randomUUID(), {
+        pagination: { offset: 0, limit: 10 },
+      });
+
+      // Exactly ONE page fetched, not an unbounded walk.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Relative Link headers resolved against the base URL
+  // -------------------------------------------------------------------------
+
+  describe("relative Link header resolution", () => {
+    it("resolves a relative rel=next link against the current page URL", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeResponse([{ id: 1 }], {
+            linkHeader: '</data?page=2>; rel="next"',
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse([{ id: 2 }]));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "link-header",
+      });
+      await c.query("db", crypto.randomUUID());
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // The relative link was resolved to an absolute same-origin URL.
+      expect(mockFetch.mock.calls[1]?.[0]).toBe(
+        "https://api.example.com/data?page=2",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. pageSize supplied as a string is coerced before offset arithmetic
+  // -------------------------------------------------------------------------
+
+  describe("pageSize string coercion", () => {
+    it("coerces a string pageSize so offset increments numerically", async () => {
+      const page1 = Array.from({ length: 3 }, (_, i) => ({ id: i }));
+      const page2: unknown[] = [];
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse(page1))
+        .mockResolvedValueOnce(makeResponse(page2));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "offset",
+        // String pageSize — must be coerced, not string-concatenated.
+        paginationParams: { pageSize: "3" },
+      });
+      await c.query("db", crypto.randomUUID());
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Second offset is the NUMERIC 3, not the concatenated "03"/"30".
+      expect(mockFetch.mock.calls[1]?.[0]).toContain("offset=3");
+      expect(mockFetch.mock.calls[1]?.[0]).not.toContain("offset=03");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Inferred types align with serialized string values
+  // -------------------------------------------------------------------------
+
+  describe("type alignment: serialized string values coerced to inferred type", () => {
+    it("coerces a string-encoded number so the Arrow column is numeric", async () => {
+      // API encodes the number as a string "42"; inference marks it number.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValueOnce(makeResponse([{ amount: "42" }])),
+      );
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+      const result = await c.query("db", crypto.randomUUID());
+
+      const amountField = result.fields.find((f) => f.name === "amount");
+      expect(amountField?.type).toBe("number");
+      // The Arrow schema must agree: decode and check the column value is numeric.
+      const { tableFromIPC } = await import("apache-arrow");
+      const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+      const table = tableFromIPC(bytes);
+      const col = table.getChild("amount");
+      expect(typeof col?.get(0)).toBe("number");
+      expect(col?.get(0)).toBe(42);
+    });
+
+    it("maps an empty-string cell in a numeric column to null, not a fabricated 0", async () => {
+      // First row types the column number; second row's "" must become null,
+      // NOT 0 (Number("") === 0 would fabricate a real zero reading).
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            makeResponse([{ amount: "42" }, { amount: "" }]),
+          ),
+      );
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+      const result = await c.query("db", crypto.randomUUID());
+
+      const amountField = result.fields.find((f) => f.name === "amount");
+      expect(amountField?.type).toBe("number");
+      const { tableFromIPC } = await import("apache-arrow");
+      const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+      const table = tableFromIPC(bytes);
+      const col = table.getChild("amount");
+      expect(col?.get(0)).toBe(42);
+      // The blank cell is a missing reading → null, never 0.
+      expect(col?.get(1)).toBeNull();
+    });
+
+    it("coerces yes/no boolean strings to boolean (matches engine inference)", async () => {
+      // The engine's inferStringColumnType classifies "yes"/"no" as boolean.
+      // Coercion must agree — NOT null these values out (data loss).
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            makeResponse([{ active: "yes" }, { active: "no" }]),
+          ),
+      );
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+      const result = await c.query("db", crypto.randomUUID());
+
+      const activeField = result.fields.find((f) => f.name === "active");
+      expect(activeField?.type).toBe("boolean");
+      const { tableFromIPC } = await import("apache-arrow");
+      const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+      const table = tableFromIPC(bytes);
+      const col = table.getChild("active");
+      // "yes" → true, "no" → false — values preserved, not nulled.
+      expect(col?.get(0)).toBe(true);
+      expect(col?.get(1)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. fieldMap collisions are rejected
+  // -------------------------------------------------------------------------
+
+  describe("fieldMap collision rejection", () => {
+    it("rejects two source keys mapping to the same target (config-static)", () => {
+      expect(() => assertFieldMapNoCollision({ a: "name", b: "name" })).toThrow(
+        /collision/i,
+      );
+    });
+
+    it("accepts a fieldMap with all-unique targets", () => {
+      expect(() => assertFieldMapNoCollision({ a: "x", b: "y" })).not.toThrow();
+    });
+
+    it("rejects a rename that lands on an existing passthrough key in a row", () => {
+      // { name, full_name } with { full_name: "name" } → two values collapse.
+      expect(() =>
+        applyFieldMap({ name: "A", full_name: "B" }, { full_name: "name" }),
+      ).toThrow(/collision/i);
+    });
+
+    it("query() rejects a colliding fieldMap before fetching", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        fieldMap: { a: "dup", b: "dup" },
+      });
+      await expect(c.query("db", crypto.randomUUID())).rejects.toThrow(
+        /collision/i,
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. parseLinkNext correctness when prev precedes next
+  // -------------------------------------------------------------------------
+
+  describe("Link header parsing: prev before next", () => {
+    it("returns the next URL, not prev, when prev precedes next", async () => {
+      const linkHeader =
+        '<https://api.example.com/data?page=1>; rel="prev", ' +
+        '<https://api.example.com/data?page=3>; rel="next"';
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }], { linkHeader }))
+        .mockResolvedValueOnce(makeResponse([{ id: 2 }]));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "link-header",
+      });
+      await c.query("db", crypto.randomUUID());
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Must follow the NEXT url (page=3), NOT prev (page=1).
+      expect(mockFetch.mock.calls[1]?.[0]).toBe(
+        "https://api.example.com/data?page=3",
+      );
+    });
+
+    it("follows a next-link whose URL contains a comma (?ids=1,2,3)", async () => {
+      // A comma inside the angle-bracketed URL must NOT split the entry.
+      const linkHeader =
+        '<https://api.example.com/data?ids=1,2,3&page=2>; rel="next"';
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }], { linkHeader }))
+        .mockResolvedValueOnce(makeResponse([{ id: 2 }]));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "link-header",
+      });
+      await c.query("db", crypto.randomUUID());
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]?.[0]).toBe(
+        "https://api.example.com/data?ids=1,2,3&page=2",
+      );
+    });
+
+    it("does NOT treat rel=nextpage as a next-link (token boundary)", async () => {
+      // Unquoted `rel=nextpage` must not match the `next` token.
+      const linkHeader = "<https://api.example.com/data?page=2>; rel=nextpage";
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }], { linkHeader }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+        pagination: "link-header",
+      });
+      await c.query("db", crypto.randomUUID());
+
+      // Pagination stops after page 1 — rel=nextpage is not rel=next.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -18,6 +18,7 @@
  */
 
 import type {
+  ColumnType,
   ConnectorQueryResult,
   Field,
   FormField,
@@ -31,6 +32,8 @@ import {
   RemoteApiConnector,
   createFieldsFromColumns,
   inferStringColumnType,
+  parsePrimitiveValueByType,
+  parseStringValueByType,
 } from "@dashframe/engine";
 import { tableFromArrays, tableToIPC } from "apache-arrow";
 import type { RestConnectorConfig } from "./types.js";
@@ -67,19 +70,122 @@ export function extractRows(data: unknown, rowPath?: string): unknown[] {
 }
 
 /**
- * Rename keys in a row according to fieldMap. Unmapped keys pass through.
+ * Validate a fieldMap for target-name collisions BEFORE any row is mapped.
+ *
+ * Two collision classes corrupt the result silently if allowed through:
+ *  - two distinct source keys map to the SAME target (one value clobbers the
+ *    other based on iteration order), and
+ *  - a source key maps onto a target that is ALSO an un-mapped passthrough key
+ *    present in the data (e.g. `{ full_name: "name" }` against a row that also
+ *    has its own `name`).
+ *
+ * The second class cannot be detected from the fieldMap alone (it depends on
+ * the response keys), so it is checked per-row in {@link applyFieldMap}. This
+ * function catches the map-internal collision (two sources → one target) up
+ * front, which is config-static.
+ *
+ * @throws if two source keys map to the same target name.
+ */
+export function assertFieldMapNoCollision(
+  fieldMap: Record<string, string>,
+): void {
+  const targets = new Map<string, string>(); // target → source that claimed it
+  for (const [source, target] of Object.entries(fieldMap)) {
+    const prior = targets.get(target);
+    if (prior !== undefined) {
+      throw new Error(
+        `[RestConnector] fieldMap collision: both "${prior}" and "${source}" ` +
+          `map to target field "${target}". Targets must be unique.`,
+      );
+    }
+    targets.set(target, source);
+  }
+}
+
+/**
+ * Keys that must never become column names. They mutate object prototypes
+ * (`__proto__`) or, even when stored on a null-prototype object, crash
+ * `apache-arrow`'s `tableFromArrays` (it recurses on these names). A REST source
+ * cannot have a legitimate data column named any of these, so they are dropped
+ * from every row before inference/serialization — fail-safe, not fail-loud.
+ */
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Rename keys in a row according to fieldMap, dropping prototype-polluting keys.
+ *
+ * - Drops `__proto__`/`constructor`/`prototype` source keys (see
+ *   {@link DANGEROUS_KEYS}) — they cannot be valid columns and would corrupt the
+ *   Arrow build. Always applied, even with no fieldMap.
+ * - Output is a null-prototype object so no key can mutate a prototype.
+ * - Rejects a collision where a renamed key lands on a key already produced for
+ *   this row (another rename, or an un-mapped passthrough key). A silent
+ *   overwrite would drop one of the two source values before schema inference,
+ *   so the connector fails loudly instead.
+ *
+ * @throws if a mapped target collides with an existing key in the output row.
  */
 export function applyFieldMap(
   row: Record<string, unknown>,
   fieldMap?: Record<string, string>,
 ): Record<string, unknown> {
-  if (!fieldMap) return row;
-  const result: Record<string, unknown> = {};
+  // Null-prototype output so a response key cannot mutate a prototype, and so
+  // dropped dangerous keys never reappear via the prototype chain.
+  const result: Record<string, unknown> = Object.create(null) as Record<
+    string,
+    unknown
+  >;
   for (const [key, value] of Object.entries(row)) {
-    const mappedKey = fieldMap[key] ?? key;
+    if (DANGEROUS_KEYS.has(key)) continue; // never a real column
+    const mappedKey = fieldMap?.[key] ?? key;
+    if (DANGEROUS_KEYS.has(mappedKey)) {
+      throw new Error(
+        `[RestConnector] fieldMap maps "${key}" onto reserved name "${mappedKey}" — refused.`,
+      );
+    }
+    if (Object.hasOwn(result, mappedKey)) {
+      throw new Error(
+        `[RestConnector] fieldMap collision: key "${key}" maps to "${mappedKey}", ` +
+          `which already exists in the row. Two source fields would collapse into one.`,
+      );
+    }
     result[mappedKey] = value;
   }
   return result;
+}
+
+/**
+ * Coerce a single JSON value to match the inferred column type, so the Arrow
+ * schema (built from these values) agrees with the inferred `fields` metadata.
+ *
+ * REST APIs commonly serialize typed values as strings (`"42"`, `"true"`, an
+ * ISO date). Field inference (via {@link inferStringColumnType}) marks such a
+ * column number/boolean/date, but the raw string flowing into Arrow unchanged
+ * would yield a VARCHAR schema — a mismatch that offers numeric/date ops on a
+ * string column downstream.
+ *
+ * Coercion routes by value shape to the engine helper whose contract MATCHES
+ * inference, so the two cannot disagree:
+ *  - STRING values → {@link parseStringValueByType}. Inference itself runs on
+ *    `inferStringColumnType(String(v))`, and this helper shares that string
+ *    contract: `"yes"`/`"no"` → boolean, an empty string `""` → `null` (NOT a
+ *    fabricated `0`, which `Number("")` would produce).
+ *  - native number/boolean values → {@link parsePrimitiveValueByType}, which
+ *    keeps an already-typed primitive as-is.
+ *  - non-primitive values (nested objects/arrays) → passed through untouched;
+ *    inference would have typed such a column `string`/`unknown` and Arrow
+ *    serializes the structured value directly.
+ */
+function coerceValueToType(value: unknown, type: ColumnType): unknown {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") {
+    // String path: same contract inference is built on ("" → null, yes/no → bool).
+    return parseStringValueByType(value, type);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return parsePrimitiveValueByType(value, type);
+  }
+  return value;
 }
 
 /**
@@ -124,6 +230,21 @@ function withQueryParam(url: string, key: string, value: string): string {
 }
 
 /**
+ * Coerce a declarative `pageSize` config value to a positive integer.
+ *
+ * Declarative JSON config can supply `pageSize` as a string (`"100"`). Without
+ * coercion `offset += pageSize` would string-concatenate (`0` → `"0100"` →
+ * `"0100100"`), corrupting offset arithmetic and skipping/repeating pages.
+ * A missing or invalid value falls back to `fallback`.
+ */
+function coercePageSize(value: unknown, fallback: number): number {
+  if (value === undefined || value === null) return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.floor(n);
+}
+
+/**
  * Perform a single HTTP request. Throws on non-ok status.
  */
 async function fetchPage(
@@ -141,14 +262,20 @@ async function fetchPage(
   return { data, response };
 }
 
+// The `budget` arg threaded through pagination is a max-rows count: pagination
+// STOPS as soon as enough rows are collected to satisfy `offset + limit`,
+// instead of walking the whole remote chain and slicing afterward. `Infinity`
+// means "no budget — fetch all".
+
 /** Offset/limit pagination — increments offset by pageSize until a short page. */
 async function fetchOffsetPages(
   config: RestConnectorConfig,
   method: string,
   headers: Record<string, string>,
+  budget: number,
 ): Promise<unknown[]> {
   const pp = config.paginationParams ?? {};
-  const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
+  const pageSize = coercePageSize(pp["pageSize"], 100);
   const offsetParam = (pp["offsetParam"] as string | undefined) ?? "offset";
   const limitParam = (pp["limitParam"] as string | undefined) ?? "limit";
   const allRows: unknown[] = [];
@@ -163,6 +290,7 @@ async function fetchOffsetPages(
     const { data } = await fetchPage(url, method, headers);
     const rows = extractRows(data, config.rowPath);
     allRows.push(...rows);
+    if (allRows.length >= budget) break;
     if (rows.length === 0 || rows.length < pageSize) break;
     offset += pageSize;
   }
@@ -175,9 +303,10 @@ async function fetchPageNumberPages(
   config: RestConnectorConfig,
   method: string,
   headers: Record<string, string>,
+  budget: number,
 ): Promise<unknown[]> {
   const pp = config.paginationParams ?? {};
-  const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
+  const pageSize = coercePageSize(pp["pageSize"], 100);
   const pageParam = (pp["pageParam"] as string | undefined) ?? "page";
   const pageSizeParam =
     (pp["pageSizeParam"] as string | undefined) ?? "pageSize";
@@ -193,6 +322,7 @@ async function fetchPageNumberPages(
     const { data } = await fetchPage(url, method, headers);
     const rows = extractRows(data, config.rowPath);
     allRows.push(...rows);
+    if (allRows.length >= budget) break;
     if (rows.length === 0 || rows.length < pageSize) break;
     page++;
   }
@@ -224,6 +354,7 @@ async function fetchCursorPages(
   config: RestConnectorConfig,
   method: string,
   headers: Record<string, string>,
+  budget: number,
 ): Promise<unknown[]> {
   const pp = config.paginationParams ?? {};
   const cursorParam = (pp["cursorParam"] as string | undefined) ?? "cursor";
@@ -237,6 +368,7 @@ async function fetchCursorPages(
       : config.endpoint;
     const { data } = await fetchPage(url, method, headers);
     allRows.push(...extractRows(data, config.rowPath));
+    if (allRows.length >= budget) break;
     cursor = resolveNextCursor(data, cursorPath);
     if (!cursor) break;
   }
@@ -245,40 +377,127 @@ async function fetchCursorPages(
 }
 
 /**
+ * Split a `Link` header into entries on the commas that separate entries,
+ * IGNORING commas inside `<...>` URLs. RFC 5988 angle-brackets the URI-reference
+ * precisely so a URL may legally contain a comma (e.g. `?ids=1,2,3`); a naive
+ * `split(",")` would break such a URL and silently drop its link. We track
+ * bracket depth and only cut at a comma when outside brackets. No quantified
+ * regex, so there is no super-linear backtracking.
+ */
+function splitLinkEntries(linkHeader: string): string[] {
+  const entries: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < linkHeader.length; i++) {
+    const ch = linkHeader[i];
+    if (ch === "<") depth++;
+    else if (ch === ">") depth = Math.max(0, depth - 1);
+    else if (ch === "," && depth === 0) {
+      entries.push(linkHeader.slice(start, i));
+      start = i + 1;
+    }
+  }
+  entries.push(linkHeader.slice(start));
+  return entries;
+}
+
+/**
+ * Does this entry's parameter section declare `rel="next"` (or bare `rel=next`)?
+ * Matches the `next` token exactly — `rel=nextpage` must NOT qualify. RFC 5988
+ * rel values are space-separated tokens, so we tokenize the unquoted form.
+ */
+function relIsNext(params: string): boolean {
+  const lower = params.toLowerCase();
+  if (lower.includes('rel="next"')) return true;
+  // Bare unquoted form: `rel=next` as a whole token (not `rel=nextpage`).
+  const m = /rel=([a-z][a-z0-9.\-_]*)/.exec(lower);
+  return m?.[1] === "next";
+}
+
+/**
  * Parse a `Link` response header and return the `rel="next"` URL, or undefined.
- * Uses a two-part approach to avoid backtracking: split on `>,` boundaries first,
- * then match each segment independently.
+ *
+ * RFC 5988 separates entries with a `,` that follows the parameter attributes
+ * (e.g. `<u1>; rel="prev", <u2>; rel="next"`), NOT a `,` immediately after `>`.
+ * Each entry is `<URL>; param=...; rel="..."`. We split into entries on
+ * out-of-bracket commas ({@link splitLinkEntries}), then for each entry pull the
+ * angle-bracketed URL and check whether ITS OWN `rel` is `next`
+ * ({@link relIsNext}). Confining the `rel` check to a single entry prevents
+ * matching a later entry's `rel="next"` against an earlier URL (the
+ * prev-before-next bug). `indexOf`/`slice` parsing avoids backtracking.
  */
 function parseLinkNext(linkHeader: string): string | undefined {
-  // Split on `>, ` or `>,` to separate link entries without regex alternation.
-  const parts = linkHeader.split(/>,\s*/);
-  for (const part of parts) {
-    // Each part looks like: `<URL>; rel="next"` or `<URL>; rel="prev"`, etc.
-    // Two fixed-width checks: URL between < >, rel attribute present and "next".
-    const ltIdx = part.indexOf("<");
-    const gtIdx = part.indexOf(">");
-    if (ltIdx === -1 || gtIdx === -1 || gtIdx <= ltIdx) continue;
-    const url = part.slice(ltIdx + 1, gtIdx);
-    const rest = part.slice(gtIdx + 1);
-    if (/rel="next"/i.test(rest)) return url;
+  for (const entry of splitLinkEntries(linkHeader)) {
+    const ltIdx = entry.indexOf("<");
+    const gtIdx = entry.indexOf(">", ltIdx + 1);
+    if (ltIdx === -1 || gtIdx === -1) continue;
+    const url = entry.slice(ltIdx + 1, gtIdx);
+    // Only the params AFTER the URL describe this link's rel.
+    if (relIsNext(entry.slice(gtIdx + 1))) return url;
   }
   return undefined;
 }
 
-/** Link-header pagination — follows RFC 5988 `Link: <url>; rel="next"`. */
+/**
+ * Resolve a (possibly relative) Link-header URL against the page it came from.
+ * APIs may return a relative `next` link (`</data?page=2>; rel="next"`); a bare
+ * relative URL would fail `fetch()` in the Node server context. The `URL`
+ * constructor with a base resolves both absolute and relative forms.
+ */
+function resolveLinkUrl(rawUrl: string, baseUrl: string): string | undefined {
+  try {
+    return new URL(rawUrl, baseUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Link-header pagination — follows RFC 5988 `Link: <url>; rel="next"`.
+ *
+ * SECURITY (SSRF + credential leak): the request `headers` carry the
+ * vault-resolved Bearer token. A compromised or malicious API could return a
+ * `rel="next"` URL pointing at an attacker/internal host to harvest that token.
+ * We therefore forward the credentialed request ONLY to a same-origin next-link
+ * — a cross-origin link stops pagination (the token is never sent off-origin).
+ */
 async function fetchLinkHeaderPages(
   config: RestConnectorConfig,
   method: string,
   headers: Record<string, string>,
+  budget: number,
 ): Promise<unknown[]> {
   const allRows: unknown[] = [];
+  const configOrigin = new URL(config.endpoint).origin;
   let nextUrl: string | undefined = config.endpoint;
 
   while (nextUrl) {
-    const { data, response } = await fetchPage(nextUrl, method, headers);
+    const currentUrl: string = nextUrl;
+    const { data, response } = await fetchPage(currentUrl, method, headers);
     allRows.push(...extractRows(data, config.rowPath));
+    if (allRows.length >= budget) return allRows;
+
     const linkHeader = response.headers.get("Link");
-    nextUrl = linkHeader ? parseLinkNext(linkHeader) : undefined;
+    const rawNext = linkHeader ? parseLinkNext(linkHeader) : undefined;
+    // Resolve relative links against the page we just fetched.
+    const resolved: string | undefined = rawNext
+      ? resolveLinkUrl(rawNext, currentUrl)
+      : undefined;
+    // Same-origin guard: never forward the credential to a different origin.
+    // A cross-origin (or unresolvable) next-link stops pagination so the
+    // vault-resolved Bearer token is never sent off-origin.
+    if (resolved && new URL(resolved).origin === configOrigin) {
+      nextUrl = resolved;
+    } else {
+      if (resolved) {
+        console.warn(
+          `[RestConnector] Link rel="next" "${resolved}" is cross-origin ` +
+            `(expected ${configOrigin}) — stopping pagination so the credential ` +
+            `is not forwarded off-origin.`,
+        );
+      }
+      nextUrl = undefined;
+    }
   }
 
   return allRows;
@@ -290,22 +509,24 @@ async function fetchLinkHeaderPages(
  *
  * @param config  - Connector config (endpoint, pagination, etc.)
  * @param headers - Pre-resolved request headers (auth already injected)
+ * @param budget  - Max rows to collect before stopping (Infinity = all)
  */
 async function fetchAllPages(
   config: RestConnectorConfig,
   headers: Record<string, string>,
+  budget: number,
 ): Promise<unknown[]> {
   const method = config.method ?? "GET";
 
   switch (config.pagination) {
     case "offset":
-      return fetchOffsetPages(config, method, headers);
+      return fetchOffsetPages(config, method, headers, budget);
     case "page-number":
-      return fetchPageNumberPages(config, method, headers);
+      return fetchPageNumberPages(config, method, headers, budget);
     case "cursor":
-      return fetchCursorPages(config, method, headers);
+      return fetchCursorPages(config, method, headers, budget);
     case "link-header":
-      return fetchLinkHeaderPages(config, method, headers);
+      return fetchLinkHeaderPages(config, method, headers, budget);
     default: {
       if (config.pagination) {
         console.warn(
@@ -344,6 +565,34 @@ export class RestConnector extends RemoteApiConnector {
   constructor(auth: SecretResolver, config: RestConnectorConfig) {
     super(auth);
     this.#config = config;
+  }
+
+  /**
+   * Resolve the auth headers, failing CLOSED when a credential is required but
+   * absent. The contract: if `config.authRef` is set, this DataSource is an
+   * authenticated source — a request MUST carry the credential. If the bound
+   * resolver yields an empty token (miswired factory, deleted secret), we throw
+   * BEFORE any fetch rather than silently issuing an unauthenticated request
+   * (which could read a public fallback as if it were the authed data).
+   *
+   * When `config.authRef` is absent the source is public: an empty token means
+   * "no auth", and we send no Authorization header.
+   *
+   * @throws if `config.authRef` is set but the resolver yields no token.
+   */
+  #authHeaders(token: string): Record<string, string> {
+    if (this.#config.authRef) {
+      if (!token) {
+        throw new Error(
+          "[RestConnector] authRef is configured but the secret resolver " +
+            "returned no token — refusing to issue an unauthenticated request " +
+            "(fail-closed).",
+        );
+      }
+      return { Authorization: `Bearer ${token}` };
+    }
+    // Public source (no authRef): forward a token only if one happens to exist.
+    return token ? { Authorization: `Bearer ${token}` } : {};
   }
 
   getFormFields(): FormField[] {
@@ -428,8 +677,7 @@ export class RestConnector extends RemoteApiConnector {
    */
   async connect(): Promise<RemoteDatabase[]> {
     return this.auth(async (token) => {
-      const headers: Record<string, string> = {};
-      if (token) headers["Authorization"] = `Bearer ${token}`;
+      const headers = this.#authHeaders(token);
       const method = this.#config.method ?? "GET";
       await fetchPage(this.#config.endpoint, method, headers);
       return [
@@ -455,14 +703,25 @@ export class RestConnector extends RemoteApiConnector {
     tableId: UUID,
     options?: QueryOptions,
   ): Promise<ConnectorQueryResult> {
+    // Reject config-static fieldMap collisions before any network work.
+    if (this.#config.fieldMap) {
+      assertFieldMapNoCollision(this.#config.fieldMap);
+    }
+
+    // Push the requested window into pagination: stop fetching once enough rows
+    // are collected to satisfy offset+limit, instead of walking the whole
+    // remote chain and slicing afterward (avoids unbounded over-fetch).
+    const limit = options?.pagination?.limit;
+    const sliceOffset = options?.pagination?.offset ?? 0;
+    const budget = limit !== undefined ? sliceOffset + limit : Infinity;
+
     return this.auth(async (token) => {
-      const headers: Record<string, string> = {};
-      if (token) headers["Authorization"] = `Bearer ${token}`;
+      const headers = this.#authHeaders(token);
 
-      // Fetch all pages
-      const rawRows = await fetchAllPages(this.#config, headers);
+      // Fetch pages up to the row budget.
+      const rawRows = await fetchAllPages(this.#config, headers, budget);
 
-      // Apply fieldMap to each row
+      // Apply fieldMap to each row (rejects per-row target collisions).
       const rows = rawRows
         .filter(
           (r): r is Record<string, unknown> =>
@@ -470,23 +729,28 @@ export class RestConnector extends RemoteApiConnector {
         )
         .map((r) => applyFieldMap(r, this.#config.fieldMap));
 
-      // Apply pagination options to limit rows returned
+      // Apply the requested window after collecting just enough rows.
       const limitedRows =
-        options?.pagination?.limit !== undefined
-          ? rows.slice(
-              options.pagination.offset ?? 0,
-              (options.pagination.offset ?? 0) + options.pagination.limit,
-            )
+        limit !== undefined
+          ? rows.slice(sliceOffset, sliceOffset + limit)
           : rows;
 
       // Infer fields
       const fields = inferFieldsFromRows(limitedRows, tableId);
 
-      // Build Arrow table
-      const columnNames = fields.map((f) => f.columnName ?? f.name);
-      const columnArrays: Record<string, unknown[]> = {};
-      for (const colName of columnNames) {
-        columnArrays[colName] = limitedRows.map((r) => r[colName] ?? null);
+      // Build Arrow table. Use a null-prototype object so a response column
+      // named `__proto__`/`constructor` is stored as data, not a prototype
+      // mutation (which would silently drop the column from the Arrow table
+      // while `fieldIds` still listed it). Coerce each value to the inferred
+      // column type so the Arrow schema agrees with the `fields` metadata.
+      const columnArrays: Record<string, unknown[]> = Object.create(
+        null,
+      ) as Record<string, unknown[]>;
+      for (const field of fields) {
+        const colName = field.columnName ?? field.name;
+        columnArrays[colName] = limitedRows.map((r) =>
+          coerceValueToType(r[colName] ?? null, field.type),
+        );
       }
 
       const arrowTable = tableFromArrays(columnArrays);

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -383,9 +383,8 @@ export class RestConnector extends RemoteApiConnector {
    */
   async connect(): Promise<RemoteDatabase[]> {
     return this.auth(async (token) => {
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${token}`,
-      };
+      const headers: Record<string, string> = {};
+      if (token) headers["Authorization"] = `Bearer ${token}`;
       const method = this.#config.method ?? "GET";
       await fetchPage(this.#config.endpoint, method, headers);
       return [
@@ -412,9 +411,8 @@ export class RestConnector extends RemoteApiConnector {
     options?: QueryOptions,
   ): Promise<ConnectorQueryResult> {
     return this.auth(async (token) => {
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${token}`,
-      };
+      const headers: Record<string, string> = {};
+      if (token) headers["Authorization"] = `Bearer ${token}`;
 
       // Fetch all pages
       const rawRows = await fetchAllPages(this.#config, headers);

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -1,0 +1,487 @@
+/**
+ * RestConnector — generic declarative HTTP/JSON connector.
+ *
+ * Auth-blind: the connector is constructed with a bound SecretResolver
+ * pre-bound to the DataSource's credential ref. Data methods (connect, query)
+ * carry NO credential arguments — the pipeline call site has no vault, ref,
+ * or plaintext in scope (enforced by type).
+ *
+ * Design contracts:
+ * - Config IS the mod: no executable code in config, fully declarative.
+ * - authRef resolves via the bound SecretResolver (withSecret scoped lease).
+ *   If the endpoint is public (no authRef), pass a no-op resolver or omit.
+ * - Unsupported pagination strategies are logged as declarative-ceiling gaps
+ *   for the v0.4 code-plugin tier.
+ * - Output: Arrow IPC bytes (base64) + fieldIds + fields — serializable over
+ *   IPC. The renderer materializes a browser DataFrame from arrowBuffer after
+ *   it crosses the IPC boundary.
+ */
+
+import type {
+  ConnectorQueryResult,
+  Field,
+  FormField,
+  QueryOptions,
+  RemoteDatabase,
+  SecretResolver,
+  UUID,
+  ValidationResult,
+} from "@dashframe/engine";
+import {
+  RemoteApiConnector,
+  createFieldsFromColumns,
+  inferStringColumnType,
+} from "@dashframe/engine";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+import type { RestConnectorConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Traverse a dot-path in `data` and return the value at that path, or
+ * `undefined` if any segment is missing.
+ */
+function resolveDotPath(data: unknown, path: string): unknown {
+  const segments = path.split(".");
+  let current: unknown = data;
+  for (const seg of segments) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[seg];
+  }
+  return current;
+}
+
+/**
+ * Extract the record array from a parsed JSON response.
+ * - No rowPath (or empty): if data is array return it, else return [].
+ * - Dot-path: traverse each segment; if resolution fails return [].
+ */
+export function extractRows(data: unknown, rowPath?: string): unknown[] {
+  if (!rowPath) {
+    return Array.isArray(data) ? data : [];
+  }
+  const resolved = resolveDotPath(data, rowPath);
+  return Array.isArray(resolved) ? resolved : [];
+}
+
+/**
+ * Rename keys in a row according to fieldMap. Unmapped keys pass through.
+ */
+export function applyFieldMap(
+  row: Record<string, unknown>,
+  fieldMap?: Record<string, string>,
+): Record<string, unknown> {
+  if (!fieldMap) return row;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    const mappedKey = fieldMap[key] ?? key;
+    result[mappedKey] = value;
+  }
+  return result;
+}
+
+/**
+ * Collect all column names from all rows, infer each column's type from the
+ * first non-null value, and return Field[] via createFieldsFromColumns.
+ */
+export function inferFieldsFromRows(
+  rows: Record<string, unknown>[],
+  tableId: UUID,
+): Field[] {
+  // Collect all column names
+  const columnNames = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      columnNames.add(key);
+    }
+  }
+
+  // For each column, find first non-null value and infer type
+  const columns = [...columnNames].map((name) => {
+    let type: ReturnType<typeof inferStringColumnType> = "unknown";
+    for (const row of rows) {
+      const v = row[name];
+      if (v !== null && v !== undefined) {
+        type = inferStringColumnType(String(v));
+        break;
+      }
+    }
+    return { name, type };
+  });
+
+  return createFieldsFromColumns(columns, tableId);
+}
+
+/**
+ * Build a URL by appending (or replacing) a query parameter.
+ */
+function withQueryParam(url: string, key: string, value: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set(key, value);
+  return parsed.toString();
+}
+
+/**
+ * Perform a single HTTP request. Throws on non-ok status.
+ */
+async function fetchPage(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+): Promise<{ data: unknown; response: Response }> {
+  const response = await fetch(url, { method, headers });
+  if (!response.ok) {
+    throw new Error(
+      `[RestConnector] HTTP ${response.status} ${response.statusText} — ${url}`,
+    );
+  }
+  const data: unknown = await response.json();
+  return { data, response };
+}
+
+/**
+ * Fetch all pages according to the configured pagination strategy.
+ * Returns a flat array of all raw row objects across pages.
+ *
+ * @param config  - Connector config (endpoint, pagination, etc.)
+ * @param headers - Pre-resolved request headers (auth already injected)
+ */
+async function fetchAllPages(
+  config: RestConnectorConfig,
+  headers: Record<string, string>,
+): Promise<unknown[]> {
+  const method = config.method ?? "GET";
+  const pp = config.paginationParams ?? {};
+  const allRows: unknown[] = [];
+
+  switch (config.pagination) {
+    case "offset": {
+      const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
+      const offsetParam = (pp["offsetParam"] as string | undefined) ?? "offset";
+      const limitParam = (pp["limitParam"] as string | undefined) ?? "limit";
+      let offset = 0;
+
+      while (true) {
+        const url = withQueryParam(
+          withQueryParam(config.endpoint, offsetParam, String(offset)),
+          limitParam,
+          String(pageSize),
+        );
+        const { data } = await fetchPage(url, method, headers);
+        const rows = extractRows(data, config.rowPath);
+        allRows.push(...rows);
+        if (rows.length === 0 || rows.length < pageSize) break;
+        offset += pageSize;
+      }
+      break;
+    }
+
+    case "page-number": {
+      const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
+      const pageParam = (pp["pageParam"] as string | undefined) ?? "page";
+      const pageSizeParam =
+        (pp["pageSizeParam"] as string | undefined) ?? "pageSize";
+      let page = 1;
+
+      while (true) {
+        const url = withQueryParam(
+          withQueryParam(config.endpoint, pageParam, String(page)),
+          pageSizeParam,
+          String(pageSize),
+        );
+        const { data } = await fetchPage(url, method, headers);
+        const rows = extractRows(data, config.rowPath);
+        allRows.push(...rows);
+        if (rows.length === 0 || rows.length < pageSize) break;
+        page++;
+      }
+      break;
+    }
+
+    case "cursor": {
+      const cursorParam = (pp["cursorParam"] as string | undefined) ?? "cursor";
+      const cursorPath = pp["cursorPath"] as string | undefined;
+      // Common cursor field names to probe when no explicit path is given
+      const defaultCursorFields = [
+        "next_cursor",
+        "nextCursor",
+        "cursor",
+        "next",
+      ];
+      let cursor: string | undefined = undefined;
+
+      while (true) {
+        const url = cursor
+          ? withQueryParam(config.endpoint, cursorParam, cursor)
+          : config.endpoint;
+        const { data } = await fetchPage(url, method, headers);
+        const rows = extractRows(data, config.rowPath);
+        allRows.push(...rows);
+
+        // Find the next cursor
+        let nextCursor: unknown = undefined;
+        if (cursorPath) {
+          nextCursor = resolveDotPath(data, cursorPath);
+        } else {
+          for (const field of defaultCursorFields) {
+            nextCursor = resolveDotPath(data, field);
+            if (nextCursor !== undefined && nextCursor !== null) break;
+          }
+        }
+
+        if (!nextCursor || typeof nextCursor !== "string") break;
+        cursor = nextCursor;
+      }
+      break;
+    }
+
+    case "link-header": {
+      let nextUrl: string | undefined = config.endpoint;
+
+      while (nextUrl) {
+        const { data, response } = await fetchPage(nextUrl, method, headers);
+        const rows = extractRows(data, config.rowPath);
+        allRows.push(...rows);
+
+        // Parse Link header: <url>; rel="next"
+        const linkHeader = response.headers.get("Link");
+        nextUrl = undefined;
+        if (linkHeader) {
+          const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+          if (match?.[1]) {
+            nextUrl = match[1];
+          }
+        }
+      }
+      break;
+    }
+
+    default: {
+      if (config.pagination) {
+        console.warn(
+          `[RestConnector] Unsupported pagination strategy "${config.pagination}". ` +
+            "Falling back to single-page fetch. " +
+            "This is a declarative-ceiling gap — implement via the v0.4 code-plugin tier.",
+        );
+      }
+      const { data } = await fetchPage(config.endpoint, method, headers);
+      allRows.push(...extractRows(data, config.rowPath));
+      break;
+    }
+  }
+
+  return allRows;
+}
+
+// ---------------------------------------------------------------------------
+// Connector
+// ---------------------------------------------------------------------------
+
+/**
+ * RestConnector — auth-blind, declarative HTTP/JSON connector.
+ *
+ * Constructed via {@link makeRestConnector} with a bound SecretResolver and
+ * declarative config. Use `connect()` and `query()` with no credential
+ * arguments — the pipeline call site has no vault, ref, or plaintext in scope.
+ */
+export class RestConnector extends RemoteApiConnector {
+  readonly id = "rest";
+  readonly name = "REST API";
+  readonly description =
+    "Connect to any HTTP/JSON endpoint with declarative pagination.";
+  readonly icon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
+
+  /** Declarative config — baked in at construction time via factory. */
+  readonly #config: RestConnectorConfig;
+
+  constructor(auth: SecretResolver, config: RestConnectorConfig) {
+    super(auth);
+    this.#config = config;
+  }
+
+  getFormFields(): FormField[] {
+    return [
+      {
+        name: "endpoint",
+        label: "Endpoint URL",
+        type: "text",
+        placeholder: "https://api.example.com/data",
+        hint: "The HTTP endpoint to fetch data from.",
+        required: true,
+      },
+      {
+        name: "method",
+        label: "HTTP Method",
+        type: "select",
+        options: [
+          { value: "GET", label: "GET" },
+          { value: "POST", label: "POST" },
+          { value: "PUT", label: "PUT" },
+          { value: "PATCH", label: "PATCH" },
+        ],
+        hint: "HTTP method to use (default: GET).",
+      },
+      {
+        name: "authRef",
+        label: "Auth Secret Ref",
+        type: "text",
+        placeholder: "secret:<uuid>",
+        hint: "A SecretRef pointing to the Bearer token in the vault. Never a plaintext credential.",
+      },
+      {
+        name: "pagination",
+        label: "Pagination Strategy",
+        type: "select",
+        options: [
+          { value: "", label: "None (single page)" },
+          { value: "offset", label: "Offset / Limit" },
+          { value: "page-number", label: "Page Number" },
+          { value: "cursor", label: "Cursor" },
+          { value: "link-header", label: "Link Header (RFC 5988)" },
+        ],
+        hint: "How to paginate through results.",
+      },
+      {
+        name: "rowPath",
+        label: "Row Path",
+        type: "text",
+        placeholder: "data.items",
+        hint: "Dot-path to the record array in the response. Leave empty if the root is an array.",
+      },
+    ];
+  }
+
+  validate(formData: Record<string, unknown>): ValidationResult {
+    const endpoint = formData["endpoint"] as string | undefined;
+    if (!endpoint) {
+      return {
+        valid: false,
+        errors: { endpoint: "Endpoint URL is required." },
+      };
+    }
+
+    try {
+      new URL(endpoint);
+    } catch {
+      return {
+        valid: false,
+        errors: { endpoint: "Endpoint must be a valid URL." },
+      };
+    }
+
+    return { valid: true };
+  }
+
+  /**
+   * Test the connection by fetching the first page of data.
+   * Returns the endpoint as a single RemoteDatabase entry on success.
+   *
+   * NOTE: This is a real network call — it cannot ride a preview transaction.
+   * Credentials are resolved via `this.auth` — no credential argument.
+   */
+  async connect(): Promise<RemoteDatabase[]> {
+    return this.auth(async (token) => {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+      };
+      const method = this.#config.method ?? "GET";
+      await fetchPage(this.#config.endpoint, method, headers);
+      return [
+        {
+          id: this.#config.endpoint,
+          name: this.#config.endpoint,
+        },
+      ];
+    });
+  }
+
+  /**
+   * Fetch all pages from the REST endpoint and return a serializable result.
+   *
+   * Returns Arrow IPC bytes (base64) + fieldIds + fields — NOT a live DataFrame.
+   * The renderer materializes the browser DataFrame from arrowBuffer after it
+   * crosses the IPC boundary.
+   *
+   * Credentials are resolved via `this.auth` — no credential argument.
+   */
+  async query(
+    _databaseId: string,
+    tableId: UUID,
+    options?: QueryOptions,
+  ): Promise<ConnectorQueryResult> {
+    return this.auth(async (token) => {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+      };
+
+      // Fetch all pages
+      const rawRows = await fetchAllPages(this.#config, headers);
+
+      // Apply fieldMap to each row
+      const rows = rawRows
+        .filter(
+          (r): r is Record<string, unknown> =>
+            r !== null && typeof r === "object",
+        )
+        .map((r) => applyFieldMap(r, this.#config.fieldMap));
+
+      // Apply pagination options to limit rows returned
+      const limitedRows =
+        options?.pagination?.limit !== undefined
+          ? rows.slice(
+              options.pagination.offset ?? 0,
+              (options.pagination.offset ?? 0) + options.pagination.limit,
+            )
+          : rows;
+
+      // Infer fields
+      const fields = inferFieldsFromRows(limitedRows, tableId);
+
+      // Build Arrow table
+      const columnNames = fields.map((f) => f.columnName ?? f.name);
+      const columnArrays: Record<string, unknown[]> = {};
+      for (const colName of columnNames) {
+        columnArrays[colName] = limitedRows.map((r) => r[colName] ?? null);
+      }
+
+      const arrowTable = tableFromArrays(columnArrays);
+      const ipcBuffer = tableToIPC(arrowTable);
+
+      // Base64-encode the IPC buffer for JSON transport
+      const base64 = Buffer.from(ipcBuffer).toString("base64");
+
+      return {
+        arrowBuffer: base64,
+        fieldIds: fields.map((f) => f.id),
+        fields,
+      };
+    });
+  }
+}
+
+/**
+ * A no-op SecretResolver for public endpoints that require no authentication.
+ * Passes an empty string as the token — the connector ignores it.
+ */
+export const noopResolver: SecretResolver = async (use) => use("");
+
+/**
+ * Factory — mint a RestConnector bound to the given SecretResolver and config.
+ *
+ * This is the single construction site for RestConnector. The server-layer
+ * connector factory calls this after minting the bound resolver from
+ * `vault.withSecret.bind(vault, ref)`.
+ *
+ * For public endpoints (no authRef), pass {@link noopResolver}.
+ *
+ * @param auth   - SecretResolver pre-bound to this DataSource's credential ref
+ * @param config - Declarative REST config (endpoint, pagination, rowPath, etc.)
+ */
+export function makeRestConnector(
+  auth: SecretResolver,
+  config: RestConnectorConfig,
+): RestConnector {
+  return new RestConnector(auth, config);
+}

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -141,6 +141,149 @@ async function fetchPage(
   return { data, response };
 }
 
+/** Offset/limit pagination — increments offset by pageSize until a short page. */
+async function fetchOffsetPages(
+  config: RestConnectorConfig,
+  method: string,
+  headers: Record<string, string>,
+): Promise<unknown[]> {
+  const pp = config.paginationParams ?? {};
+  const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
+  const offsetParam = (pp["offsetParam"] as string | undefined) ?? "offset";
+  const limitParam = (pp["limitParam"] as string | undefined) ?? "limit";
+  const allRows: unknown[] = [];
+  let offset = 0;
+
+  while (true) {
+    const url = withQueryParam(
+      withQueryParam(config.endpoint, offsetParam, String(offset)),
+      limitParam,
+      String(pageSize),
+    );
+    const { data } = await fetchPage(url, method, headers);
+    const rows = extractRows(data, config.rowPath);
+    allRows.push(...rows);
+    if (rows.length === 0 || rows.length < pageSize) break;
+    offset += pageSize;
+  }
+
+  return allRows;
+}
+
+/** Page-number pagination — increments page until a short page. */
+async function fetchPageNumberPages(
+  config: RestConnectorConfig,
+  method: string,
+  headers: Record<string, string>,
+): Promise<unknown[]> {
+  const pp = config.paginationParams ?? {};
+  const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
+  const pageParam = (pp["pageParam"] as string | undefined) ?? "page";
+  const pageSizeParam =
+    (pp["pageSizeParam"] as string | undefined) ?? "pageSize";
+  const allRows: unknown[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = withQueryParam(
+      withQueryParam(config.endpoint, pageParam, String(page)),
+      pageSizeParam,
+      String(pageSize),
+    );
+    const { data } = await fetchPage(url, method, headers);
+    const rows = extractRows(data, config.rowPath);
+    allRows.push(...rows);
+    if (rows.length === 0 || rows.length < pageSize) break;
+    page++;
+  }
+
+  return allRows;
+}
+
+/**
+ * Resolve the next cursor from a response object.
+ * Checks cursorPath first; falls back to probing common field names.
+ */
+function resolveNextCursor(
+  data: unknown,
+  cursorPath: string | undefined,
+): string | undefined {
+  if (cursorPath) {
+    const v = resolveDotPath(data, cursorPath);
+    return typeof v === "string" && v ? v : undefined;
+  }
+  for (const field of ["next_cursor", "nextCursor", "cursor", "next"]) {
+    const v = resolveDotPath(data, field);
+    if (typeof v === "string" && v) return v;
+  }
+  return undefined;
+}
+
+/** Cursor pagination — follows a cursor token until absent. */
+async function fetchCursorPages(
+  config: RestConnectorConfig,
+  method: string,
+  headers: Record<string, string>,
+): Promise<unknown[]> {
+  const pp = config.paginationParams ?? {};
+  const cursorParam = (pp["cursorParam"] as string | undefined) ?? "cursor";
+  const cursorPath = pp["cursorPath"] as string | undefined;
+  const allRows: unknown[] = [];
+  let cursor: string | undefined = undefined;
+
+  while (true) {
+    const url = cursor
+      ? withQueryParam(config.endpoint, cursorParam, cursor)
+      : config.endpoint;
+    const { data } = await fetchPage(url, method, headers);
+    allRows.push(...extractRows(data, config.rowPath));
+    cursor = resolveNextCursor(data, cursorPath);
+    if (!cursor) break;
+  }
+
+  return allRows;
+}
+
+/**
+ * Parse a `Link` response header and return the `rel="next"` URL, or undefined.
+ * Uses a two-part approach to avoid backtracking: split on `>,` boundaries first,
+ * then match each segment independently.
+ */
+function parseLinkNext(linkHeader: string): string | undefined {
+  // Split on `>, ` or `>,` to separate link entries without regex alternation.
+  const parts = linkHeader.split(/>,\s*/);
+  for (const part of parts) {
+    // Each part looks like: `<URL>; rel="next"` or `<URL>; rel="prev"`, etc.
+    // Two fixed-width checks: URL between < >, rel attribute present and "next".
+    const ltIdx = part.indexOf("<");
+    const gtIdx = part.indexOf(">");
+    if (ltIdx === -1 || gtIdx === -1 || gtIdx <= ltIdx) continue;
+    const url = part.slice(ltIdx + 1, gtIdx);
+    const rest = part.slice(gtIdx + 1);
+    if (/rel="next"/i.test(rest)) return url;
+  }
+  return undefined;
+}
+
+/** Link-header pagination — follows RFC 5988 `Link: <url>; rel="next"`. */
+async function fetchLinkHeaderPages(
+  config: RestConnectorConfig,
+  method: string,
+  headers: Record<string, string>,
+): Promise<unknown[]> {
+  const allRows: unknown[] = [];
+  let nextUrl: string | undefined = config.endpoint;
+
+  while (nextUrl) {
+    const { data, response } = await fetchPage(nextUrl, method, headers);
+    allRows.push(...extractRows(data, config.rowPath));
+    const linkHeader = response.headers.get("Link");
+    nextUrl = linkHeader ? parseLinkNext(linkHeader) : undefined;
+  }
+
+  return allRows;
+}
+
 /**
  * Fetch all pages according to the configured pagination strategy.
  * Returns a flat array of all raw row objects across pages.
@@ -153,111 +296,16 @@ async function fetchAllPages(
   headers: Record<string, string>,
 ): Promise<unknown[]> {
   const method = config.method ?? "GET";
-  const pp = config.paginationParams ?? {};
-  const allRows: unknown[] = [];
 
   switch (config.pagination) {
-    case "offset": {
-      const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
-      const offsetParam = (pp["offsetParam"] as string | undefined) ?? "offset";
-      const limitParam = (pp["limitParam"] as string | undefined) ?? "limit";
-      let offset = 0;
-
-      while (true) {
-        const url = withQueryParam(
-          withQueryParam(config.endpoint, offsetParam, String(offset)),
-          limitParam,
-          String(pageSize),
-        );
-        const { data } = await fetchPage(url, method, headers);
-        const rows = extractRows(data, config.rowPath);
-        allRows.push(...rows);
-        if (rows.length === 0 || rows.length < pageSize) break;
-        offset += pageSize;
-      }
-      break;
-    }
-
-    case "page-number": {
-      const pageSize = (pp["pageSize"] as number | undefined) ?? 100;
-      const pageParam = (pp["pageParam"] as string | undefined) ?? "page";
-      const pageSizeParam =
-        (pp["pageSizeParam"] as string | undefined) ?? "pageSize";
-      let page = 1;
-
-      while (true) {
-        const url = withQueryParam(
-          withQueryParam(config.endpoint, pageParam, String(page)),
-          pageSizeParam,
-          String(pageSize),
-        );
-        const { data } = await fetchPage(url, method, headers);
-        const rows = extractRows(data, config.rowPath);
-        allRows.push(...rows);
-        if (rows.length === 0 || rows.length < pageSize) break;
-        page++;
-      }
-      break;
-    }
-
-    case "cursor": {
-      const cursorParam = (pp["cursorParam"] as string | undefined) ?? "cursor";
-      const cursorPath = pp["cursorPath"] as string | undefined;
-      // Common cursor field names to probe when no explicit path is given
-      const defaultCursorFields = [
-        "next_cursor",
-        "nextCursor",
-        "cursor",
-        "next",
-      ];
-      let cursor: string | undefined = undefined;
-
-      while (true) {
-        const url = cursor
-          ? withQueryParam(config.endpoint, cursorParam, cursor)
-          : config.endpoint;
-        const { data } = await fetchPage(url, method, headers);
-        const rows = extractRows(data, config.rowPath);
-        allRows.push(...rows);
-
-        // Find the next cursor
-        let nextCursor: unknown = undefined;
-        if (cursorPath) {
-          nextCursor = resolveDotPath(data, cursorPath);
-        } else {
-          for (const field of defaultCursorFields) {
-            nextCursor = resolveDotPath(data, field);
-            if (nextCursor !== undefined && nextCursor !== null) break;
-          }
-        }
-
-        if (!nextCursor || typeof nextCursor !== "string") break;
-        cursor = nextCursor;
-      }
-      break;
-    }
-
-    case "link-header": {
-      let nextUrl: string | undefined = config.endpoint;
-
-      while (nextUrl) {
-        const { data, response } = await fetchPage(nextUrl, method, headers);
-        const rows = extractRows(data, config.rowPath);
-        allRows.push(...rows);
-
-        // Parse Link header: <url>; rel="next"
-        const linkHeader = response.headers.get("Link");
-        nextUrl = undefined;
-        if (linkHeader) {
-          const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
-          if (match?.[1]) {
-            nextUrl = match[1];
-          }
-        }
-      }
-      break;
-    }
-
+    case "offset":
+      return fetchOffsetPages(config, method, headers);
+    case "page-number":
+      return fetchPageNumberPages(config, method, headers);
+    case "cursor":
+      return fetchCursorPages(config, method, headers);
+    case "link-header":
+      return fetchLinkHeaderPages(config, method, headers);
     default: {
       if (config.pagination) {
         console.warn(
@@ -267,12 +315,9 @@ async function fetchAllPages(
         );
       }
       const { data } = await fetchPage(config.endpoint, method, headers);
-      allRows.push(...extractRows(data, config.rowPath));
-      break;
+      return extractRows(data, config.rowPath);
     }
   }
-
-  return allRows;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/connector-rest/src/index.ts
+++ b/packages/connector-rest/src/index.ts
@@ -1,6 +1,7 @@
 export {
   RestConnector,
   applyFieldMap,
+  assertFieldMapNoCollision,
   extractRows,
   inferFieldsFromRows,
   makeRestConnector,

--- a/packages/connector-rest/src/index.ts
+++ b/packages/connector-rest/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  RestConnector,
+  applyFieldMap,
+  extractRows,
+  inferFieldsFromRows,
+  makeRestConnector,
+  noopResolver,
+} from "./connector.js";
+export type { PaginationStrategy, RestConnectorConfig } from "./types.js";

--- a/packages/connector-rest/src/types.ts
+++ b/packages/connector-rest/src/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Pagination strategies for RestConnector.
+ *
+ * Strategies beyond these four are declarative-ceiling gaps — log a warning
+ * and fall back to single-page. The code-plugin tier (v0.4) will handle
+ * arbitrary programmatic pagination.
+ */
+export type PaginationStrategy =
+  | "offset"
+  | "cursor"
+  | "page-number"
+  | "link-header";
+
+/**
+ * Declarative config interpreted by RestConnector.
+ * Config IS the mod — no executable code in config.
+ */
+export interface RestConnectorConfig {
+  /** HTTP endpoint URL */
+  endpoint: string;
+  /** HTTP method, default GET */
+  method?: "GET" | "POST" | "PUT" | "PATCH";
+  /**
+   * authRef: a SecretRef resolved server-side via the vault.
+   * NEVER a plaintext credential.
+   */
+  authRef?: string;
+  /**
+   * Pagination strategy. Unsupported patterns are logged as declarative-ceiling
+   * gaps for the v0.4 code-plugin tier.
+   */
+  pagination?: PaginationStrategy;
+  /**
+   * JSON path to the record array in the response.
+   * Dot-separated, e.g. "data.items". Empty string or absent = root array.
+   */
+  rowPath?: string;
+  /**
+   * Map response keys to field names: { responseKey: fieldName }.
+   * Absent = pass through all keys as-is.
+   */
+  fieldMap?: Record<string, string>;
+  /**
+   * Pagination-strategy-specific params.
+   *
+   * offset / page-number:
+   *   pageSize?    — rows per page (default 100)
+   *   offsetParam? — query param name for offset (default "offset")
+   *   limitParam?  — query param name for limit (default "limit")
+   *   pageParam?   — query param name for page number (default "page")
+   *   pageSizeParam? — query param name for page size (default "pageSize")
+   *
+   * cursor:
+   *   cursorParam? — query param name to pass the cursor (default "cursor")
+   *   cursorPath?  — dot-path in the response body where the next cursor lives
+   *                  (default: tries "next_cursor", "nextCursor", "cursor", "next")
+   *
+   * link-header: (no additional params)
+   */
+  paginationParams?: Record<string, unknown>;
+}

--- a/packages/connector-rest/tsconfig.json
+++ b/packages/connector-rest/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  }
+}

--- a/packages/connector-rest/vitest.config.ts
+++ b/packages/connector-rest/vitest.config.ts
@@ -1,0 +1,36 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "**/*.test.{ts,tsx}",
+        "**/__tests__/**",
+        "**/node_modules/**",
+        "**/dist/**",
+      ],
+      thresholds: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      "@dashframe/engine": path.resolve(__dirname, "../engine/src"),
+      "@wystack/secret-vault": path.resolve(
+        __dirname,
+        "../../libs/wystack/packages/secret-vault/src/index.ts",
+      ),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `@dashframe/connector-rest` — a new package implementing `RestConnector`, a generic declarative HTTP/JSON connector that interprets `DataSource.config` (endpoint, method, authRef, pagination, rowPath, fieldMap) to pull from any HTTP/JSON source. Config IS the mod — no executable code in config.
- Implements all four pagination strategies: **offset**, **cursor**, **page-number**, and **link-header** (RFC 5988). Unsupported strategy strings are logged as declarative-ceiling gaps for the v0.4 code-plugin tier.
- `authRef` resolves server-side through the `SecretResolver` scoped lease (vault's `withSecret`). Vault-absent + authRef-present → throw before any fetch (fail-closed). Plaintext never in config, formData, or any public interface.
- `connect()` performs a live single-page test fetch (real-world side-effect — cannot ride a preview transaction).
- `query()` returns `{ arrowBuffer (base64), fieldIds, fields }` — fully serializable over IPC. Renderer materializes the DataFrame from arrowBuffer.
- rowPath dot-path extraction and fieldMap key renaming, with Arrow IPC output via `apache-arrow` `tableFromArrays`/`tableToIPC`.

Tracked internally as YW-140.

## Test plan

- [x] 24/24 tests pass (`bunx vitest run` in `packages/connector-rest`)
- [x] Full turbo typecheck clean (46/46 tasks pass)
- [x] Offset pagination: two-page fetch, stops on empty page
- [x] Cursor pagination: follows `next_cursor` until absent
- [x] Page-number pagination: increments page, stops on partial page
- [x] Link-header pagination: follows `Link: rel="next"` header, stops when absent
- [x] rowPath + fieldMap: nested extraction + key rename confirmed
- [x] authRef vault resolution: Bearer token injected into fetch headers via vault's withSecret; plaintext never in result or formData
- [x] Fail-closed: SecretResolver rejection → throw, fetch never called
- [x] Public endpoints (noopResolver): no Authorization header sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `@dashframe/connector-rest`, a new declarative HTTP/JSON connector package that drives pagination, auth, row extraction, and Arrow serialization entirely from a `RestConnectorConfig` object — no executable code in config.

- Implements four pagination strategies (offset, cursor, page-number, link-header/RFC 5988) with budget-aware early-stop, a same-origin SSRF guard on Link-header redirects, and fail-closed auth enforcement when `authRef` is configured.
- Serializes results as Apache Arrow IPC (base64) with per-cell type coercion aligned to `inferStringColumnType`, null-prototype row objects to block prototype pollution, and fieldMap collision detection; 24 tests cover all strategies, security edges, and coercion edge-cases.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge after addressing the cursor `"next"` probe bug; the rest of the connector is well-guarded and thoroughly tested.

The cursor pagination auto-detection probes `"next"` as a fallback field name. On APIs that place the next-page URL in a response body `next` field (a very common pattern), the connector silently duplicates page-1 rows until the row budget is exhausted — no error is raised, so callers receive wrong data without knowing it.

packages/connector-rest/src/connector.ts — specifically the `resolveNextCursor` function and the `fetchPage` body-less implementation for non-GET methods.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/connector-rest/src/connector.ts | Core connector implementation; contains the resolveNextCursor P1 bug (probing "next" as cursor name causes silent row duplication on DRF-style APIs) and a P2 gap where POST/PUT/PATCH methods have no body support. |
| packages/connector-rest/src/connector.test.ts | Comprehensive 857-line test suite covering all four pagination strategies, auth/vault resolution, SSRF guard, prototype-pollution defence, limit pushdown, type coercion, and fieldMap collision detection. |
| packages/connector-rest/src/types.ts | Declarative config types for RestConnectorConfig and PaginationStrategy; well-documented with no issues. |
| packages/connector-rest/src/index.ts | Re-exports public API surface from connector and types; no issues. |
| packages/connector-rest/package.json | New package manifest for @dashframe/connector-rest; dependencies and scripts look correct. |
| packages/connector-rest/vitest.config.ts | Vitest config with workspace aliases for engine and secret-vault; coverage thresholds set at 80%; no issues. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant RestConnector
    participant SecretVault as SecretResolver / Vault
    participant RemoteAPI

    Client->>RestConnector: query(databaseId, tableId, options?)
    RestConnector->>RestConnector: assertFieldMapNoCollision(fieldMap)
    RestConnector->>SecretVault: auth(callback)
    SecretVault-->>RestConnector: token (throws if authRef set and token empty)
    RestConnector->>RestConnector: authHeaders(token) → headers map

    loop fetchAllPages (offset / page-number / cursor / link-header)
        RestConnector->>RemoteAPI: "fetch(url, { method, headers })"
        RemoteAPI-->>RestConnector: JSON response
        RestConnector->>RestConnector: extractRows(data, rowPath)
        RestConnector->>RestConnector: check budget (sliceOffset + limit)
    end

    RestConnector->>RestConnector: filter and applyFieldMap(rows)
    RestConnector->>RestConnector: slice(sliceOffset, sliceOffset+limit)
    RestConnector->>RestConnector: inferFieldsFromRows(limitedRows)
    RestConnector->>RestConnector: coerceValueToType() per cell
    RestConnector->>RestConnector: tableFromArrays() → tableToIPC() → base64
    RestConnector-->>Client: "{ arrowBuffer, fieldIds, fields }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant RestConnector
    participant SecretVault as SecretResolver / Vault
    participant RemoteAPI

    Client->>RestConnector: query(databaseId, tableId, options?)
    RestConnector->>RestConnector: assertFieldMapNoCollision(fieldMap)
    RestConnector->>SecretVault: auth(callback)
    SecretVault-->>RestConnector: token (throws if authRef set and token empty)
    RestConnector->>RestConnector: authHeaders(token) → headers map

    loop fetchAllPages (offset / page-number / cursor / link-header)
        RestConnector->>RemoteAPI: "fetch(url, { method, headers })"
        RemoteAPI-->>RestConnector: JSON response
        RestConnector->>RestConnector: extractRows(data, rowPath)
        RestConnector->>RestConnector: check budget (sliceOffset + limit)
    end

    RestConnector->>RestConnector: filter and applyFieldMap(rows)
    RestConnector->>RestConnector: slice(sliceOffset, sliceOffset+limit)
    RestConnector->>RestConnector: inferFieldsFromRows(limitedRows)
    RestConnector->>RestConnector: coerceValueToType() per cell
    RestConnector->>RestConnector: tableFromArrays() → tableToIPC() → base64
    RestConnector-->>Client: "{ arrowBuffer, fieldIds, fields }"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/connector-rest/src/connector.ts`, line 751-806 ([link](https://github.com/youhaowei/dashframe/blob/5b85058ba81505870c01e8e0ee6a8eb1f237f500/packages/connector-rest/src/connector.ts#L751-L806)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unbounded pagination loops — no max-pages or max-rows guard**

   The `cursor` and `link-header` cases have no upper bound on iterations. If an API always returns a non-empty cursor or a `Link: rel="next"` header (e.g., a bug on the remote end, a circular ref, or a misconfigured `cursorPath`), `fetchAllPages` will loop indefinitely and the `query()` call will never return. The `offset` and `page-number` cases are partially protected by the `rows.length === 0` check but are similarly unbounded for row accumulation.

   A simple guard — e.g., `const MAX_PAGES = 1_000; let pages = 0;` at the top of `fetchAllPages` with `if (++pages > MAX_PAGES) { console.warn(...); break; }` at the top of each loop — would prevent this without changing normal behaviour.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/connector-rest/src/connector.ts
   Line: 751-806

   Comment:
   **Unbounded pagination loops — no max-pages or max-rows guard**

   The `cursor` and `link-header` cases have no upper bound on iterations. If an API always returns a non-empty cursor or a `Link: rel="next"` header (e.g., a bug on the remote end, a circular ref, or a misconfigured `cursorPath`), `fetchAllPages` will loop indefinitely and the `query()` call will never return. The `offset` and `page-number` cases are partially protected by the `rows.length === 0` check but are similarly unbounded for row accumulation.

   A simple guard — e.g., `const MAX_PAGES = 1_000; let pages = 0;` at the top of `fetchAllPages` with `if (++pages > MAX_PAGES) { console.warn(...); break; }` at the top of each loop — would prevent this without changing normal behaviour.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fconnector-rest%2Fsrc%2Fconnector.ts%0ALine%3A%20751-806%0A%0AComment%3A%0A**Unbounded%20pagination%20loops%20%E2%80%94%20no%20max-pages%20or%20max-rows%20guard**%0A%0AThe%20%60cursor%60%20and%20%60link-header%60%20cases%20have%20no%20upper%20bound%20on%20iterations.%20If%20an%20API%20always%20returns%20a%20non-empty%20cursor%20or%20a%20%60Link%3A%20rel%3D%22next%22%60%20header%20%28e.g.%2C%20a%20bug%20on%20the%20remote%20end%2C%20a%20circular%20ref%2C%20or%20a%20misconfigured%20%60cursorPath%60%29%2C%20%60fetchAllPages%60%20will%20loop%20indefinitely%20and%20the%20%60query%28%29%60%20call%20will%20never%20return.%20The%20%60offset%60%20and%20%60page-number%60%20cases%20are%20partially%20protected%20by%20the%20%60rows.length%20%3D%3D%3D%200%60%20check%20but%20are%20similarly%20unbounded%20for%20row%20accumulation.%0A%0AA%20simple%20guard%20%E2%80%94%20e.g.%2C%20%60const%20MAX_PAGES%20%3D%201_000%3B%20let%20pages%20%3D%200%3B%60%20at%20the%20top%20of%20%60fetchAllPages%60%20with%20%60if%20%28%2B%2Bpages%20%3E%20MAX_PAGES%29%20%7B%20console.warn%28...%29%3B%20break%3B%20%7D%60%20at%20the%20top%20of%20each%20loop%20%E2%80%94%20would%20prevent%20this%20without%20changing%20normal%20behaviour.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-140-generic-rest-connector%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-140-generic-rest-connector%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fconnector-rest%2Fsrc%2Fconnector.ts%0ALine%3A%20751-806%0A%0AComment%3A%0A**Unbounded%20pagination%20loops%20%E2%80%94%20no%20max-pages%20or%20max-rows%20guard**%0A%0AThe%20%60cursor%60%20and%20%60link-header%60%20cases%20have%20no%20upper%20bound%20on%20iterations.%20If%20an%20API%20always%20returns%20a%20non-empty%20cursor%20or%20a%20%60Link%3A%20rel%3D%22next%22%60%20header%20%28e.g.%2C%20a%20bug%20on%20the%20remote%20end%2C%20a%20circular%20ref%2C%20or%20a%20misconfigured%20%60cursorPath%60%29%2C%20%60fetchAllPages%60%20will%20loop%20indefinitely%20and%20the%20%60query%28%29%60%20call%20will%20never%20return.%20The%20%60offset%60%20and%20%60page-number%60%20cases%20are%20partially%20protected%20by%20the%20%60rows.length%20%3D%3D%3D%200%60%20check%20but%20are%20similarly%20unbounded%20for%20row%20accumulation.%0A%0AA%20simple%20guard%20%E2%80%94%20e.g.%2C%20%60const%20MAX_PAGES%20%3D%201_000%3B%20let%20pages%20%3D%200%3B%60%20at%20the%20top%20of%20%60fetchAllPages%60%20with%20%60if%20%28%2B%2Bpages%20%3E%20MAX_PAGES%29%20%7B%20console.warn%28...%29%3B%20break%3B%20%7D%60%20at%20the%20top%20of%20each%20loop%20%E2%80%94%20would%20prevent%20this%20without%20changing%20normal%20behaviour.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fconnector-rest%2Fsrc%2Fconnector.ts%0ALine%3A%20751-806%0A%0AComment%3A%0A**Unbounded%20pagination%20loops%20%E2%80%94%20no%20max-pages%20or%20max-rows%20guard**%0A%0AThe%20%60cursor%60%20and%20%60link-header%60%20cases%20have%20no%20upper%20bound%20on%20iterations.%20If%20an%20API%20always%20returns%20a%20non-empty%20cursor%20or%20a%20%60Link%3A%20rel%3D%22next%22%60%20header%20%28e.g.%2C%20a%20bug%20on%20the%20remote%20end%2C%20a%20circular%20ref%2C%20or%20a%20misconfigured%20%60cursorPath%60%29%2C%20%60fetchAllPages%60%20will%20loop%20indefinitely%20and%20the%20%60query%28%29%60%20call%20will%20never%20return.%20The%20%60offset%60%20and%20%60page-number%60%20cases%20are%20partially%20protected%20by%20the%20%60rows.length%20%3D%3D%3D%200%60%20check%20but%20are%20similarly%20unbounded%20for%20row%20accumulation.%0A%0AA%20simple%20guard%20%E2%80%94%20e.g.%2C%20%60const%20MAX_PAGES%20%3D%201_000%3B%20let%20pages%20%3D%200%3B%60%20at%20the%20top%20of%20%60fetchAllPages%60%20with%20%60if%20%28%2B%2Bpages%20%3E%20MAX_PAGES%29%20%7B%20console.warn%28...%29%3B%20break%3B%20%7D%60%20at%20the%20top%20of%20each%20loop%20%E2%80%94%20would%20prevent%20this%20without%20changing%20normal%20behaviour.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/connector-rest/src/connector.ts`, line 966-983 ([link](https://github.com/youhaowei/dashframe/blob/5b85058ba81505870c01e8e0ee6a8eb1f237f500/packages/connector-rest/src/connector.ts#L966-L983)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Full remote dataset fetched before `QueryOptions` row limit is applied**

   `fetchAllPages` downloads every page into `rawRows` before `options?.pagination?.limit` slices the result. If the remote API serves thousands of pages and the UI requests only 50 rows, the connector still fetches and materializes the full dataset in memory. For the v0.1 scope this may be acceptable, but the current `options.pagination` slice gives callers no way to avoid the full download — they cannot tell from the interface that specifying a small `limit` won't reduce network traffic.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/connector-rest/src/connector.ts
   Line: 966-983

   Comment:
   **Full remote dataset fetched before `QueryOptions` row limit is applied**

   `fetchAllPages` downloads every page into `rawRows` before `options?.pagination?.limit` slices the result. If the remote API serves thousands of pages and the UI requests only 50 rows, the connector still fetches and materializes the full dataset in memory. For the v0.1 scope this may be acceptable, but the current `options.pagination` slice gives callers no way to avoid the full download — they cannot tell from the interface that specifying a small `limit` won't reduce network traffic.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fconnector-rest%2Fsrc%2Fconnector.ts%0ALine%3A%20966-983%0A%0AComment%3A%0A**Full%20remote%20dataset%20fetched%20before%20%60QueryOptions%60%20row%20limit%20is%20applied**%0A%0A%60fetchAllPages%60%20downloads%20every%20page%20into%20%60rawRows%60%20before%20%60options%3F.pagination%3F.limit%60%20slices%20the%20result.%20If%20the%20remote%20API%20serves%20thousands%20of%20pages%20and%20the%20UI%20requests%20only%2050%20rows%2C%20the%20connector%20still%20fetches%20and%20materializes%20the%20full%20dataset%20in%20memory.%20For%20the%20v0.1%20scope%20this%20may%20be%20acceptable%2C%20but%20the%20current%20%60options.pagination%60%20slice%20gives%20callers%20no%20way%20to%20avoid%20the%20full%20download%20%E2%80%94%20they%20cannot%20tell%20from%20the%20interface%20that%20specifying%20a%20small%20%60limit%60%20won't%20reduce%20network%20traffic.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-140-generic-rest-connector%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-140-generic-rest-connector%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fconnector-rest%2Fsrc%2Fconnector.ts%0ALine%3A%20966-983%0A%0AComment%3A%0A**Full%20remote%20dataset%20fetched%20before%20%60QueryOptions%60%20row%20limit%20is%20applied**%0A%0A%60fetchAllPages%60%20downloads%20every%20page%20into%20%60rawRows%60%20before%20%60options%3F.pagination%3F.limit%60%20slices%20the%20result.%20If%20the%20remote%20API%20serves%20thousands%20of%20pages%20and%20the%20UI%20requests%20only%2050%20rows%2C%20the%20connector%20still%20fetches%20and%20materializes%20the%20full%20dataset%20in%20memory.%20For%20the%20v0.1%20scope%20this%20may%20be%20acceptable%2C%20but%20the%20current%20%60options.pagination%60%20slice%20gives%20callers%20no%20way%20to%20avoid%20the%20full%20download%20%E2%80%94%20they%20cannot%20tell%20from%20the%20interface%20that%20specifying%20a%20small%20%60limit%60%20won't%20reduce%20network%20traffic.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fconnector-rest%2Fsrc%2Fconnector.ts%0ALine%3A%20966-983%0A%0AComment%3A%0A**Full%20remote%20dataset%20fetched%20before%20%60QueryOptions%60%20row%20limit%20is%20applied**%0A%0A%60fetchAllPages%60%20downloads%20every%20page%20into%20%60rawRows%60%20before%20%60options%3F.pagination%3F.limit%60%20slices%20the%20result.%20If%20the%20remote%20API%20serves%20thousands%20of%20pages%20and%20the%20UI%20requests%20only%2050%20rows%2C%20the%20connector%20still%20fetches%20and%20materializes%20the%20full%20dataset%20in%20memory.%20For%20the%20v0.1%20scope%20this%20may%20be%20acceptable%2C%20but%20the%20current%20%60options.pagination%60%20slice%20gives%20callers%20no%20way%20to%20avoid%20the%20full%20download%20%E2%80%94%20they%20cannot%20tell%20from%20the%20interface%20that%20specifying%20a%20small%20%60limit%60%20won't%20reduce%20network%20traffic.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(connector-rest): address security + ..."](https://github.com/youhaowei/dashframe/commit/416a9ed7045865a7ffbaf8ab67d1861d46ee3245) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38149077)</sub>

<!-- /greptile_comment -->