### PR TITLE
fix(server): guard insight read-walker definition blobs — Zod-parse before cast [YW-293]

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
     "@types/bun": "^1.2.0",
+    "drizzle-orm": "^0.45.1",
     "esbuild": "^0.28.0",
     "typescript": "5.7.2",
     "vitest": "^4.1.6"

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -3037,5 +3037,138 @@ describe("command vocabulary", () => {
         ).resolves.toBeDefined();
       });
     });
+
+    describe("read-walker sink-guard (wouldCreateCycle + isOrphanedBy)", () => {
+      // These are the READ-side mirrors of the write-sink guard tested above.
+      // wouldCreateCycle and isOrphanedBy both walk the stored definition blob
+      // and were previously bare-cast (trusting provenance rather than parsing).
+      // A corrupt intermediate node in the chain must produce a clear error,
+      // not crash on undefined property access deep inside the walk.
+
+      it("should throw a clear 'corrupt definition' error when the target insight's stored blob is invalid (SetInsightSource → wouldCreateCycle)", async () => {
+        // Contract: wouldCreateCycle parses each definition blob it encounters;
+        // a corrupt blob throws "corrupt definition" instead of crashing on
+        // undefined property access.
+        //
+        // Note on unscoped db.update: the update runs BETWEEN CreateInsight(A) and
+        // CreateInsight(B) — at update time the insights table holds only A, so the
+        // unscoped update correctly targets A alone. If this test is refactored and
+        // B is created before the update, add a .where(eq(schema.insights.id, aId))
+        // using drizzle-orm's eq to preserve isolation (matching the write-sink
+        // guard suite's pattern, see describe block note at line ~2844).
+        const { tableId } = await makeTable();
+        const aId = id();
+
+        // Create A — the insight that will be used as the walk target.
+        await commit(
+          cmd("CreateInsight", {
+            id: aId,
+            name: "A",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Corrupt A's definition (A is the only insight row at this point).
+        await db.update(schema.insights).set({
+          definition: {
+            // baseTableId intentionally omitted — corrupt blob
+            selectedFields: [],
+            metrics: [],
+          },
+        });
+
+        // Create B after the corruption so the unscoped update does not affect it.
+        const bId = id();
+        await commit(
+          cmd("CreateInsight", {
+            id: bId,
+            name: "B",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // SetInsightSource(B, A) calls wouldCreateCycle(ctx, B, A). The walk
+        // starts at A, parses A's (corrupt) definition — must throw.
+        await expect(
+          commit(
+            cmd("SetInsightSource", {
+              id: bId,
+              source: { sourceType: "insight", sourceId: aId },
+            }),
+          ),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+
+      it("should throw a clear 'corrupt definition' error when an insight in the scan has an invalid stored blob (DeleteNode DataTable → findOrphanedInsights → isOrphanedBy)", async () => {
+        // Contract: isOrphanedBy parses each definition blob it receives; a
+        // corrupt blob throws "corrupt definition" rather than crashing on
+        // undefined property access or silently mis-classifying the orphan.
+        //
+        // Path: DeleteNode(DataTable) → findOrphanedInsights → isOrphanedBy per row.
+        const { tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Corrupt the stored definition — baseTableId missing (required field).
+        await db.update(schema.insights).set({
+          definition: {
+            selectedFields: [],
+            metrics: [],
+            // baseTableId intentionally omitted
+          },
+        });
+
+        // DeleteNode(tableId) triggers the orphan scan; the corrupt blob must
+        // produce a clean error (no silent no-op or crash on property access).
+        await expect(
+          commit(cmd("DeleteNode", { id: tableId })),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+
+      it("should throw a clear 'corrupt definition' error when a corrupt insight is encountered during a DataSource delete (deleteDataSourceDependents → isOrphanedBy)", async () => {
+        // Contract: isOrphanedBy is called from two paths — findOrphanedInsights
+        // (DataTable delete) and deleteDataSourceDependents (DataSource delete).
+        // Both paths must throw on a corrupt blob; this test covers the second.
+        //
+        // Path: DeleteNode(DataSource) → deleteDataSourceDependents →
+        //   [...ownedTableIds].some(tableId => isOrphanedBy(row, tableId))
+        //
+        // deleteDataSourceDependents fetches ALL insight rows and calls
+        // isOrphanedBy on each. Any corrupt row aborts the entire scan.
+        const { sourceId, tableId } = await makeTable();
+        const insightId = id();
+
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableId },
+          }),
+        );
+
+        // Corrupt the insight's stored definition.
+        await db.update(schema.insights).set({
+          definition: {
+            selectedFields: [],
+            metrics: [],
+            // baseTableId intentionally omitted — corrupt blob
+          },
+        });
+
+        // DeleteNode(DataSource) triggers deleteDataSourceDependents, which scans
+        // all insights and calls isOrphanedBy on each. The corrupt blob must
+        // produce a clean error; the delete does not silently skip the corrupt row.
+        await expect(
+          commit(cmd("DeleteNode", { id: sourceId })),
+        ).rejects.toThrow(/corrupt definition/);
+      });
+    });
   });
 });

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -24,13 +24,14 @@ import {
   TestBackend,
 } from "@wystack/secret-vault";
 import { createWyStack, type WyStackApp } from "@wystack/server";
+import { eq } from "drizzle-orm";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { functions } from "../functions";
-import { cmd } from "./commands";
+import { cmd, storedInsightDefinitionSchema } from "./commands";
 
 /** Compose a SecretVault backed by TestBackend. ONLY for test setup. */
 function makeTestVault(): SecretVault {
@@ -3038,48 +3039,31 @@ describe("command vocabulary", () => {
       });
     });
 
-    describe("read-walker sink-guard (wouldCreateCycle + isOrphanedBy)", () => {
+    describe("read-walker sink-guard (wouldCreateCycle + orphan scan)", () => {
       // These are the READ-side mirrors of the write-sink guard tested above.
-      // wouldCreateCycle and isOrphanedBy both walk the stored definition blob
-      // and were previously bare-cast (trusting provenance rather than parsing).
-      // A corrupt intermediate node in the chain must produce a clear error,
-      // not crash on undefined property access deep inside the walk.
+      // wouldCreateCycle and the orphan scan (parseRowDefinition + definition
+      // Refers) both read the stored definition blob and were previously bare-
+      // cast (trusting provenance rather than parsing). A corrupt node must
+      // produce a clear error, not crash on undefined property access.
 
       it("should throw a clear 'corrupt definition' error when the target insight's stored blob is invalid (SetInsightSource → wouldCreateCycle)", async () => {
         // Contract: wouldCreateCycle parses each definition blob it encounters;
         // a corrupt blob throws "corrupt definition" instead of crashing on
         // undefined property access.
-        //
-        // Note on unscoped db.update: the update runs BETWEEN CreateInsight(A) and
-        // CreateInsight(B) — at update time the insights table holds only A, so the
-        // unscoped update correctly targets A alone. If this test is refactored and
-        // B is created before the update, add a .where(eq(schema.insights.id, aId))
-        // using drizzle-orm's eq to preserve isolation (matching the write-sink
-        // guard suite's pattern, see describe block note at line ~2844).
         const { tableId } = await makeTable();
         const aId = id();
+        const bId = id();
 
-        // Create A — the insight that will be used as the walk target.
+        // Create both insights up front; the corruption is scoped to A alone
+        // via .where(eq(...)) so this test does not depend on insertion order
+        // or row count (matching the write-sink guard suite's recommended
+        // pattern — see describe block note at line ~2844).
         await commit(
           cmd("CreateInsight", {
             id: aId,
             name: "A",
             source: { sourceType: "dataTable", sourceId: tableId },
           }),
-        );
-
-        // Corrupt A's definition (A is the only insight row at this point).
-        await db.update(schema.insights).set({
-          definition: {
-            // baseTableId intentionally omitted — corrupt blob
-            selectedFields: [],
-            metrics: [],
-          },
-        });
-
-        // Create B after the corruption so the unscoped update does not affect it.
-        const bId = id();
-        await commit(
           cmd("CreateInsight", {
             id: bId,
             name: "B",
@@ -3087,8 +3071,22 @@ describe("command vocabulary", () => {
           }),
         );
 
+        // Corrupt ONLY A's definition — the walk target. B stays valid.
+        await db
+          .update(schema.insights)
+          .set({
+            definition: {
+              // baseTableId intentionally omitted — corrupt blob
+              selectedFields: [],
+              metrics: [],
+            },
+          })
+          .where(eq(schema.insights.id, aId));
+
         // SetInsightSource(B, A) calls wouldCreateCycle(ctx, B, A). The walk
-        // starts at A, parses A's (corrupt) definition — must throw.
+        // starts at A, parses A's (corrupt) definition — must throw. require
+        // InsightDefinition(B) and requireSourceExists(A) run first and pass
+        // (B is valid; requireSourceExists only checks A's row exists, no parse).
         await expect(
           commit(
             cmd("SetInsightSource", {
@@ -3099,12 +3097,13 @@ describe("command vocabulary", () => {
         ).rejects.toThrow(/corrupt definition/);
       });
 
-      it("should throw a clear 'corrupt definition' error when an insight in the scan has an invalid stored blob (DeleteNode DataTable → findOrphanedInsights → isOrphanedBy)", async () => {
-        // Contract: isOrphanedBy parses each definition blob it receives; a
+      it("should throw a clear 'corrupt definition' error when an insight in the scan has an invalid stored blob (DeleteNode DataTable → findOrphanedInsights)", async () => {
+        // Contract: the orphan scan parses each definition blob it reads; a
         // corrupt blob throws "corrupt definition" rather than crashing on
         // undefined property access or silently mis-classifying the orphan.
         //
-        // Path: DeleteNode(DataTable) → findOrphanedInsights → isOrphanedBy per row.
+        // Path: DeleteNode(DataTable) → findOrphanedInsights →
+        //   parseRowDefinition(row) per row.
         const { tableId } = await makeTable();
         const insightId = id();
 
@@ -3132,16 +3131,15 @@ describe("command vocabulary", () => {
         ).rejects.toThrow(/corrupt definition/);
       });
 
-      it("should throw a clear 'corrupt definition' error when a corrupt insight is encountered during a DataSource delete (deleteDataSourceDependents → isOrphanedBy)", async () => {
-        // Contract: isOrphanedBy is called from two paths — findOrphanedInsights
-        // (DataTable delete) and deleteDataSourceDependents (DataSource delete).
-        // Both paths must throw on a corrupt blob; this test covers the second.
+      it("should throw a clear 'corrupt definition' error when a corrupt insight is encountered during a DataSource delete (deleteDataSourceDependents)", async () => {
+        // Contract: the parse-or-throw guard is reached from two paths —
+        // findOrphanedInsights (DataTable delete) and deleteDataSourceDependents
+        // (DataSource delete). Both must throw on a corrupt blob; this covers
+        // the second.
         //
         // Path: DeleteNode(DataSource) → deleteDataSourceDependents →
-        //   [...ownedTableIds].some(tableId => isOrphanedBy(row, tableId))
-        //
-        // deleteDataSourceDependents fetches ALL insight rows and calls
-        // isOrphanedBy on each. Any corrupt row aborts the entire scan.
+        //   parseRowDefinition(row) per insight (parsed ONCE), then
+        //   [...ownedTableIds].some(tableId => definitionRefers(def, tableId)).
         const { sourceId, tableId } = await makeTable();
         const insightId = id();
 
@@ -3163,11 +3161,80 @@ describe("command vocabulary", () => {
         });
 
         // DeleteNode(DataSource) triggers deleteDataSourceDependents, which scans
-        // all insights and calls isOrphanedBy on each. The corrupt blob must
-        // produce a clean error; the delete does not silently skip the corrupt row.
+        // all insights and parses each. The corrupt blob must produce a clean
+        // error; the delete does not silently skip the corrupt row.
         await expect(
           commit(cmd("DeleteNode", { id: sourceId })),
         ).rejects.toThrow(/corrupt definition/);
+      });
+
+      it("should parse each insight definition once per DataSource delete, not once per owned table (no O(insights × tables) re-parse)", async () => {
+        // Regression for the perf finding: deleteDataSourceDependents must parse
+        // each insight's definition ONCE, then compare the parsed result against
+        // every owned table — not re-validate the JSON per table. We assert this
+        // by spying on storedInsightDefinitionSchema.safeParse and counting calls
+        // for a DataSource with multiple tables and one referencing insight.
+        //
+        // CRITICAL: the orphan insight must source the LAST-iterated owned table.
+        // ownedTableIds iterates in insertion order, and the old per-table code
+        // `[...ownedTableIds].some(t => isOrphanedBy(row, t))` short-circuits on
+        // the first match. If the insight sourced the FIRST table, the old code
+        // would also parse only once (match on iteration 0) and this assertion
+        // would pass against the unfixed code — a no-op guard. Sourcing the LAST
+        // table forces the old code to parse all 3 tables before matching (3x),
+        // while the fix parses once regardless of which table matches.
+        // makeTable creates the DataSource + its first owned table (table A,
+        // unused as the insight source — it just anchors the source).
+        const { sourceId } = await makeTable();
+
+        // Add a second + third table to the SAME data source so ownedTableIds
+        // has >1 entry — the loop that previously re-parsed per table.
+        const tableB = id();
+        const tableC = id();
+        await commit(
+          cmd("CreateDataTable", {
+            id: tableB,
+            dataSourceId: sourceId,
+            name: "B",
+            table: "b.csv",
+          }),
+          cmd("CreateDataTable", {
+            id: tableC,
+            dataSourceId: sourceId,
+            name: "C",
+            table: "c.csv",
+          }),
+        );
+
+        // One insight sourcing table C — the LAST-created table, so the old
+        // short-circuiting .some(...) would re-parse on tables A and B before
+        // matching C (3 parses). The fix parses once.
+        const insightId = id();
+        await commit(
+          cmd("CreateInsight", {
+            id: insightId,
+            name: "I",
+            source: { sourceType: "dataTable", sourceId: tableC },
+          }),
+        );
+
+        // Spy on the schema's safeParse to count how many times the insight's
+        // definition is validated during the delete scan.
+        const parseSpy = vi.spyOn(storedInsightDefinitionSchema, "safeParse");
+
+        const result = await commit(cmd("DeleteNode", { id: sourceId }));
+
+        // The insight is surfaced as an orphan (correctness preserved).
+        const value = result.results[0]?.value as {
+          orphanedNodes: { id: string }[];
+        };
+        expect(value.orphanedNodes.map((n) => n.id)).toContain(insightId);
+
+        // With 3 owned tables and the insight sourcing the last one, the old
+        // per-table re-parse would call safeParse 3x inside the .some(...) loop.
+        // The fix parses once.
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+        parseSpy.mockRestore();
       });
     });
   });

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -262,6 +262,10 @@ async function requireSourceExists(
  * This is a simple linear walk (O(depth)); cycle detection could be done with
  * a visited set for diamond DAGs, but the typical chain depth is small and
  * diamonds are architecturally uncommon at authoring time.
+ *
+ * A corrupt `definition` blob on any encountered row throws immediately
+ * (aborting the walk) rather than treating the node as a leaf; callers must
+ * handle or propagate that error.
  */
 async function wouldCreateCycle(
   ctx: { db: import("@wystack/db").TrackedDb },
@@ -282,7 +286,13 @@ async function wouldCreateCycle(
       .where(eq("id", currentId))
       .first()) as InsightRow | undefined;
     if (!row) break; // reached a leaf (DataTable or unknown)
-    const def = row.definition as StoredInsightDefinition;
+    const parsed = storedInsightDefinitionSchema.safeParse(row.definition);
+    if (!parsed.success) {
+      throw new Error(
+        `Insight ${currentId} has a corrupt definition: ${parsed.error.message}`,
+      );
+    }
+    const def = parsed.data as StoredInsightDefinition;
     const src = def.source;
     if (!src || src.sourceType !== "insight") break; // leaf
     if (src.sourceId === startId) return true; // cycle found
@@ -1579,9 +1589,19 @@ export interface DeleteNodeResult {
  * full-table scan filtered in application code (PGLite single-connection, the
  * table is small in practice). A future index on a promoted column would speed
  * this up; the read is intentionally bounded to the delete path.
+ *
+ * A corrupt `definition` blob throws immediately (fail-closed), aborting the
+ * entire scan. One bad row blocks a delete until the row is repaired — the
+ * deliberate trade-off vs. silently mis-classifying orphans or skipping the row.
  */
 function isOrphanedBy(row: InsightRow, sourceId: string): boolean {
-  const def = row.definition as StoredInsightDefinition;
+  const parsed = storedInsightDefinitionSchema.safeParse(row.definition);
+  if (!parsed.success) {
+    throw new Error(
+      `Insight ${row.id} has a corrupt definition: ${parsed.error.message}`,
+    );
+  }
+  const def = parsed.data as StoredInsightDefinition;
   // Primary source check.
   const primaryMatch = def.source
     ? def.source.sourceId === sourceId

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -179,8 +179,11 @@ const insightSourceSchema = z.object({
  * to match the read-path's defensive coalescing (`?? []`) — older or
  * externally written rows that omit them remain readable instead of being
  * rejected as corrupt.
+ *
+ * Exported so tests can assert parse-call counts (e.g. the orphan scan parses
+ * each insight once, not once per owned table).
  */
-const storedInsightDefinitionSchema = z.object({
+export const storedInsightDefinitionSchema = z.object({
   baseTableId: z.string(),
   source: insightSourceSchema.optional(),
   // `.nullish().default([])` — a null value (SQL JSONB can store null for an
@@ -1590,18 +1593,36 @@ export interface DeleteNodeResult {
  * table is small in practice). A future index on a promoted column would speed
  * this up; the read is intentionally bounded to the delete path.
  *
+ * Parsing is split from comparison: `parseRowDefinition` validates the JSONB
+ * blob ONCE per insight (fail-closed throw on corrupt), and `definitionRefers`
+ * is a pure check against the already-parsed definition. This keeps the
+ * DataSource-delete scan at O(insights) parses instead of O(insights × tables)
+ * — `deleteDataSourceDependents` compares one parsed definition against every
+ * owned table without re-validating per table.
+ *
  * A corrupt `definition` blob throws immediately (fail-closed), aborting the
  * entire scan. One bad row blocks a delete until the row is repaired — the
  * deliberate trade-off vs. silently mis-classifying orphans or skipping the row.
  */
-function isOrphanedBy(row: InsightRow, sourceId: string): boolean {
+function parseRowDefinition(row: InsightRow): StoredInsightDefinition {
   const parsed = storedInsightDefinitionSchema.safeParse(row.definition);
   if (!parsed.success) {
     throw new Error(
       `Insight ${row.id} has a corrupt definition: ${parsed.error.message}`,
     );
   }
-  const def = parsed.data as StoredInsightDefinition;
+  return parsed.data as StoredInsightDefinition;
+}
+
+/**
+ * Pure orphan check against an already-parsed definition — no validation, no
+ * DB access. An Insight is orphaned by `sourceId` if its primary source (or
+ * legacy `baseTableId`) equals it, or any join's `rightTableId` equals it.
+ */
+function definitionRefers(
+  def: StoredInsightDefinition,
+  sourceId: string,
+): boolean {
   // Primary source check.
   const primaryMatch = def.source
     ? def.source.sourceId === sourceId
@@ -1618,7 +1639,10 @@ async function findOrphanedInsights(
   sourceId: string,
 ): Promise<{ id: string }[]> {
   const allInsights = (await ctx.db.from(insights).all()) as InsightRow[];
-  return allInsights.filter((row) => isOrphanedBy(row, sourceId));
+  // Parse each definition once (fail-closed), then check the single sourceId.
+  return allInsights.filter((row) =>
+    definitionRefers(parseRowDefinition(row), sourceId),
+  );
 }
 
 /**
@@ -1669,9 +1693,12 @@ async function deleteDataSourceDependents(
   const orphanedNodes: OrphanedNode[] = [];
   for (const row of allInsights) {
     if (seen.has(row.id)) continue;
+    // Parse each insight's definition ONCE (fail-closed), then compare the
+    // parsed result against every owned table — not re-parsing per table.
+    const def = parseRowDefinition(row);
     // Check primary source and all join dependencies against every owned table.
     const orphaned = [...ownedTableIds].some((tableId) =>
-      isOrphanedBy(row, tableId),
+      definitionRefers(def, tableId),
     );
     if (orphaned) {
       seen.add(row.id);

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
         "@types/bun": "^1.2.0",
+        "drizzle-orm": "^0.45.1",
         "esbuild": "^0.28.0",
         "typescript": "5.7.2",
         "vitest": "^4.1.6",


### PR DESCRIPTION
## Summary

- Guards the two insight READ-walker functions that were bare-casting `row.definition` to `StoredInsightDefinition` without validation — the READ-side mirror of the write-sink guard added by YW-290 (#144).
- `wouldCreateCycle` now calls `storedInsightDefinitionSchema.safeParse` before walking the source chain; a corrupt intermediate node throws `"Insight <id> has a corrupt definition"` instead of crashing on `def.source` property access.
- `isOrphanedBy` same fix; fail-closed aborts the entire delete-path scan rather than silently mis-classifying orphans or crashing.
- Both sites reuse the existing `storedInsightDefinitionSchema` and the same pattern as `requireInsightDefinition` — identical error message format, same Zod schema, same posture.
- JSDoc updates on both functions document the throw-on-corrupt behavior so the fail-closed trade-off is explicit.
- 3 new tests: `SetInsightSource → wouldCreateCycle`, `DeleteNode(DataTable) → isOrphanedBy`, `DeleteNode(DataSource) → isOrphanedBy`.

## Context

YW-290 (#144) established the sink-guard principle (validate at the point of USE, never trust provenance from the DB) and added `storedInsightDefinitionSchema` for all WRITE paths. `wouldCreateCycle` and `isOrphanedBy` are the two READ-side walkers that were missed — they both read `row.definition` and bare-cast it, relying on the DB having written a valid shape. This PR closes that gap.

## Test plan

- [x] `bun run --filter "@dashframe/server" test` — 242/242 pass (239 pre-existing + 3 new)
- [x] `bun run --filter "@dashframe/server" typecheck` — clean
- [x] `bun run --filter "@dashframe/server" lint` — clean
- [x] `prettier --check` — clean
- [x] `wystack-agent-kit:code-review` (opus, high effort) — 2 MUSTs found and fixed; 4 SUGGESTs addressed
- [x] `wystack-agent-kit:qa` — all 5 contracts pass (wouldCreateCycle guard, isOrphanedBy via DataTable delete, isOrphanedBy via DataSource delete, happy-path cycle detection, happy-path orphan detection)

## Tracked internally as YW-293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Guards the two insight READ-walker functions (`wouldCreateCycle` and the orphan scan) against corrupt `definition` blobs by replacing bare `as StoredInsightDefinition` casts with `storedInsightDefinitionSchema.safeParse`, closing the READ-side gap left open when write-path validation was added in PR #144. As a side effect, `isOrphanedBy` is refactored into `parseRowDefinition` (parse-once, fail-closed) and `definitionRefers` (pure comparison), reducing the DataSource-delete scan from O(insights × tables) parses to O(insights).

- `wouldCreateCycle` now throws `"Insight <id> has a corrupt definition"` on any bad node encountered during the walk, aborting rather than crashing on a missing property.
- `isOrphanedBy` is split into `parseRowDefinition` + `definitionRefers`; `deleteDataSourceDependents` parses each insight's definition once and compares the result against all owned tables in a pure loop.
- Four new tests cover: corrupt-blob throw via `SetInsightSource`, corrupt-blob throw via `DeleteNode(DataTable)`, corrupt-blob throw via `DeleteNode(DataSource)`, and a spy-based regression asserting one `safeParse` call per insight regardless of owned-table count.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are defensive guards on existing DB-read paths, no schema or API surface changes, and the new behaviour (throw on corrupt blob) is explicitly tested and documented.

The change replaces silent crash-on-undefined with a clear thrown error; it tightens behaviour rather than loosening it. The refactoring of isOrphanedBy into parseRowDefinition + definitionRefers is mechanical and verified by four targeted new tests, including a spy-based regression for the O(insights × tables) parse issue. No new write paths, no schema migrations, and no callers outside the server package are affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/commands.ts | Replaces bare casts with Zod-validated parsing in wouldCreateCycle and the orphan scan; splits isOrphanedBy into parseRowDefinition (fail-closed) + definitionRefers (pure), fixing an O(insights × tables) re-parse in deleteDataSourceDependents; exports storedInsightDefinitionSchema for test spy coverage |
| apps/server/src/functions/commands.test.ts | Adds 4 new tests covering wouldCreateCycle corrupt-blob throw, findOrphanedInsights corrupt-blob throw (DataTable and DataSource paths), and a spy-based regression for the O(insights × tables) parse fix; wouldCreateCycle test correctly scopes the corrupt update with .where(eq(schema.insights.id, aId)) |
| apps/server/package.json | Adds drizzle-orm as a devDependency to give tests access to the eq() operator for scoped .where() updates without pulling it into the production bundle |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[wouldCreateCycle] -->|row.definition| B{safeParse}
    B -->|success| C[def.source walk]
    B -->|failure| D[throw corrupt definition]
    C -->|sourceType=insight| E[advance to next node]
    C -->|leaf / cycle| F[return true/false]

    G[findOrphanedInsights] -->|each row| H[parseRowDefinition]
    H -->|safeParse| I{valid?}
    I -->|yes| J[definitionRefers pure check]
    I -->|no| K[throw corrupt definition]
    J --> L[filter result]

    M[deleteDataSourceDependents] -->|each insight once| N[parseRowDefinition]
    N -->|safeParse| O{valid?}
    O -->|yes| P[def cached]
    O -->|no| Q[throw corrupt definition]
    P -->|ownedTableIds.some| R[definitionRefers pure N tables]
    R --> S[orphanedNodes]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[wouldCreateCycle] -->|row.definition| B{safeParse}
    B -->|success| C[def.source walk]
    B -->|failure| D[throw corrupt definition]
    C -->|sourceType=insight| E[advance to next node]
    C -->|leaf / cycle| F[return true/false]

    G[findOrphanedInsights] -->|each row| H[parseRowDefinition]
    H -->|safeParse| I{valid?}
    I -->|yes| J[definitionRefers pure check]
    I -->|no| K[throw corrupt definition]
    J --> L[filter result]

    M[deleteDataSourceDependents] -->|each insight once| N[parseRowDefinition]
    N -->|safeParse| O{valid?}
    O -->|yes| P[def cached]
    O -->|no| Q[throw corrupt definition]
    P -->|ownedTableIds.some| R[definitionRefers pure N tables]
    R --> S[orphanedNodes]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): resolve read-walker review ..."](https://github.com/youhaowei/dashframe/commit/f42d76fa119be15706bf192edd65d46aa832ecc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39332421)</sub>

<!-- /greptile_comment -->