### PR TITLE
feat(server): persistent draft controller + ctx.db draft seam [YW-260]

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,6 +37,7 @@
     "@wystack/db": "workspace:*",
     "@wystack/secret-vault": "workspace:*",
     "@wystack/server": "workspace:*",
+    "drizzle-orm": "^0.45.1",
     "hono": "^4.12.9",
     "zod": "^4.1.12"
   },

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -40,6 +40,7 @@ import {
 } from "@dashframe/engine-server/arrow-data-path";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
+import type { DraftTrackedDb, TrackedDb } from "@wystack/db";
 import {
   isSecretRef,
   type SecretRef,
@@ -218,19 +219,77 @@ export interface DashframeServer {
 }
 
 /**
- * Build the WyStack app with vault injection and onWrite hook wiring — without
- * starting an HTTP server.
+ * Pull a draft handle out of a handler context. A `draftId` in the context bag
+ * means "execute this write into the draft overlay, not canonical." Returns the
+ * id string, or `undefined` for the no-draft (canonical) path.
+ */
+function draftIdFromContext(
+  context: Record<string, unknown> | undefined,
+): string | undefined {
+  const id = context?.draftId;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+/**
+ * The ctx.db draft seam. When a `draftId` is present in the context,
+ * substitute the `tracked` handle with its draft-scoped overlay so existing
+ * command handlers write into `<table>__draft` (the withDraft write-path)
+ * UNMODIFIED. The no-draft path returns `tracked` untouched — byte-identical,
+ * zero-overhead.
  *
- * Extracted from `createDashframeServer` so the vault-injection seam (the
- * anti-shadow merge and the short-circuit path) can be driven by direct unit
- * tests without a live socket. `createDashframeServer` calls this internally;
- * tests import and exercise it directly.
+ * `ctx.db` is set from the `tracked` argument inside @wystack/server's
+ * `runHandler` (it always wins over the context bag), so the substitution MUST
+ * happen on the `tracked` argument here, not by injecting a context key.
+ * `withDraft(draftId)` is a pure @wystack/db primitive that accepts any
+ * caller-supplied id.
+ *
+ * CONSUMER CONSTRAINTS — the seam is dormant in this slice (no host injects a
+ * draftId). The host that wires draftId into request context owns these:
+ *   - LOG SYNC. A write mutation reached via raw `app.call({draftId})` lands in
+ *     `<table>__draft` but does NOT append to `draft_command_log`; since publish
+ *     replays only the log, that write is visible in the overlay yet dropped on
+ *     publish. Drafted WRITES must route through `DraftController.appendToDraft`
+ *     (which keeps shadow + log in sync); the seam alone is safe for drafted
+ *     READS (coalesced reads need no log).
+ *   - DRAFTABLE COMMANDS. `withDraft` supports PK-pinned reads/writes
+ *     (`where(eq("id", …))`). A command whose handler filters a shadow table by a
+ *     non-PK column (e.g. delete `data_frames` by `insightId`) is not draftable
+ *     as-is; such paths must be PK-addressed or blocked before drafting.
+ *   - CREDENTIAL SIDE EFFECTS. See draft-controller.ts SECURITY BOUNDARY: a
+ *     credentialed handler's `vault.store` is a real side effect even in a draft.
+ *   - AUTHORIZATION. draftId is caller-supplied; a multi-tenant host must
+ *     authorize it against the caller (single-user desktop is exempt).
+ */
+function withDraftSeam(
+  tracked: TrackedDb | DraftTrackedDb,
+  context: Record<string, unknown> | undefined,
+): TrackedDb | DraftTrackedDb {
+  const draftId = draftIdFromContext(context);
+  if (draftId === undefined) return tracked;
+  // A draft handle has no nested `withDraft`; only a base TrackedDb is scoped.
+  // `call` always passes a fresh base TrackedDb, so this is the live path.
+  return "withDraft" in tracked ? tracked.withDraft(draftId) : tracked;
+}
+
+/**
+ * Build the WyStack app with the draft seam, vault injection, and the
+ * onWrite hook — without starting an HTTP server.
+ *
+ * Extracted from `createDashframeServer` so the seams (the anti-shadow vault
+ * merge, the draft-scoped db substitution) can be driven by direct unit tests
+ * without a live socket. `createDashframeServer` calls this internally; tests
+ * import and exercise it directly.
  *
  * Security invariant: `vault` is injected into every handler context via a
  * static spread that wins over per-call context. The merge order
  * `{ ...(context ?? {}), ...staticContext }` means the vault key cannot be
  * shadowed by a caller-supplied context — the vault identity is fixed for the
  * lifetime of the returned app.
+ *
+ * Draft seam: when the per-request context carries a `draftId`, `call`/
+ * `runHandler` route the write through `tracked.withDraft(draftId)` so the
+ * unmodified handler lands in the `<table>__draft` overlay. A context with NO
+ * draftId is unchanged — the canonical path is byte-identical (zero-overhead).
  *
  * onWrite/runHandler asymmetry: `onWrite` fires after a write committed via
  * `call` (`tablesWritten.size > 0`) but NOT after writes triggered by
@@ -252,35 +311,46 @@ export async function buildDashframeApp(opts: {
   const staticContext: Record<string, unknown> = vault != null ? { vault } : {};
   const hasStaticContext = Object.keys(staticContext).length > 0;
 
-  return vault == null && onWrite == null
-    ? rawApp
-    : {
-        ...rawApp,
-        async call(path, args, context) {
-          // Static context wins over per-request context: spread per-request
-          // first so that static keys (vault) cannot be shadowed by a crafted
-          // request context. The vault identity must be fixed for the server
-          // lifetime; a request-supplied vault key would be ignored.
-          const merged = hasStaticContext
-            ? { ...(context ?? {}), ...staticContext }
-            : context;
-          const result = await rawApp.call(path, args, merged);
-          if (onWrite != null && result.tablesWritten.size > 0) {
-            try {
-              onWrite();
-            } catch (err) {
-              console.error("[dashframe] onWrite hook threw:", err);
-            }
-          }
-          return result;
-        },
-        async runHandler(path, args, tracked, context) {
-          const merged = hasStaticContext
-            ? { ...(context ?? {}), ...staticContext }
-            : context;
-          return rawApp.runHandler(path, args, tracked, merged);
-        },
+  // The draft seam wraps `call` itself (not just runHandler): `rawApp.call`
+  // mints its own fresh TrackedDb internally, so a draftId-bearing `call` would
+  // otherwise hit canonical. We mirror rawApp.call's composition (fresh tracked
+  // → runHandler → result shape) but pass the draft-scoped handle when a draftId
+  // is present, leaving the no-draft path identical to rawApp.call.
+  return {
+    ...rawApp,
+    async call(path, args, context) {
+      // Static context wins over per-request context: spread per-request first
+      // so static keys (vault) cannot be shadowed by a crafted request context.
+      const merged = hasStaticContext
+        ? { ...(context ?? {}), ...staticContext }
+        : (context ?? {});
+      const tracked = rawApp.createTracked();
+      const effective = withDraftSeam(tracked, merged);
+      const result = await rawApp.runHandler(path, args, effective, merged);
+      // `tracked` and `effective` share the same tracker sets (withDraft reuses
+      // the base tracker), so tablesWritten reflects the write either way.
+      const tablesWritten = tracked.tablesWritten;
+      if (onWrite != null && tablesWritten.size > 0) {
+        try {
+          onWrite();
+        } catch (err) {
+          console.error("[dashframe] onWrite hook threw:", err);
+        }
+      }
+      return {
+        result,
+        tablesRead: tracked.tablesRead,
+        tablesWritten,
       };
+    },
+    async runHandler(path, args, tracked, context) {
+      const merged = hasStaticContext
+        ? { ...(context ?? {}), ...staticContext }
+        : (context ?? {});
+      const effective = withDraftSeam(tracked, merged);
+      return rawApp.runHandler(path, args, effective, merged);
+    },
+  };
 }
 
 export async function createDashframeServer(
@@ -474,4 +544,8 @@ function tokenMatches(actual: string, expected: string): boolean {
   return timingSafeEqual(actualBytes, expectedBytes);
 }
 
+export {
+  createDraftController,
+  type DraftController,
+} from "./draft-controller";
 export type { Functions } from "./functions";

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -1,0 +1,508 @@
+/**
+ * DraftController — the persistent draft lifecycle.
+ *
+ * These tests pin the load-bearing contracts of the copy-on-write draft overlay
+ * against a REAL artifact DB (PGlite), exercising the controller exactly as a
+ * host would: open a draft, write through NORMAL command handlers (the same
+ * `cmd(...)` vocabulary the UI and agent emit — proven isolated by routing
+ * through `ctx.db` with a draftId in context), then publish or discard.
+ *
+ * Contracts under test:
+ *   - Isolation      — a draft write is invisible in canonical until publish.
+ *   - Persistence    — the draft survives a simulated process restart (close +
+ *                      reopen the DB, rebuild app + controller from scratch).
+ *   - Atomic publish — replaying the log lands all rows on canonical at once.
+ *   - Discard        — drops the draft's deltas; canonical is untouched.
+ *   - Sparse overlay — a draft over a large canonical set stores ONLY the
+ *                      touched rows in `<table>__draft`, never a full copy.
+ */
+import {
+  dataSourcesDraft,
+  draftCommandLog,
+  insightsDraft,
+  openArtifactDb,
+  schema,
+} from "@dashframe/server-core";
+import type { Command } from "@wystack/server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildDashframeApp, createDraftController } from "./app";
+import { cmd } from "./functions/commands";
+
+const { insights, dataSources } = schema;
+
+describe("DraftController (persisted draft overlay)", () => {
+  let dir: string;
+  let dbPath: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: Awaited<ReturnType<typeof buildDashframeApp>>;
+  let controller: ReturnType<typeof createDraftController>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-draft-"));
+    dbPath = join(dir, "artifacts.db");
+    ({ db, app, controller } = await openStack(dbPath));
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Open the full stack (db + app with the draft seam + controller) at a path. */
+  async function openStack(path: string) {
+    const openedDb = await openArtifactDb({ path });
+    const builtApp = await buildDashframeApp({ db: openedDb });
+    return {
+      db: openedDb,
+      app: builtApp,
+      controller: createDraftController(builtApp, openedDb),
+    };
+  }
+
+  function id(): string {
+    return crypto.randomUUID();
+  }
+
+  /** Append a batch to a draft via the controller's normal applyCommands seam. */
+  async function appendCmds(draftId: string, ...commands: Command[]) {
+    return controller.appendToDraft(draftId, commands);
+  }
+
+  /** Seed a DataSource + DataTable on CANONICAL (the draft's base). */
+  async function seedTable(
+    target: ReturnType<typeof createDraftController>,
+  ): Promise<{ sourceId: string; tableId: string }> {
+    const sourceId = id();
+    const tableId = id();
+    // Publish a tiny draft to land the base rows on canonical without a separate
+    // canonical-write path — keeps the test using only the controller's surface.
+    const seed = await target.openDraft();
+    await target.appendToDraft(seed, [
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "T",
+        table: "t.csv",
+      }),
+    ]);
+    await target.publishDraft(seed);
+    return { sourceId, tableId };
+  }
+
+  async function canonicalInsights() {
+    return db.select().from(insights);
+  }
+  async function draftInsightRows(draftId: string) {
+    const rows = await db.select().from(insightsDraft);
+    return rows.filter((r) => r.draftId === draftId);
+  }
+  async function draftDataSourceRows(draftId: string) {
+    const rows = await db.select().from(dataSourcesDraft);
+    return rows.filter((r) => r.draftId === draftId);
+  }
+
+  it("isolates a draft write — invisible in canonical until publish", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Draft insight",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Canonical does NOT see the draft insight.
+    const canonical = await canonicalInsights();
+    expect(canonical.find((r) => r.id === insightId)).toBeUndefined();
+
+    // The draft overlay DOES hold it (the shadow row exists, scoped to draftId).
+    const shadow = await draftInsightRows(draftId);
+    expect(shadow).toHaveLength(1);
+    expect(shadow[0]?.id).toBe(insightId);
+    expect(shadow[0]?.name).toBe("Draft insight");
+  });
+
+  it("survives a simulated reload — the draftId is the durable handle", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Persisted insight",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Simulate a process restart: close the DB, drop the in-memory app +
+    // controller (and wystack's ephemeral lifecycle Map with them), reopen the
+    // SAME file, rebuild the stack from scratch.
+    await db.$client.close();
+    ({ db, controller } = await openStack(dbPath));
+
+    // The persisted command log survived — the reopened controller reads it.
+    const log = await controller.getDraftLog(draftId);
+    expect(log).toHaveLength(1);
+    expect(log[0]?.path).toBeTruthy();
+
+    // The shadow row survived too — still isolated from canonical.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId),
+    ).toBeUndefined();
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+
+    // Publishing the REHYDRATED draft (cold path) lands it on canonical.
+    await controller.publishDraft(draftId);
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId)?.name,
+    ).toBe("Persisted insight");
+  });
+
+  it("publishes atomically — the whole log lands on canonical, then the draft is gone", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightA = id();
+    const insightB = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightA,
+        name: "A",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightB,
+        name: "B",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    const result = await controller.publishDraft(draftId);
+
+    // Both insights landed on canonical.
+    const canonical = await canonicalInsights();
+    expect(canonical.find((r) => r.id === insightA)?.name).toBe("A");
+    expect(canonical.find((r) => r.id === insightB)?.name).toBe("B");
+    // The publish reported the canonical table it wrote (host flushes this to
+    // invalidation). `insights` is the canonical name, not the shadow.
+    expect(result.tablesWritten.has("insights")).toBe(true);
+
+    // The draft is fully torn down: no shadow rows, no command-log rows.
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(0);
+  });
+
+  it("discards a draft — canonical is left untouched", async () => {
+    const { tableId } = await seedTable(controller);
+    const before = await canonicalInsights();
+
+    const draftId = await controller.openDraft();
+    // Touch TWO distinct shadow tables (data_sources__draft + insights__draft) so
+    // the sweep is proven across more than one entry of the closed set — a sweep
+    // bug on any single shadow table would otherwise hide behind insights-only.
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "Throwaway src" }),
+      cmd("CreateInsight", {
+        id: id(),
+        name: "Throwaway",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    // The draft holds a row in BOTH shadow tables before discard.
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(1);
+
+    await controller.discardDraft(draftId);
+
+    // Canonical insights are byte-identical to before the draft existed.
+    const after = await canonicalInsights();
+    expect(after).toHaveLength(before.length);
+    // The draft's deltas are gone across BOTH shadow tables AND the command log.
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(0);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(0);
+  });
+
+  it("does NOT draft when no draftId is in context — the seam writes straight to canonical", async () => {
+    // The negative half of the seam contract: withDraftSeam must return the base
+    // tracked handle untouched when context has no draftId, so an ordinary RPC
+    // (`app.call` with an empty context) lands on CANONICAL, never a shadow. A
+    // regression in draftIdFromContext that minted a spurious id would silently
+    // redirect canonical writes into a dangling shadow — this catches that.
+    const sourceId = id();
+    const create = cmd("CreateDataSource", {
+      id: sourceId,
+      type: "csv",
+      name: "Direct",
+    });
+    await app.call(create.path, create.args, {});
+
+    // Landed on canonical.
+    const canonical = await db.select().from(dataSources);
+    expect(canonical.find((r) => r.id === sourceId)).toBeDefined();
+    // No shadow row exists for ANY draft (the no-draft path never touches a shadow).
+    expect(await db.select().from(dataSourcesDraft)).toHaveLength(0);
+  });
+
+  it("re-seqs the durable log across appends — replace-all, never append-only-duplicate (writeLog bookkeeping)", async () => {
+    // The controller's load-bearing novelty over wystack's in-memory lifecycle is
+    // that `draft_command_log` is a MATERIALIZED projection: each append re-runs
+    // compactLog over the full history and REPLACE-ALLs the draftId's rows with a
+    // dense 0..n re-seq. This pins that bookkeeping — a second append must not
+    // leave the first batch's rows orphaned (append-only) or duplicated; the log
+    // must equal the full ordered history exactly once.
+    const { tableId } = await seedTable(controller);
+    const draftId = await controller.openDraft();
+
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: id(),
+        name: "First",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: id(),
+        name: "Second",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // The persisted log holds exactly the two commands, in order — not 1 (lost),
+    // not 3+ (the first batch re-inserted alongside a stale copy).
+    const log = await controller.getDraftLog(draftId);
+    expect(log).toHaveLength(2);
+    expect(log.map((c) => c.path)).toEqual([
+      cmd("CreateInsight", {
+        id: id(),
+        name: "x",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }).path,
+      cmd("CreateInsight", {
+        id: id(),
+        name: "y",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }).path,
+    ]);
+
+    // The raw rows carry a dense 0..n seq (the unique (draft_id, seq) index is
+    // satisfied only if the re-seq is dense and the replace-all ran).
+    const rows = (await db.select().from(draftCommandLog))
+      .filter((r) => r.draftId === draftId)
+      .sort((a, b) => a.seq - b.seq);
+    expect(rows.map((r) => r.seq)).toEqual([0, 1]);
+  });
+
+  it("coalesces a jsonb column + PK-pinned read INSIDE a draft — a draft-only row is read back through the seam (gap-1 + gap-2)", async () => {
+    // This is the regression that bb9b745 fixed end-to-end through the controller:
+    //   gap-1 — the draft write-path bypassed the jsonb codec, so a jsonb column
+    //           (insights.definition) did not round-trip through <table>__draft.
+    //   gap-2 — a PK-pinned draft read (`from(t).where(eq("id",x)).first()`) did
+    //           not pin the draft row, so a handler reading a draft-only artifact
+    //           by id saw nothing.
+    // SetInsightSource exercises BOTH at once: it does a PK-pinned read of the
+    // insight's jsonb `definition` (requireInsightDefinition → from(insights)
+    // .where(eq("id",id)).first()), mutates it, and writes the jsonb back —
+    // entirely on a row that exists ONLY in the draft shadow. If either fix
+    // were absent the handler would throw "Insight not found" (gap-2) or write a
+    // corrupt/empty definition (gap-1).
+    const { tableId } = await seedTable(controller);
+    // A second canonical DataTable to re-point the source to.
+    const sourceId2 = id();
+    const tableId2 = id();
+    const seed2 = await controller.openDraft();
+    await controller.appendToDraft(seed2, [
+      cmd("CreateDataSource", { id: sourceId2, type: "csv", name: "S2" }),
+      cmd("CreateDataTable", {
+        id: tableId2,
+        dataSourceId: sourceId2,
+        name: "T2",
+        table: "t2.csv",
+      }),
+    ]);
+    await controller.publishDraft(seed2);
+
+    const insightId = id();
+    const draftId = await controller.openDraft();
+    // Create the insight INSIDE the draft (so it lives only in the shadow), with
+    // its jsonb `definition.source` pointed at table 1.
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Composed",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Re-point the source in a SEPARATE batch. SetInsightSource must PK-read the
+    // draft-only insight's jsonb definition (gap-2 + gap-1 read) before writing.
+    // A broken primitive throws here.
+    await appendCmds(
+      draftId,
+      cmd("SetInsightSource", {
+        id: insightId,
+        source: { sourceType: "dataTable", sourceId: tableId2 },
+      }),
+    );
+
+    // The shadow row's jsonb `definition` coalesced and round-tripped: the
+    // re-point landed, proving the jsonb codec ran on the draft write-path.
+    const shadow = await draftInsightRows(draftId);
+    expect(shadow).toHaveLength(1);
+    const def = shadow[0]?.definition as {
+      source?: { sourceId?: string };
+      baseTableId?: string;
+    };
+    expect(def?.source?.sourceId).toBe(tableId2);
+    expect(def?.baseTableId).toBe(tableId2);
+    // Canonical never saw the draft-only insight.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId),
+    ).toBeUndefined();
+
+    // Publishing replays the (compacted) log onto canonical; the final jsonb
+    // definition lands intact (end-to-end through the publish path too).
+    await controller.publishDraft(draftId);
+    const published = (await canonicalInsights()).find(
+      (r) => r.id === insightId,
+    );
+    const pubDef = published?.definition as { source?: { sourceId?: string } };
+    expect(pubDef?.source?.sourceId).toBe(tableId2);
+  });
+
+  it("cold-publishes from the durable log alone — a fresh stack with no in-memory state lands identically", async () => {
+    // The warm publish (other tests) replays the same in-process append state.
+    // This pins the COLD path: the appending process is gone; publish reads the
+    // log fresh off disk and replays. The brief's load-bearing claim — publish
+    // never forks on whether the opening process is alive — lives here.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Cold",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Drop ALL in-memory state: close the db, rebuild the stack from the file.
+    await db.$client.close();
+    ({ db, controller } = await openStack(dbPath));
+
+    // Publish reads the log fresh (no append happened in THIS process) and replays.
+    const result = await controller.publishDraft(draftId);
+    expect(result.tablesWritten.has("insights")).toBe(true);
+
+    // Canonical has the row; shadow + log are swept — identical to a warm publish.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId)?.name,
+    ).toBe("Cold");
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(0);
+  });
+
+  it("publishes to CANONICAL even when a draftId leaks into the publish context — the replay is never re-drafted", async () => {
+    // applyCommands dispatches the replay through the (wrapped) runHandler, which
+    // re-applies withDraftSeam from the publish context. If a consumer forwards a
+    // request context that still carries `draftId`, an un-stripped publish would
+    // re-scope the replay into <table>__draft and then dropDraft would sweep it —
+    // the publish would silently land nothing on canonical. publishDraft must
+    // strip draftId so the replay is unambiguously canonical.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Leaky-ctx",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Publish with a HOSTILE context that echoes the same draftId (simulating a
+    // consumer that forwards the request context verbatim).
+    await controller.publishDraft(draftId, { draftId });
+
+    // The row landed on CANONICAL — not lost into the shadow.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId)?.name,
+    ).toBe("Leaky-ctx");
+    // And the draft is fully torn down (publish succeeded, not a phantom).
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+  });
+
+  it("is a SPARSE overlay — a draft over many canonical rows stores only touched rows", async () => {
+    // Seed a "large" canonical set: 10 insights on canonical.
+    const { tableId } = await seedTable(controller);
+    const seededIds: string[] = [];
+    const seed = await controller.openDraft();
+    const seedCmds: Command[] = [];
+    for (let i = 0; i < 10; i++) {
+      const iid = id();
+      seededIds.push(iid);
+      seedCmds.push(
+        cmd("CreateInsight", {
+          id: iid,
+          name: `Insight ${i}`,
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+    }
+    await controller.appendToDraft(seed, seedCmds);
+    await controller.publishDraft(seed);
+    expect(await canonicalInsights()).toHaveLength(10);
+
+    // Open a draft and touch exactly ONE of the 10 canonical insights.
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("RenameNode", {
+        id: seededIds[0]!,
+        name: "Touched",
+      }),
+    );
+
+    // The shadow holds ONLY the one touched row — NOT a full copy of all 10.
+    const shadow = await draftInsightRows(draftId);
+    expect(shadow).toHaveLength(1);
+    expect(shadow[0]?.id).toBe(seededIds[0]);
+
+    // The other 9 canonical insights have no shadow row for this draft.
+    const allShadow = await db.select().from(insightsDraft);
+    expect(allShadow.filter((r) => r.draftId === draftId)).toHaveLength(1);
+  });
+});

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -1,0 +1,313 @@
+/**
+ * DraftController — the PERSISTENT draft lifecycle.
+ *
+ * The draft system has three legs (per @wystack/server's draft-lifecycle.ts):
+ *   1. Read overlay  — `withDraft(draftId)` coalesce (canonical ⊕ delta). READ.
+ *   2. Write storage — `<table>__draft` shadow + a compacted command log. WRITE.
+ *   3. Lifecycle     — open / append / publish / discard. CONDUCTS legs 1 & 2.
+ *
+ * wystack ships leg 3 as `createDraftLifecycle`, but that object holds its log +
+ * touchedTables in an in-memory `Map`: a draft evaporates on process restart and
+ * there is no rehydrate seam (`open()` always mints a fresh id; teardown helpers
+ * are module-private). DashFrame requires a draft that SURVIVES a restart, with
+ * the draftId as the durable handle. So DashFrame owns leg 3 — this controller —
+ * and persists it into the durable artifact tables (`draft_command_log` + the
+ * six `<table>__draft` shadows in @dashframe/server-core).
+ *
+ * This CONDUCTS wystack's mechanism, it does NOT reimplement it. The three
+ * load-bearing primitives are composed verbatim:
+ *   - `withDraft(draftId)` write-path — the ONLY way `<table>__draft` rows are
+ *     written. The controller drives `runHandler(..., draftDb, ...)`; it never
+ *     authors a shadow-table INSERT/UPDATE itself.
+ *   - `compactLog(log)` — wystack's exported net-effect collapse (create+delete
+ *     cancel, last-update-wins, create-kept-with-final-update). Never reimplemented.
+ *   - `applyCommands(app, log, {commit})` — wystack's publish-is-log-replay engine
+ *     (one atomic tracked transaction onto CANONICAL). The same primitive
+ *     `createDraftLifecycle.publish` calls.
+ * What the controller re-expresses is only BOOKKEEPING — where the log lives and
+ * how the shadow is swept — forced by the persistence requirement, not gratuitous.
+ * The crux that makes this clean: `withDraft(draftId)` accepts ANY caller-supplied
+ * draftId (a pure @wystack/db primitive, no coupling to the lifecycle Map), so the
+ * controller mints and owns the handle end to end.
+ *
+ * Durable-log invariant: `draft_command_log` is a MATERIALIZED PROJECTION of
+ * `compactLog(history)`. Each append re-runs `compactLog` over the full log and
+ * REPLACE-ALLs the draftId's rows (re-seq 0..n). The table therefore always holds
+ * exactly the list `applyCommands` will replay, already compacted, in replay order
+ * — one publish source, warm or cold, so publish semantics never fork on whether
+ * the opening process is still alive.
+ *
+ * SECURITY BOUNDARY: credential TABLE STATE is never drafted.
+ * `secret_mappings` and `project_meta` have no shadow; the six shadow tables here
+ * are the closed set, so a drafted write to a credential table has nowhere to
+ * land. NOTE the scope: this closes the at-rest-table channel, NOT a handler's
+ * vault SIDE EFFECT — a credentialed command run inside a draft would still call
+ * `vault.store` for real (not drafted, not swept on discard, re-run on publish).
+ * The seam is dormant in this slice (no host injects a draftId), so this is not
+ * yet live; the consumer that wires draftId into request context must enforce the
+ * credential-side-effect boundary at THAT seam (deny-list credentialed paths in a
+ * draft, or make vault.store draft-aware) before routing untrusted drafts.
+ */
+import {
+  dashboardsDraft,
+  dataFramesDraft,
+  dataSourcesDraft,
+  dataTablesDraft,
+  draftCommandLog,
+  insightsDraft,
+  visualizationsDraft,
+  type ArtifactDb,
+} from "@dashframe/server-core";
+import {
+  applyCommands,
+  compactLog,
+  type Command,
+  type CommandResult,
+  type CommitResult,
+  type DraftCommand,
+  type WyStackApp,
+} from "@wystack/server";
+import { eq } from "drizzle-orm";
+
+/**
+ * The closed set of `<table>__draft` shadows a draft can touch. Discard
+ * and post-publish teardown sweep by draftId across exactly these six — a static,
+ * schema-owned set, NOT runtime discovery. A new artifact table is a schema
+ * change, so this list is the authoritative enumeration. Sweeping the full closed
+ * set is strictly more robust than the lifecycle's touchedTables-driven sweep: it
+ * cannot miss a table because a write was never recorded.
+ */
+const DRAFT_SHADOW_TABLES = [
+  dataSourcesDraft,
+  dataTablesDraft,
+  dataFramesDraft,
+  insightsDraft,
+  visualizationsDraft,
+  dashboardsDraft,
+] as const;
+
+/** A persisted log row mapped back to the `DraftCommand` shape replay consumes. */
+function rowToDraftCommand(row: {
+  path: string;
+  args: unknown;
+  compactionKey: string | null;
+  kind: string | null;
+}): DraftCommand {
+  const cmd: DraftCommand = { path: row.path, args: row.args };
+  if (row.compactionKey !== null) cmd.compactionKey = row.compactionKey;
+  if (row.kind !== null) cmd.kind = row.kind as DraftCommand["kind"];
+  return cmd;
+}
+
+export interface DraftController {
+  /**
+   * Open a new draft and return its durable handle. No wystack call, no shadow
+   * rows — the draftId is the whole result. `baseVersion` is recorded for a
+   * future conflict-detection pass (out of scope for this mechanism slice); it
+   * is opaque and not inspected here.
+   */
+  openDraft(baseVersion?: unknown): Promise<string>;
+  /**
+   * Apply a batch INSIDE the draft. Routes each command's writes through the
+   * `withDraft(draftId)` write-path into `<table>__draft` (durable), then
+   * materializes the compacted command log into `draft_command_log`.
+   *
+   * The log is the source of truth (publish replays only the log). The per-batch
+   * shadow writes and the log projection are NOT wrapped in one transaction, so
+   * an append interrupted mid-batch (a handler throws, or the process dies before
+   * `writeLog`) can leave shadow rows that the log does not yet reference. Those
+   * orphans are INERT: publish ignores the shadow entirely and `dropDraft` sweeps
+   * the full closed set regardless, so canonical is never corrupted — the draft's
+   * recovery posture is "re-append the full batch" (matches wystack's lifecycle,
+   * which documents the same non-atomic-across-batch contract). The append is
+   * effect-free on canonical until publish.
+   *
+   * SINGLE-WRITER per draftId. `readLog → compactLog → writeLog` (replace-all) is
+   * not atomic, so two concurrent `appendToDraft` calls on the SAME draftId race:
+   * both read the same prior log and the last `writeLog` wins, erasing the other
+   * batch's log rows while its shadow rows linger (then get swept on publish) —
+   * silent command loss. A draft is a single editing session's handle; the
+   * consumer must serialize appends per draftId (do not fan out). When the seam
+   * is wired into a multi-session host, that host owns the per-draft lock.
+   * Returns per-command results (same shape as `applyCommands`).
+   */
+  appendToDraft(
+    draftId: string,
+    batch: DraftCommand[],
+    context?: Record<string, unknown>,
+  ): Promise<CommandResult[]>;
+  /**
+   * Publish = replay the durable command log atomically onto canonical via
+   * `applyCommands(app, log, {commit})`, then sweep the (now-inert) shadow + log.
+   * Reads ONLY `draft_command_log` — never the shadow — so it works identically
+   * whether or not the opening process is still alive. Returns the CommitResult
+   * (`tablesWritten` is what the host flushes to invalidation).
+   */
+  publishDraft(
+    draftId: string,
+    context?: Record<string, unknown>,
+  ): Promise<CommitResult>;
+  /**
+   * Discard = drop the draft's deltas: delete every `<table>__draft` row and
+   * every `draft_command_log` row for this draftId. Canonical is untouched.
+   * Pure DELETE-by-draftId; no wystack call needed.
+   */
+  discardDraft(draftId: string): Promise<void>;
+  /** Read-only peek at a draft's persisted (compacted) command log. */
+  getDraftLog(draftId: string): Promise<Command[]>;
+}
+
+/**
+ * Build the persistent draft controller over a WyStack app + the project's
+ * artifact DB. The app resolves command paths and backs both the shadow writes
+ * (via `withDraft`) and the publish replay; the typed `ArtifactDb` is the durable
+ * store for `draft_command_log` + the shadow sweeps.
+ */
+export function createDraftController(
+  app: WyStackApp,
+  db: ArtifactDb,
+): DraftController {
+  /** Read the draft's persisted command log, ordered for replay. */
+  async function readLog(draftId: string): Promise<DraftCommand[]> {
+    const rows = await db
+      .select({
+        path: draftCommandLog.path,
+        args: draftCommandLog.args,
+        compactionKey: draftCommandLog.compactionKey,
+        kind: draftCommandLog.kind,
+      })
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId))
+      // Order by the durable seq (0..n) — the replace-all dense re-seq in
+      // `writeLog` is what makes this the exact replay order publish consumes.
+      .orderBy(draftCommandLog.seq);
+    return rows.map(rowToDraftCommand);
+  }
+
+  /**
+   * Replace-all the draftId's log rows with `compacted`, re-seq 0..n. Materializes
+   * `compactLog`'s net-effect list so the table always equals what replay consumes
+   * — never append-only (compaction can DROP earlier positions, so append-only
+   * would drift from the replay source). The unique (draft_id, seq) index is
+   * satisfied by the dense re-seq.
+   */
+  async function writeLog(
+    draftId: string,
+    compacted: DraftCommand[],
+  ): Promise<void> {
+    await db
+      .delete(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    if (compacted.length === 0) return;
+    await db.insert(draftCommandLog).values(
+      compacted.map((cmd, seq) => ({
+        draftId,
+        seq,
+        path: cmd.path,
+        // `args` is opaque JSON-shaped data the lifecycle never interprets; store
+        // it verbatim. `?? null` because jsonb stores SQL NULL for an absent arg.
+        args: (cmd.args ?? null) as unknown,
+        compactionKey: cmd.compactionKey ?? null,
+        kind: cmd.kind ?? null,
+      })),
+    );
+  }
+
+  /**
+   * Delete every log row + shadow row for a draft. Canonical untouched.
+   *
+   * Log-FIRST is load-bearing for publish idempotency: `publishDraft` reads only
+   * `draft_command_log`, so once the log is gone a retried publish reads an empty
+   * log and is a no-op rather than a second replay onto canonical. Sweeping the
+   * (now-inert) shadow rows after the log means a teardown that fails partway —
+   * log deleted, a shadow delete throws — leaves only orphaned shadow rows that
+   * publish already ignores; it never leaves a live log that would double-replay.
+   */
+  async function dropDraft(draftId: string): Promise<void> {
+    await db
+      .delete(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    for (const shadow of DRAFT_SHADOW_TABLES) {
+      // `draftId` is a BOUND parameter (guard the sink); the table identifiers
+      // are static schema objects, not caller input.
+      await db.delete(shadow).where(eq(shadow.draftId, draftId));
+    }
+  }
+
+  return {
+    async openDraft(_baseVersion?: unknown): Promise<string> {
+      // DashFrame owns the handle. `withDraft` accepts any id, so a UUID is the
+      // durable draftId across the shadow tables and the command log.
+      return crypto.randomUUID();
+    },
+
+    async appendToDraft(draftId, batch, context = {}) {
+      // Route writes through the draft handle so each handler's `ctx.db.into/
+      // update/delete` lands in `<table>__draft` (the withDraft write-path),
+      // exactly as createDraftLifecycle.append does — the controller drives the
+      // path, it never authors a shadow-table write.
+      const draftDb = app.createTracked().withDraft(draftId);
+      const results: CommandResult[] = [];
+      for (const cmd of batch) {
+        const value = await app.runHandler(
+          cmd.path,
+          cmd.args,
+          draftDb,
+          context,
+        );
+        results.push({ id: cmd.id, value });
+      }
+      // Project the compacted full log into draft_command_log. Read the prior
+      // log, concat this batch, compact (wystack's exported algorithm), replace-all.
+      const prior = await readLog(draftId);
+      const compacted = compactLog([...prior, ...batch]);
+      await writeLog(draftId, compacted);
+      return results;
+    },
+
+    async publishDraft(draftId, context = {}) {
+      // ONE publish path, warm or cold: the durable log is always the source.
+      const log = await readLog(draftId);
+      // Replay the ordered command log onto CANONICAL, atomically. applyCommands
+      // dispatches each command via the (wrapped) `runHandler`, which re-applies
+      // `withDraftSeam` to the transaction tracker from THIS context. A `draftId`
+      // left in the replay context would therefore re-scope the publish back into
+      // `<table>__draft` — the changes would land in the shadow and then be swept
+      // by `dropDraft`, silently losing the publish. Strip it so the replay is
+      // unambiguously canonical (the log is the read overlay's source, not a
+      // draft-scoped write). `publishContext` carries the rest (e.g. vault).
+      const publishContext = { ...context };
+      delete publishContext.draftId;
+      const result = (await applyCommands(app, log, {
+        mode: "commit",
+        context: publishContext,
+      })) as CommitResult;
+      // Teardown AFTER the canonical commit landed durably. `dropDraft` deletes
+      // the log first (its own invariant) so a retried publish finds no log and
+      // is a no-op rather than a double-replay; then it sweeps the now-inert
+      // shadow rows. The host flushes result.tablesWritten to invalidation (the
+      // controller does not, mirroring applyCommands' posture).
+      //
+      // KNOWN DURABILITY WINDOW: the canonical commit and the log delete are two
+      // separate transactions — `applyCommands` owns its own tx and does not
+      // accept an outer one. A process crash in the gap (canonical committed, log
+      // not yet deleted) leaves the log intact, so a retried publish replays onto
+      // canonical a second time — a duplicate-PK throw for create commands, with
+      // no clean recovery (canonical already holds the row; discard only sweeps
+      // the shadow). Closing this needs either an `applyCommands` that accepts an
+      // outer transaction (wystack-side) or a durable publish-state marker on a
+      // draft record (no draft record exists in this slice). Out of scope for the
+      // mechanism slice; tracked as follow-up before the seam is wired live.
+      await dropDraft(draftId);
+      return result;
+    },
+
+    async discardDraft(draftId) {
+      await dropDraft(draftId);
+    },
+
+    async getDraftLog(draftId) {
+      return readLog(draftId);
+    },
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
         "@wystack/db": "workspace:*",
         "@wystack/secret-vault": "workspace:*",
         "@wystack/server": "workspace:*",
+        "drizzle-orm": "^0.45.1",
         "hono": "^4.12.9",
         "zod": "^4.1.12",
       },


### PR DESCRIPTION
## What

A persistent **DraftController** that conducts the wystack draft mechanism over DashFrame's durable YW-125 tables, plus the `ctx.db` draft seam in `app.ts` that routes command handlers into the draft overlay.

The controller **composes** wystack's three load-bearing primitives verbatim — it does not reimplement YW-121:
- `withDraft(draftId)` write-path — the only way `<table>__draft` rows are written (the controller drives `runHandler(..., draftDb, ...)`; it never authors a shadow INSERT).
- `compactLog(log)` — wystack's net-effect collapse, used as-is.
- `applyCommands(app, log, {commit})` — wystack's publish-is-log-replay engine.

What the controller re-expresses is only **bookkeeping** — where the log lives (`draft_command_log`) and how the shadow is swept — forced by the persistence requirement. wystack's `createDraftLifecycle` holds its log + touchedTables in a process-local `Map` with no rehydrate seam, so a draft evaporates on restart. DashFrame owns leg-3 (lifecycle) and persists it, so the **draftId is the durable handle** across a process restart.

**publish = atomic command-log replay onto canonical**, and it is **cold-safe**: `publishDraft` reads *only* `draft_command_log` (never the shadow) and replays through `applyCommands` onto a canonical tracker, so publish semantics never fork on whether the opening process is still alive.

**The `withDraftSeam`**: when a `draftId` is present in handler context, the seam substitutes the `tracked` handle with its `withDraft(draftId)` overlay so existing command handlers write into `<table>__draft` **unmodified**. The no-draft path is byte-identical, zero-overhead. The seam wraps `call` itself (not just `runHandler`) because `rawApp.call` mints its own internal `TrackedDb` that would otherwise bypass the overlay.

## Security boundary — credentials are never drafted

The six `<table>__draft` shadows are a **closed set** (`DRAFT_SHADOW_TABLES`); `secret_mappings` and `project_meta` have no shadow, so a drafted write to a credential table has nowhere to land. NOTE the precise scope: this closes the *at-rest table-state* channel, **not** a handler's `vault.store` *side effect*. The seam is **dormant in this slice** (no host injects a draftId into request context). The consumer ticket that wires `draftId` into request context MUST enforce the credential-side-effect boundary at that seam (deny-list credentialed command paths inside a draft, or make `vault.store` draft-aware) before routing untrusted drafts. This is documented inline in `draft-controller.ts`.

## Stacking

This PR is **stacked on #152** (`charixandra/bump-wystack-draft-foundation`), which bumps `libs/wystack` `86fe885 → bb9b745` — the foundation fix that corrected (a) the jsonb codec bypass on draft writes and (b) PK-filtered draft reads. The controller depends on that fix; this PR is verified against exactly what it merges onto. **Merge #152 first.**

## Verification (against the FIXED primitive bb9b745)

The test suite exercises the full draft lifecycle against a real artifact DB (PGlite). New tests added to exercise the two fixed paths end-to-end through the controller:
- **gap-1 (jsonb codec) + gap-2 (PK-pinned draft read)** — `SetInsightSource` inside a draft does a PK-pinned read of a draft-only insight's jsonb `definition`, mutates it, writes it back; would throw "Insight not found" (gap-2) or corrupt the blob (gap-1) against the broken primitive.
- **cold-publish** — close the DB + rebuild the stack with no in-memory append state, then publish from the durable log alone; lands identically to a warm publish.
- **no-draftId seam negative path**, **multi-table discard sweep**, and **log re-seq/replace-all bookkeeping** added from review.

Local gate: whole-graph `typecheck` + `lint` + `format` + full `test` all green; `wystack-agent-kit:code-review --effort high` (correctness, simplify, principal+api-contract, qa+testing lenses) triaged and resolved.

Tracked internally as YW-260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a persistent `DraftController` for the wystack draft mechanism and the `ctx.db` draft seam in `app.ts`. The controller persists draft state (`draft_command_log` + six shadow tables) so drafts survive process restarts, composing wystack primitives (`withDraft`, `compactLog`, `applyCommands`) without reimplementing them. The seam is explicitly dormant — no host currently injects a `draftId` into request context.

- **`draft-controller.ts`**: Implements `openDraft / appendToDraft / publishDraft / discardDraft` backed by `draft_command_log` with a replace-all compacted log strategy; sweep covers the full closed set of six shadow tables.
- **`app.ts`**: `buildDashframeApp` now unconditionally wraps `rawApp`, replacing `rawApp.call` with a hand-composed `createTracked + withDraftSeam + runHandler` path; the no-draft path is zero-overhead but `rawApp.call` is no longer on the hot path for any caller.
- **`draft-controller.test.ts`**: Full lifecycle tested against PGlite including isolation, cold-publish, sparse overlay, re-seq bookkeeping, and a hostile-context publish guard.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a dormant mechanism slice — no host currently injects a draftId into request context so the new code is not on any live production path.

The persistent draft lifecycle is well-designed and thoroughly tested. The unconditional wrapping of rawApp.call means rawApp.call is never invoked for any caller; correctness rests on the assumption that rawApp.call is purely createTracked + runHandler internally, which could silently break on a wystack upgrade. Three deferred durability gaps (partial-batch non-atomicity, single-writer concurrency, post-commit crash window) were flagged in the prior review round and are documented inline as pre-activation follow-ups.

apps/server/src/app.ts — the rawApp.call bypass affects all callers; apps/server/src/draft-controller.ts — deferred durability gaps need resolution before the seam is activated
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-controller.ts | New persistent DraftController; single-writer concurrency limitation, partial-batch non-atomicity, and the post-publish crash window are all documented inline. Logic is sound for the dormant-seam phase. |
| apps/server/src/app.ts | Adds withDraftSeam/draftIdFromContext helpers; buildDashframeApp now unconditionally wraps rawApp — rawApp.call is bypassed for all callers in favour of a hand-composed createTracked+runHandler path. No-draft path is zero-overhead; correctness depends on rawApp.call being purely createTracked+runHandler internally. |
| apps/server/src/draft-controller.test.ts | Comprehensive lifecycle tests against real PGlite: isolation, persistence/cold-publish, sparse overlay, re-seq bookkeeping, hostile-context publish guard, and the no-draftId seam negative path. |
| apps/server/package.json | Adds drizzle-orm as a direct dependency; required because draft-controller.ts imports eq directly rather than through a re-exporting workspace package. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host
    participant DC as DraftController
    participant App as WyStackApp (wrapped)
    participant DB as ArtifactDb

    Host->>DC: openDraft()
    DC-->>Host: draftId (UUID, no DB write)

    Host->>DC: appendToDraft(draftId, batch)
    DC->>App: createTracked().withDraft(draftId)
    App-->>DC: draftDb
    loop each command in batch
        DC->>App: runHandler(cmd, draftDb, ctx)
        App->>DB: INSERT/UPDATE table__draft rows
    end
    DC->>DB: readLog(draftId)
    DC->>DC: compactLog(prior + batch)
    DC->>DB: DELETE + INSERT draft_command_log (re-seq 0..n)
    DC-->>Host: CommandResult[]

    Host->>DC: publishDraft(draftId)
    DC->>DB: readLog(draftId)
    DC->>App: applyCommands(log, commit)
    App->>DB: replay onto canonical (atomic tx)
    App-->>DC: CommitResult
    Note over DC,DB: crash here leaves log intact, retry double-replays
    DC->>DB: dropDraft (DELETE log then shadow rows)
    DC-->>Host: CommitResult

    Host->>DC: discardDraft(draftId)
    DC->>DB: dropDraft (log + 6 shadow tables)
    DC-->>Host: void
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host
    participant DC as DraftController
    participant App as WyStackApp (wrapped)
    participant DB as ArtifactDb

    Host->>DC: openDraft()
    DC-->>Host: draftId (UUID, no DB write)

    Host->>DC: appendToDraft(draftId, batch)
    DC->>App: createTracked().withDraft(draftId)
    App-->>DC: draftDb
    loop each command in batch
        DC->>App: runHandler(cmd, draftDb, ctx)
        App->>DB: INSERT/UPDATE table__draft rows
    end
    DC->>DB: readLog(draftId)
    DC->>DC: compactLog(prior + batch)
    DC->>DB: DELETE + INSERT draft_command_log (re-seq 0..n)
    DC-->>Host: CommandResult[]

    Host->>DC: publishDraft(draftId)
    DC->>DB: readLog(draftId)
    DC->>App: applyCommands(log, commit)
    App->>DB: replay onto canonical (atomic tx)
    App-->>DC: CommitResult
    Note over DC,DB: crash here leaves log intact, retry double-replays
    DC->>DB: dropDraft (DELETE log then shadow rows)
    DC-->>Host: CommitResult

    Host->>DC: discardDraft(draftId)
    DC->>DB: dropDraft (log + 6 shadow tables)
    DC-->>Host: void
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["feat(server): \[YW-260\] persistent draft ..."](https://github.com/youhaowei/dashframe/commit/f2bf621217a40dd5179bcc05854f14bcddacbe4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39326400)</sub>

<!-- /greptile_comment -->