### PR TITLE
fix(server): runHandler snapshot-hook parity for canonical writes [YW-270]

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -232,11 +232,37 @@ export interface DashframeServer {
  * shadowed by a caller-supplied context — the vault identity is fixed for the
  * lifetime of the returned app.
  *
- * onWrite/runHandler asymmetry: `onWrite` fires after a write committed via
- * `call` (`tablesWritten.size > 0`) but NOT after writes triggered by
- * `runHandler`. The `runHandler` path is a lower-level escape hatch that
- * bypasses the call-result shape; callers invoking it directly are responsible
- * for their own side-effects. This asymmetry is a known gap tracked separately.
+ * onWrite/runHandler asymmetry — INTENTIONAL and load-bearing:
+ *
+ * `onWrite` fires after `call` (`tablesWritten.size > 0`) but NOT after
+ * `runHandler`. This is correct because every current production caller of
+ * `runHandler` falls into one of two non-canonical categories:
+ *
+ *   1. `applyCommands(mode: 'preview')` — used exclusively by `buildPreviewDiff`
+ *      (all three call sites in preview-diff.ts use mode `'preview'`). Preview
+ *      executes handlers then forces a transaction rollback; nothing persists, so
+ *      `onWrite` must NOT fire.
+ *
+ *   2. `draftLifecycle.append(draftId, batch)` — routes writes through a
+ *      `base.withDraft(draftId)` handle, so every `ctx.db.into/update/delete`
+ *      lands in `<table>__draft` shadow tables. Draft writes are not canonical;
+ *      `onWrite` drives canonical snapshot persistence and must NOT fire for
+ *      draft-overlay writes.
+ *
+ * `draftLifecycle` is not yet wired into the DashFrame server (the draft
+ * overlay substrate landed in recent wystack + server-core work; route
+ * integration is a future ticket). When it is wired,
+ * the `publish` method calls `applyCommands(app, boundLog, { mode: 'commit' })`
+ * and returns a `CommitResult` with `tablesWritten`. OBLIGATION: the caller that
+ * wires `publish` into a server route MUST fire `onWrite()` when
+ * `result.tablesWritten.size > 0` — the lifecycle does not fire it (by design;
+ * it is a generic WyStack primitive with no DashFrame dependency). Adding
+ * `onWrite` to this `runHandler` wrapper cannot safely cover that future path
+ * because: (a) preview also uses canonical `TrackedDb` handles that look
+ * identical at this level, and (b) `runHandler` is called per-command while
+ * `tablesWritten` accumulates across the batch — the per-command check would
+ * fire multiple times or miss the first-write-only case. The clean seam is the
+ * `publish` return site, not here.
  */
 export async function buildDashframeApp(opts: {
   db: object;
@@ -274,6 +300,11 @@ export async function buildDashframeApp(opts: {
           }
           return result;
         },
+        // runHandler: vault injection only — no onWrite. See the function-level
+        // comment for the full rationale; short form: all current production
+        // callers are either preview (rollback) or draft-overlay (non-canonical).
+        // When draftLifecycle.publish is wired into a server route, THAT site
+        // must fire onWrite on CommitResult.tablesWritten — not here.
         async runHandler(path, args, tracked, context) {
           const merged = hasStaticContext
             ? { ...(context ?? {}), ...staticContext }


### PR DESCRIPTION
## Summary

- **Verdict: working as designed.** Investigated YW-270 — the `runHandler`/`onWrite` asymmetry in `buildDashframeApp` is intentional, not a bug.
- Every current production caller of `app.runHandler` is either preview-mode (executes-then-rolls-back, nothing persists) or draft-overlay (writes to `<table>__draft` shadow tables, not canonical). Neither should trigger `onWrite`.
- Replaced the vague "a known gap tracked separately" comment with a definitive, exhaustive explanation — plus an explicit **OBLIGATION** callout for the future route that wires `draftLifecycle.publish` into the server.

## Investigation evidence

**Production `runHandler` callers (non-test):**

1. `libs/wystack/packages/server/src/apply-commands.ts:235` — called by `applyCommands`. All three production call sites in `preview-diff.ts` (lines 408, 443, 487) use `mode: 'preview'` exclusively. Preview executes-then-rolls-back; `onWrite` must NOT fire.

2. `libs/wystack/packages/server/src/draft-lifecycle.ts:348` — called by `draftLifecycle.append`, which routes writes through `base.withDraft(draftId)`. All writes land in `<table>__draft` shadow tables, not canonical. `onWrite` must NOT fire.

**`draftLifecycle` not yet wired into production:** `createDraftLifecycle` is exported from `@wystack/server` but never instantiated in `apps/` or `packages/` production code. The draft overlay substrate (lifecycle + delta-table schema) landed in recent wystack + server-core work; the route integration is a future ticket.

**Why `onWrite` can't be added to `runHandler` safely:** Preview also uses canonical `TrackedDb` handles that look identical to commit handles at the `runHandler` level (same type, same transaction flow) — no structural way to distinguish them here. Additionally, `runHandler` is called per-command against a shared accumulating `tx`, so a per-command `onWrite` check would misfire. The correct seam for the future `draftLifecycle.publish` path is the `publish` return site, which receives `CommitResult.tablesWritten` and can fire `onWrite` exactly once per committed batch.

## What changed

Single file: `apps/server/src/app.ts` (`buildDashframeApp` JSDoc + one inline comment on the `runHandler` wrapper). No behavioral changes.

Tracked internally as YW-270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a vague "known gap tracked separately" comment in `buildDashframeApp` with a definitive, evidence-backed explanation of the intentional `onWrite`/`runHandler` asymmetry. No behavioral changes are made; the only modifications are JSDoc and an inline comment.

- **JSDoc rewrite**: documents the two production `runHandler` call sites (preview-mode rollback and draft-overlay shadow tables) that justify suppressing `onWrite`, and explains structurally why the wrapper cannot safely be enhanced.
- **Inline comment**: adds a short cross-reference on the `runHandler` wrapper itself, plus an explicit OBLIGATION note for the future `draftLifecycle.publish` integration route.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is documentation only; no executable code paths were altered.

Every line changed is a comment or JSDoc string. The new text accurately describes the existing runtime behavior (confirmed by reading the call vs runHandler branches), correctly identifies both production runHandler call sites, and places the future OBLIGATION note precisely at the correct integration seam. No logic, no branching, no type signatures, and no tests were touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Comment-only update: replaces a placeholder 'known gap' note with an exhaustive, accurate explanation of why onWrite does not fire from the runHandler wrapper, plus an OBLIGATION callout for the future draftLifecycle.publish integration site. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client Request] --> B{buildDashframeApp wrapper}

    B -->|app.call| C[rawApp.call]
    C --> D{tablesWritten.size > 0?}
    D -->|Yes| E[onWrite fires\ncanonical snapshot hook]
    D -->|No| F[Return result]
    E --> F

    B -->|app.runHandler| G[rawApp.runHandler]
    G --> H{Caller type?}
    H -->|applyCommands mode preview| I[Transaction rollback\nnothing persists]
    H -->|draftLifecycle.append| J[Writes to __draft\nshadow tables only]
    I --> K[onWrite must NOT fire]
    J --> K

    L[Future: draftLifecycle.publish] --> M[applyCommands mode commit]
    M --> N[Returns CommitResult.tablesWritten]
    N --> O[OBLIGATION: publish call-site\nmust fire onWrite here]

    style E fill:#90EE90
    style K fill:#FFB6C1
    style O fill:#FFD700
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Client Request] --> B{buildDashframeApp wrapper}

    B -->|app.call| C[rawApp.call]
    C --> D{tablesWritten.size > 0?}
    D -->|Yes| E[onWrite fires\ncanonical snapshot hook]
    D -->|No| F[Return result]
    E --> F

    B -->|app.runHandler| G[rawApp.runHandler]
    G --> H{Caller type?}
    H -->|applyCommands mode preview| I[Transaction rollback\nnothing persists]
    H -->|draftLifecycle.append| J[Writes to __draft\nshadow tables only]
    I --> K[onWrite must NOT fire]
    J --> K

    L[Future: draftLifecycle.publish] --> M[applyCommands mode commit]
    M --> N[Returns CommitResult.tablesWritten]
    N --> O[OBLIGATION: publish call-site\nmust fire onWrite here]

    style E fill:#90EE90
    style K fill:#FFB6C1
    style O fill:#FFD700
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/76e7b1bb8968b47825f250997189e57fe5930586) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39331556)</sub>

<!-- /greptile_comment -->