### PR TITLE
feat(server-core): [YW-125] draft delta-table schema + compacted command log

### DIFF
--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -52,11 +52,11 @@ export {
   dataFrames,
   dataFramesDraft,
   dataSources,
-  // Draft shadow tables (YW-125)
+  // Draft shadow tables
   dataSourcesDraft,
   dataTables,
   dataTablesDraft,
-  // Draft command log (YW-125)
+  // Draft command log
   draftCommandLog,
   insights,
   insightsDraft,

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -43,6 +43,31 @@ export {
   resolveProjectDir,
   type ResolveProjectDirOptions,
 } from "./project-dir";
-export { schema, type Schema } from "./schema";
+export {
+  // Constants
+  PROJECT_META_ID,
+  PROJECT_META_SINGLETON_KEY,
+  dashboards,
+  dashboardsDraft,
+  dataFrames,
+  dataFramesDraft,
+  dataSources,
+  // Draft shadow tables (YW-125)
+  dataSourcesDraft,
+  dataTables,
+  dataTablesDraft,
+  // Draft command log (YW-125)
+  draftCommandLog,
+  insights,
+  insightsDraft,
+  // Canonical artifact tables
+  projectMeta,
+  schema,
+  secretMappings,
+  visualizations,
+  visualizationsDraft,
+  type ArtifactProvenance,
+  type Schema,
+} from "./schema";
 export { DASHFRAME_PROJECT_VERSION } from "./version";
 export { applyDataFrameWriteGate } from "./write-gate";

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -206,6 +206,31 @@ describe("draft_command_log table", () => {
   test("draft_command_log Drizzle table name is 'draft_command_log'", () => {
     expect(getTableName(draftCommandLog)).toBe("draft_command_log");
   });
+
+  test("draft_command_log enforces unique (draft_id, seq) — duplicate seq within same draft must fail", async () => {
+    // Insert a command at seq=1 for draft 'd1'.
+    await db.execute(
+      sql.raw(
+        `INSERT INTO "draft_command_log" (id, draft_id, seq, path) VALUES ('00000000-0000-0000-0000-000000000001', 'd1', 1, 'doSomething')`,
+      ),
+    );
+    // A second command at the SAME seq=1 within the same draft must violate the unique index.
+    await expect(
+      db.execute(
+        sql.raw(
+          `INSERT INTO "draft_command_log" (id, draft_id, seq, path) VALUES ('00000000-0000-0000-0000-000000000002', 'd1', 1, 'doSomethingElse')`,
+        ),
+      ),
+    ).rejects.toThrow();
+    // A command at seq=1 for a DIFFERENT draft ('d2') is allowed.
+    await expect(
+      db.execute(
+        sql.raw(
+          `INSERT INTO "draft_command_log" (id, draft_id, seq, path) VALUES ('00000000-0000-0000-0000-000000000003', 'd2', 1, 'doSomething')`,
+        ),
+      ),
+    ).resolves.toBeDefined();
+  });
 });
 
 // ─── 4. Command-log compaction — collapses add-tweak-delete to net effect ──────

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -112,7 +112,6 @@ describe("draft shadow tables — existence and shape", () => {
     test(`${name} has composite PK (draft_id, id) — enforced by DB`, async () => {
       // Try to insert a duplicate (draft_id, id) pair — must throw a PK violation.
       const tableSqlName = getTableName(drizzleTable);
-      const cols = await liveColumns(tableSqlName);
       // Build a minimal insert with only the NOT NULL non-default columns.
       // The shadow columns (draft_id, id, __tombstone) are always present.
       await db.execute(
@@ -128,7 +127,6 @@ describe("draft shadow tables — existence and shape", () => {
           ),
         ),
       ).rejects.toThrow();
-      void cols; // consumed above
     });
 
     test(`${name} Drizzle table name matches SQL name`, () => {
@@ -148,7 +146,6 @@ describe("draft shadow tables — existence and shape", () => {
     test(`${name} composite PK config is (draft_id, id)`, () => {
       const cfg = getTableConfig(drizzleTable);
       expect(cfg.primaryKeys).toHaveLength(1);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const pkCols = cfg.primaryKeys[0]!.columns.map((c) => c.name);
       expect(pkCols).toContain("draft_id");
       expect(pkCols).toContain("id");
@@ -324,7 +321,6 @@ describe("compactLog — net-effect collapse", () => {
     ];
     const result = compactLog(log);
     expect(result).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect((result[0]!.args as { name: string }).name).toBe("C");
   });
 
@@ -352,11 +348,8 @@ describe("compactLog — net-effect collapse", () => {
     const result = compactLog(log);
     // create + last-update survive, in original order
     expect(result).toHaveLength(2);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result[0]!.kind).toBe("create");
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result[1]!.kind).toBe("update");
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect((result[1]!.args as { name: string }).name).toBe("Final");
   });
 
@@ -379,7 +372,6 @@ describe("compactLog — net-effect collapse", () => {
     const result = compactLog(log);
     // Update is superseded by the delete; delete is kept.
     expect(result).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(result[0]!.kind).toBe("delete");
   });
 
@@ -416,7 +408,6 @@ describe("compactLog — net-effect collapse", () => {
     const result = compactLog(log);
     // i1 create+delete cancelled; i2 create survives
     expect(result).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect((result[0]!.args as { id: string }).id).toBe("i2");
   });
 

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the YW-125 draft delta-table schema.
+ * Tests for the draft delta-table schema.
  *
  * Load-bearing contracts:
  *   1. Each of the 6 draftable artifact tables has a `__draft` shadow with the

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Tests for the YW-125 draft delta-table schema.
+ *
+ * Load-bearing contracts:
+ *   1. Each of the 6 draftable artifact tables has a `__draft` shadow with the
+ *      correct (draft_id, id) composite PK + `__tombstone` column.
+ *   2. NO shadow exists for secret_mappings, project_meta (security boundary).
+ *   3. The draft_command_log table exists with the right shape.
+ *   4. compactLog collapses add-tweak-delete chains to net effect (the
+ *      DashFrame-side port of @wystack/server compactLog, since command-log
+ *      compaction is enforced by the schema test before the server primitive
+ *      is wired).
+ *
+ * These tests run against PGlite in-memory to verify the Drizzle schema
+ * materialises correctly — not just that the TypeScript types compile.
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { getTableColumns, getTableName, sql } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  dashboardsDraft,
+  dataFramesDraft,
+  dataSourcesDraft,
+  dataTablesDraft,
+  draftCommandLog,
+  insightsDraft,
+  schema,
+  visualizationsDraft,
+} from "./schema";
+import { syncSchema } from "./sync-schema";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type Db = ReturnType<typeof drizzle>;
+let pg: PGlite;
+let db: Db;
+
+beforeEach(async () => {
+  pg = new PGlite();
+  await pg.waitReady;
+  db = drizzle(pg, { schema });
+  await syncSchema(db, schema);
+});
+
+afterEach(async () => {
+  await pg.close();
+});
+
+/**
+ * Returns true iff the named table exists in the current PGlite database.
+ * Uses pg_tables for a direct DDL check (bypasses Drizzle layer).
+ */
+async function tableExists(tableName: string): Promise<boolean> {
+  const res = await db.execute(
+    sql`SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = ${tableName}`,
+  );
+  // PGlite returns { rows: [...] }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((res as any).rows?.length ?? 0) > 0;
+}
+
+/**
+ * Returns the set of column names for the named table from the information
+ * schema — a cross-check against the live DDL, not just the Drizzle object.
+ */
+async function liveColumns(tableName: string): Promise<Set<string>> {
+  const res = await db.execute(
+    sql`SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = ${tableName}`,
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (res as any).rows as Array<{ column_name: string }>;
+  return new Set(rows.map((r) => r.column_name));
+}
+
+// ─── 1. Shadow tables exist with the correct shape ────────────────────────────
+
+const ARTIFACT_SHADOWS = [
+  { name: "data_sources__draft", drizzleTable: dataSourcesDraft },
+  { name: "data_tables__draft", drizzleTable: dataTablesDraft },
+  { name: "data_frames__draft", drizzleTable: dataFramesDraft },
+  { name: "insights__draft", drizzleTable: insightsDraft },
+  { name: "visualizations__draft", drizzleTable: visualizationsDraft },
+  { name: "dashboards__draft", drizzleTable: dashboardsDraft },
+] as const;
+
+describe("draft shadow tables — existence and shape", () => {
+  for (const { name, drizzleTable } of ARTIFACT_SHADOWS) {
+    test(`${name} is materialised by syncSchema`, async () => {
+      expect(await tableExists(name)).toBe(true);
+    });
+
+    test(`${name} has draft_id column`, async () => {
+      const cols = await liveColumns(name);
+      expect(cols.has("draft_id")).toBe(true);
+    });
+
+    test(`${name} has __tombstone column`, async () => {
+      const cols = await liveColumns(name);
+      expect(cols.has("__tombstone")).toBe(true);
+    });
+
+    test(`${name} has id column`, async () => {
+      const cols = await liveColumns(name);
+      expect(cols.has("id")).toBe(true);
+    });
+
+    test(`${name} has composite PK (draft_id, id) — enforced by DB`, async () => {
+      // Try to insert a duplicate (draft_id, id) pair — must throw a PK violation.
+      const tableSqlName = getTableName(drizzleTable);
+      const cols = await liveColumns(tableSqlName);
+      // Build a minimal insert with only the NOT NULL non-default columns.
+      // The shadow columns (draft_id, id, __tombstone) are always present.
+      await db.execute(
+        sql.raw(
+          `INSERT INTO "${tableSqlName}" (draft_id, id, __tombstone) VALUES ('d1', '00000000-0000-0000-0000-000000000001', false)`,
+        ),
+      );
+      // Second insert with the same (draft_id, id) must fail.
+      await expect(
+        db.execute(
+          sql.raw(
+            `INSERT INTO "${tableSqlName}" (draft_id, id, __tombstone) VALUES ('d1', '00000000-0000-0000-0000-000000000001', false)`,
+          ),
+        ),
+      ).rejects.toThrow();
+      void cols; // consumed above
+    });
+
+    test(`${name} Drizzle table name matches SQL name`, () => {
+      expect(getTableName(drizzleTable)).toBe(name);
+    });
+
+    test(`${name} Drizzle schema has draft_id + __tombstone column defs`, () => {
+      const columns = getTableColumns(drizzleTable);
+      // draft_id maps to the JS property `draftId`
+      expect(columns["draftId"]).toBeDefined();
+      expect(columns["draftId"].name).toBe("draft_id");
+      // __tombstone maps to the JS property `tombstone`
+      expect(columns["tombstone"]).toBeDefined();
+      expect(columns["tombstone"].name).toBe("__tombstone");
+    });
+
+    test(`${name} composite PK config is (draft_id, id)`, () => {
+      const cfg = getTableConfig(drizzleTable);
+      expect(cfg.primaryKeys).toHaveLength(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const pkCols = cfg.primaryKeys[0]!.columns.map((c) => c.name);
+      expect(pkCols).toContain("draft_id");
+      expect(pkCols).toContain("id");
+    });
+  }
+});
+
+// ─── 2. Security boundary — NO shadow for credential/infra tables ─────────────
+
+describe("security boundary — no shadow for credential/infra tables", () => {
+  test("secret_mappings__draft does NOT exist", async () => {
+    expect(await tableExists("secret_mappings__draft")).toBe(false);
+  });
+
+  test("project_meta__draft does NOT exist", async () => {
+    expect(await tableExists("project_meta__draft")).toBe(false);
+  });
+
+  test("schema export has no secret_mappings draft entry", () => {
+    const keys = Object.keys(schema);
+    const forbidden = keys.filter(
+      (k) =>
+        k.toLowerCase().includes("secret") && k.toLowerCase().includes("draft"),
+    );
+    expect(forbidden).toHaveLength(0);
+  });
+
+  test("schema export has no project_meta draft entry", () => {
+    const keys = Object.keys(schema);
+    const forbidden = keys.filter(
+      (k) =>
+        k.toLowerCase().includes("projectmeta") &&
+        k.toLowerCase().includes("draft"),
+    );
+    expect(forbidden).toHaveLength(0);
+  });
+});
+
+// ─── 3. Draft command log table ───────────────────────────────────────────────
+
+describe("draft_command_log table", () => {
+  test("draft_command_log is materialised by syncSchema", async () => {
+    expect(await tableExists("draft_command_log")).toBe(true);
+  });
+
+  test("draft_command_log has the expected columns", async () => {
+    const cols = await liveColumns("draft_command_log");
+    expect(cols.has("id")).toBe(true);
+    expect(cols.has("draft_id")).toBe(true);
+    expect(cols.has("seq")).toBe(true);
+    expect(cols.has("path")).toBe(true);
+    expect(cols.has("args")).toBe(true);
+    expect(cols.has("compaction_key")).toBe(true);
+    expect(cols.has("kind")).toBe(true);
+    expect(cols.has("created_at")).toBe(true);
+  });
+
+  test("draft_command_log Drizzle table name is 'draft_command_log'", () => {
+    expect(getTableName(draftCommandLog)).toBe("draft_command_log");
+  });
+});
+
+// ─── 4. Command-log compaction — collapses add-tweak-delete to net effect ──────
+//
+// Mirrors the @wystack/server compactLog contract. DashFrame's compactLog is
+// the same algorithm (DashFrame hosts the command log, so it must honour the
+// same compaction rules at publish time). These tests verify the algorithm
+// independently of the DB layer.
+
+/**
+ * Minimal port of @wystack/server DraftCommand + compactLog for the schema
+ * tests. The real implementation is in @wystack/server — this is the
+ * DashFrame-side verification that the compaction contract is understood and
+ * honoured before the server primitive is wired.
+ */
+interface DraftCommand {
+  path: string;
+  args?: unknown;
+  compactionKey?: string;
+  kind?: "create" | "update" | "delete";
+}
+
+function compactLog(log: DraftCommand[]): DraftCommand[] {
+  const survivingCreate = new Map<string, number>();
+  const lastUpdate = new Map<string, number>();
+  const survivingDelete = new Map<string, number>();
+
+  log.forEach((cmd, i) => {
+    const key = cmd.compactionKey;
+    if (key === undefined || cmd.kind === undefined) return;
+    if (cmd.kind === "create") {
+      survivingCreate.set(key, i);
+      lastUpdate.delete(key);
+      survivingDelete.delete(key);
+    } else if (cmd.kind === "update") {
+      lastUpdate.set(key, i);
+    } else {
+      // delete
+      if (survivingCreate.has(key)) {
+        // Cancels a live create — row never existed canonically. Drop all.
+        survivingCreate.delete(key);
+        lastUpdate.delete(key);
+        survivingDelete.delete(key);
+      } else {
+        // Delete of a canonical row — wins, supersedes prior updates.
+        lastUpdate.delete(key);
+        survivingDelete.set(key, i);
+      }
+    }
+  });
+
+  const survivingIndices = new Set<number>();
+  for (const m of [survivingCreate, lastUpdate, survivingDelete]) {
+    for (const idx of m.values()) survivingIndices.add(idx);
+  }
+
+  const out: DraftCommand[] = [];
+  log.forEach((cmd, i) => {
+    if (cmd.compactionKey === undefined || cmd.kind === undefined) {
+      out.push(cmd);
+      return;
+    }
+    if (survivingIndices.has(i)) out.push(cmd);
+  });
+  return out;
+}
+
+describe("compactLog — net-effect collapse", () => {
+  test("create + delete of a NEW row → both dropped (never published)", () => {
+    const log: DraftCommand[] = [
+      {
+        path: "addInsight",
+        args: { id: "i1" },
+        compactionKey: "insight:i1",
+        kind: "create",
+      },
+      {
+        path: "tweakInsight",
+        args: { id: "i1", name: "x" },
+        compactionKey: "insight:i1",
+        kind: "update",
+      },
+      {
+        path: "deleteInsight",
+        args: { id: "i1" },
+        compactionKey: "insight:i1",
+        kind: "delete",
+      },
+    ];
+    expect(compactLog(log)).toHaveLength(0);
+  });
+
+  test("redundant updates → only the last survives", () => {
+    const log: DraftCommand[] = [
+      {
+        path: "renameInsight",
+        args: { id: "i1", name: "A" },
+        compactionKey: "insight:i1",
+        kind: "update",
+      },
+      {
+        path: "renameInsight",
+        args: { id: "i1", name: "B" },
+        compactionKey: "insight:i1",
+        kind: "update",
+      },
+      {
+        path: "renameInsight",
+        args: { id: "i1", name: "C" },
+        compactionKey: "insight:i1",
+        kind: "update",
+      },
+    ];
+    const result = compactLog(log);
+    expect(result).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect((result[0]!.args as { name: string }).name).toBe("C");
+  });
+
+  test("create + later updates → create kept + last update kept (in order)", () => {
+    const log: DraftCommand[] = [
+      {
+        path: "addInsight",
+        args: { id: "i1", name: "Initial" },
+        compactionKey: "insight:i1",
+        kind: "create",
+      },
+      {
+        path: "renameInsight",
+        args: { id: "i1", name: "Renamed" },
+        compactionKey: "insight:i1",
+        kind: "update",
+      },
+      {
+        path: "renameInsight",
+        args: { id: "i1", name: "Final" },
+        compactionKey: "insight:i1",
+        kind: "update",
+      },
+    ];
+    const result = compactLog(log);
+    // create + last-update survive, in original order
+    expect(result).toHaveLength(2);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result[0]!.kind).toBe("create");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result[1]!.kind).toBe("update");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect((result[1]!.args as { name: string }).name).toBe("Final");
+  });
+
+  test("delete of a canonical row → kept", () => {
+    // No prior create for this key → it's a canonical row being deleted.
+    const log: DraftCommand[] = [
+      {
+        path: "renameInsight",
+        args: { id: "existing", name: "X" },
+        compactionKey: "insight:existing",
+        kind: "update",
+      },
+      {
+        path: "deleteInsight",
+        args: { id: "existing" },
+        compactionKey: "insight:existing",
+        kind: "delete",
+      },
+    ];
+    const result = compactLog(log);
+    // Update is superseded by the delete; delete is kept.
+    expect(result).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(result[0]!.kind).toBe("delete");
+  });
+
+  test("commands with no compactionKey are always preserved in order", () => {
+    const log: DraftCommand[] = [
+      { path: "refreshSource", args: { id: "s1" } }, // no key — always kept
+      { path: "refreshSource", args: { id: "s1" } }, // no key — always kept
+    ];
+    const result = compactLog(log);
+    expect(result).toHaveLength(2);
+  });
+
+  test("independent keys compact independently", () => {
+    const log: DraftCommand[] = [
+      {
+        path: "addInsight",
+        args: { id: "i1" },
+        compactionKey: "insight:i1",
+        kind: "create",
+      },
+      {
+        path: "addInsight",
+        args: { id: "i2" },
+        compactionKey: "insight:i2",
+        kind: "create",
+      },
+      {
+        path: "deleteInsight",
+        args: { id: "i1" },
+        compactionKey: "insight:i1",
+        kind: "delete",
+      },
+    ];
+    const result = compactLog(log);
+    // i1 create+delete cancelled; i2 create survives
+    expect(result).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect((result[0]!.args as { id: string }).id).toBe("i2");
+  });
+
+  test("empty log → empty result", () => {
+    expect(compactLog([])).toHaveLength(0);
+  });
+});

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -11,8 +11,8 @@
  *
  * Draft overlay tables (`<table>__draft`):
  * Six artifact tables have a parallel `__draft` shadow that the @wystack/db
- * `withDraft` primitive (YW-120/YW-121) resolves against for coalesced reads
- * and sparse writes. Each shadow carries `draft_id TEXT NOT NULL` + the
+ * `withDraft` primitive resolves against for coalesced reads and sparse writes.
+ * Each shadow carries `draft_id TEXT NOT NULL` + the
  * canonical columns (sparse — NULLs mean "no override") + `__tombstone
  * BOOLEAN NOT NULL DEFAULT false`, keyed `(draft_id, id)`.
  *
@@ -232,10 +232,10 @@ export const secretMappings = pgTable("secret_mappings", {
     .defaultNow(),
 });
 
-// ─── Draft shadow tables (YW-125) ─────────────────────────────────────────────
+// ─── Draft shadow tables ──────────────────────────────────────────────────────
 //
 // Each `<table>__draft` is the sparse overlay the @wystack/db `withDraft`
-// primitive (YW-120/YW-121) reads from (via FULL OUTER JOIN coalesce) and
+// primitive reads from (via FULL OUTER JOIN coalesce) and
 // writes into (via sparse upsert + tombstone). Contract:
 //
 //   - Same columns as canonical, all NULLABLE (a NULL means "no override").
@@ -377,7 +377,7 @@ export const dashboardsDraft = pgTable(
   (t) => [primaryKey({ columns: [t.draftId, t.id] })],
 );
 
-// ─── Draft command log (YW-125) ───────────────────────────────────────────────
+// ─── Draft command log ────────────────────────────────────────────────────────
 //
 // Stores the ordered `DraftCommand[]` per draft for replay at publish time.
 // Publish = command-log replay (NOT a row-delta copy): the command log
@@ -430,7 +430,7 @@ export const schema = {
   dashboards,
   // Credential infrastructure — NOT drafted (security boundary)
   secretMappings,
-  // Draft shadow tables (artifact overlay — YW-125)
+  // Draft shadow tables (artifact overlay)
   dataSourcesDraft,
   dataTablesDraft,
   dataFramesDraft,

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -8,13 +8,27 @@
  * The actual secrets live in the OS keychain via the SecretVault substrate; the
  * `secret_mappings` table persists the ref → backend/locator binding so refs
  * stay resolvable across restarts.
+ *
+ * Draft overlay tables (`<table>__draft`):
+ * Six artifact tables have a parallel `__draft` shadow that the @wystack/db
+ * `withDraft` primitive (YW-120/YW-121) resolves against for coalesced reads
+ * and sparse writes. Each shadow carries `draft_id TEXT NOT NULL` + the
+ * canonical columns (sparse — NULLs mean "no override") + `__tombstone
+ * BOOLEAN NOT NULL DEFAULT false`, keyed `(draft_id, id)`.
+ *
+ * SECURITY INVARIANT: credentials are NEVER drafted. `secret_mappings` and
+ * `project_meta` have NO shadow — they are infrastructure/singleton tables
+ * that route through the SecretVault, not the draft overlay. A
+ * `secret_mappings__draft` table would be a credential-in-draft leak surface.
  */
 
 import {
+  boolean,
   index,
   integer,
   jsonb,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   uuid,
@@ -29,7 +43,10 @@ export interface ArtifactProvenance {
   runId?: string;
 }
 
+// ─── Canonical tables ─────────────────────────────────────────────────────────
+
 // project_meta — exactly one row per project. Holds version + identity.
+// NOT drafted: singleton infrastructure, never modified via the draft overlay.
 export const projectMeta = pgTable("project_meta", {
   id: text("id").primaryKey(),
   singletonKey: integer("singleton_key")
@@ -200,6 +217,9 @@ export const dashboards = pgTable(
 // `vault.has(ref)` returns false and `vault.withSecret(ref, …)` throws. Persisting
 // it in the SAME project DB as the ref keeps the two in one transactional/backup
 // boundary so they can never drift. See DrizzleMappingStore in mapping-store.ts.
+//
+// NOT drafted: credential infrastructure. SECURITY BOUNDARY — a
+// `secret_mappings__draft` would be a credential-in-draft leak surface.
 export const secretMappings = pgTable("secret_mappings", {
   // The SecretRef (`secret:<uuid>`) — the stable handle minted by vault.store().
   ref: text("ref").primaryKey(),
@@ -212,7 +232,195 @@ export const secretMappings = pgTable("secret_mappings", {
     .defaultNow(),
 });
 
+// ─── Draft shadow tables (YW-125) ─────────────────────────────────────────────
+//
+// Each `<table>__draft` is the sparse overlay the @wystack/db `withDraft`
+// primitive (YW-120/YW-121) reads from (via FULL OUTER JOIN coalesce) and
+// writes into (via sparse upsert + tombstone). Contract:
+//
+//   - Same columns as canonical, all NULLABLE (a NULL means "no override").
+//   - `draft_id TEXT NOT NULL` — scopes rows to one open draft.
+//   - `__tombstone BOOLEAN NOT NULL DEFAULT false` — marks deleted rows.
+//   - Composite PK `(draft_id, id)` — the key the withDraft write-path
+//     uses for ON CONFLICT upsert (must match exactly).
+//
+// Reads: canonical ⊕ draft delta — a no-draft read never touches these tables
+// (zero-overhead property). Writes: only changed/created/tombstoned rows land
+// here; the canonical table stays pristine until publish (replay via command log).
+//
+// SECURITY INVARIANT: credentials are never drafted. `secret_mappings` and
+// `project_meta` have NO shadow. This is a hard boundary.
+
+export const dataSourcesDraft = pgTable(
+  "data_sources__draft",
+  {
+    draftId: text("draft_id").notNull(),
+    id: uuid("id").notNull(),
+    // Sparse overrides — nullable: a NULL means "no change to this column".
+    name: text("name"),
+    kind: text("kind"),
+    storage: text("storage"),
+    config: jsonb("config"),
+    schema: jsonb("schema"),
+    contentHash: text("content_hash"),
+    rowCount: integer("row_count"),
+    lastImport: timestamp("last_import", { withTimezone: true }),
+    createdBy: jsonb("created_by").$type<ArtifactProvenance>(),
+    parentArtifactId: uuid("parent_artifact_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+    // Draft control columns — owned by the withDraft write-path.
+    tombstone: boolean("__tombstone").notNull().default(false),
+  },
+  (t) => [primaryKey({ columns: [t.draftId, t.id] })],
+);
+
+export const dataTablesDraft = pgTable(
+  "data_tables__draft",
+  {
+    draftId: text("draft_id").notNull(),
+    id: uuid("id").notNull(),
+    // Sparse overrides.
+    dataSourceId: uuid("data_source_id"),
+    name: text("name"),
+    table: text("table"),
+    sourceSchema: jsonb("source_schema"),
+    fields: jsonb("fields"),
+    metrics: jsonb("metrics"),
+    dataFrameId: uuid("data_frame_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
+    // Draft control columns.
+    tombstone: boolean("__tombstone").notNull().default(false),
+  },
+  (t) => [primaryKey({ columns: [t.draftId, t.id] })],
+);
+
+export const dataFramesDraft = pgTable(
+  "data_frames__draft",
+  {
+    draftId: text("draft_id").notNull(),
+    id: uuid("id").notNull(),
+    // Sparse overrides.
+    storage: jsonb("storage"),
+    fieldIds: jsonb("field_ids"),
+    primaryKey: jsonb("primary_key"),
+    name: text("name"),
+    insightId: uuid("insight_id"),
+    rowCount: integer("row_count"),
+    columnCount: integer("column_count"),
+    analysis: jsonb("analysis"),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    // Draft control columns.
+    tombstone: boolean("__tombstone").notNull().default(false),
+  },
+  (t) => [primaryKey({ columns: [t.draftId, t.id] })],
+);
+
+export const insightsDraft = pgTable(
+  "insights__draft",
+  {
+    draftId: text("draft_id").notNull(),
+    id: uuid("id").notNull(),
+    // Sparse overrides.
+    name: text("name"),
+    definition: jsonb("definition"),
+    schema: jsonb("schema"),
+    createdBy: jsonb("created_by").$type<ArtifactProvenance>(),
+    parentArtifactId: uuid("parent_artifact_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+    // Draft control columns.
+    tombstone: boolean("__tombstone").notNull().default(false),
+  },
+  (t) => [primaryKey({ columns: [t.draftId, t.id] })],
+);
+
+export const visualizationsDraft = pgTable(
+  "visualizations__draft",
+  {
+    draftId: text("draft_id").notNull(),
+    id: uuid("id").notNull(),
+    // Sparse overrides.
+    insightId: uuid("insight_id"),
+    name: text("name"),
+    chartType: text("chart_type"),
+    encoding: jsonb("encoding"),
+    options: jsonb("options"),
+    createdBy: jsonb("created_by").$type<ArtifactProvenance>(),
+    parentArtifactId: uuid("parent_artifact_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+    // Draft control columns.
+    tombstone: boolean("__tombstone").notNull().default(false),
+  },
+  (t) => [primaryKey({ columns: [t.draftId, t.id] })],
+);
+
+export const dashboardsDraft = pgTable(
+  "dashboards__draft",
+  {
+    draftId: text("draft_id").notNull(),
+    id: uuid("id").notNull(),
+    // Sparse overrides.
+    name: text("name"),
+    description: text("description"),
+    layout: jsonb("layout"),
+    controls: jsonb("controls"),
+    createdBy: jsonb("created_by").$type<ArtifactProvenance>(),
+    parentArtifactId: uuid("parent_artifact_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
+    // Draft control columns.
+    tombstone: boolean("__tombstone").notNull().default(false),
+  },
+  (t) => [primaryKey({ columns: [t.draftId, t.id] })],
+);
+
+// ─── Draft command log (YW-125) ───────────────────────────────────────────────
+//
+// Stores the ordered `DraftCommand[]` per draft for replay at publish time.
+// Publish = command-log replay (NOT a row-delta copy): the command log
+// preserves INTENT GROUPING that a row-delta cannot reconstruct.
+//
+// Compaction: each append compacts the log per compactionKey, collapsing
+// add-tweak-delete chains to net effect so the log cannot grow unbounded.
+// The compaction algorithm (from @wystack/server `compactLog`):
+//   - create + later delete  → both dropped (row never existed canonically)
+//   - redundant updates      → only the last survives
+//   - create + later updates → create kept + last update kept (in order)
+//   - delete of canonical    → kept, supersedes prior updates
+//   - no compactionKey/kind  → kept as-is (order preserved)
+//
+// The delta tables answer reads; the command log is the PUBLISH source.
+// Different artifacts, different jobs.
+export const draftCommandLog = pgTable(
+  "draft_command_log",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    draftId: text("draft_id").notNull(),
+    // Sequence position within this draft (monotonically increasing per draft).
+    // Used to preserve replay order after compaction.
+    seq: integer("seq").notNull(),
+    // The command envelope: path + args (opaque JSON). Mirrors DraftCommand from
+    // @wystack/server — `path` names the handler, `args` are the call arguments.
+    path: text("path").notNull(),
+    args: jsonb("args"),
+    // Compaction fields (nullable: a plain Command with no key is never
+    // compacted). These mirror DraftCommand.compactionKey / DraftCommand.kind.
+    compactionKey: text("compaction_key"),
+    kind: text("kind"), // 'create' | 'update' | 'delete' | null
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [index("draft_command_log_draft_id_seq_idx").on(t.draftId, t.seq)],
+);
+
+// ─── Schema export ────────────────────────────────────────────────────────────
+
 export const schema = {
+  // Canonical artifact tables
   projectMeta,
   dataSources,
   dataTables,
@@ -220,7 +428,17 @@ export const schema = {
   insights,
   visualizations,
   dashboards,
+  // Credential infrastructure — NOT drafted (security boundary)
   secretMappings,
+  // Draft shadow tables (artifact overlay — YW-125)
+  dataSourcesDraft,
+  dataTablesDraft,
+  dataFramesDraft,
+  insightsDraft,
+  visualizationsDraft,
+  dashboardsDraft,
+  // Draft command log — publish source (replay at publish, not for reads)
+  draftCommandLog,
 } as const;
 
 export type Schema = typeof schema;

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -31,6 +31,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 
@@ -414,7 +415,11 @@ export const draftCommandLog = pgTable(
       .notNull()
       .defaultNow(),
   },
-  (t) => [index("draft_command_log_draft_id_seq_idx").on(t.draftId, t.seq)],
+  // Unique on (draft_id, seq): seq is the monotonic replay position within a
+  // draft; duplicates would make publish replay order ambiguous.
+  (t) => [
+    uniqueIndex("draft_command_log_draft_id_seq_idx").on(t.draftId, t.seq),
+  ],
 );
 
 // ─── Schema export ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds 6 `<table>__draft` shadow tables (one per draftable artifact: `data_sources`, `data_tables`, `data_frames`, `insights`, `visualizations`, `dashboards`) matching the exact @wystack/db `withDraft` write-path contract: `draft_id TEXT NOT NULL`, canonical columns all nullable (sparse — NULL = no override), `__tombstone BOOLEAN NOT NULL DEFAULT false`, composite PK `(draft_id, id)`.
- Adds `draft_command_log` table for ordered `DraftCommand[]` storage per draft, supporting compacted replay at publish time (command-log replay is the publish mechanism, NOT a row-delta copy).
- **Security invariant enforced**: `secret_mappings` and `project_meta` have NO shadow tables. Credentials route through the SecretVault, never the draft overlay.

## Contract verification

Wystack `withDraft` write-path (86fe8856) confirmed: the shadow table DDL in this PR matches the write-path's exact `(draft_id, <pk>)` ON CONFLICT key and `__tombstone` column contract from `packages/db/src/__tests__/with-draft-write.test.ts` and `writeShadowRow`.

## Command-log compaction

`compactLog` collapses add-tweak-delete chains per `compactionKey` to net effect:
- create + delete (new row) → both dropped
- redundant updates → only the last survives
- create + later updates → create + last update kept in order
- delete of canonical row → kept, supersedes prior updates
- no `compactionKey` → always preserved

## Tests

62 new assertions in `schema.test.ts`:
- Each of the 6 shadows materialises, has `draft_id` + `__tombstone`, and enforces `(draft_id, id)` uniqueness at the DB level.
- Security boundary: asserts `secret_mappings__draft` and `project_meta__draft` do NOT exist.
- Command log: columns + table name verified.
- `compactLog`: all documented compaction cases.

## Local review gate

- Full `turbo typecheck`: 46/46 tasks successful
- All 132 server-core tests pass (62 new + 70 pre-existing)
- Security boundary verified: no shadow for `secret_mappings` / `project_meta`
- Shadow schemas match the withDraft write-path contract (verified against wystack 86fe8856 source)

Tracked internally as YW-125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the draft delta-table schema for DashFrame's `withDraft` overlay layer: 6 `__draft` shadow tables (one per draftable artifact) plus `draft_command_log` for compacted command-log replay at publish time, with the `secret_mappings` / `project_meta` security boundary enforced at the schema level.

- **6 shadow tables** (`data_sources__draft` through `dashboards__draft`) each mirror their canonical columns as nullable sparse overrides, carry `draft_id` + `__tombstone`, and enforce a composite PK `(draft_id, id)` matching the `withDraft` write-path upsert contract exactly.
- **`draft_command_log`** stores ordered `DraftCommand[]` per draft with a `uniqueIndex` on `(draft_id, seq)` to prevent replay-order ambiguity; publish is command-log replay, not a row-delta copy.
- **62 new tests** verify table materialization, the security boundary, unique-seq enforcement, and `compactLog` net-effect collapse — but one edge case in the `compactLog` verification implementation is missing both a test and a fix (canonical delete → create same key → delete new row silently drops the canonical delete).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the compactLog fix applied — the schema DDL and DB-level constraints are correct; only the compaction algorithm specification has a logic gap.

The `compactLog` function in `schema.test.ts` serves as the DashFrame-side specification for command-log compaction. Its `create` and cancel-create branches both unconditionally call `survivingDelete.delete(key)`, which erases a prior canonical delete when the sequence is "canonical delete → create (same key) → delete of new row". No test covers this path, so the gap is invisible today, but if DashFrame implements compactLog from this specification, a canonical row that should be deleted at publish time would silently survive.

packages/server-core/src/schema.test.ts — the compactLog implementation and its test coverage for the canonical-delete interaction.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server-core/src/schema.ts | Adds 6 `__draft` shadow tables and `draft_command_log`; canonical columns correctly mirrored as nullable, composite PKs on `(draft_id, id)` match the `withDraft` write-path contract, security boundary (no shadow for `secret_mappings`/`project_meta`) is enforced, and `uniqueIndex` on `(draft_id, seq)` guards replay order. |
| packages/server-core/src/schema.test.ts | 62 new assertions covering shadow-table shape, security boundary, command-log uniqueness, and compactLog net-effect collapse; `compactLog` implementation has a logic bug where a canonical delete is silently dropped under the sequence "canonical delete → create (same key) → delete of new row", and no test covers this scenario. |
| packages/server-core/src/index.ts | Re-exports all new draft tables and constants from schema.ts; all symbols are present and correctly grouped, though comment section headings are slightly misleading (addressed in a previous thread). |

</details>

</details>

<details><summary><h3>Entity Relationship Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    data_sources {
        uuid id PK
        text name
        text kind
        text storage
        jsonb config
    }
    data_sources__draft {
        text draft_id PK
        uuid id PK
        text name
        boolean __tombstone
    }
    data_tables {
        uuid id PK
        uuid data_source_id FK
    }
    data_tables__draft {
        text draft_id PK
        uuid id PK
        boolean __tombstone
    }
    insights {
        uuid id PK
        text name
        jsonb definition
    }
    insights__draft {
        text draft_id PK
        uuid id PK
        boolean __tombstone
    }
    dashboards {
        uuid id PK
        text name
        jsonb layout
    }
    dashboards__draft {
        text draft_id PK
        uuid id PK
        boolean __tombstone
    }
    draft_command_log {
        uuid id PK
        text draft_id
        integer seq
        text path
        jsonb args
        text compaction_key
        text kind
    }
    secret_mappings {
        text ref PK
        text backend
        text locator
    }
    data_sources ||--o{ data_sources__draft : "draft overlay"
    data_tables ||--o{ data_tables__draft : "draft overlay"
    insights ||--o{ insights__draft : "draft overlay"
    dashboards ||--o{ dashboards__draft : "draft overlay"
    data_sources ||--o{ data_tables : "has"
    draft_command_log }o--|| data_sources__draft : "published via replay"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
erDiagram
    data_sources {
        uuid id PK
        text name
        text kind
        text storage
        jsonb config
    }
    data_sources__draft {
        text draft_id PK
        uuid id PK
        text name
        boolean __tombstone
    }
    data_tables {
        uuid id PK
        uuid data_source_id FK
    }
    data_tables__draft {
        text draft_id PK
        uuid id PK
        boolean __tombstone
    }
    insights {
        uuid id PK
        text name
        jsonb definition
    }
    insights__draft {
        text draft_id PK
        uuid id PK
        boolean __tombstone
    }
    dashboards {
        uuid id PK
        text name
        jsonb layout
    }
    dashboards__draft {
        text draft_id PK
        uuid id PK
        boolean __tombstone
    }
    draft_command_log {
        uuid id PK
        text draft_id
        integer seq
        text path
        jsonb args
        text compaction_key
        text kind
    }
    secret_mappings {
        text ref PK
        text backend
        text locator
    }
    data_sources ||--o{ data_sources__draft : "draft overlay"
    data_tables ||--o{ data_tables__draft : "draft overlay"
    insights ||--o{ insights__draft : "draft overlay"
    dashboards ||--o{ dashboards__draft : "draft overlay"
    data_sources ||--o{ data_tables : "has"
    draft_command_log }o--|| data_sources__draft : "published via replay"
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fserver-core%2Fsrc%2Fschema.test.ts%3A261-283%0A**%60compactLog%60%20drops%20the%20canonical%20delete%20when%20the%20sequence%20is%20%22canonical%20delete%20%E2%86%92%20create%20%28same%20key%29%20%E2%86%92%20delete%20of%20new%20row%22**%0A%0AWhen%20a%20canonical%20delete%20lands%20first%20%28sets%20%60survivingDelete%60%29%2C%20a%20later%20create%20for%20the%20same%20key%20unconditionally%20calls%20%60survivingDelete.delete%28key%29%60%20%E2%80%94%20erasing%20the%20canonical%20delete%20from%20the%20surviving%20set.%20A%20subsequent%20delete%20of%20the%20newly%20created%20row%20then%20cancels%20the%20create%20via%20the%20%60survivingCreate%60%20path%2C%20also%20calling%20%60survivingDelete.delete%28key%29%60%20again.%20The%20result%3A%20%60compactLog%60%20returns%20%60%5B%5D%60%2C%20silently%20dropping%20the%20canonical%20delete%20entirely.%20At%20publish%20time%20the%20canonical%20row%20would%20remain%20in%20the%20DB%20when%20it%20should%20have%20been%20removed.%0A%0AConcrete%20failing%20case%3A%20%60%5B%7Bkind%3A%22delete%22%7D%2C%20%7Bkind%3A%22create%22%7D%2C%20%7Bkind%3A%22delete%22%7D%5D%60%20all%20sharing%20the%20same%20%60compactionKey%60%20%E2%80%94%20expected%20output%20is%20%60%5B%7Bkind%3A%22delete%22%7D%5D%60%20%28the%20first%20canonical%20delete%29%2C%20actual%20output%20is%20%60%5B%5D%60.%0A%0A%60%60%60suggestion%0A%20%20log.forEach%28%28cmd%2C%20i%29%20%3D%3E%20%7B%0A%20%20%20%20const%20key%20%3D%20cmd.compactionKey%3B%0A%20%20%20%20if%20%28key%20%3D%3D%3D%20undefined%20%7C%7C%20cmd.kind%20%3D%3D%3D%20undefined%29%20return%3B%0A%20%20%20%20if%20%28cmd.kind%20%3D%3D%3D%20%22create%22%29%20%7B%0A%20%20%20%20%20%20survivingCreate.set%28key%2C%20i%29%3B%0A%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%2F%2F%20survivingDelete%20is%20intentionally%20NOT%20cleared%3A%20a%20prior%20canonical%20delete%0A%20%20%20%20%20%20%2F%2F%20targets%20the%20canonical%20row%20and%20is%20independent%20of%20this%20new%20draft%20create.%0A%20%20%20%20%7D%20else%20if%20%28cmd.kind%20%3D%3D%3D%20%22update%22%29%20%7B%0A%20%20%20%20%20%20lastUpdate.set%28key%2C%20i%29%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%2F%2F%20delete%0A%20%20%20%20%20%20if%20%28survivingCreate.has%28key%29%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Cancels%20the%20live%20create%20%E2%80%94%20row%20never%20existed%20canonically.%20Drop%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20create%20and%20any%20pending%20updates%2C%20but%20preserve%20any%20prior%20canonical%20delete.%0A%20%20%20%20%20%20%20%20survivingCreate.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Delete%20of%20a%20canonical%20row%20%E2%80%94%20wins%2C%20supersedes%20prior%20updates.%0A%20%20%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20survivingDelete.set%28key%2C%20i%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-125-draft-delta-table-schema%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-125-draft-delta-table-schema%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fserver-core%2Fsrc%2Fschema.test.ts%3A261-283%0A**%60compactLog%60%20drops%20the%20canonical%20delete%20when%20the%20sequence%20is%20%22canonical%20delete%20%E2%86%92%20create%20%28same%20key%29%20%E2%86%92%20delete%20of%20new%20row%22**%0A%0AWhen%20a%20canonical%20delete%20lands%20first%20%28sets%20%60survivingDelete%60%29%2C%20a%20later%20create%20for%20the%20same%20key%20unconditionally%20calls%20%60survivingDelete.delete%28key%29%60%20%E2%80%94%20erasing%20the%20canonical%20delete%20from%20the%20surviving%20set.%20A%20subsequent%20delete%20of%20the%20newly%20created%20row%20then%20cancels%20the%20create%20via%20the%20%60survivingCreate%60%20path%2C%20also%20calling%20%60survivingDelete.delete%28key%29%60%20again.%20The%20result%3A%20%60compactLog%60%20returns%20%60%5B%5D%60%2C%20silently%20dropping%20the%20canonical%20delete%20entirely.%20At%20publish%20time%20the%20canonical%20row%20would%20remain%20in%20the%20DB%20when%20it%20should%20have%20been%20removed.%0A%0AConcrete%20failing%20case%3A%20%60%5B%7Bkind%3A%22delete%22%7D%2C%20%7Bkind%3A%22create%22%7D%2C%20%7Bkind%3A%22delete%22%7D%5D%60%20all%20sharing%20the%20same%20%60compactionKey%60%20%E2%80%94%20expected%20output%20is%20%60%5B%7Bkind%3A%22delete%22%7D%5D%60%20%28the%20first%20canonical%20delete%29%2C%20actual%20output%20is%20%60%5B%5D%60.%0A%0A%60%60%60suggestion%0A%20%20log.forEach%28%28cmd%2C%20i%29%20%3D%3E%20%7B%0A%20%20%20%20const%20key%20%3D%20cmd.compactionKey%3B%0A%20%20%20%20if%20%28key%20%3D%3D%3D%20undefined%20%7C%7C%20cmd.kind%20%3D%3D%3D%20undefined%29%20return%3B%0A%20%20%20%20if%20%28cmd.kind%20%3D%3D%3D%20%22create%22%29%20%7B%0A%20%20%20%20%20%20survivingCreate.set%28key%2C%20i%29%3B%0A%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%2F%2F%20survivingDelete%20is%20intentionally%20NOT%20cleared%3A%20a%20prior%20canonical%20delete%0A%20%20%20%20%20%20%2F%2F%20targets%20the%20canonical%20row%20and%20is%20independent%20of%20this%20new%20draft%20create.%0A%20%20%20%20%7D%20else%20if%20%28cmd.kind%20%3D%3D%3D%20%22update%22%29%20%7B%0A%20%20%20%20%20%20lastUpdate.set%28key%2C%20i%29%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%2F%2F%20delete%0A%20%20%20%20%20%20if%20%28survivingCreate.has%28key%29%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Cancels%20the%20live%20create%20%E2%80%94%20row%20never%20existed%20canonically.%20Drop%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20create%20and%20any%20pending%20updates%2C%20but%20preserve%20any%20prior%20canonical%20delete.%0A%20%20%20%20%20%20%20%20survivingCreate.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Delete%20of%20a%20canonical%20row%20%E2%80%94%20wins%2C%20supersedes%20prior%20updates.%0A%20%20%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20survivingDelete.set%28key%2C%20i%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&repo=youhaowei%2Fdashframe&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fserver-core%2Fsrc%2Fschema.test.ts%3A261-283%0A**%60compactLog%60%20drops%20the%20canonical%20delete%20when%20the%20sequence%20is%20%22canonical%20delete%20%E2%86%92%20create%20%28same%20key%29%20%E2%86%92%20delete%20of%20new%20row%22**%0A%0AWhen%20a%20canonical%20delete%20lands%20first%20%28sets%20%60survivingDelete%60%29%2C%20a%20later%20create%20for%20the%20same%20key%20unconditionally%20calls%20%60survivingDelete.delete%28key%29%60%20%E2%80%94%20erasing%20the%20canonical%20delete%20from%20the%20surviving%20set.%20A%20subsequent%20delete%20of%20the%20newly%20created%20row%20then%20cancels%20the%20create%20via%20the%20%60survivingCreate%60%20path%2C%20also%20calling%20%60survivingDelete.delete%28key%29%60%20again.%20The%20result%3A%20%60compactLog%60%20returns%20%60%5B%5D%60%2C%20silently%20dropping%20the%20canonical%20delete%20entirely.%20At%20publish%20time%20the%20canonical%20row%20would%20remain%20in%20the%20DB%20when%20it%20should%20have%20been%20removed.%0A%0AConcrete%20failing%20case%3A%20%60%5B%7Bkind%3A%22delete%22%7D%2C%20%7Bkind%3A%22create%22%7D%2C%20%7Bkind%3A%22delete%22%7D%5D%60%20all%20sharing%20the%20same%20%60compactionKey%60%20%E2%80%94%20expected%20output%20is%20%60%5B%7Bkind%3A%22delete%22%7D%5D%60%20%28the%20first%20canonical%20delete%29%2C%20actual%20output%20is%20%60%5B%5D%60.%0A%0A%60%60%60suggestion%0A%20%20log.forEach%28%28cmd%2C%20i%29%20%3D%3E%20%7B%0A%20%20%20%20const%20key%20%3D%20cmd.compactionKey%3B%0A%20%20%20%20if%20%28key%20%3D%3D%3D%20undefined%20%7C%7C%20cmd.kind%20%3D%3D%3D%20undefined%29%20return%3B%0A%20%20%20%20if%20%28cmd.kind%20%3D%3D%3D%20%22create%22%29%20%7B%0A%20%20%20%20%20%20survivingCreate.set%28key%2C%20i%29%3B%0A%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%2F%2F%20survivingDelete%20is%20intentionally%20NOT%20cleared%3A%20a%20prior%20canonical%20delete%0A%20%20%20%20%20%20%2F%2F%20targets%20the%20canonical%20row%20and%20is%20independent%20of%20this%20new%20draft%20create.%0A%20%20%20%20%7D%20else%20if%20%28cmd.kind%20%3D%3D%3D%20%22update%22%29%20%7B%0A%20%20%20%20%20%20lastUpdate.set%28key%2C%20i%29%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%2F%2F%20delete%0A%20%20%20%20%20%20if%20%28survivingCreate.has%28key%29%29%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Cancels%20the%20live%20create%20%E2%80%94%20row%20never%20existed%20canonically.%20Drop%20the%0A%20%20%20%20%20%20%20%20%2F%2F%20create%20and%20any%20pending%20updates%2C%20but%20preserve%20any%20prior%20canonical%20delete.%0A%20%20%20%20%20%20%20%20survivingCreate.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Delete%20of%20a%20canonical%20row%20%E2%80%94%20wins%2C%20supersedes%20prior%20updates.%0A%20%20%20%20%20%20%20%20lastUpdate.delete%28key%29%3B%0A%20%20%20%20%20%20%20%20survivingDelete.set%28key%2C%20i%29%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%29%3B%0A%60%60%60%0A%0A&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/server-core/src/schema.test.ts:261-283
**`compactLog` drops the canonical delete when the sequence is "canonical delete → create (same key) → delete of new row"**

When a canonical delete lands first (sets `survivingDelete`), a later create for the same key unconditionally calls `survivingDelete.delete(key)` — erasing the canonical delete from the surviving set. A subsequent delete of the newly created row then cancels the create via the `survivingCreate` path, also calling `survivingDelete.delete(key)` again. The result: `compactLog` returns `[]`, silently dropping the canonical delete entirely. At publish time the canonical row would remain in the DB when it should have been removed.

Concrete failing case: `[{kind:"delete"}, {kind:"create"}, {kind:"delete"}]` all sharing the same `compactionKey` — expected output is `[{kind:"delete"}]` (the first canonical delete), actual output is `[]`.

```suggestion
  log.forEach((cmd, i) => {
    const key = cmd.compactionKey;
    if (key === undefined || cmd.kind === undefined) return;
    if (cmd.kind === "create") {
      survivingCreate.set(key, i);
      lastUpdate.delete(key);
      // survivingDelete is intentionally NOT cleared: a prior canonical delete
      // targets the canonical row and is independent of this new draft create.
    } else if (cmd.kind === "update") {
      lastUpdate.set(key, i);
    } else {
      // delete
      if (survivingCreate.has(key)) {
        // Cancels the live create — row never existed canonically. Drop the
        // create and any pending updates, but preserve any prior canonical delete.
        survivingCreate.delete(key);
        lastUpdate.delete(key);
      } else {
        // Delete of a canonical row — wins, supersedes prior updates.
        lastUpdate.delete(key);
        survivingDelete.set(key, i);
      }
    }
  });
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(server-core): enforce unique (draft\_..."](https://github.com/youhaowei/dashframe/commit/39a38e6908f379bb42e23adfa08662cfdd0a261b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38253712)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->