### PR TITLE
feat(server): persistent draft controller + ctx.db draft seam [YW-260]

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
     "@types/bun": "^1.2.0",
-    "drizzle-orm": "^0.45.1",
     "esbuild": "^0.28.0",
     "typescript": "5.7.2",
     "vitest": "^4.1.6"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -37,6 +37,7 @@
     "@wystack/db": "workspace:*",
     "@wystack/secret-vault": "workspace:*",
     "@wystack/server": "workspace:*",
+    "drizzle-orm": "^0.45.1",
     "hono": "^4.12.9",
     "zod": "^4.1.12"
   },

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -331,7 +331,7 @@ export function createFallThroughDraftDb(
  *   - AUTHORIZATION. draftId is caller-supplied; a multi-tenant host must
  *     authorize it against the caller (single-user desktop is exempt).
  */
-function withDraftSeam(
+export function withDraftSeam(
   tracked: TrackedDb | DraftTrackedDb,
   context: Record<string, unknown> | undefined,
 ): TrackedDb | DraftTrackedDb {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -38,14 +38,18 @@ import {
   createArrowDataPath,
   type ArrowQueryRunner,
 } from "@dashframe/engine-server/arrow-data-path";
+import { schema } from "@dashframe/server-core";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
+import type { DraftTrackedDb, TrackedDb } from "@wystack/db";
 import {
   isSecretRef,
   type SecretRef,
   type SecretVault,
 } from "@wystack/secret-vault";
 import { createRoutes, createWyStack, type WyStackApp } from "@wystack/server";
+import type { Table } from "drizzle-orm";
+import { getTableName } from "drizzle-orm";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { createHash, timingSafeEqual } from "node:crypto";
@@ -218,19 +222,150 @@ export interface DashframeServer {
 }
 
 /**
- * Build the WyStack app with vault injection and onWrite hook wiring — without
- * starting an HTTP server.
+ * Pull a draft handle out of a handler context. A `draftId` in the context bag
+ * means "execute this write into the draft overlay, not canonical." Returns the
+ * id string, or `undefined` for the no-draft (canonical) path.
+ */
+function draftIdFromContext(
+  context: Record<string, unknown> | undefined,
+): string | undefined {
+  const id = context?.draftId;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+/**
+ * The CLOSED set of canonical table names that have a `<table>__draft` shadow
+ * (the draftable artifact tables). This MIRRORS draft-controller.ts's
+ * DRAFT_SHADOW_TABLES — by the credential-security-boundary design, credential
+ * and project tables (`secret_mappings`, `project_meta`) intentionally have NO
+ * shadow, so a draft read against them must coalesce-read NOTHING and fall
+ * through to canonical (there is no `project_meta__draft` relation to JOIN).
+ * A new artifact table is a schema change, so this static set is authoritative.
+ */
+const DRAFTABLE_TABLE_NAMES: ReadonlySet<string> = new Set([
+  getTableName(schema.dataSources),
+  getTableName(schema.dataTables),
+  getTableName(schema.dataFrames),
+  getTableName(schema.insights),
+  getTableName(schema.visualizations),
+  getTableName(schema.dashboards),
+]);
+
+/**
+ * A draft-scoped db handle that FALLS THROUGH to canonical for non-draftable
+ * tables. `from(table)`/`into(table)` route to the wystack draft overlay only
+ * when `table` has a `<table>__draft` shadow; for a non-draftable table (e.g.
+ * `project_meta`, which has no shadow by the security-boundary design) they
+ * delegate to the base canonical handle, so a handler reading `project_meta`
+ * inside a draft reads canonical instead of failing on a missing
+ * `project_meta__draft` relation.
  *
- * Extracted from `createDashframeServer` so the vault-injection seam (the
- * anti-shadow merge and the short-circuit path) can be driven by direct unit
- * tests without a live socket. `createDashframeServer` calls this internally;
- * tests import and exercise it directly.
+ * This keeps "handlers run UNMODIFIED inside a draft" true: a query like
+ * `projectInfo` (reads only `project_meta`) just works; a command touching
+ * draftable artifacts gets the overlay. The draftable-table POLICY lives here
+ * in DashFrame (which owns the closed shadow set), not in the generic
+ * @wystack/db `withDraft` primitive.
+ *
+ * Shape note: returned as `DraftTrackedDb` because that is the type the seam
+ * yields; both base and draft handles share the `from/into/transaction` surface
+ * handlers use, and `runHandler` already casts to `TrackedDb` (the builder
+ * return-type difference is never observed by a handler).
+ */
+export function createFallThroughDraftDb(
+  base: TrackedDb,
+  draftId: string,
+): DraftTrackedDb {
+  const draft = base.withDraft(draftId);
+  const isDraftable = (table: Table): boolean =>
+    DRAFTABLE_TABLE_NAMES.has(getTableName(table));
+  return {
+    // The draft handle reuses the base tracker's sets, so reads/writes through
+    // EITHER target accumulate into the same tablesRead/tablesWritten — the
+    // call-result shape sees a draftable write and a canonical read alike.
+    tablesRead: draft.tablesRead,
+    tablesWritten: draft.tablesWritten,
+    raw: draft.raw,
+    from(table) {
+      return (
+        isDraftable(table) ? draft.from(table) : base.from(table)
+      ) as ReturnType<DraftTrackedDb["from"]>;
+    },
+    into(table) {
+      return (
+        isDraftable(table) ? draft.into(table) : base.into(table)
+      ) as ReturnType<DraftTrackedDb["into"]>;
+    },
+    transaction: draft.transaction.bind(draft),
+  };
+}
+
+/**
+ * The ctx.db draft seam. When a `draftId` is present in the context,
+ * substitute the `tracked` handle with a draft-scoped overlay so existing
+ * command handlers write into `<table>__draft` (the withDraft write-path)
+ * UNMODIFIED — for DRAFTABLE tables. A read/write to a non-draftable table
+ * (no shadow, e.g. `project_meta`) falls through to canonical so the unmodified
+ * handler does not hit a missing `<table>__draft` relation. The no-draft path
+ * returns `tracked` untouched — byte-identical, zero-overhead.
+ *
+ * `ctx.db` is set from the `tracked` argument inside @wystack/server's
+ * `runHandler` (it always wins over the context bag), so the substitution MUST
+ * happen on the `tracked` argument here, not by injecting a context key.
+ * `withDraft(draftId)` is a pure @wystack/db primitive that accepts any
+ * caller-supplied id.
+ *
+ * CONSUMER CONSTRAINTS — the seam is dormant in this slice (no host injects a
+ * draftId). The host that wires draftId into request context owns these:
+ *   - LOG SYNC. A write mutation reached via raw `app.call({draftId})` lands in
+ *     `<table>__draft` but does NOT append to `draft_command_log`; since publish
+ *     replays only the log, that write is visible in the overlay yet dropped on
+ *     publish. Drafted WRITES must route through `DraftController.appendToDraft`
+ *     (which keeps shadow + log in sync); the seam alone is safe for drafted
+ *     READS (coalesced reads need no log).
+ *   - DRAFTABLE COMMANDS. `withDraft` supports PK-pinned reads/writes
+ *     (`where(eq("id", …))`). A command whose handler filters a shadow table by a
+ *     non-PK column (e.g. delete `data_frames` by `insightId`) is not draftable
+ *     as-is; such paths must be PK-addressed or blocked before drafting.
+ *   - CREDENTIAL SIDE EFFECTS. See draft-controller.ts SECURITY BOUNDARY: a
+ *     credentialed handler's `vault.store` is a real side effect even in a draft.
+ *   - AUTHORIZATION. draftId is caller-supplied; a multi-tenant host must
+ *     authorize it against the caller (single-user desktop is exempt).
+ */
+function withDraftSeam(
+  tracked: TrackedDb | DraftTrackedDb,
+  context: Record<string, unknown> | undefined,
+): TrackedDb | DraftTrackedDb {
+  const draftId = draftIdFromContext(context);
+  if (draftId === undefined) return tracked;
+  // A draft handle has no nested `withDraft`; only a base TrackedDb is scoped.
+  // `call` always passes a fresh base TrackedDb, so this is the live path. The
+  // fall-through wrapper routes non-draftable tables to canonical.
+  return "withDraft" in tracked
+    ? createFallThroughDraftDb(tracked, draftId)
+    : tracked;
+}
+
+/**
+ * Build the WyStack app with the draft seam, vault injection, and the
+ * onWrite hook — without starting an HTTP server.
+ *
+ * Extracted from `createDashframeServer` so the seams (the anti-shadow vault
+ * merge, the draft-scoped db substitution) can be driven by direct unit tests
+ * without a live socket. `createDashframeServer` calls this internally; tests
+ * import and exercise it directly.
  *
  * Security invariant: `vault` is injected into every handler context via a
  * static spread that wins over per-call context. The merge order
  * `{ ...(context ?? {}), ...staticContext }` means the vault key cannot be
  * shadowed by a caller-supplied context — the vault identity is fixed for the
  * lifetime of the returned app.
+ *
+ * Draft seam: when the per-request context carries a `draftId`, `call`/
+ * `runHandler` substitute the tracked handle with a draft-scoped one that routes
+ * DRAFTABLE-table reads/writes through the `<table>__draft` overlay and falls
+ * through to canonical for non-draftable tables (project_meta, secrets — no
+ * shadow by the credential-security boundary). A context with NO draftId is
+ * unchanged — the canonical path is byte-identical (zero-overhead).
  *
  * onWrite/runHandler asymmetry — INTENTIONAL and load-bearing:
  *
@@ -243,26 +378,23 @@ export interface DashframeServer {
  *      executes handlers then forces a transaction rollback; nothing persists, so
  *      `onWrite` must NOT fire.
  *
- *   2. `draftLifecycle.append(draftId, batch)` — routes writes through a
- *      `base.withDraft(draftId)` handle, so every `ctx.db.into/update/delete`
- *      lands in `<table>__draft` shadow tables. Draft writes are not canonical;
- *      `onWrite` drives canonical snapshot persistence and must NOT fire for
- *      draft-overlay writes.
+ *   2. The draft controller's `appendToDraft` — routes writes through a
+ *      `withDraft(draftId)` handle, so every `ctx.db.into/update/delete` lands in
+ *      `<table>__draft` shadow tables. Draft writes are not canonical; `onWrite`
+ *      drives canonical snapshot persistence and must NOT fire for draft-overlay
+ *      writes.
  *
- * `draftLifecycle` is not yet wired into the DashFrame server (the draft
- * overlay substrate landed in recent wystack + server-core work; route
- * integration is a future ticket). When it is wired,
- * the `publish` method calls `applyCommands(app, boundLog, { mode: 'commit' })`
- * and returns a `CommitResult` with `tablesWritten`. OBLIGATION: the caller that
- * wires `publish` into a server route MUST fire `onWrite()` when
- * `result.tablesWritten.size > 0` — the lifecycle does not fire it (by design;
- * it is a generic WyStack primitive with no DashFrame dependency). Adding
- * `onWrite` to this `runHandler` wrapper cannot safely cover that future path
- * because: (a) preview also uses canonical `TrackedDb` handles that look
- * identical at this level, and (b) `runHandler` is called per-command while
- * `tablesWritten` accumulates across the batch — the per-command check would
- * fire multiple times or miss the first-write-only case. The clean seam is the
- * `publish` return site, not here.
+ * When the controller's `publishDraft` replays the log via
+ * `applyCommands(app, log, { mode: 'commit' })` and returns a `CommitResult` with
+ * `tablesWritten`, OBLIGATION: the caller that wires `publishDraft` into a server
+ * route MUST fire `onWrite()` when `result.tablesWritten.size > 0` — the
+ * controller does not fire it (mirroring `applyCommands`' posture). Adding
+ * `onWrite` to this `runHandler` wrapper cannot safely cover that path because:
+ * (a) preview also uses canonical `TrackedDb` handles that look identical at this
+ * level, and (b) `runHandler` is called per-command while `tablesWritten`
+ * accumulates across the batch — the per-command check would fire multiple times
+ * or miss the first-write-only case. The clean seam is the `publishDraft` return
+ * site, not here.
  */
 export async function buildDashframeApp(opts: {
   db: object;
@@ -278,40 +410,55 @@ export async function buildDashframeApp(opts: {
   const staticContext: Record<string, unknown> = vault != null ? { vault } : {};
   const hasStaticContext = Object.keys(staticContext).length > 0;
 
-  return vault == null && onWrite == null
-    ? rawApp
-    : {
-        ...rawApp,
-        async call(path, args, context) {
-          // Static context wins over per-request context: spread per-request
-          // first so that static keys (vault) cannot be shadowed by a crafted
-          // request context. The vault identity must be fixed for the server
-          // lifetime; a request-supplied vault key would be ignored.
-          const merged = hasStaticContext
-            ? { ...(context ?? {}), ...staticContext }
-            : context;
-          const result = await rawApp.call(path, args, merged);
-          if (onWrite != null && result.tablesWritten.size > 0) {
-            try {
-              onWrite();
-            } catch (err) {
-              console.error("[dashframe] onWrite hook threw:", err);
-            }
-          }
-          return result;
-        },
-        // runHandler: vault injection only — no onWrite. See the function-level
-        // comment for the full rationale; short form: all current production
-        // callers are either preview (rollback) or draft-overlay (non-canonical).
-        // When draftLifecycle.publish is wired into a server route, THAT site
-        // must fire onWrite on CommitResult.tablesWritten — not here.
-        async runHandler(path, args, tracked, context) {
-          const merged = hasStaticContext
-            ? { ...(context ?? {}), ...staticContext }
-            : context;
-          return rawApp.runHandler(path, args, tracked, merged);
-        },
+  // The draft seam wraps `call` itself (not just runHandler): `rawApp.call`
+  // mints its own fresh TrackedDb internally, so a draftId-bearing `call` would
+  // otherwise hit canonical. We mirror rawApp.call's composition (fresh tracked
+  // → runHandler → result shape) but pass the draft-scoped handle when a draftId
+  // is present, leaving the no-draft path identical to rawApp.call.
+  //
+  // EQUIVALENCE (load-bearing): rawApp.call is a THIN composition — `const t =
+  // createTracked(); const result = await runHandler(path, args, t, context);
+  // return { result, tablesRead: t.tablesRead, tablesWritten: t.tablesWritten }`
+  // — with no retry, no error normalization, no separate tablesRead pass (see
+  // @wystack/server create.ts). This decomposition reproduces it byte-for-byte
+  // on the no-draft path. RE-MIRROR POINT: if a wystack upgrade adds logic INSIDE
+  // rawApp.call, this wrapper must be updated to match — it cannot delegate to
+  // rawApp.call because that path mints an internal tracker the seam can't reach.
+  return {
+    ...rawApp,
+    async call(path, args, context) {
+      // Static context wins over per-request context: spread per-request first
+      // so static keys (vault) cannot be shadowed by a crafted request context.
+      const merged = hasStaticContext
+        ? { ...(context ?? {}), ...staticContext }
+        : (context ?? {});
+      const tracked = rawApp.createTracked();
+      const effective = withDraftSeam(tracked, merged);
+      const result = await rawApp.runHandler(path, args, effective, merged);
+      // `tracked` and `effective` share the same tracker sets (withDraft reuses
+      // the base tracker), so tablesWritten reflects the write either way.
+      const tablesWritten = tracked.tablesWritten;
+      if (onWrite != null && tablesWritten.size > 0) {
+        try {
+          onWrite();
+        } catch (err) {
+          console.error("[dashframe] onWrite hook threw:", err);
+        }
+      }
+      return {
+        result,
+        tablesRead: tracked.tablesRead,
+        tablesWritten,
       };
+    },
+    async runHandler(path, args, tracked, context) {
+      const merged = hasStaticContext
+        ? { ...(context ?? {}), ...staticContext }
+        : (context ?? {});
+      const effective = withDraftSeam(tracked, merged);
+      return rawApp.runHandler(path, args, effective, merged);
+    },
+  };
 }
 
 export async function createDashframeServer(
@@ -505,4 +652,8 @@ function tokenMatches(actual: string, expected: string): boolean {
   return timingSafeEqual(actualBytes, expectedBytes);
 }
 
+export {
+  createDraftController,
+  type DraftController,
+} from "./draft-controller";
 export type { Functions } from "./functions";

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -33,6 +33,7 @@ import {
   buildDashframeApp,
   createDraftController,
   createFallThroughDraftDb,
+  withDraftSeam,
 } from "./app";
 import { cmd } from "./functions/commands";
 
@@ -557,6 +558,68 @@ describe("DraftController (persisted draft overlay)", () => {
         source: { sourceType: "dataTable", sourceId: tableId },
       }),
     );
+    expect(
+      (await db.select().from(insights)).find((r) => r.id === insightId),
+    ).toBeUndefined();
+    expect(
+      (await db.select().from(insightsDraft)).filter(
+        (r) => r.draftId === draftId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("appendToDraft routes through the fall-through seam — the append path uses the SAME base+draftId-context mechanism the call path does (non-draftable reads fall through)", async () => {
+    // Regression: appendToDraft must NOT pre-build a raw `withDraft(draftId)`
+    // handle (which `withDraftSeam` returns unchanged — no fall-through), or a
+    // command handler reading a non-draftable table mid-append would throw on the
+    // missing `<table>__draft` relation. It must pass a BASE TrackedDb + draftId
+    // in context so `withDraftSeam` builds the per-table fall-through wrapper —
+    // the identical seam the `call` path funnels through.
+    //
+    // This pins the exact mechanism appendToDraft now relies on: feed a base
+    // handle + `{ draftId }` to `withDraftSeam` (what app.runHandler does for a
+    // drafted append) and confirm the resulting handle reads a non-draftable
+    // table (project_meta) from canonical without throwing, while a draftable
+    // table is overlay-scoped.
+    const metaId = id();
+    await db.insert(projectMeta).values({
+      id: metaId,
+      version: "0.2.0",
+      projectId: id(),
+      name: "Append-path project",
+      schemaVersion: 3,
+      createdBy: "test",
+    });
+
+    const draftId = await controller.openDraft();
+    // Exactly what appendToDraft feeds runHandler: base handle + draftId-context.
+    const baseDb = app.createTracked();
+    const seamDb = withDraftSeam(baseDb, { draftId });
+
+    // The seam must have built a fall-through draft handle (NOT returned the base
+    // unchanged, NOT a raw draft handle that throws on project_meta).
+    let row: unknown;
+    await expect(
+      (async () => {
+        row = await seamDb.from(projectMeta).first();
+      })(),
+    ).resolves.toBeUndefined(); // did not throw on missing project_meta__draft
+    expect((row as { id?: unknown })?.id).toBe(metaId);
+
+    // A draftable write through the SAME seam handle lands in the shadow (overlay
+    // scoping intact), proving it is the fall-through wrapper, not bare canonical.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Append-routed",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    // The insight written via appendToDraft is isolated in the shadow (the append
+    // path's overlay write-path still works end-to-end through the new seam).
     expect(
       (await db.select().from(insights)).find((r) => r.id === insightId),
     ).toBeUndefined();

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -1,0 +1,657 @@
+/**
+ * DraftController — the persistent draft lifecycle.
+ *
+ * These tests pin the load-bearing contracts of the copy-on-write draft overlay
+ * against a REAL artifact DB (PGlite), exercising the controller exactly as a
+ * host would: open a draft, write through NORMAL command handlers (the same
+ * `cmd(...)` vocabulary the UI and agent emit — proven isolated by routing
+ * through `ctx.db` with a draftId in context), then publish or discard.
+ *
+ * Contracts under test:
+ *   - Isolation      — a draft write is invisible in canonical until publish.
+ *   - Persistence    — the draft survives a simulated process restart (close +
+ *                      reopen the DB, rebuild app + controller from scratch).
+ *   - Atomic publish — replaying the log lands all rows on canonical at once.
+ *   - Discard        — drops the draft's deltas; canonical is untouched.
+ *   - Sparse overlay — a draft over a large canonical set stores ONLY the
+ *                      touched rows in `<table>__draft`, never a full copy.
+ */
+import {
+  dataSourcesDraft,
+  draftCommandLog,
+  insightsDraft,
+  openArtifactDb,
+  schema,
+} from "@dashframe/server-core";
+import type { Command } from "@wystack/server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildDashframeApp,
+  createDraftController,
+  createFallThroughDraftDb,
+} from "./app";
+import { cmd } from "./functions/commands";
+
+const { insights, dataSources, projectMeta } = schema;
+
+describe("DraftController (persisted draft overlay)", () => {
+  let dir: string;
+  let dbPath: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: Awaited<ReturnType<typeof buildDashframeApp>>;
+  let controller: ReturnType<typeof createDraftController>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-draft-"));
+    dbPath = join(dir, "artifacts.db");
+    ({ db, app, controller } = await openStack(dbPath));
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Open the full stack (db + app with the draft seam + controller) at a path. */
+  async function openStack(path: string) {
+    const openedDb = await openArtifactDb({ path });
+    const builtApp = await buildDashframeApp({ db: openedDb });
+    return {
+      db: openedDb,
+      app: builtApp,
+      controller: createDraftController(builtApp, openedDb),
+    };
+  }
+
+  function id(): string {
+    return crypto.randomUUID();
+  }
+
+  /** Append a batch to a draft via the controller's normal applyCommands seam. */
+  async function appendCmds(draftId: string, ...commands: Command[]) {
+    return controller.appendToDraft(draftId, commands);
+  }
+
+  /** Seed a DataSource + DataTable on CANONICAL (the draft's base). */
+  async function seedTable(
+    target: ReturnType<typeof createDraftController>,
+  ): Promise<{ sourceId: string; tableId: string }> {
+    const sourceId = id();
+    const tableId = id();
+    // Publish a tiny draft to land the base rows on canonical without a separate
+    // canonical-write path — keeps the test using only the controller's surface.
+    const seed = await target.openDraft();
+    await target.appendToDraft(seed, [
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "T",
+        table: "t.csv",
+      }),
+    ]);
+    await target.publishDraft(seed);
+    return { sourceId, tableId };
+  }
+
+  async function canonicalInsights() {
+    return db.select().from(insights);
+  }
+  async function draftInsightRows(draftId: string) {
+    const rows = await db.select().from(insightsDraft);
+    return rows.filter((r) => r.draftId === draftId);
+  }
+  async function draftDataSourceRows(draftId: string) {
+    const rows = await db.select().from(dataSourcesDraft);
+    return rows.filter((r) => r.draftId === draftId);
+  }
+
+  it("isolates a draft write — invisible in canonical until publish", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Draft insight",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Canonical does NOT see the draft insight.
+    const canonical = await canonicalInsights();
+    expect(canonical.find((r) => r.id === insightId)).toBeUndefined();
+
+    // The draft overlay DOES hold it (the shadow row exists, scoped to draftId).
+    const shadow = await draftInsightRows(draftId);
+    expect(shadow).toHaveLength(1);
+    expect(shadow[0]?.id).toBe(insightId);
+    expect(shadow[0]?.name).toBe("Draft insight");
+  });
+
+  it("survives a simulated reload — the draftId is the durable handle", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Persisted insight",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Simulate a process restart: close the DB, drop the in-memory app +
+    // controller (and wystack's ephemeral lifecycle Map with them), reopen the
+    // SAME file, rebuild the stack from scratch.
+    await db.$client.close();
+    ({ db, controller } = await openStack(dbPath));
+
+    // The persisted command log survived — the reopened controller reads it.
+    const log = await controller.getDraftLog(draftId);
+    expect(log).toHaveLength(1);
+    expect(log[0]?.path).toBeTruthy();
+
+    // The shadow row survived too — still isolated from canonical.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId),
+    ).toBeUndefined();
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+
+    // Publishing the REHYDRATED draft (cold path) lands it on canonical.
+    await controller.publishDraft(draftId);
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId)?.name,
+    ).toBe("Persisted insight");
+  });
+
+  it("publishes atomically — the whole log lands on canonical, then the draft is gone", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightA = id();
+    const insightB = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightA,
+        name: "A",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightB,
+        name: "B",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    const result = await controller.publishDraft(draftId);
+
+    // Both insights landed on canonical.
+    const canonical = await canonicalInsights();
+    expect(canonical.find((r) => r.id === insightA)?.name).toBe("A");
+    expect(canonical.find((r) => r.id === insightB)?.name).toBe("B");
+    // The publish reported the canonical table it wrote (host flushes this to
+    // invalidation). `insights` is the canonical name, not the shadow.
+    expect(result.tablesWritten.has("insights")).toBe(true);
+
+    // The draft is fully torn down: no shadow rows, no command-log rows.
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(0);
+  });
+
+  it("discards a draft — canonical is left untouched", async () => {
+    const { tableId } = await seedTable(controller);
+    const before = await canonicalInsights();
+
+    const draftId = await controller.openDraft();
+    // Touch TWO distinct shadow tables (data_sources__draft + insights__draft) so
+    // the sweep is proven across more than one entry of the closed set — a sweep
+    // bug on any single shadow table would otherwise hide behind insights-only.
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "Throwaway src" }),
+      cmd("CreateInsight", {
+        id: id(),
+        name: "Throwaway",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    // The draft holds a row in BOTH shadow tables before discard.
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(1);
+
+    await controller.discardDraft(draftId);
+
+    // Canonical insights are byte-identical to before the draft existed.
+    const after = await canonicalInsights();
+    expect(after).toHaveLength(before.length);
+    // The draft's deltas are gone across BOTH shadow tables AND the command log.
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(0);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(0);
+  });
+
+  it("does NOT draft when no draftId is in context — the seam writes straight to canonical", async () => {
+    // The negative half of the seam contract: withDraftSeam must return the base
+    // tracked handle untouched when context has no draftId, so an ordinary RPC
+    // (`app.call` with an empty context) lands on CANONICAL, never a shadow. A
+    // regression in draftIdFromContext that minted a spurious id would silently
+    // redirect canonical writes into a dangling shadow — this catches that.
+    const sourceId = id();
+    const create = cmd("CreateDataSource", {
+      id: sourceId,
+      type: "csv",
+      name: "Direct",
+    });
+    await app.call(create.path, create.args, {});
+
+    // Landed on canonical.
+    const canonical = await db.select().from(dataSources);
+    expect(canonical.find((r) => r.id === sourceId)).toBeDefined();
+    // No shadow row exists for ANY draft (the no-draft path never touches a shadow).
+    expect(await db.select().from(dataSourcesDraft)).toHaveLength(0);
+  });
+
+  it("re-seqs the durable log across appends — replace-all, never append-only-duplicate (writeLog bookkeeping)", async () => {
+    // The controller's load-bearing novelty over wystack's in-memory lifecycle is
+    // that `draft_command_log` is a MATERIALIZED projection: each append re-runs
+    // compactLog over the full history and REPLACE-ALLs the draftId's rows with a
+    // dense 0..n re-seq. This pins that bookkeeping — a second append must not
+    // leave the first batch's rows orphaned (append-only) or duplicated; the log
+    // must equal the full ordered history exactly once.
+    const { tableId } = await seedTable(controller);
+    const draftId = await controller.openDraft();
+
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: id(),
+        name: "First",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: id(),
+        name: "Second",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // The persisted log holds exactly the two commands, in order — not 1 (lost),
+    // not 3+ (the first batch re-inserted alongside a stale copy).
+    const log = await controller.getDraftLog(draftId);
+    expect(log).toHaveLength(2);
+    expect(log.map((c) => c.path)).toEqual([
+      cmd("CreateInsight", {
+        id: id(),
+        name: "x",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }).path,
+      cmd("CreateInsight", {
+        id: id(),
+        name: "y",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }).path,
+    ]);
+
+    // The raw rows carry a dense 0..n seq (the unique (draft_id, seq) index is
+    // satisfied only if the re-seq is dense and the replace-all ran).
+    const rows = (await db.select().from(draftCommandLog))
+      .filter((r) => r.draftId === draftId)
+      .sort((a, b) => a.seq - b.seq);
+    expect(rows.map((r) => r.seq)).toEqual([0, 1]);
+  });
+
+  it("coalesces a jsonb column + PK-pinned read INSIDE a draft — a draft-only row is read back through the seam (gap-1 + gap-2)", async () => {
+    // This is the regression that bb9b745 fixed end-to-end through the controller:
+    //   gap-1 — the draft write-path bypassed the jsonb codec, so a jsonb column
+    //           (insights.definition) did not round-trip through <table>__draft.
+    //   gap-2 — a PK-pinned draft read (`from(t).where(eq("id",x)).first()`) did
+    //           not pin the draft row, so a handler reading a draft-only artifact
+    //           by id saw nothing.
+    // SetInsightSource exercises BOTH at once: it does a PK-pinned read of the
+    // insight's jsonb `definition` (requireInsightDefinition → from(insights)
+    // .where(eq("id",id)).first()), mutates it, and writes the jsonb back —
+    // entirely on a row that exists ONLY in the draft shadow. If either fix
+    // were absent the handler would throw "Insight not found" (gap-2) or write a
+    // corrupt/empty definition (gap-1).
+    const { tableId } = await seedTable(controller);
+    // A second canonical DataTable to re-point the source to.
+    const sourceId2 = id();
+    const tableId2 = id();
+    const seed2 = await controller.openDraft();
+    await controller.appendToDraft(seed2, [
+      cmd("CreateDataSource", { id: sourceId2, type: "csv", name: "S2" }),
+      cmd("CreateDataTable", {
+        id: tableId2,
+        dataSourceId: sourceId2,
+        name: "T2",
+        table: "t2.csv",
+      }),
+    ]);
+    await controller.publishDraft(seed2);
+
+    const insightId = id();
+    const draftId = await controller.openDraft();
+    // Create the insight INSIDE the draft (so it lives only in the shadow), with
+    // its jsonb `definition.source` pointed at table 1.
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Composed",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Re-point the source in a SEPARATE batch. SetInsightSource must PK-read the
+    // draft-only insight's jsonb definition (gap-2 + gap-1 read) before writing.
+    // A broken primitive throws here.
+    await appendCmds(
+      draftId,
+      cmd("SetInsightSource", {
+        id: insightId,
+        source: { sourceType: "dataTable", sourceId: tableId2 },
+      }),
+    );
+
+    // The shadow row's jsonb `definition` coalesced and round-tripped: the
+    // re-point landed, proving the jsonb codec ran on the draft write-path.
+    const shadow = await draftInsightRows(draftId);
+    expect(shadow).toHaveLength(1);
+    const def = shadow[0]?.definition as {
+      source?: { sourceId?: string };
+      baseTableId?: string;
+    };
+    expect(def?.source?.sourceId).toBe(tableId2);
+    expect(def?.baseTableId).toBe(tableId2);
+    // Canonical never saw the draft-only insight.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId),
+    ).toBeUndefined();
+
+    // Publishing replays the (compacted) log onto canonical; the final jsonb
+    // definition lands intact (end-to-end through the publish path too).
+    await controller.publishDraft(draftId);
+    const published = (await canonicalInsights()).find(
+      (r) => r.id === insightId,
+    );
+    const pubDef = published?.definition as { source?: { sourceId?: string } };
+    expect(pubDef?.source?.sourceId).toBe(tableId2);
+  });
+
+  it("cold-publishes from the durable log alone — a fresh stack with no in-memory state lands identically", async () => {
+    // The warm publish (other tests) replays the same in-process append state.
+    // This pins the COLD path: the appending process is gone; publish reads the
+    // log fresh off disk and replays. The brief's load-bearing claim — publish
+    // never forks on whether the opening process is alive — lives here.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Cold",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Drop ALL in-memory state: close the db, rebuild the stack from the file.
+    await db.$client.close();
+    ({ db, controller } = await openStack(dbPath));
+
+    // Publish reads the log fresh (no append happened in THIS process) and replays.
+    const result = await controller.publishDraft(draftId);
+    expect(result.tablesWritten.has("insights")).toBe(true);
+
+    // Canonical has the row; shadow + log are swept — identical to a warm publish.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId)?.name,
+    ).toBe("Cold");
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(0);
+  });
+
+  it("publishes to CANONICAL even when a draftId leaks into the publish context — the replay is never re-drafted", async () => {
+    // applyCommands dispatches the replay through the (wrapped) runHandler, which
+    // re-applies withDraftSeam from the publish context. If a consumer forwards a
+    // request context that still carries `draftId`, an un-stripped publish would
+    // re-scope the replay into <table>__draft and then dropDraft would sweep it —
+    // the publish would silently land nothing on canonical. publishDraft must
+    // strip draftId so the replay is unambiguously canonical.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Leaky-ctx",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Publish with a HOSTILE context that echoes the same draftId (simulating a
+    // consumer that forwards the request context verbatim).
+    await controller.publishDraft(draftId, { draftId });
+
+    // The row landed on CANONICAL — not lost into the shadow.
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId)?.name,
+    ).toBe("Leaky-ctx");
+    // And the draft is fully torn down (publish succeeded, not a phantom).
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+  });
+
+  it("is a SPARSE overlay — a draft over many canonical rows stores only touched rows", async () => {
+    // Seed a "large" canonical set: 10 insights on canonical.
+    const { tableId } = await seedTable(controller);
+    const seededIds: string[] = [];
+    const seed = await controller.openDraft();
+    const seedCmds: Command[] = [];
+    for (let i = 0; i < 10; i++) {
+      const iid = id();
+      seededIds.push(iid);
+      seedCmds.push(
+        cmd("CreateInsight", {
+          id: iid,
+          name: `Insight ${i}`,
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+    }
+    await controller.appendToDraft(seed, seedCmds);
+    await controller.publishDraft(seed);
+    expect(await canonicalInsights()).toHaveLength(10);
+
+    // Open a draft and touch exactly ONE of the 10 canonical insights.
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("RenameNode", {
+        id: seededIds[0]!,
+        name: "Touched",
+      }),
+    );
+
+    // The shadow holds ONLY the one touched row — NOT a full copy of all 10.
+    const shadow = await draftInsightRows(draftId);
+    expect(shadow).toHaveLength(1);
+    expect(shadow[0]?.id).toBe(seededIds[0]);
+
+    // The other 9 canonical insights have no shadow row for this draft.
+    const allShadow = await db.select().from(insightsDraft);
+    expect(allShadow.filter((r) => r.draftId === draftId)).toHaveLength(1);
+  });
+
+  it("reads a NON-DRAFTABLE table (project_meta) inside a draft — falls through to canonical, no missing-shadow throw", async () => {
+    // project_meta has NO `__draft` shadow by the credential-security-boundary
+    // design. A handler reading it inside a draftId context must coalesce-read
+    // NOTHING and fall through to canonical — NOT fail on a missing
+    // `project_meta__draft` relation. The fall-through draft handle (what the
+    // seam yields when a draftId is present) routes non-draftable tables to the
+    // base canonical handle.
+    const draftId = await controller.openDraft();
+    const draftDb = createFallThroughDraftDb(app.createTracked(), draftId);
+
+    // Seed a canonical project_meta row (openArtifactDb materializes the table
+    // but openProject is what normally seeds the row). Reading it through the
+    // draft handle must return THIS canonical row, not throw on a missing
+    // `project_meta__draft` relation.
+    const metaId = id();
+    await db.insert(projectMeta).values({
+      id: metaId,
+      version: "0.2.0",
+      projectId: id(),
+      name: "Test project",
+      schemaVersion: 3,
+      createdBy: "test",
+    });
+    const canonicalRow = (await db.select().from(projectMeta))[0];
+    expect(canonicalRow).toBeDefined();
+
+    let row: unknown;
+    await expect(
+      (async () => {
+        row = await draftDb.from(projectMeta).first();
+      })(),
+    ).resolves.toBeUndefined(); // i.e. did not throw
+    expect((row as { id?: unknown })?.id).toBe(metaId);
+
+    // And a DRAFTABLE table still routes to the overlay (sanity: the wrapper is
+    // not just delegating everything to canonical). A draft insert lands in the
+    // shadow, invisible to canonical.
+    const insightId = id();
+    const { tableId } = await seedTable(controller);
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Drafted",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    expect(
+      (await db.select().from(insights)).find((r) => r.id === insightId),
+    ).toBeUndefined();
+    expect(
+      (await db.select().from(insightsDraft)).filter(
+        (r) => r.draftId === draftId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("round-trips the command correlation id through the durable log — warm AND cold publish echo it", async () => {
+    // Command.id is the opaque correlation handle a consumer uses to match a
+    // CommitResult back to the command that produced it. The persisted log must
+    // carry it so publish (which replays the REHYDRATED log, even without a
+    // restart) echoes the same id — not undefined.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+    const correlationId = `corr-${id()}`;
+
+    const draftId = await controller.openDraft();
+    // A command carrying an explicit correlation id.
+    const create: Command = {
+      id: correlationId,
+      ...cmd("CreateInsight", {
+        id: insightId,
+        name: "Correlated",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    };
+    await controller.appendToDraft(draftId, [create]);
+
+    // The persisted log preserved the correlation id.
+    const log = await controller.getDraftLog(draftId);
+    expect(log).toHaveLength(1);
+    expect(log[0]?.id).toBe(correlationId);
+
+    // Warm publish (same process) replays the rehydrated log; its result echoes
+    // the correlation id, not undefined.
+    const result = await controller.publishDraft(draftId);
+    expect(result.results.map((r) => r.id)).toContain(correlationId);
+  });
+
+  it("preserves the command id across a cold publish — rehydrated from the durable log alone", async () => {
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+    const correlationId = `corr-${id()}`;
+
+    const draftId = await controller.openDraft();
+    await controller.appendToDraft(draftId, [
+      {
+        id: correlationId,
+        ...cmd("CreateInsight", {
+          id: insightId,
+          name: "Cold-correlated",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      },
+    ]);
+
+    // Drop in-memory state: close + rebuild the stack from the file.
+    await db.$client.close();
+    ({ db, app, controller } = await openStack(dbPath));
+
+    // The cold publish reads the log fresh; the correlation id survives because
+    // it was persisted alongside path/args.
+    const result = await controller.publishDraft(draftId);
+    expect(result.results.map((r) => r.id)).toContain(correlationId);
+  });
+
+  it("snapshots each command before persisting — a caller mutating args after append does not corrupt the durable log", async () => {
+    // appendToDraft runs the handler against the live command, then persists a
+    // DEEP COPY of what ran. If the caller mutates the command/args afterward,
+    // the durable log must still replay the command as it actually executed.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    const mutable = cmd("CreateInsight", {
+      id: insightId,
+      name: "Original",
+      source: { sourceType: "dataTable", sourceId: tableId },
+    });
+    await controller.appendToDraft(draftId, [mutable]);
+
+    // Mutate the command's args AFTER the append returned (simulating a caller
+    // reusing/mutating the object). The persisted log must be unaffected.
+    (mutable.args as { name: string }).name = "Mutated-after-append";
+
+    const log = await controller.getDraftLog(draftId);
+    expect((log[0]?.args as { name?: string })?.name).toBe("Original");
+
+    // And the published canonical row reflects what RAN, not the later mutation.
+    await controller.publishDraft(draftId);
+    expect(
+      (await db.select().from(insights)).find((r) => r.id === insightId)?.name,
+    ).toBe("Original");
+  });
+});

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -286,11 +286,17 @@ export function createDraftController(
     },
 
     async appendToDraft(draftId, batch, context = {}) {
-      // Route writes through the draft handle so each handler's `ctx.db.into/
-      // update/delete` lands in `<table>__draft` (the withDraft write-path),
-      // exactly as createDraftLifecycle.append does — the controller drives the
-      // path, it never authors a shadow-table write.
-      const draftDb = app.createTracked().withDraft(draftId);
+      // Route writes through the draft overlay by passing a BASE TrackedDb plus a
+      // `draftId` in context, so `app.runHandler`'s `withDraftSeam` builds the
+      // per-table FALL-THROUGH draft handle (draftable tables → `<table>__draft`,
+      // non-draftable like project_meta → canonical). Building the raw
+      // `createTracked().withDraft(draftId)` here would bypass that wrapper —
+      // `withDraftSeam` returns an already-draft handle unchanged — so a command
+      // whose handler reads a non-draftable table would throw on the missing
+      // `<table>__draft` relation. Both withDraft entry points (call/runHandler
+      // and this append) must go through the same fall-through seam.
+      const baseDb = app.createTracked();
+      const draftContext = { ...context, draftId };
       const results: CommandResult[] = [];
       // Snapshot each command AS IT SUCCESSFULLY RUNS, before compaction/persist.
       // The handler runs against the live `cmd` (what actually executed); the
@@ -305,8 +311,8 @@ export function createDraftController(
         const value = await app.runHandler(
           cmd.path,
           cmd.args,
-          draftDb,
-          context,
+          baseDb,
+          draftContext,
         );
         ranSnapshots.push(structuredClone(cmd) as DraftCommand);
         results.push({ id: cmd.id, value });

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -1,0 +1,380 @@
+/**
+ * DraftController — the PERSISTENT draft lifecycle.
+ *
+ * The draft system has three legs (per @wystack/server's draft-lifecycle.ts):
+ *   1. Read overlay  — `withDraft(draftId)` coalesce (canonical ⊕ delta). READ.
+ *   2. Write storage — `<table>__draft` shadow + a compacted command log. WRITE.
+ *   3. Lifecycle     — open / append / publish / discard. CONDUCTS legs 1 & 2.
+ *
+ * wystack ships leg 3 as `createDraftLifecycle`, but that object holds its log +
+ * touchedTables in an in-memory `Map`: a draft evaporates on process restart and
+ * there is no rehydrate seam (`open()` always mints a fresh id; teardown helpers
+ * are module-private). DashFrame requires a draft that SURVIVES a restart, with
+ * the draftId as the durable handle. So DashFrame owns leg 3 — this controller —
+ * and persists it into the durable artifact tables (`draft_command_log` + the
+ * six `<table>__draft` shadows in @dashframe/server-core).
+ *
+ * This CONDUCTS wystack's mechanism, it does NOT reimplement it. The three
+ * load-bearing primitives are composed verbatim:
+ *   - `withDraft(draftId)` write-path — the ONLY way `<table>__draft` rows are
+ *     written. The controller drives `runHandler(..., draftDb, ...)`; it never
+ *     authors a shadow-table INSERT/UPDATE itself.
+ *   - `compactLog(log)` — wystack's exported net-effect collapse (create+delete
+ *     cancel, last-update-wins, create-kept-with-final-update). Never reimplemented.
+ *   - `applyCommands(app, log, {commit})` — wystack's publish-is-log-replay engine
+ *     (one atomic tracked transaction onto CANONICAL). The same primitive
+ *     `createDraftLifecycle.publish` calls.
+ * What the controller re-expresses is only BOOKKEEPING — where the log lives and
+ * how the shadow is swept — forced by the persistence requirement, not gratuitous.
+ * The crux that makes this clean: `withDraft(draftId)` accepts ANY caller-supplied
+ * draftId (a pure @wystack/db primitive, no coupling to the lifecycle Map), so the
+ * controller mints and owns the handle end to end.
+ *
+ * Durable-log invariant: `draft_command_log` is a MATERIALIZED PROJECTION of
+ * `compactLog(history)`. Each append re-runs `compactLog` over the full log and
+ * REPLACE-ALLs the draftId's rows (re-seq 0..n). The table therefore always holds
+ * exactly the list `applyCommands` will replay, already compacted, in replay order
+ * — one publish source, warm or cold, so publish semantics never fork on whether
+ * the opening process is still alive.
+ *
+ * SECURITY BOUNDARY: credential TABLE STATE is never drafted.
+ * `secret_mappings` and `project_meta` have no shadow; the six shadow tables here
+ * are the closed set, so a drafted write to a credential table has nowhere to
+ * land. NOTE the scope: this closes the at-rest-table channel, NOT a handler's
+ * vault SIDE EFFECT — a credentialed command run inside a draft would still call
+ * `vault.store` for real (not drafted, not swept on discard, re-run on publish).
+ * The seam is dormant in this slice (no host injects a draftId), so this is not
+ * yet live; the consumer that wires draftId into request context must enforce the
+ * credential-side-effect boundary at THAT seam (deny-list credentialed paths in a
+ * draft, or make vault.store draft-aware) before routing untrusted drafts.
+ */
+import {
+  dashboardsDraft,
+  dataFramesDraft,
+  dataSourcesDraft,
+  dataTablesDraft,
+  draftCommandLog,
+  insightsDraft,
+  visualizationsDraft,
+  type ArtifactDb,
+} from "@dashframe/server-core";
+import {
+  applyCommands,
+  compactLog,
+  type Command,
+  type CommandResult,
+  type CommitResult,
+  type DraftCommand,
+  type WyStackApp,
+} from "@wystack/server";
+import { eq, getTableName } from "drizzle-orm";
+
+/**
+ * The closed set of `<table>__draft` shadows a draft can touch. Discard
+ * and post-publish teardown sweep by draftId across exactly these six — a static,
+ * schema-owned set, NOT runtime discovery. A new artifact table is a schema
+ * change, so this list is the authoritative enumeration. Sweeping the full closed
+ * set is strictly more robust than the lifecycle's touchedTables-driven sweep: it
+ * cannot miss a table because a write was never recorded.
+ */
+const DRAFT_SHADOW_TABLES = [
+  dataSourcesDraft,
+  dataTablesDraft,
+  dataFramesDraft,
+  insightsDraft,
+  visualizationsDraft,
+  dashboardsDraft,
+] as const;
+
+/** A persisted log row mapped back to the `DraftCommand` shape replay consumes. */
+function rowToDraftCommand(row: {
+  path: string;
+  args: unknown;
+  cmdId: string | null;
+  compactionKey: string | null;
+  kind: string | null;
+}): DraftCommand {
+  const cmd: DraftCommand = { path: row.path, args: row.args };
+  // Rehydrate the command correlation id so a replay's CommandResult.id matches
+  // the originally-emitted command (warm or cold publish behave identically).
+  if (row.cmdId !== null) cmd.id = row.cmdId;
+  if (row.compactionKey !== null) cmd.compactionKey = row.compactionKey;
+  if (row.kind !== null) cmd.kind = row.kind as DraftCommand["kind"];
+  return cmd;
+}
+
+export interface DraftController {
+  /**
+   * Open a new draft and return its durable handle. No wystack call, no shadow
+   * rows — the draftId is the whole result. `baseVersion` is recorded for a
+   * future conflict-detection pass (out of scope for this mechanism slice); it
+   * is opaque and not inspected here.
+   */
+  openDraft(baseVersion?: unknown): Promise<string>;
+  /**
+   * Apply a batch INSIDE the draft. Routes each command's writes through the
+   * `withDraft(draftId)` write-path into `<table>__draft` (durable), then
+   * materializes the compacted command log into `draft_command_log`.
+   *
+   * The log is the source of truth (publish replays only the log). The per-batch
+   * shadow writes and the log projection are NOT wrapped in one transaction, so
+   * an append interrupted mid-batch (a handler throws, or the process dies before
+   * `writeLog`) can leave shadow rows that the log does not yet reference. Those
+   * orphans are INERT: publish ignores the shadow entirely and `dropDraft` sweeps
+   * the full closed set regardless, so canonical is never corrupted — the draft's
+   * recovery posture is "re-append the full batch" (matches wystack's lifecycle,
+   * which documents the same non-atomic-across-batch contract). The append is
+   * effect-free on canonical until publish.
+   *
+   * SINGLE-WRITER per draftId. `readLog → compactLog → writeLog` (replace-all) is
+   * not atomic, so two concurrent `appendToDraft` calls on the SAME draftId race:
+   * both read the same prior log and the last `writeLog` wins, erasing the other
+   * batch's log rows while its shadow rows linger (then get swept on publish) —
+   * silent command loss. A draft is a single editing session's handle; the
+   * consumer must serialize appends per draftId (do not fan out). When the seam
+   * is wired into a multi-session host, that host owns the per-draft lock.
+   * Returns per-command results (same shape as `applyCommands`).
+   */
+  appendToDraft(
+    draftId: string,
+    batch: DraftCommand[],
+    context?: Record<string, unknown>,
+  ): Promise<CommandResult[]>;
+  /**
+   * Publish = replay the durable command log atomically onto canonical via
+   * `applyCommands(app, log, {commit})`, then sweep the (now-inert) shadow + log.
+   * Reads ONLY `draft_command_log` — never the shadow — so it works identically
+   * whether or not the opening process is still alive. Returns the CommitResult
+   * (`tablesWritten` is what the host flushes to invalidation).
+   */
+  publishDraft(
+    draftId: string,
+    context?: Record<string, unknown>,
+  ): Promise<CommitResult>;
+  /**
+   * Discard = drop the draft's deltas: delete every `<table>__draft` row and
+   * every `draft_command_log` row for this draftId. Canonical is untouched.
+   * Pure DELETE-by-draftId; no wystack call needed.
+   */
+  discardDraft(draftId: string): Promise<void>;
+  /** Read-only peek at a draft's persisted (compacted) command log. */
+  getDraftLog(draftId: string): Promise<Command[]>;
+}
+
+/**
+ * Build the persistent draft controller over a WyStack app + the project's
+ * artifact DB. The app resolves command paths and backs both the shadow writes
+ * (via `withDraft`) and the publish replay; the typed `ArtifactDb` is the durable
+ * store for `draft_command_log` + the shadow sweeps.
+ */
+export function createDraftController(
+  app: WyStackApp,
+  db: ArtifactDb,
+): DraftController {
+  /** Read the draft's persisted command log, ordered for replay. */
+  async function readLog(draftId: string): Promise<DraftCommand[]> {
+    const rows = await db
+      .select({
+        path: draftCommandLog.path,
+        args: draftCommandLog.args,
+        cmdId: draftCommandLog.cmdId,
+        compactionKey: draftCommandLog.compactionKey,
+        kind: draftCommandLog.kind,
+      })
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId))
+      // Order by the durable seq (0..n) — the replace-all dense re-seq in
+      // `writeLog` is what makes this the exact replay order publish consumes.
+      .orderBy(draftCommandLog.seq);
+    return rows.map(rowToDraftCommand);
+  }
+
+  /**
+   * Replace-all the draftId's log rows with `compacted`, re-seq 0..n. Materializes
+   * `compactLog`'s net-effect list so the table always equals what replay consumes
+   * — never append-only (compaction can DROP earlier positions, so append-only
+   * would drift from the replay source). The unique (draft_id, seq) index is
+   * satisfied by the dense re-seq.
+   *
+   * ATOMIC: the delete + insert run in ONE transaction so an interrupted replace
+   * (crash or insert failure after the delete) cannot leave the log erased while
+   * shadow rows remain — the swap is all-or-nothing. Without this, the next
+   * `publishDraft` could read an empty/partial log and silently drop committed
+   * draft history.
+   */
+  async function writeLog(
+    draftId: string,
+    compacted: DraftCommand[],
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(draftCommandLog)
+        .where(eq(draftCommandLog.draftId, draftId));
+      if (compacted.length === 0) return;
+      await tx.insert(draftCommandLog).values(
+        compacted.map((cmd, seq) => ({
+          draftId,
+          seq,
+          path: cmd.path,
+          // `args` is opaque JSON-shaped data the lifecycle never interprets;
+          // store it verbatim. `?? null` because jsonb stores SQL NULL for an
+          // absent arg.
+          args: (cmd.args ?? null) as unknown,
+          cmdId: cmd.id ?? null,
+          compactionKey: cmd.compactionKey ?? null,
+          kind: cmd.kind ?? null,
+        })),
+      );
+    });
+  }
+
+  /**
+   * Delete a draft's durable command log. This is the publish IDEMPOTENCY GATE:
+   * `publishDraft` reads only `draft_command_log`, so once the log is gone a
+   * retried publish reads an empty log and is a no-op rather than a second replay
+   * onto canonical. A failure here MUST surface (the log still drives publish).
+   */
+  async function deleteLog(draftId: string): Promise<void> {
+    await db
+      .delete(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+  }
+
+  /**
+   * Sweep a draft's `<table>__draft` shadow rows across the closed set. These
+   * rows are INERT once the log is gone (publish never reads the shadow; a read
+   * overlay for a draft with no log coalesces nothing), so a partial sweep leaves
+   * only orphaned, ignored rows. `throwOnError` lets the caller choose: discard
+   * wants a hard failure (the draft must be fully gone); post-publish cleanup
+   * wants best-effort (the canonical commit already succeeded — a sweep error
+   * must NOT turn a committed publish into a reported failure).
+   */
+  async function sweepShadows(
+    draftId: string,
+    { throwOnError }: { throwOnError: boolean },
+  ): Promise<void> {
+    for (const shadow of DRAFT_SHADOW_TABLES) {
+      // `draftId` is a BOUND parameter (guard the sink); the table identifiers
+      // are static schema objects, not caller input.
+      try {
+        await db.delete(shadow).where(eq(shadow.draftId, draftId));
+      } catch (err) {
+        if (throwOnError) throw err;
+        console.error(
+          `[dashframe] draft ${draftId}: shadow sweep of ${getTableName(shadow)} failed (inert rows orphaned, log already cleared):`,
+          err,
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete every log row + shadow row for a draft. Log-FIRST + hard-fail on any
+   * step: used by discard, where the whole draft must be removed atomically-ish
+   * (a failure should surface so the caller knows the draft is not fully gone).
+   */
+  async function dropDraft(draftId: string): Promise<void> {
+    await deleteLog(draftId);
+    await sweepShadows(draftId, { throwOnError: true });
+  }
+
+  return {
+    async openDraft(_baseVersion?: unknown): Promise<string> {
+      // DashFrame owns the handle. `withDraft` accepts any id, so a UUID is the
+      // durable draftId across the shadow tables and the command log.
+      return crypto.randomUUID();
+    },
+
+    async appendToDraft(draftId, batch, context = {}) {
+      // Route writes through the draft handle so each handler's `ctx.db.into/
+      // update/delete` lands in `<table>__draft` (the withDraft write-path),
+      // exactly as createDraftLifecycle.append does — the controller drives the
+      // path, it never authors a shadow-table write.
+      const draftDb = app.createTracked().withDraft(draftId);
+      const results: CommandResult[] = [];
+      // Snapshot each command AS IT SUCCESSFULLY RUNS, before compaction/persist.
+      // The handler runs against the live `cmd` (what actually executed); the
+      // SNAPSHOT is what we compact + persist. Without this, a caller mutating a
+      // command or its nested `args` after `appendToDraft` started (while a
+      // handler awaits) would make the durable log replay a command different
+      // from the one the shadow reflects. The deep copy freezes the executed
+      // form. `structuredClone` handles nested args; commands are plain JSON-ish
+      // envelopes (path/args/id/compactionKey/kind) so it round-trips cleanly.
+      const ranSnapshots: DraftCommand[] = [];
+      for (const cmd of batch) {
+        const value = await app.runHandler(
+          cmd.path,
+          cmd.args,
+          draftDb,
+          context,
+        );
+        ranSnapshots.push(structuredClone(cmd) as DraftCommand);
+        results.push({ id: cmd.id, value });
+      }
+      // Project the compacted full log into draft_command_log. Read the prior
+      // log, concat the snapshots of what just ran, compact (wystack's exported
+      // algorithm), replace-all (atomically — see writeLog).
+      const prior = await readLog(draftId);
+      const compacted = compactLog([...prior, ...ranSnapshots]);
+      await writeLog(draftId, compacted);
+      return results;
+    },
+
+    async publishDraft(draftId, context = {}) {
+      // ONE publish path, warm or cold: the durable log is always the source.
+      const log = await readLog(draftId);
+      // Replay the ordered command log onto CANONICAL, atomically. applyCommands
+      // dispatches each command via the (wrapped) `runHandler`, which re-applies
+      // `withDraftSeam` to the transaction tracker from THIS context. A `draftId`
+      // left in the replay context would therefore re-scope the publish back into
+      // `<table>__draft` — the changes would land in the shadow and then be swept
+      // by `dropDraft`, silently losing the publish. Strip it so the replay is
+      // unambiguously canonical (the log is the read overlay's source, not a
+      // draft-scoped write). `publishContext` carries the rest (e.g. vault).
+      const publishContext = { ...context };
+      delete publishContext.draftId;
+      const result = (await applyCommands(app, log, {
+        mode: "commit",
+        context: publishContext,
+      })) as CommitResult;
+      // Teardown AFTER the canonical commit landed durably. Two phases, in order:
+      //
+      //  1. deleteLog — the idempotency gate. This MUST run and surface failures:
+      //     publish reads only the log, so deleting it is what makes a retried
+      //     publish a no-op instead of a second canonical replay.
+      //  2. sweepShadows — BEST-EFFORT. The shadow rows are inert once the log is
+      //     gone (publish never reads them). A sweep error must NOT turn an
+      //     already-committed publish into a reported failure (the caller would
+      //     surface a false error or retry into an empty log); we log and return
+      //     the CommitResult. Orphaned inert shadow rows are harmless and are
+      //     re-swept by the next discard/publish of the same draftId.
+      //
+      // The host flushes result.tablesWritten to invalidation (the controller
+      // does not, mirroring applyCommands' posture).
+      //
+      // KNOWN DURABILITY WINDOW (tracked: see GitHub issue referenced below): the
+      // canonical commit and `deleteLog` are two separate transactions —
+      // `applyCommands` owns its own tx and does not accept an outer one. A
+      // process crash in the gap (canonical committed, log not yet deleted) leaves
+      // the log intact, so a retried publish replays onto canonical a second time
+      // — a duplicate-PK throw for create commands, with no clean recovery
+      // (canonical already holds the row; discard only sweeps the shadow). Closing
+      // this needs either an `applyCommands` that accepts an outer transaction
+      // (wystack-side) or a durable publish-state marker on a draft record (no
+      // draft record exists in this slice). Out of scope for the mechanism slice;
+      // must be closed before the seam is wired live — tracked as DashFrame
+      // GitHub issue #157.
+      await deleteLog(draftId);
+      await sweepShadows(draftId, { throwOnError: false });
+      return result;
+    },
+
+    async discardDraft(draftId) {
+      await dropDraft(draftId);
+    },
+
+    async getDraftLog(draftId) {
+      return readLog(draftId);
+    },
+  };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
         "@wystack/db": "workspace:*",
         "@wystack/secret-vault": "workspace:*",
         "@wystack/server": "workspace:*",
+        "drizzle-orm": "^0.45.1",
         "hono": "^4.12.9",
         "zod": "^4.1.12",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -112,7 +112,6 @@
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
         "@types/bun": "^1.2.0",
-        "drizzle-orm": "^0.45.1",
         "esbuild": "^0.28.0",
         "typescript": "5.7.2",
         "vitest": "^4.1.6",

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -198,6 +198,7 @@ describe("draft_command_log table", () => {
     expect(cols.has("seq")).toBe(true);
     expect(cols.has("path")).toBe(true);
     expect(cols.has("args")).toBe(true);
+    expect(cols.has("cmd_id")).toBe(true);
     expect(cols.has("compaction_key")).toBe(true);
     expect(cols.has("kind")).toBe(true);
     expect(cols.has("created_at")).toBe(true);

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -407,6 +407,11 @@ export const draftCommandLog = pgTable(
     // @wystack/server — `path` names the handler, `args` are the call arguments.
     path: text("path").notNull(),
     args: jsonb("args"),
+    // The optional command correlation id (`Command.id`) — opaque, echoed back
+    // on `CommandResult.id` so a publish replay can correlate its results to the
+    // commands that produced them. Nullable: a command may carry no id. (Distinct
+    // from the row `id` PK above, which identifies the log row, not the command.)
+    cmdId: text("cmd_id"),
     // Compaction fields (nullable: a plain Command with no key is never
     // compacted). These mirror DraftCommand.compactionKey / DraftCommand.kind.
     compactionKey: text("compaction_key"),


### PR DESCRIPTION
The DashFrame draft controller — the heart of the assistant drive loop. CONDUCTS the wystack draft mechanism (`withDraft` write-path + `compactLog` + `applyCommands`) over DashFrame's durable YW-125 tables; does NOT reimplement YW-121.

## What it does
- `createDraftController(app, db)`: `openDraft` / `appendToDraft` / `publishDraft` / `discardDraft` / `getDraftLog`.
- **Persistent**: a draft survives process restart with the draftId as the durable handle (log materialized into `draft_command_log`).
- **publish = atomic command-log replay** onto canonical via `applyCommands(commit)` — cold-safe (reads only the durable log, never the shadow), idempotent retry (drops log before sweep).
- **ctx.db draft seam** (`withDraftSeam` in app.ts): when a `draftId` is in context, substitutes `ctx.db` with the draft-scoped overlay so command handlers write into `<table>__draft` UNMODIFIED.
- **Security boundary**: credentials never drafted — closed 6-table shadow set, no `secret_mappings`/`project_meta` shadow.

## Foundation
Builds on the now-merged wystack draft foundation (`5b02c0c`: withDraft + lifecycle + jsonb encode/decode codecs + PK-filtered reads). Verified end-to-end against the FIXED primitive: jsonb round-trips, PK-pinned draft reads, cold-publish, discard sweep.

(Supersedes #153, which auto-closed when its bump base branch merged. Rebased onto main, identical content + the read-decode foundation.)

Tracked internally as YW-260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces the persistent draft controller (`createDraftController`) and the `ctx.db` draft seam (`withDraftSeam` / `createFallThroughDraftDb`) for DashFrame's agent drive loop, building on the wystack draft foundation. The seam is dormant in this slice — no host yet injects a `draftId` into request context — so no existing behavior changes.

- **`createDraftController`** (new file): implements `openDraft` / `appendToDraft` / `publishDraft` / `discardDraft` / `getDraftLog` over real PGlite tables. The durable log (`draft_command_log`) is a materialized compacted projection (replace-all on each append); publish reads only the log, never the shadow, making warm and cold publish identical. The known durability window between the canonical commit and `deleteLog` is correctly documented and tracked as GitHub issue #157.
- **Draft seam** (`app.ts`): `createFallThroughDraftDb` routes draftable artifact tables to `<table>__draft` and falls through to canonical for non-draftable tables (`project_meta`, `secret_mappings`). `buildDashframeApp` now unconditionally wraps `rawApp` to insert the seam; the no-draft path is byte-identical to the original `rawApp.call` decomposition.
- **`drizzle-orm` promotion**: moved from `devDependencies` to `dependencies`, correct since `getTableName` / `eq` are used in production runtime code.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the draft seam is dormant (no host injects a draftId), so canonical read/write paths are unchanged. The new controller adds durable state on top of existing shadow tables with no schema-breaking changes.

All load-bearing invariants are correct and thoroughly tested: publish strips draftId before replay, writeLog is atomic (transactional delete+insert), the fall-through seam correctly routes non-draftable tables to canonical, and appendToDraft avoids the raw withDraft handle that would bypass the seam. The publish crash window is documented and tracked as GitHub issue #157. The cmdId column addition is nullable and handled by the existing syncSchema bootstrapper. No ticket IDs in source, no security regressions.

No files require special attention. The two static constant sets (DRAFTABLE_TABLE_NAMES in app.ts and DRAFT_SHADOW_TABLES in draft-controller.ts) must stay in sync when a new artifact table is added — both are annotated to that effect.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-controller.ts | New persistent draft lifecycle controller: open/append/publish/discard over real PGlite tables. Correctly routes through fall-through seam, strips draftId before publish replay, and uses transactional writeLog for atomic log replacement. Known durability window now tracked as GitHub issue #157. |
| apps/server/src/app.ts | Adds draft seam: withDraftSeam, createFallThroughDraftDb, and draftIdFromContext. The buildDashframeApp wrapper now unconditionally wraps rawApp, decomposing rawApp.call into createTracked + runHandler to allow draft handle injection. No-draft path is byte-identical. |
| apps/server/src/draft-controller.test.ts | Comprehensive integration test suite (13 cases) covering isolation, persistence/cold-reload, atomic publish, discard, no-draft canonical path, log re-seq, jsonb round-trip, sparse overlay, non-draftable fall-through, appendToDraft seam routing, command correlation IDs, and mutation snapshot safety. |
| packages/server-core/src/schema.ts | Adds nullable cmd_id text column to draft_command_log for command correlation ID persistence. As a nullable, default-less column, it is auto-added to existing tables by syncSchema's renderAddNullableColumnsIfNotExists — no separate migration needed. |
| packages/server-core/src/schema.test.ts | Adds assertion for cmd_id column in the draft_command_log schema contract test. |
| apps/server/package.json | Promotes drizzle-orm from devDependencies to dependencies — correct, since getTableName and eq are used in production runtime code. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host
    participant DraftController
    participant App as WyStackApp (wrapped)
    participant SeamDb as FallThroughDraftDb
    participant Shadow as table__draft
    participant Log as draft_command_log
    participant Canonical as canonical tables

    Host->>DraftController: openDraft()
    DraftController-->>Host: draftId (UUID)

    Host->>DraftController: appendToDraft(draftId, batch)
    DraftController->>App: createTracked() → baseDb
    loop for each cmd in batch
        DraftController->>App: runHandler(path, args, baseDb, draftId-context)
        App->>SeamDb: withDraftSeam → FallThroughDraftDb
        Note over SeamDb: draftable tables → shadow<br/>non-draftable → canonical
        SeamDb->>Shadow: write (draftable tables)
        SeamDb->>Canonical: read (non-draftable: project_meta)
        App-->>DraftController: handler result
    end
    DraftController->>Log: readLog(draftId) → prior
    DraftController->>DraftController: compactLog([...prior, ...ranSnapshots])
    DraftController->>Log: writeLog (tx: delete + insert, re-seq 0..n)
    DraftController-->>Host: CommandResult[]

    Host->>DraftController: publishDraft(draftId)
    DraftController->>Log: readLog(draftId) → compacted commands
    DraftController->>App: applyCommands(app, log, commit, no-draftId-context)
    App->>Canonical: atomic commit of all commands
    App-->>DraftController: CommitResult
    DraftController->>Log: deleteLog(draftId) [idempotency gate]
    DraftController->>Shadow: sweepShadows best-effort all 6 tables
    DraftController-->>Host: CommitResult
    Note over Host: Host MUST fire onWrite(tablesWritten)

    Host->>DraftController: discardDraft(draftId)
    DraftController->>Log: deleteLog(draftId)
    DraftController->>Shadow: sweepShadows throw on error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host
    participant DraftController
    participant App as WyStackApp (wrapped)
    participant SeamDb as FallThroughDraftDb
    participant Shadow as table__draft
    participant Log as draft_command_log
    participant Canonical as canonical tables

    Host->>DraftController: openDraft()
    DraftController-->>Host: draftId (UUID)

    Host->>DraftController: appendToDraft(draftId, batch)
    DraftController->>App: createTracked() → baseDb
    loop for each cmd in batch
        DraftController->>App: runHandler(path, args, baseDb, draftId-context)
        App->>SeamDb: withDraftSeam → FallThroughDraftDb
        Note over SeamDb: draftable tables → shadow<br/>non-draftable → canonical
        SeamDb->>Shadow: write (draftable tables)
        SeamDb->>Canonical: read (non-draftable: project_meta)
        App-->>DraftController: handler result
    end
    DraftController->>Log: readLog(draftId) → prior
    DraftController->>DraftController: compactLog([...prior, ...ranSnapshots])
    DraftController->>Log: writeLog (tx: delete + insert, re-seq 0..n)
    DraftController-->>Host: CommandResult[]

    Host->>DraftController: publishDraft(draftId)
    DraftController->>Log: readLog(draftId) → compacted commands
    DraftController->>App: applyCommands(app, log, commit, no-draftId-context)
    App->>Canonical: atomic commit of all commands
    App-->>DraftController: CommitResult
    DraftController->>Log: deleteLog(draftId) [idempotency gate]
    DraftController->>Shadow: sweepShadows best-effort all 6 tables
    DraftController-->>Host: CommitResult
    Note over Host: Host MUST fire onWrite(tablesWritten)

    Host->>DraftController: discardDraft(draftId)
    DraftController->>Log: deleteLog(draftId)
    DraftController->>Shadow: sweepShadows throw on error
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["chore(server): drop duplicate drizzle-or..."](https://github.com/youhaowei/dashframe/commit/59f11d728aac9a8d40cdea51067d6e6fad1f426b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39463883)</sub>

<!-- /greptile_comment -->