### PR TITLE
feat(assistant): privacy-aware read layer — graph resolver + tiered reads + command guide [YW-280]

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,6 +15,10 @@
     "./functions": {
       "bun": "./src/functions.ts",
       "default": "./src/functions.ts"
+    },
+    "./assistant-read-host": {
+      "bun": "./src/assistant-read-host.ts",
+      "default": "./src/assistant-read-host.ts"
     }
   },
   "scripts": {

--- a/apps/server/src/assistant-read-host.test.ts
+++ b/apps/server/src/assistant-read-host.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Assistant read host — the resolver against the REAL server seam.
+ *
+ * The read.test.ts in @dashframe/assistant proves the resolver + floor logic
+ * against a fake reader. THIS test proves the load-bearing INTEGRATION the fake
+ * cannot: the host adapter dispatching real reads through the WyStack app's
+ * server seam, against a real PGlite DB, with the real draft overlay and the
+ * real Field.sensitivity classification.
+ *
+ * Contracts under test:
+ *   - DRAFT OVERLAY: a draft-scoped reader sees an insight created INSIDE a
+ *     draft; a canonical reader does NOT. Structure reads route through the
+ *     withDraftSeam, never raw DB.
+ *   - INHERIT-SOURCE (real sensitivity): readData masks (profiles-only) when a
+ *     real Field.sensitivity on the source is "sensitive"; does not mask a
+ *     fully-cleared source. Structure is never gated.
+ *   - NEIGHBORHOOD/TRAVERSAL over real artifacts.
+ */
+
+import { createReadTools, type DataReadResult } from "@dashframe/assistant";
+import { openArtifactDb } from "@dashframe/server-core";
+import type { Field } from "@dashframe/types";
+import type { Command } from "@wystack/server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { neighbors } from "@dashframe/assistant";
+import { buildDashframeApp, createDraftController } from "./app";
+import { createAssistantReadHost } from "./assistant-read-host";
+import { cmd } from "./functions/commands";
+
+describe("assistant read host (resolver over the real server seam)", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: Awaited<ReturnType<typeof buildDashframeApp>>;
+  let controller: ReturnType<typeof createDraftController>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-read-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await buildDashframeApp({ db });
+    controller = createDraftController(app, db);
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const id = () => crypto.randomUUID();
+
+  /** Publish a batch to CANONICAL through the controller (its only write seam). */
+  async function publish(...commands: Command[]) {
+    const d = await controller.openDraft();
+    await controller.appendToDraft(d, commands);
+    await controller.publishDraft(d);
+  }
+
+  function field(name: string, sensitivity: Field["sensitivity"]): Field {
+    return { id: id(), name, tableId: "", type: "string", sensitivity };
+  }
+
+  // -------------------------------------------------------------------------
+  // Draft overlay: the reader sees the assistant's in-progress draft edits.
+  // -------------------------------------------------------------------------
+  it("a draft-scoped reader sees an insight created inside the draft; canonical does not", async () => {
+    const sourceId = id();
+    const tableId = id();
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Orders",
+        table: "orders.csv",
+      }),
+    );
+
+    // Create an insight INSIDE a draft (not published).
+    const draftId = await controller.openDraft();
+    const insightId = id();
+    await controller.appendToDraft(draftId, [
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Draft-only insight",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    ]);
+
+    // Draft-scoped reader: the insight is visible (reads the overlay).
+    const draftReader = createAssistantReadHost({ app, draftId });
+    const fromDraft = await draftReader.getInsight(insightId);
+    expect(fromDraft?.name).toBe("Draft-only insight");
+
+    // Canonical reader (no draftId): the insight does NOT exist yet.
+    const canonicalReader = createAssistantReadHost({ app });
+    expect(await canonicalReader.getInsight(insightId)).toBeNull();
+  });
+
+  it("filtered list reads do NOT throw under an active draftId (non-PK filter)", async () => {
+    // The draft-overlay coalesce THROWS on a non-PK server-side read filter
+    // (app.ts withDraftSeam contract). The host adapter must read unfiltered and
+    // filter in JS. Exercise the filtered paths under a draftId: they must
+    // succeed, not throw.
+    const sourceId = id();
+    const tableId = id();
+    const insightId = id();
+    const vizId = id();
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Orders",
+        table: "orders.csv",
+      }),
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Revenue",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+      cmd("CreateVisualization", {
+        id: vizId,
+        name: "Bar",
+        insightId,
+        visualizationType: "barY",
+        spec: {},
+      }),
+    );
+
+    const draftId = await controller.openDraft();
+    const reader = createAssistantReadHost({ app, draftId });
+    // Each of these issues a non-PK filter that would throw if sent server-side
+    // under the draft; the adapter reads unfiltered + filters in JS.
+    expect((await reader.listDataTables(sourceId)).map((t) => t.id)).toEqual([
+      tableId,
+    ]);
+    expect(
+      (await reader.listVisualizations(insightId)).map((v) => v.id),
+    ).toEqual([vizId]);
+    // getDataFrameByInsight (no dataframe materialized) resolves to null, not throw.
+    expect(await reader.getDataFrameByInsight(insightId)).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Inherit-source masking over REAL Field.sensitivity.
+  // -------------------------------------------------------------------------
+  it("readData masks (profiles-only) when a real source column is sensitive", async () => {
+    const sourceId = id();
+    const tableId = id();
+    const emailField = field("email", "sensitive");
+    const amountField = field("amount", "cleared");
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Orders",
+        table: "orders.csv",
+        fields: [
+          { ...emailField, tableId },
+          { ...amountField, tableId },
+        ],
+      }),
+    );
+
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+
+    const res = await readData.execute("c", { kind: "dataTable", id: tableId });
+    const data = res.details as DataReadResult;
+
+    // Masked: a sensitive source column inherits up to the whole read.
+    expect(data.masked).toBe(true);
+    // Structure NEVER gated: both columns + their real sensitivity flow.
+    const byName = new Map(data.columns.map((c) => [c.name, c]));
+    expect(byName.get("email")?.sensitivity).toBe("sensitive");
+    expect(byName.get("amount")?.sensitivity).toBe("cleared");
+    // Profiles-only — no raw rows.
+    expect(data.sample).toBeUndefined();
+  });
+
+  it("readData does NOT mask a fully-cleared source, still profiles-only", async () => {
+    const sourceId = id();
+    const tableId = id();
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Regions",
+        table: "regions.csv",
+        fields: [{ ...field("region", "cleared"), tableId }],
+      }),
+    );
+
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", { kind: "dataTable", id: tableId });
+    const data = res.details as DataReadResult;
+    expect(data.masked).toBe(false);
+    expect(data.columns.map((c) => c.name)).toEqual(["region"]);
+    expect(data.sample).toBeUndefined();
+  });
+
+  it("masks (fail-closed) a table with UNKNOWN columns (no fields discovered yet)", async () => {
+    // A table created before schema discovery/classification has empty `fields`.
+    // "Unknown columns" must mask exactly like "unresolvable" — a not-yet-seen
+    // column could be sensitive, so an unclassified table reads MASKED.
+    const sourceId = id();
+    const tableId = id();
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Undiscovered",
+        table: "undiscovered.csv",
+        // no `fields` — columns not discovered yet
+      }),
+    );
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", { kind: "dataTable", id: tableId });
+    expect((res.details as DataReadResult).masked).toBe(true);
+  });
+
+  it("an insight inherits its base table's sensitivity (insight result masks)", async () => {
+    const sourceId = id();
+    const tableId = id();
+    const emailField = field("email", "sensitive");
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Orders",
+        table: "orders.csv",
+        fields: [{ ...emailField, tableId }],
+      }),
+    );
+    const insightId = id();
+    await publish(
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Revenue",
+        source: { sourceType: "dataTable", sourceId: tableId },
+        selectedFields: [emailField.id],
+      }),
+    );
+
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+    // A viz reads its insight's result — the agent reads the insight here.
+    const res = await readData.execute("c", { kind: "insight", id: insightId });
+    expect((res.details as DataReadResult).masked).toBe(true);
+  });
+
+  it("masks when a METRIC's sourceTable (a DIFFERENT, sensitive table) is read", async () => {
+    // Isolate the metric-resolution path: the BASE table is fully cleared; the
+    // sensitive column lives ONLY in a separate table reached via the metric's
+    // sourceTable. Masking therefore depends solely on the metric hop resolving
+    // that table — narrowing to selectedFields (or skipping metric tables) fails
+    // OPEN here.
+    const sourceId = id();
+    const baseTableId = id();
+    const metricTableId = id();
+    const regionField = field("region", "cleared");
+    const salaryField = field("salary", "sensitive");
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: baseTableId,
+        dataSourceId: sourceId,
+        name: "Regions",
+        table: "regions.csv",
+        fields: [{ ...regionField, tableId: baseTableId }], // cleared base
+      }),
+      cmd("CreateDataTable", {
+        id: metricTableId,
+        dataSourceId: sourceId,
+        name: "Salaries",
+        table: "salaries.csv",
+        fields: [{ ...salaryField, tableId: metricTableId }], // sensitive, metric-only
+      }),
+    );
+    const insightId = id();
+    await publish(
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Avg salary by region",
+        source: { sourceType: "dataTable", sourceId: baseTableId },
+        selectedFields: [regionField.id], // cleared dimension ONLY
+        metrics: [
+          {
+            id: id(),
+            name: "Avg salary",
+            sourceTable: metricTableId, // ← sensitive table, NOT the base
+            columnName: "salary",
+            aggregation: "avg",
+          },
+        ],
+      }),
+    );
+
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", { kind: "insight", id: insightId });
+    expect((res.details as DataReadResult).masked).toBe(true);
+  });
+
+  it("masks (fail-closed) when a joined table is DELETED out from under the insight", async () => {
+    // AddJoin validates rightTableId at write time, so a dangling ref arises via
+    // DELETION: deleting a DataTable does NOT cascade-delete dependent insights
+    // (drift-repair territory), leaving the join's rightTableId dangling. The
+    // base is cleared, so masking depends entirely on the dangling-ref →
+    // forceMask path — a vanished table may have held the only sensitive column.
+    const sourceId = id();
+    const baseTableId = id();
+    const joinTableId = id();
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: baseTableId,
+        dataSourceId: sourceId,
+        name: "Regions",
+        table: "regions.csv",
+        fields: [{ ...field("region", "cleared"), tableId: baseTableId }],
+      }),
+      cmd("CreateDataTable", {
+        id: joinTableId,
+        dataSourceId: sourceId,
+        name: "Lookup",
+        table: "lookup.csv",
+        fields: [{ ...field("code", "cleared"), tableId: joinTableId }],
+      }),
+    );
+    const insightId = id();
+    await publish(
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Joined",
+        source: { sourceType: "dataTable", sourceId: baseTableId },
+      }),
+    );
+    await publish(
+      cmd("AddJoin", {
+        id: insightId,
+        join: {
+          type: "left",
+          rightTableId: joinTableId,
+          leftKey: "region",
+          rightKey: "code",
+        },
+      }),
+    );
+    // Now delete the joined table — the insight's join ref is left dangling.
+    await publish(cmd("DeleteNode", { id: joinTableId }));
+
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", { kind: "insight", id: insightId });
+    // Dangling join table → forceMask → masked, even though the base is cleared.
+    expect((res.details as DataReadResult).masked).toBe(true);
+  });
+
+  it("masks a composed insight (insight-on-insight) whose upstream source is sensitive", async () => {
+    // baseTableId of an insight-sourced insight holds the UPSTREAM INSIGHT id.
+    // Resolving it as a table would yield null → empty set → fail OPEN.
+    const sourceId = id();
+    const tableId = id();
+    const emailField = field("email", "sensitive");
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Orders",
+        table: "orders.csv",
+        fields: [{ ...emailField, tableId }],
+      }),
+    );
+    const baseInsightId = id();
+    await publish(
+      cmd("CreateInsight", {
+        id: baseInsightId,
+        name: "Base",
+        source: { sourceType: "dataTable", sourceId: tableId },
+        selectedFields: [emailField.id],
+      }),
+    );
+    const composedInsightId = id();
+    await publish(
+      cmd("CreateInsight", {
+        id: composedInsightId,
+        name: "Composed",
+        source: { sourceType: "insight", sourceId: baseInsightId },
+      }),
+    );
+
+    const reader = createAssistantReadHost({ app });
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "insight",
+      id: composedInsightId,
+    });
+    // Inherits the upstream insight's sensitive source through the chain.
+    expect((res.details as DataReadResult).masked).toBe(true);
+
+    // And the composed insight's neighborhood reaches its upstream INSIGHT (the
+    // base edge is not silently dropped as a non-existent table).
+    const hood = await neighbors(reader, {
+      kind: "insight",
+      id: composedInsightId,
+    });
+    expect(
+      hood!.downstream.some(
+        (n) => n.ref.kind === "insight" && n.ref.id === baseInsightId,
+      ),
+    ).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Neighborhood over real artifacts.
+  // -------------------------------------------------------------------------
+  it("neighborhood of an insight = its base table (down) + viz (up), 1 hop", async () => {
+    const sourceId = id();
+    const tableId = id();
+    const insightId = id();
+    const vizId = id();
+    await publish(
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Orders",
+        table: "orders.csv",
+      }),
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Revenue",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+      cmd("CreateVisualization", {
+        id: vizId,
+        name: "Bar",
+        insightId,
+        visualizationType: "barY",
+        spec: {},
+      }),
+    );
+
+    const reader = createAssistantReadHost({ app });
+    const hood = await neighbors(reader, { kind: "insight", id: insightId });
+    expect(hood).not.toBeNull();
+    expect(hood!.downstream.map((n) => n.ref.id)).toContain(tableId);
+    expect(hood!.upstream.map((n) => n.ref.id)).toContain(vizId);
+    // NOT the source (2 hops down) — ambient is 1 hop.
+    expect(hood!.downstream.map((n) => n.ref.id)).not.toContain(sourceId);
+  });
+});

--- a/apps/server/src/assistant-read-host.ts
+++ b/apps/server/src/assistant-read-host.ts
@@ -1,0 +1,275 @@
+/**
+ * Host adapter — binds the assistant's `GraphReader` PORT to this server's read
+ * seam, scoped to a draft.
+ *
+ * The assistant package (@dashframe/assistant) defines the read layer as a
+ * privacy-aware graph resolver over a `GraphReader` port (it cannot import this
+ * server — apps/server depends on the assistant, not the reverse). This file is
+ * the HOST half: it implements the port by dispatching every structure read
+ * through `app.runHandler(path, args, tracked, { draftId })` — the SERVER SEAM,
+ * against the DRAFT-OVERLAY view (the withDraftSeam read path). The assistant
+ * never sees the DB or the draftId; it gets a reader already scoped to the draft.
+ *
+ * Two invariants this adapter upholds:
+ *   1. SINGLE STRUCTURE EGRESS — every structure read goes through the registered
+ *      query functions (getInsight, getDataTable, …), never a raw DB query. The
+ *      reads are byte-identical to what the renderer issues.
+ *   2. SINGLE VALUE EGRESS via the FLOOR — `readDataProfile` resolves the
+ *      artifact's CONTRIBUTING SOURCE FIELDS (real Field.sensitivity, read
+ *      through the same seam) and hands them to the assistant's `applyFloor`,
+ *      which makes the binary inherit-source masking decision and emits
+ *      profiles-only (the v0.3 conservative floor until the perception assembler lands). This adapter
+ *      NEVER reads or assembles row data — profiles-only is structural.
+ */
+
+import {
+  applyFloor,
+  type ColumnProfile,
+  type DashboardRead,
+  type DataFrameRead,
+  type DataReadResult,
+  type GraphReader,
+  type NodeRef,
+} from "@dashframe/assistant";
+import type {
+  DataSource,
+  DataTable,
+  Field,
+  Insight,
+  UUID,
+  Visualization,
+} from "@dashframe/types";
+import type { WyStackApp } from "@wystack/server";
+
+/**
+ * The set of project source files the assistant may open via `readSource` — its
+ * BACKUP/verification path for the command vocabulary. Allowlisted, not
+ * arbitrary FS access: the agent can fall back to the command source when the
+ * crafted guide is insufficient, and nothing else.
+ */
+const READABLE_SOURCES: ReadonlySet<string> = new Set([
+  "apps/server/src/functions/commands.ts",
+]);
+
+export interface AssistantReadHostOptions {
+  app: WyStackApp;
+  /**
+   * The active draft handle. Every read is scoped to this draft's overlay, so
+   * the assistant perceives its own in-progress edits. Omit for a canonical-only
+   * reader (e.g. a read with no open draft).
+   */
+  draftId?: string;
+  /**
+   * Reads an allowlisted source file's text. Injected (not a direct fs import)
+   * so the host owns the filesystem boundary; the adapter only enforces the
+   * allowlist. Omit to disable source fallback.
+   */
+  readSourceFile?: (file: string) => Promise<string>;
+}
+
+/**
+ * Build a draft-scoped `GraphReader` over the server app. The returned reader is
+ * the assistant's single structure-and-value egress; pass it to
+ * `createReadTools(reader)` to get the four fixed read tools.
+ */
+export function createAssistantReadHost(
+  opts: AssistantReadHostOptions,
+): GraphReader {
+  const { app, draftId, readSourceFile } = opts;
+
+  // Every read carries the draftId in context so the withDraftSeam routes the
+  // read against the draft overlay. A fresh TrackedDb per call (read-only; the
+  // tracking sets are discarded — we never publish from a read).
+  const context: Record<string, unknown> =
+    draftId !== undefined ? { draftId } : {};
+
+  async function read<T>(path: string, args: unknown): Promise<T> {
+    const tracked = app.createTracked();
+    return (await app.runHandler(path, args, tracked, context)) as T;
+  }
+
+  /**
+   * The contributing source fields for a data read, plus a fail-closed signal.
+   * `forceMask` means "I could not confidently enumerate every contributing
+   * column" — the floor masks regardless of `fields` (a masked read is always
+   * safe; an unmasked-but-incomplete one is the leak).
+   */
+  interface SourceResolution {
+    fields: Field[];
+    forceMask: boolean;
+  }
+
+  /**
+   * Resolve the CONTRIBUTING SOURCE FIELDS for a data read — the inherit-source
+   * key. EVERY column the artifact reads from contributes; missing any sensitive
+   * one would fail OPEN, so this errs toward `forceMask` whenever resolution is
+   * incomplete.
+   *
+   *   - dataTable: its own fields.
+   *   - insight: the union of EVERY contributing column —
+   *       • base-source fields (the base may be a dataTable OR another insight —
+   *         insight-on-insight composition writes the upstream INSIGHT id into
+   *         `baseTableId`; the chain is walked, cycle-guarded),
+   *       • join-table fields (joins read those tables; the join KEYS are columns
+   *         too),
+   *       • metric columns (`metric.columnName` over `metric.sourceTable`; an
+   *         aggregate like SUM(salary) reads a column the dimension projection
+   *         never lists).
+   *     Narrowing to `selectedFields` is UNSAFE — it omits metric/join columns —
+   *     so the contributing set is the FULL union above. A read where any
+   *     contributing table/column can't be resolved sets `forceMask`.
+   */
+  async function sourceFieldsFor(node: NodeRef): Promise<SourceResolution> {
+    if (node.kind === "dataTable") {
+      const table = await read<DataTable | null>("getDataTable", {
+        id: node.id,
+      });
+      // Fail closed on an absent table OR one with no known columns yet (a table
+      // created before schema discovery/classification has empty `fields`).
+      // "Unknown columns" must mask exactly like "unresolvable" — the inherit-
+      // source floor's whole point is that unknown ⇒ restricted.
+      if (table === null || (table.fields?.length ?? 0) === 0)
+        return { fields: table?.fields ?? [], forceMask: true };
+      return { fields: table.fields, forceMask: false };
+    }
+    return resolveInsightSourceFields(node.id, new Set<UUID>());
+  }
+
+  /**
+   * Walk an insight's full contributing-column set. `seen` guards the
+   * insight-on-insight source chain against cycles (the server rejects cycles on
+   * write, but a read must never loop). Any unresolved hop forces masking.
+   */
+  async function resolveInsightSourceFields(
+    insightId: UUID,
+    seen: Set<UUID>,
+  ): Promise<SourceResolution> {
+    if (seen.has(insightId)) return { fields: [], forceMask: true };
+    seen.add(insightId);
+
+    const insight = await read<Insight | null>("getInsight", { id: insightId });
+    if (insight === null) return { fields: [], forceMask: true };
+
+    const fields: Field[] = [];
+    let forceMask = false;
+    // Add a referenced table's fields. A DANGLING ref (null table) forces
+    // masking: deleting a DataTable does NOT cascade-delete dependent insights
+    // (the server routes them to drift-repair), so an insight can carry a
+    // dangling join `rightTableId` / metric `sourceTable`. A draft can also
+    // delete a table the insight still references. If that vanished table held
+    // the only sensitive column, silently contributing nothing would fail OPEN —
+    // so an unresolvable table is treated as "I couldn't see its columns" and
+    // masks. Guard the sink, not the write-time FK check.
+    const addTableFields = async (tableId: UUID): Promise<void> => {
+      const table = await read<DataTable | null>("getDataTable", {
+        id: tableId,
+      });
+      // Null (dangling) OR empty-fields (columns not discovered yet) → fail
+      // closed: a table whose columns we can't enumerate may hide a sensitive one.
+      if (table === null || (table.fields?.length ?? 0) === 0) forceMask = true;
+      else fields.push(...table.fields);
+    };
+
+    // Base source: a dataTable, OR an upstream insight (composition). Probe as a
+    // table first; if it resolves to a table, add its fields (fail closed on
+    // empty fields via addTableFields). If NOT a table, it is an insight id —
+    // recurse into its source.
+    const baseTable = await read<DataTable | null>("getDataTable", {
+      id: insight.baseTableId,
+    });
+    if (baseTable !== null) {
+      await addTableFields(insight.baseTableId);
+    } else {
+      const upstream = await resolveInsightSourceFields(
+        insight.baseTableId,
+        seen,
+      );
+      fields.push(...upstream.fields);
+      forceMask = forceMask || upstream.forceMask;
+    }
+
+    // Join tables — every joined table's columns are read (incl. the join keys).
+    for (const j of insight.joins ?? []) await addTableFields(j.rightTableId);
+
+    // Metric source tables — a metric reads `columnName` from `sourceTable`,
+    // which the dimension projection never lists. Add those tables' fields.
+    for (const m of insight.metrics ?? []) {
+      if (m.sourceTable) await addTableFields(m.sourceTable);
+    }
+
+    return { fields, forceMask };
+  }
+
+  return {
+    // --- structure reads (ungated) — straight through the server seam ---
+    getDataSource: (id) => read<DataSource | null>("getDataSource", { id }),
+    getDataTable: (id) => read<DataTable | null>("getDataTable", { id }),
+    getDataFrameEntry: (id) =>
+      read<DataFrameRead | null>("getDataFrameEntry", { id }),
+    getInsight: (id) => read<Insight | null>("getInsight", { id }),
+    getVisualization: (id) =>
+      read<Visualization | null>("getVisualization", { id }),
+    getDashboard: (id) => read<DashboardRead | null>("getDashboard", { id }),
+
+    listDataSources: () => read<DataSource[]>("listDataSources", {}),
+    // NOTE: the *filtered* list/get reads below pass NO server-side filter and
+    // filter in JS. The draft-overlay coalesce supports an UNFILTERED `.all()`
+    // and a PK-pinned `.where(eq(id, …))`, but THROWS on any non-PK read filter
+    // (see app.ts withDraftSeam / wystack tracked-db). `listDataTables`'s
+    // dataSourceId filter, `listVisualizations`'s insightId filter, and
+    // `getDataFrameByInsight`'s insightId lookup are all non-PK — issuing them
+    // server-side would throw under an active draftId. Reading unfiltered (which
+    // coalesces correctly) and filtering here is identical in canonical too.
+    listDataTables: async (dataSourceId) => {
+      const all = await read<DataTable[]>("listDataTables", {});
+      return dataSourceId === undefined
+        ? all
+        : all.filter((t) => t.dataSourceId === dataSourceId);
+    },
+    listDataFrames: () => read<DataFrameRead[]>("listDataFrames", {}),
+    listInsights: () => read<Insight[]>("listInsights", {}),
+    listVisualizations: async (insightId) => {
+      const all = await read<Visualization[]>("listVisualizations", {});
+      return insightId === undefined
+        ? all
+        : all.filter((v) => v.insightId === insightId);
+    },
+    listDashboards: () => read<DashboardRead[]>("listDashboards", {}),
+    getDataFrameByInsight: async (insightId) => {
+      const all = await read<DataFrameRead[]>("listDataFrames", {});
+      return all.find((d) => d.insightId === insightId) ?? null;
+    },
+
+    // --- value read (floor-gated) — the single value egress ---
+    async readDataProfile(node: NodeRef): Promise<DataReadResult> {
+      const { fields, forceMask } = await sourceFieldsFor(node);
+      // Hand the contributing source fields to the assistant's floor. It makes
+      // the binary inherit-source masking decision and emits profiles-only.
+      // We pass name/type/sensitivity (structure) and no stats (v0.3 emits no
+      // row-derived stats — that arrives with the perception assembler).
+      // `forceMask` carries the fail-closed signal up: if resolution couldn't
+      // enumerate every contributing column, the floor masks regardless.
+      const profileInput = fields.map(
+        (
+          f,
+        ): Pick<Field, "name" | "type" | "sensitivity"> & {
+          stats?: ColumnProfile["stats"];
+        } => ({
+          name: f.name,
+          type: f.type,
+          ...(f.sensitivity !== undefined
+            ? { sensitivity: f.sensitivity }
+            : {}),
+        }),
+      );
+      return applyFloor(node, profileInput, { forceMask });
+    },
+
+    // --- source fallback (allowlisted) ---
+    async readSource(file: string): Promise<string | null> {
+      if (readSourceFile === undefined) return null;
+      if (!READABLE_SOURCES.has(file)) return null;
+      return readSourceFile(file);
+    },
+  };
+}

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -222,6 +222,23 @@ function patchInsightMetricDefinition(
 }
 
 /**
+ * Coalesce a row timestamp to epoch ms, null-safe.
+ *
+ * Canonical artifact tables stamp `created_at` with a DB default, so a canonical
+ * read always has it. But the DRAFT-OVERLAY view coalesces canonical ⊕ the sparse
+ * `<table>__draft` delta, and the draft shadow leaves `created_at` NULL for an
+ * artifact CREATED inside a draft (it has no canonical base, and publish stamps
+ * the real value). A draft-created artifact read through the overlay therefore
+ * carries a null timestamp until publish — `.getTime()` on it throws. Coalesce
+ * null → 0 (epoch): the artifact is unpublished, so it has no real creation time
+ * yet; 0 is the honest placeholder the read path can surface without crashing.
+ * `updatedAt` stays optional (null → undefined) via `?.getTime()` at call sites.
+ */
+export function tsToMillis(value: Date | null | undefined): number {
+  return value != null ? value.getTime() : 0;
+}
+
+/**
  * Map a `data_sources` row to the `DataSource` read DTO.
  *
  * Presence flags (hasApiKey / hasConnectionString) are derived from the vault
@@ -275,7 +292,7 @@ async function rowToDataSource(
     type: row.kind,
     name: row.name,
     config: { hasApiKey, hasConnectionString, ...otherKeys },
-    createdAt: row.createdAt.getTime(),
+    createdAt: tsToMillis(row.createdAt),
   };
 }
 
@@ -289,7 +306,7 @@ function rowToDataTable(row: DataTableRow): DataTable {
     fields: row.fields as Field[],
     metrics: row.metrics as Metric[],
     dataFrameId: row.dataFrameId ?? undefined,
-    createdAt: row.createdAt.getTime(),
+    createdAt: tsToMillis(row.createdAt),
     lastFetchedAt: row.lastFetchedAt?.getTime(),
   };
 }
@@ -300,7 +317,7 @@ function rowToDataFrame(row: DataFrameRow): DataFrameEntry {
     storage: row.storage as DataFrameStorageLocation,
     fieldIds: row.fieldIds as UUID[],
     primaryKey: (row.primaryKey as string | string[] | null) ?? undefined,
-    createdAt: row.createdAt.getTime(),
+    createdAt: tsToMillis(row.createdAt),
     name: row.name,
     insightId: row.insightId ?? undefined,
     rowCount: row.rowCount ?? undefined,
@@ -320,7 +337,7 @@ function rowToInsight(row: InsightRow): Insight {
     filters: definition.filters,
     sorts: definition.sorts,
     joins: definition.joins,
-    createdAt: row.createdAt.getTime(),
+    createdAt: tsToMillis(row.createdAt),
     updatedAt: row.updatedAt?.getTime(),
   };
 }
@@ -358,7 +375,7 @@ function rowToVisualization(row: VisualizationRow): Visualization {
     visualizationType: row.chartType as VisualizationType,
     encoding: row.encoding as VisualizationEncoding | undefined,
     spec: options.spec ?? {},
-    createdAt: row.createdAt.getTime(),
+    createdAt: tsToMillis(row.createdAt),
     updatedAt: row.updatedAt?.getTime(),
   };
 }

--- a/apps/server/src/functions/command-guide-freshness.test.ts
+++ b/apps/server/src/functions/command-guide-freshness.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Command-guide FRESHNESS — the drift detector.
+ *
+ * The assistant's command vocabulary GUIDE (@dashframe/assistant) is the agent's
+ * PRIMARY reference for the commands it can apply (the applyCommand tool). It is hand-crafted,
+ * so it can DRIFT from the real command registry as commands are added/removed.
+ * This test is the freshness check the ticket requires: it asserts the guide's
+ * documented command names EXACTLY equal the live registry's command names
+ * (COMMAND_PATHS keys — the single source of truth tying each cmd() name to its
+ * dispatch path).
+ *
+ * A new command without a guide entry, or a removed command still documented,
+ * FAILS here at CI — the guide cannot silently lie to the agent. The fix when it
+ * fails is to update the guide (COMMAND_GUIDE in
+ * packages/assistant/src/read/command-guide.ts), not to weaken this test.
+ */
+
+import { GUIDE_COMMAND_NAMES } from "@dashframe/assistant";
+import { describe, expect, it } from "vitest";
+
+import { COMMAND_PATHS } from "./commands";
+
+describe("command guide freshness (guide ⟷ cmd() registry)", () => {
+  const registryNames = new Set(Object.keys(COMMAND_PATHS));
+  const guideNames = GUIDE_COMMAND_NAMES;
+
+  it("documents every command in the registry (no undocumented command)", () => {
+    const missing = [...registryNames].filter((n) => !guideNames.has(n));
+    expect(missing, "registry commands missing from the guide").toEqual([]);
+  });
+
+  it("documents no command that the registry does not define (no stale entry)", () => {
+    const stale = [...guideNames].filter((n) => !registryNames.has(n));
+    expect(stale, "guide entries not in the registry").toEqual([]);
+  });
+
+  it("guide and registry have identical command-name sets", () => {
+    expect([...guideNames].sort()).toEqual([...registryNames].sort());
+  });
+});

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -2109,7 +2109,9 @@ export type CommandName = keyof CommandPayloads;
  * under in the app `functions`. The single source of truth tying the typed
  * vocabulary to the dispatched path.
  */
-const COMMAND_PATHS: { [K in CommandName]: keyof typeof commandFunctions } = {
+export const COMMAND_PATHS: {
+  [K in CommandName]: keyof typeof commandFunctions;
+} = {
   GetOrCreateDataSource: "getOrCreateDataSource",
   CreateDataSource: "createDataSource",
   SetDataSourceConfig: "setDataSourceConfig",

--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -21,6 +21,8 @@ import { schema } from "@dashframe/server-core";
 import { eq, jsonb, text, uuid } from "@wystack/db";
 import { mutation, query } from "@wystack/server";
 
+import { tsToMillis } from "./app-artifacts";
+
 const { dashboards } = schema;
 
 type DashboardRow = typeof dashboards.$inferSelect;
@@ -71,7 +73,11 @@ function rowToDashboard(row: DashboardRow): DashboardResult {
     description: row.description ?? undefined,
     items: (row.layout as DashboardItem[]) ?? [],
     controls: (row.controls as DashboardControl[] | null) ?? undefined,
-    createdAt: row.createdAt.getTime(),
+    // Null-safe via the shared `tsToMillis` (app-artifacts.ts): the draft overlay
+    // returns NULL created_at for a dashboard created inside a draft (the sparse
+    // `<table>__draft` row has no canonical base; publish stamps the real value),
+    // so coalesce null → 0 rather than crash on `.getTime()`.
+    createdAt: tsToMillis(row.createdAt),
     updatedAt: row.updatedAt?.getTime(),
   };
 }

--- a/bun.lock
+++ b/bun.lock
@@ -461,6 +461,7 @@
       "name": "@dashframe/assistant",
       "version": "0.1.0",
       "dependencies": {
+        "@dashframe/types": "workspace:*",
         "@earendil-works/pi-agent-core": "0.79.6",
         "@earendil-works/pi-ai": "0.79.6",
         "typebox": "1.1.38",

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -20,6 +20,7 @@
     "check": "bun run typecheck && bun run lint && bun run test"
   },
   "dependencies": {
+    "@dashframe/types": "workspace:*",
     "@earendil-works/pi-agent-core": "0.79.6",
     "@earendil-works/pi-ai": "0.79.6",
     "typebox": "1.1.38"

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -27,3 +27,7 @@ export {
   type ToolHandlerConfig,
   type ToolHandlerErrorDetails,
 } from "./tool.js";
+
+// READ layer — privacy-aware graph resolver: 4 fixed read tools, the floor, the
+// GraphReader port, and the command vocabulary guide.
+export * from "./read/index.js";

--- a/packages/assistant/src/read/command-guide.test.ts
+++ b/packages/assistant/src/read/command-guide.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Command guide — internal consistency.
+ *
+ * The cross-package FRESHNESS check (guide vs the live COMMAND_PATHS registry)
+ * lives in apps/server/src/functions/command-guide-freshness.test.ts, where the
+ * real registry is importable. Here we pin the guide's self-consistency: every
+ * documented entry has a non-empty contract, names are unique, and the rendered
+ * text is well-formed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  COMMAND_GUIDE,
+  GUIDE_COMMAND_NAMES,
+  renderCommandGuide,
+} from "./command-guide.js";
+
+describe("command guide — self consistency", () => {
+  it("every entry has a name, summary, and at least one arg", () => {
+    for (const e of COMMAND_GUIDE) {
+      expect(e.name, "name").toBeTruthy();
+      expect(e.summary.length, `${e.name} summary`).toBeGreaterThan(0);
+      expect(Object.keys(e.args).length, `${e.name} args`).toBeGreaterThan(0);
+    }
+  });
+
+  it("command names are unique", () => {
+    const names = COMMAND_GUIDE.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("GUIDE_COMMAND_NAMES exactly mirrors the guide entries", () => {
+    expect(GUIDE_COMMAND_NAMES.size).toBe(COMMAND_GUIDE.length);
+    for (const e of COMMAND_GUIDE)
+      expect(GUIDE_COMMAND_NAMES.has(e.name)).toBe(true);
+  });
+
+  it("renders a non-empty block naming a command and the source fallback", () => {
+    const text = renderCommandGuide();
+    expect(text).toContain("AddField");
+    expect(text).toContain("apps/server/src/functions/commands.ts");
+  });
+});

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -1,0 +1,367 @@
+/**
+ * The COMMAND VOCABULARY GUIDE — the assistant's PRIMARY reference for the
+ * commands it can apply (the applyCommand tool lands next and depends on
+ * this).
+ *
+ * Each entry is a concise CONTRACT per command: the command NAME (the `cmd()`
+ * name the apply tool uses), a one-line summary of effect, and its argument
+ * shape. This is hand-crafted for the agent — a clean, navigable surface, not a
+ * dump of the source. The SOURCE (apps/server/src/functions/commands.ts) is the
+ * BACKUP/verification path: the agent can open it via `readSource` when the
+ * guide is insufficient.
+ *
+ * FRESHNESS: the guide can DRIFT from the real command registry as commands are
+ * added/removed. `GUIDE_COMMAND_NAMES` is the freshness anchor — a test in
+ * apps/server (command-guide-freshness.test.ts) compares it against the live
+ * `COMMAND_PATHS` registry and FAILS when they diverge, so a new command without
+ * a guide entry (or a removed command still documented) is caught at CI. The
+ * guide cannot silently lie to the agent.
+ *
+ * The guide does NOT carry full arg schemas (those live in the typed
+ * `CommandPayloads` / the mutation handlers) — it carries the contract the agent
+ * reasons over. For exact arg validation, the apply tool checks against
+ * the typed payload at the seam; for exact arg shapes the agent falls back to
+ * source.
+ */
+
+/** One command's agent-facing contract. */
+export interface CommandGuideEntry {
+  /** The `cmd()` command name — what the apply tool dispatches on. */
+  name: string;
+  /** Logical group for navigation. */
+  group:
+    | "dataSource"
+    | "dataTable"
+    | "field"
+    | "metric"
+    | "insight"
+    | "visualization"
+    | "dashboard"
+    | "node";
+  /** One-line effect summary. */
+  summary: string;
+  /** Argument names → terse type/role. The contract, not the full schema. */
+  args: Record<string, string>;
+  /** Cautions the agent must heed (idempotency, validation, side effects). */
+  notes?: string;
+}
+
+/**
+ * The crafted guide. Ordered by group for readability. Names MUST match the
+ * `cmd()` command names exactly (the freshness test enforces this against
+ * COMMAND_PATHS).
+ */
+export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
+  // --- DataSource ---
+  {
+    name: "GetOrCreateDataSource",
+    group: "dataSource",
+    summary: "Idempotent upsert of a data source by client-minted id.",
+    args: { id: "UUID", type: "connector id", name: "display name" },
+    notes: "Safe to retry — finds existing by PK or inserts. No credentials.",
+  },
+  {
+    name: "CreateDataSource",
+    group: "dataSource",
+    summary: "Create a data source, storing any credentials in the vault.",
+    args: {
+      id: "UUID",
+      type: "connector id",
+      name: "display name",
+      "apiKey?": "secret",
+      "connectionString?": "secret",
+    },
+    notes: "Credentials go to the vault; never echoed back on read.",
+  },
+  {
+    name: "SetDataSourceConfig",
+    group: "dataSource",
+    summary: "Replace a data source's credential + non-credential config.",
+    args: {
+      id: "UUID",
+      "apiKey?": "secret",
+      "connectionString?": "secret",
+      "extra?": "non-credential settings",
+    },
+    notes: "`extra` must NOT contain apiKey/connectionString (rejected).",
+  },
+  // --- DataTable ---
+  {
+    name: "CreateDataTable",
+    group: "dataTable",
+    summary: "Create a data table under a data source.",
+    args: {
+      id: "UUID",
+      dataSourceId: "UUID",
+      name: "display name",
+      table: "source table name",
+      "sourceSchema?": "discovered schema",
+      "fields?": "Field[]",
+      "metrics?": "Metric[]",
+      "dataFrameId?": "UUID",
+    },
+  },
+  {
+    name: "SetDataTableSchema",
+    group: "dataTable",
+    summary: "Replace a data table's discovered source schema.",
+    args: { id: "UUID", sourceSchema: "discovered schema" },
+  },
+  {
+    name: "RefreshDataTable",
+    group: "dataTable",
+    summary: "Point a data table at a new dataframe and stamp lastFetchedAt.",
+    args: { id: "UUID", dataFrameId: "UUID" },
+  },
+  // --- Field (polymorphic: nodeId targets a DataTable or an Insight) ---
+  {
+    name: "AddField",
+    group: "field",
+    summary: "Append a field to a data table (or select it on an insight).",
+    args: { nodeId: "UUID (table|insight)", field: "Field" },
+    notes: "Rejects a duplicate field id.",
+  },
+  {
+    name: "UpdateField",
+    group: "field",
+    summary: "Update a field by id on a data table.",
+    args: {
+      nodeId: "UUID (table)",
+      fieldId: "UUID",
+      updates: "Partial<Field>",
+    },
+    notes: "Rejected on insight nodes — insight fields are inherited.",
+  },
+  {
+    name: "RemoveField",
+    group: "field",
+    summary: "Remove a field by id.",
+    args: { nodeId: "UUID (table|insight)", fieldId: "UUID" },
+    notes: "Rejects a missing id.",
+  },
+  // --- Metric (polymorphic via nodeId) ---
+  {
+    name: "AddMetric",
+    group: "metric",
+    summary: "Add a metric to a data table or insight.",
+    args: { nodeId: "UUID (table|insight)", metric: "Metric | InsightMetric" },
+    notes:
+      "Insight metrics carry `sourceTable`; table metrics carry `tableId`. " +
+      "The handler validates the shape for the insight path.",
+  },
+  {
+    name: "UpdateMetric",
+    group: "metric",
+    summary: "Update a metric by id.",
+    args: {
+      nodeId: "UUID (table|insight)",
+      metricId: "UUID",
+      updates: "Partial<Metric>",
+    },
+  },
+  {
+    name: "RemoveMetric",
+    group: "metric",
+    summary: "Remove a metric by id.",
+    args: { nodeId: "UUID (table|insight)", metricId: "UUID" },
+    notes: "Rejects a missing id.",
+  },
+  // --- Insight ---
+  {
+    name: "CreateInsight",
+    group: "insight",
+    summary: "Create an insight over a data table or another insight.",
+    args: {
+      id: "UUID",
+      name: "display name",
+      source: "{ sourceType: 'dataTable'|'insight', sourceId: UUID }",
+      "selectedFields?": "UUID[]",
+      "metrics?": "InsightMetric[] (sourceTable, not tableId)",
+    },
+    notes: "Validates source exists; rejects self-reference cycles.",
+  },
+  {
+    name: "SetInsightSource",
+    group: "insight",
+    summary: "Re-point an insight's source.",
+    args: {
+      id: "UUID",
+      source: "{ sourceType: 'dataTable'|'insight', sourceId: UUID }",
+    },
+    notes: "Validates existence + cycle detection.",
+  },
+  {
+    name: "SelectFields",
+    group: "insight",
+    summary: "Replace-all the insight's selected dimension field ids.",
+    args: { id: "UUID", fieldIds: "UUID[]" },
+  },
+  {
+    name: "SetInsightFilter",
+    group: "insight",
+    summary: "Replace-all the insight's filter predicates.",
+    args: {
+      id: "UUID",
+      filters:
+        "TypedInsightFilter[] — value is { kind:'value', v } | { kind:'lateBound', ref }",
+    },
+    notes: "v: null means IS NULL. lateBound defers binding to publish.",
+  },
+  {
+    name: "SetInsightSort",
+    group: "insight",
+    summary: "Replace-all the insight's sort order.",
+    args: { id: "UUID", sorts: "InsightSort[] ({ field, direction })" },
+  },
+  {
+    name: "AddJoin",
+    group: "insight",
+    summary: "Append a join to an insight.",
+    args: {
+      id: "UUID",
+      join: "{ type, rightTableId: UUID, leftKey, rightKey }",
+    },
+    notes: "Validates rightTableId resolves to a data table.",
+  },
+  {
+    name: "UpdateJoin",
+    group: "insight",
+    summary: "Edit the join at an array index.",
+    args: { id: "UUID", joinIndex: "number", updates: "Partial<join>" },
+  },
+  {
+    name: "RemoveJoin",
+    group: "insight",
+    summary: "Drop the join at an array index.",
+    args: { id: "UUID", joinIndex: "number" },
+  },
+  // --- Visualization ---
+  {
+    name: "CreateVisualization",
+    group: "visualization",
+    summary: "Create a chart over an insight.",
+    args: {
+      id: "UUID",
+      name: "display name",
+      insightId: "UUID",
+      visualizationType: "chart type",
+      spec: "Vega-Lite spec",
+      "encoding?": "field→channel encoding",
+    },
+    notes: "The `data` key is stripped from spec before storage.",
+  },
+  {
+    name: "SetChartType",
+    group: "visualization",
+    summary: "Change a chart's type.",
+    args: { id: "UUID", visualizationType: "chart type" },
+  },
+  {
+    name: "SetChartEncoding",
+    group: "visualization",
+    summary: "Set a chart's field→channel encoding (and optionally the spec).",
+    args: {
+      id: "UUID",
+      encoding: "field→channel encoding",
+      "spec?": "Vega-Lite spec (omit to leave untouched)",
+    },
+  },
+  // --- Dashboard ---
+  {
+    name: "CreateDashboard",
+    group: "dashboard",
+    summary: "Create an empty dashboard.",
+    args: { id: "UUID", name: "display name", "description?": "text" },
+  },
+  {
+    name: "AddDashboardItem",
+    group: "dashboard",
+    summary: "Place a viz panel or markdown block on a dashboard.",
+    args: {
+      dashboardId: "UUID",
+      item: "{ id, type:'visualization'|'markdown', visualizationId?|content?, x,y,width,height }",
+    },
+    notes: "Rejects a duplicate item id.",
+  },
+  {
+    name: "UpdateDashboardItem",
+    group: "dashboard",
+    summary: "Move / resize / edit one dashboard item.",
+    args: {
+      dashboardId: "UUID",
+      itemId: "UUID",
+      updates: "Partial item (id and type are pinned, not editable)",
+    },
+    notes: "Rejects a missing itemId.",
+  },
+  {
+    name: "SetDashboardLayout",
+    group: "dashboard",
+    summary: "Replace-all the dashboard layout (bulk rearrange).",
+    args: { dashboardId: "UUID", items: "DashboardItemInput[]" },
+    notes: "Rejects duplicate item ids.",
+  },
+  {
+    name: "RemoveDashboardItem",
+    group: "dashboard",
+    summary: "Remove one panel from a dashboard.",
+    args: { dashboardId: "UUID", itemId: "UUID" },
+    notes: "Rejects a missing itemId.",
+  },
+  // --- Cross-cutting (polymorphic over artifact kinds) ---
+  {
+    name: "RenameNode",
+    group: "node",
+    summary: "Rename any artifact (table, source, insight, viz, dashboard).",
+    args: { id: "UUID", name: "new name" },
+    notes:
+      "Polymorphic — probes kinds in a fixed order and renames the first hit.",
+  },
+  {
+    name: "DeleteNode",
+    group: "node",
+    summary: "Delete any artifact, cascading through ownership edges.",
+    args: { id: "UUID" },
+    notes:
+      "Cascades ownership edges (source→table); stops at reference edges and " +
+      "reports orphanedNodes for drift-repair.",
+  },
+] as const;
+
+/**
+ * The set of command names the guide documents — the FRESHNESS ANCHOR. The
+ * apps/server freshness test asserts this exactly equals the live registry's
+ * command names (COMMAND_PATHS keys), so the guide can neither omit a real
+ * command nor document a removed one without failing CI.
+ */
+export const GUIDE_COMMAND_NAMES: ReadonlySet<string> = new Set(
+  COMMAND_GUIDE.map((e) => e.name),
+);
+
+/**
+ * Render the guide as a compact text block for injection into the agent's
+ * context (the PRIMARY reference the apply tool hands the model). Source-backup
+ * remains reachable via `readSource("apps/server/src/functions/commands.ts")`.
+ */
+export function renderCommandGuide(): string {
+  const lines: string[] = [
+    "# Command vocabulary (primary reference)",
+    "Each command is applied via the apply tool by `name`. For exact arg",
+    "schemas, fall back to source: apps/server/src/functions/commands.ts.",
+    "",
+  ];
+  let group = "";
+  for (const e of COMMAND_GUIDE) {
+    if (e.group !== group) {
+      group = e.group;
+      lines.push(`## ${group}`);
+    }
+    const args = Object.entries(e.args)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(", ");
+    lines.push(`- ${e.name} — ${e.summary}`);
+    lines.push(`  args: { ${args} }`);
+    if (e.notes) lines.push(`  note: ${e.notes}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/assistant/src/read/floor.ts
+++ b/packages/assistant/src/read/floor.ts
@@ -1,0 +1,130 @@
+/**
+ * The privacy FLOOR — the single VALUE-egress gate for the assistant's reads.
+ *
+ * THE WHOLE VALUE OF THIS FILE IS BEING AUDITABLE AT A GLANCE. v0.3 is ONE rule,
+ * binary, inherit-source:
+ *
+ *   A column is sensitive or it isn't (use the canonical Field.sensitivity enum
+ *   from @dashframe/types — `cleared` is the ONLY unrestricted state; `sensitive`
+ *   and `unclassified` both restrict, fail-closed). A data read INHERITS its
+ *   SOURCE columns' sensitivity: if ANY column the artifact reads from is
+ *   restricted, the whole data read is MASKED.
+ *
+ * That is IT. NO result-level classification, NO k-anonymity, NO per-tier
+ * cleverness — those are deferred (a future result-classification pass). STRUCTURE
+ * (column names, types, the sensitivity marker itself) ALWAYS flows ungated; only
+ * ROW/VALUE data is gated, and in v0.3 "gated" means profiles-only regardless
+ * (see below).
+ *
+ * SINGLE DATA-EGRESS BOUNDARY: all VALUE data goes through the perception
+ * assembler. THE PERCEPTION ASSEMBLER IS NOT BUILT YET — so v0.3 `readData`
+ * returns PROFILES-ONLY (column stats / shape / type, never raw rows) as the
+ * floor-held default. This is the correct conservative floor until it exists: an
+ * unmasked read still emits no rows, a masked read emits the same profiles
+ * flagged `masked: true`. When the assembler lands, the tiered
+ * profile→obfuscated→real sample plugs in HERE (the `applyFloor` seam), and the
+ * masked/unmasked decision computed here selects the tier. Nothing else in the
+ * read layer changes.
+ */
+
+import type { Field, FieldSensitivity } from "@dashframe/types";
+import { getFieldSensitivity, isFieldRestricted } from "@dashframe/types";
+
+import type { ColumnProfile, DataReadResult, NodeRef } from "./port.js";
+
+/**
+ * The inherit-source decision, in one place: is this set of source fields
+ * restricted? TRUE iff ANY field is not `cleared` (fail-closed — `unclassified`
+ * counts as restricted, exactly as `isFieldRestricted` defines the floor).
+ *
+ * This is the load-bearing binary. A masked read profiles/obfuscates; an
+ * unmasked read may (once the perception assembler lands) surface a real sample.
+ * There is no middle tier and there is no per-column gating of the OUTPUT — one
+ * sensitive contributing column masks the entire read. Coarse on purpose:
+ * auditable at a glance.
+ */
+export function isMaskedBySource(
+  sourceFields: ReadonlyArray<Pick<Field, "sensitivity">>,
+): boolean {
+  return sourceFields.some((f) => isFieldRestricted(f));
+}
+
+/**
+ * Build the per-column profiles — SHAPE, never raw rows. Every profile carries
+ * the column's OWN sensitivity (structure: the marker always flows). `stats` are
+ * non-row aggregates (counts) safe at every tier; callers pass what the source
+ * has, or omit. This is the only value-shaped data v0.3 emits, masked or not.
+ */
+export function profileColumns(
+  fields: ReadonlyArray<
+    Pick<Field, "name" | "type" | "sensitivity"> & {
+      stats?: ColumnProfile["stats"];
+    }
+  >,
+): ColumnProfile[] {
+  return fields.map((f) => {
+    const profile: ColumnProfile = {
+      name: f.name,
+      type: f.type,
+      sensitivity: getFieldSensitivity(f) as FieldSensitivity,
+    };
+    if (f.stats !== undefined) profile.stats = f.stats;
+    return profile;
+  });
+}
+
+/**
+ * Assemble the floor-gated data-read result for a node from its CONTRIBUTING
+ * source fields. The single VALUE sink: every `readData` path lands here.
+ *
+ * `masked` is the inherit-source binary over the source fields; `columns` is the
+ * profiles-only shape (always emitted, ungated structure). `sample` is never set
+ * in v0.3 — the perception assembler plugs the tiered real/obfuscated sample in
+ * at this exact seam, selected by `masked`.
+ *
+ * FAIL-CLOSED on incomplete resolution. `isMaskedBySource([])` is `false` (an
+ * empty `.some()`), which would be a FAIL-OPEN if the caller couldn't fully
+ * resolve an artifact's contributing columns (e.g. an insight whose source chain
+ * or metric/join column the host couldn't walk). The caller passes
+ * `forceMask: true` to mask regardless of the field set — "I am not certain I saw
+ * every contributing column, so mask." A masked read is always safe (profiles
+ * only, no values); an unmasked-but-incomplete read is the leak. The floor
+ * therefore ORs the caller's force signal with the field-derived binary: the
+ * resolver can only ever make the read MORE restrictive, never less.
+ */
+export function applyFloor(
+  node: NodeRef,
+  sourceFields: ReadonlyArray<
+    Pick<Field, "name" | "type" | "sensitivity"> & {
+      stats?: ColumnProfile["stats"];
+    }
+  >,
+  opts?: { forceMask?: boolean },
+): DataReadResult {
+  return {
+    node,
+    masked: (opts?.forceMask ?? false) || isMaskedBySource(sourceFields),
+    columns: profileColumns(sourceFields),
+    // wires to the perception assembler when it lands: the tiered
+    // profile→obfuscated→real sample plugs in here, selected by `masked`.
+    // Until then, profiles-only is the conservative floor — `sample` stays unset.
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Definition-literal edge (e.g. `WHERE email = 'alice@x.com'` inlined in a
+// definition).
+// ---------------------------------------------------------------------------
+//
+// The inherit-source rule already covers the COMMON case: a filter on a
+// sensitive column means that column contributes to the read → the read is
+// masked → no value leaks via the data path. STRUCTURE reads (readArtifact)
+// expose the definition verbatim, including any inlined literal — that is the
+// definition, and structure is ungated by design.
+//
+// A smart literal-scrub (redacting the inlined value from the STRUCTURE view
+// when it pins a sensitive column) is explicitly out of scope: it needs the
+// field-resolution context to know which literals pin which columns, which is a
+// subsystem, not a few lines. Deferred to a future smart-literal-scrub pass.
+// Until then the floor relies on the inherit-source data-masking rule (above),
+// which is the load-bearing gate.

--- a/packages/assistant/src/read/graph.ts
+++ b/packages/assistant/src/read/graph.ts
@@ -1,0 +1,382 @@
+/**
+ * Graph navigation — STRUCTURE resolution over the GraphReader port.
+ *
+ * The artifact graph's edges are the id references between artifacts. This file
+ * resolves a node's neighbors (one hop), traverses to a bounded depth, and finds
+ * nodes by name/type. EVERYTHING HERE IS STRUCTURE — names, types, edge ids — so
+ * it flows UNGATED (the floor lives in the data path, ./floor.ts, not here).
+ *
+ * The edge map (who references whom):
+ *
+ *   dataSource ─owns→ dataTable ─reads→ insight ─renders→ visualization ─placed→ dashboard
+ *                          │                 │                                       │
+ *                          └─materializes──→ dataFrame ←─result───┘                 │
+ *                                                                                    │
+ *   insight ─joins→ dataTable (rightTableId)                                         │
+ *   dashboard.items[].visualizationId → visualization ──────────────────────────────┘
+ *
+ * Edges are bidirectional for navigation: from an insight you can reach its base
+ * table (down) and the visualizations that render it (up). `neighbors()` returns
+ * BOTH directions so the agent perceives the full local context.
+ */
+
+import type { UUID } from "@dashframe/types";
+
+import type { GraphReader, NodeRef } from "./port.js";
+
+/** A node's structural summary — what the agent perceives without a deep read. */
+export interface NodeSummary {
+  ref: NodeRef;
+  name: string;
+}
+
+/** A node plus its one-hop neighbors, both directions, structure only. */
+export interface Neighborhood {
+  center: NodeSummary;
+  /** Edges OUT of center (things center references / owns / reads from). */
+  downstream: NodeSummary[];
+  /** Edges INTO center (things that reference center). */
+  upstream: NodeSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Node summary
+// ---------------------------------------------------------------------------
+
+/** Resolve a node's name (structure). Returns null if the node doesn't exist. */
+export async function summarize(
+  reader: GraphReader,
+  ref: NodeRef,
+): Promise<NodeSummary | null> {
+  switch (ref.kind) {
+    case "dataSource": {
+      const n = await reader.getDataSource(ref.id);
+      return n ? { ref, name: n.name } : null;
+    }
+    case "dataTable": {
+      const n = await reader.getDataTable(ref.id);
+      return n ? { ref, name: n.name } : null;
+    }
+    case "dataFrame": {
+      const n = await reader.getDataFrameEntry(ref.id);
+      return n ? { ref, name: n.name } : null;
+    }
+    case "insight": {
+      const n = await reader.getInsight(ref.id);
+      return n ? { ref, name: n.name } : null;
+    }
+    case "visualization": {
+      const n = await reader.getVisualization(ref.id);
+      return n ? { ref, name: n.name } : null;
+    }
+    case "dashboard": {
+      const n = await reader.getDashboard(ref.id);
+      return n ? { ref, name: n.name } : null;
+    }
+    default: {
+      // Exhaustive over ArtifactKind — a new kind makes this a compile error.
+      const _exhaustive: never = ref.kind;
+      return _exhaustive;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// One-hop neighbors (the edges, both directions)
+// ---------------------------------------------------------------------------
+
+/**
+ * An accumulator for a node's neighbors. Each per-kind resolver pushes the edges
+ * it knows about; keeping the push helpers here (not inlined in a big switch)
+ * keeps each resolver flat and the dispatcher trivial.
+ */
+class NeighborAcc {
+  readonly downstream: NodeSummary[] = [];
+  readonly upstream: NodeSummary[] = [];
+  constructor(private readonly reader: GraphReader) {}
+  /** Resolve a target's name and push it onto a list (drop dangling refs). */
+  async push(into: NodeSummary[], target: NodeRef): Promise<void> {
+    const s = await summarize(this.reader, target);
+    if (s !== null) into.push(s);
+  }
+  /** Push a target whose name we already have (no extra read). */
+  add(into: NodeSummary[], ref: NodeRef, name: string): void {
+    into.push({ ref, name });
+  }
+}
+
+/** dataSource → owns → dataTable (down). */
+async function dataSourceNeighbors(
+  reader: GraphReader,
+  acc: NeighborAcc,
+  id: UUID,
+): Promise<void> {
+  for (const t of await reader.listDataTables(id))
+    acc.add(acc.downstream, { kind: "dataTable", id: t.id }, t.name);
+}
+
+/** dataTable: up to its source + insights that read it; down to its dataframe. */
+async function dataTableNeighbors(
+  reader: GraphReader,
+  acc: NeighborAcc,
+  id: UUID,
+): Promise<void> {
+  const t = await reader.getDataTable(id);
+  if (t) {
+    await acc.push(acc.upstream, { kind: "dataSource", id: t.dataSourceId });
+    if (t.dataFrameId)
+      await acc.push(acc.downstream, { kind: "dataFrame", id: t.dataFrameId });
+  }
+  for (const i of await reader.listInsights()) {
+    const readsThisTable =
+      i.baseTableId === id ||
+      (i.joins ?? []).some((j) => j.rightTableId === id);
+    if (readsThisTable)
+      acc.add(acc.upstream, { kind: "insight", id: i.id }, i.name);
+  }
+}
+
+/** dataFrame → up → the insight it is the result of. */
+async function dataFrameNeighbors(
+  reader: GraphReader,
+  acc: NeighborAcc,
+  id: UUID,
+): Promise<void> {
+  const df = await reader.getDataFrameEntry(id);
+  if (df?.insightId)
+    await acc.push(acc.upstream, { kind: "insight", id: df.insightId });
+}
+
+/**
+ * Resolve an insight's base-source ref. `Insight.baseTableId` is polymorphic:
+ * for a dataTable source it is a table id; for an insight source (insight-on-
+ * insight composition) it holds the UPSTREAM INSIGHT id. The domain `Insight`
+ * type carries no `sourceType` discriminator (only `baseTableId`), so the kind
+ * must be probed — table-first, then insight, the same probe order the server's
+ * own polymorphic rename/delete resolvers use.
+ *
+ * Probe order is unambiguous because artifact ids are globally-unique UUIDs: a
+ * single id resolves to AT MOST one artifact kind, so "table-first" can only win
+ * when the id IS a table. A cross-table id collision would be a server data-
+ * integrity violation (duplicate UUID across tables), not a case this read layer
+ * papers over. Returns the correctly-kinded ref, or null if neither resolves (a
+ * dangling base — dropped, not errored).
+ */
+async function resolveBaseSource(
+  reader: GraphReader,
+  baseId: UUID,
+): Promise<NodeRef | null> {
+  if ((await reader.getDataTable(baseId)) !== null)
+    return { kind: "dataTable", id: baseId };
+  if ((await reader.getInsight(baseId)) !== null)
+    return { kind: "insight", id: baseId };
+  return null;
+}
+
+/** insight: down to base source (table OR upstream insight) + join tables +
+ * result dataframe; up to its vizzes AND any insights composed ON this one. */
+async function insightNeighbors(
+  reader: GraphReader,
+  acc: NeighborAcc,
+  id: UUID,
+): Promise<void> {
+  const i = await reader.getInsight(id);
+  if (i) {
+    // Base source is polymorphic (dataTable | upstream insight) — resolve its
+    // real kind so a composed insight's edge isn't silently dropped.
+    const base = await resolveBaseSource(reader, i.baseTableId);
+    if (base !== null) await acc.push(acc.downstream, base);
+    for (const j of i.joins ?? [])
+      await acc.push(acc.downstream, { kind: "dataTable", id: j.rightTableId });
+    const df = await reader.getDataFrameByInsight(id);
+    if (df) acc.add(acc.downstream, { kind: "dataFrame", id: df.id }, df.name);
+  }
+  for (const v of await reader.listVisualizations(id))
+    acc.add(acc.upstream, { kind: "visualization", id: v.id }, v.name);
+  // up: insights COMPOSED on this insight (insight-on-insight). Their
+  // `baseTableId` holds THIS insight's id — the reverse of the base edge above,
+  // so a composed child appears in its parent's neighborhood.
+  for (const child of await reader.listInsights()) {
+    if (child.id !== id && child.baseTableId === id)
+      acc.add(acc.upstream, { kind: "insight", id: child.id }, child.name);
+  }
+}
+
+/** visualization: down to its insight; up to dashboards that place it. */
+async function visualizationNeighbors(
+  reader: GraphReader,
+  acc: NeighborAcc,
+  id: UUID,
+): Promise<void> {
+  const v = await reader.getVisualization(id);
+  if (v) await acc.push(acc.downstream, { kind: "insight", id: v.insightId });
+  for (const d of await reader.listDashboards()) {
+    if (d.items.some((it) => it.visualizationId === id))
+      acc.add(acc.upstream, { kind: "dashboard", id: d.id }, d.name);
+  }
+}
+
+/** dashboard → down → the visualizations it places. */
+async function dashboardNeighbors(
+  reader: GraphReader,
+  acc: NeighborAcc,
+  id: UUID,
+): Promise<void> {
+  const d = await reader.getDashboard(id);
+  for (const it of d?.items ?? []) {
+    if (it.type === "visualization" && it.visualizationId)
+      await acc.push(acc.downstream, {
+        kind: "visualization",
+        id: it.visualizationId,
+      });
+  }
+}
+
+/** Per-kind neighbor resolvers — the fixed, schema-owned edge map. */
+const NEIGHBOR_RESOLVERS: Record<
+  NodeRef["kind"],
+  (reader: GraphReader, acc: NeighborAcc, id: UUID) => Promise<void>
+> = {
+  dataSource: dataSourceNeighbors,
+  dataTable: dataTableNeighbors,
+  dataFrame: dataFrameNeighbors,
+  insight: insightNeighbors,
+  visualization: visualizationNeighbors,
+  dashboard: dashboardNeighbors,
+};
+
+/**
+ * Resolve the one-hop neighbors of a node, BOTH directions. Structure only.
+ * Returns `null` if the center node doesn't exist.
+ *
+ * Each kind's edges are walked explicitly (the `NEIGHBOR_RESOLVERS` map above) —
+ * no runtime edge-discovery: the artifact model is a fixed, schema-owned shape,
+ * so the edges are enumerated exactly like the server's typed-edge cascade does.
+ * Missing neighbor targets (a dangling ref) are dropped, not errored — a read
+ * layer surfaces what exists.
+ */
+export async function neighbors(
+  reader: GraphReader,
+  ref: NodeRef,
+): Promise<Neighborhood | null> {
+  const center = await summarize(reader, ref);
+  if (center === null) return null;
+  const acc = new NeighborAcc(reader);
+  await NEIGHBOR_RESOLVERS[ref.kind](reader, acc, ref.id);
+  return { center, downstream: acc.downstream, upstream: acc.upstream };
+}
+
+// ---------------------------------------------------------------------------
+// Bounded traversal (readGraph)
+// ---------------------------------------------------------------------------
+
+/** A node reached during traversal, with its hop distance from the origin. */
+export interface ReachedNode {
+  ref: NodeRef;
+  name: string;
+  depth: number;
+}
+
+const MAX_TRAVERSAL_DEPTH = 6;
+
+/**
+ * Breadth-first structure traversal from a node out to `depth` hops. Visits each
+ * node once (cycle-safe via a visited set keyed by kind+id). Structure only —
+ * this is the grep+ls "navigate to it" reach, deliberately NOT the ambient
+ * default (that's readNeighborhood). `depth` is clamped to a sane ceiling so a
+ * runaway agent can't walk the whole graph in one call.
+ */
+export async function traverse(
+  reader: GraphReader,
+  origin: NodeRef,
+  depth: number,
+): Promise<ReachedNode[]> {
+  const clamped = Math.max(0, Math.min(depth, MAX_TRAVERSAL_DEPTH));
+  const seen = new Set<string>();
+  const key = (r: NodeRef) => `${r.kind}:${r.id}`;
+  const result: ReachedNode[] = [];
+
+  const originSummary = await summarize(reader, origin);
+  if (originSummary === null) return [];
+  seen.add(key(origin));
+  result.push({ ref: origin, name: originSummary.name, depth: 0 });
+
+  /** Expand one frontier node: return its not-yet-seen neighbors (marking them). */
+  const expand = async (node: NodeRef, d: number): Promise<NodeRef[]> => {
+    const hood = await neighbors(reader, node);
+    if (hood === null) return [];
+    const fresh: NodeRef[] = [];
+    for (const n of [...hood.downstream, ...hood.upstream]) {
+      const k = key(n.ref);
+      if (seen.has(k)) continue;
+      seen.add(k);
+      result.push({ ref: n.ref, name: n.name, depth: d });
+      fresh.push(n.ref);
+    }
+    return fresh;
+  };
+
+  let frontier: NodeRef[] = [origin];
+  for (let d = 1; d <= clamped && frontier.length > 0; d++) {
+    const expansions = await Promise.all(
+      frontier.map((node) => expand(node, d)),
+    );
+    frontier = expansions.flat();
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Find by name / type (search)
+// ---------------------------------------------------------------------------
+
+/** A search hit — node identity + name + kind (structure). */
+export interface SearchHit {
+  ref: NodeRef;
+  name: string;
+}
+
+export interface SearchQuery {
+  /** Substring matched case-insensitively against the node name. Optional. */
+  name?: string;
+  /** Restrict to one artifact kind. Optional. */
+  kind?: NodeRef["kind"];
+}
+
+/**
+ * Find nodes by name substring and/or kind across the whole graph. Structure
+ * only — the global REACH the agent navigates to on demand. An empty query
+ * (no name, no kind) returns every node, so this doubles as `ls`.
+ */
+export async function search(
+  reader: GraphReader,
+  q: SearchQuery,
+): Promise<SearchHit[]> {
+  const needle = q.name?.toLowerCase();
+  const hits: SearchHit[] = [];
+
+  // The fixed enumeration of searchable kinds → their list reader. A query
+  // pinning a kind walks only that one (efficiency); an empty query walks all
+  // (the `ls`). dataFrames are searchable too — KindSchema accepts them.
+  const lists: Array<{
+    kind: NodeRef["kind"];
+    list: () => Promise<ReadonlyArray<{ id: UUID; name: string }>>;
+  }> = [
+    { kind: "dataSource", list: () => reader.listDataSources() },
+    { kind: "dataTable", list: () => reader.listDataTables() },
+    { kind: "dataFrame", list: () => reader.listDataFrames() },
+    { kind: "insight", list: () => reader.listInsights() },
+    { kind: "visualization", list: () => reader.listVisualizations() },
+    { kind: "dashboard", list: () => reader.listDashboards() },
+  ];
+
+  for (const { kind, list } of lists) {
+    if (q.kind && q.kind !== kind) continue;
+    for (const n of await list()) {
+      if (needle && !n.name.toLowerCase().includes(needle)) continue;
+      hits.push({ ref: { kind, id: n.id }, name: n.name });
+    }
+  }
+
+  return hits;
+}

--- a/packages/assistant/src/read/index.ts
+++ b/packages/assistant/src/read/index.ts
@@ -1,0 +1,44 @@
+/**
+ * The assistant READ layer — a privacy-aware graph resolver.
+ *
+ * The agent perceives the artifact graph through four fixed tools. STRUCTURE
+ * (names, types, edges, definitions) flows ungated; VALUES pass the privacy
+ * floor (binary, inherit-source). All reads go through the GraphReader port,
+ * which the host binds to the draft-scoped server read path.
+ *
+ *   port.ts          — the read seam (host binds to app.runHandler + draftId)
+ *   floor.ts         — the privacy floor (single value-egress gate)
+ *   graph.ts         — structure navigation (neighbors, traverse, search)
+ *   tools.ts         — the 4 fixed read tools on defineToolHandler
+ *   command-guide.ts — the agent-readable command vocabulary + freshness anchor
+ */
+
+export type {
+  ColumnProfile,
+  DashboardRead,
+  DataFrameRead,
+  DataReadResult,
+  GraphReader,
+  NodeRef,
+} from "./port.js";
+
+export { applyFloor, isMaskedBySource, profileColumns } from "./floor.js";
+
+export { neighbors, search, summarize, traverse } from "./graph.js";
+export type {
+  Neighborhood,
+  NodeSummary,
+  ReachedNode,
+  SearchHit,
+  SearchQuery,
+} from "./graph.js";
+
+export { createReadTools } from "./tools.js";
+export type { ReadTools } from "./tools.js";
+
+export {
+  COMMAND_GUIDE,
+  GUIDE_COMMAND_NAMES,
+  renderCommandGuide,
+} from "./command-guide.js";
+export type { CommandGuideEntry } from "./command-guide.js";

--- a/packages/assistant/src/read/port.ts
+++ b/packages/assistant/src/read/port.ts
@@ -1,0 +1,174 @@
+/**
+ * GraphReader — the READ seam the assistant's perception layer resolves against.
+ *
+ * THE MODEL (steal GraphQL's mental model, NOT its machinery): a typed-graph
+ * resolver. The assistant navigates NODES (artifacts), follows EDGES (the id
+ * references between them), and selects FIELDS. There is no SDL, no query
+ * language, no codegen — the agent calls ~4 FIXED tools (see ./tools.ts). The
+ * defining property is THE FLOOR LIVES IN THE RESOLVER: STRUCTURE (names, types,
+ * edges) resolves freely; every resolver that returns a VALUE passes it through
+ * the privacy floor (see ./floor.ts).
+ *
+ * ARCHITECTURAL BOUNDARY — why this is a port, not a direct call:
+ * `@dashframe/server` (apps/server) DEPENDS ON `@dashframe/assistant`, so the
+ * assistant package cannot import the server (circular). It also must not read
+ * the raw DB — the single-egress invariant requires every read to go through the
+ * SERVER SEAM (the renderer's read path: `getInsight`, `getDataTable`, … in
+ * apps/server/src/functions/app-artifacts.ts + dashboards.ts), against the
+ * DRAFT-OVERLAY view so the assistant perceives its own in-progress draft edits.
+ * So the assistant defines this PORT, and the HOST (apps/server) binds it to a
+ * draft-scoped WyStack app: every `query()` call routes through
+ * `app.runHandler(path, args, tracked, { draftId })` — the withDraftSeam read
+ * path. The assistant never sees the DB, the draftId wiring, or the canonical-vs-
+ * draft choice; the host owns that and hands back a reader already scoped to the
+ * draft. The reader is the single egress boundary for structure; ./floor.ts is
+ * the single egress boundary for values.
+ */
+
+import type {
+  ArtifactKind,
+  DataSource,
+  DataTable,
+  Insight,
+  UUID,
+  Visualization,
+} from "@dashframe/types";
+
+// ---------------------------------------------------------------------------
+// Node identity
+// ---------------------------------------------------------------------------
+
+/**
+ * A node in the artifact graph: an artifact's kind + id. The kind is the
+ * canonical `ArtifactKind` from @dashframe/types — the same enum the server's
+ * polymorphic rename/delete handlers resolve against, so the assistant's graph
+ * vocabulary never forks from the artifact model.
+ */
+export interface NodeRef {
+  kind: ArtifactKind;
+  id: UUID;
+}
+
+/**
+ * A dataframe's read shape — the STRUCTURE the assistant navigates. A minimal,
+ * self-owned view (id, name, the insight back-edge, field ids, shape counts);
+ * the assistant deliberately does NOT couple to the server-private DataFrameEntry
+ * type (it would be a circular import and carries storage internals the read
+ * layer must not see). The host maps the server row down to this shape.
+ */
+export interface DataFrameRead {
+  id: UUID;
+  name: string;
+  /** Back-edge: the insight whose result this dataframe materializes. */
+  insightId?: UUID;
+  fieldIds: UUID[];
+  rowCount?: number;
+  columnCount?: number;
+}
+
+/** A dashboard's read shape (apps/server dashboards.ts `getDashboard`). */
+export interface DashboardRead {
+  id: UUID;
+  name: string;
+  description?: string;
+  items: Array<{
+    id: UUID;
+    type: "visualization" | "markdown";
+    visualizationId?: UUID;
+    content?: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// GraphReader port
+// ---------------------------------------------------------------------------
+
+/**
+ * The structure-read surface. Each method maps 1:1 to a server read function
+ * (the host binds it to `app.runHandler("<path>", args, …, { draftId })`).
+ *
+ * STRUCTURE FLOWS UNGATED. Every value returned here is a DEFINITION (names,
+ * types, edge ids, encoding shape) — never row data. Row/value data is a
+ * separate egress: it flows ONLY through `readDataProfile` (and ./floor.ts).
+ * DataSource configs already arrive credential-free from the server seam
+ * (presence booleans, never secrets — see app-artifacts.ts `rowToDataSource`).
+ */
+export interface GraphReader {
+  // --- single-artifact definition reads (structure, ungated) ---
+  getDataSource(id: UUID): Promise<DataSource | null>;
+  getDataTable(id: UUID): Promise<DataTable | null>;
+  getDataFrameEntry(id: UUID): Promise<DataFrameRead | null>;
+  getInsight(id: UUID): Promise<Insight | null>;
+  getVisualization(id: UUID): Promise<Visualization | null>;
+  getDashboard(id: UUID): Promise<DashboardRead | null>;
+
+  // --- list / find (structure, ungated) ---
+  listDataSources(): Promise<DataSource[]>;
+  listDataTables(dataSourceId?: UUID): Promise<DataTable[]>;
+  listDataFrames(): Promise<DataFrameRead[]>;
+  listInsights(): Promise<Insight[]>;
+  listVisualizations(insightId?: UUID): Promise<Visualization[]>;
+  listDashboards(): Promise<DashboardRead[]>;
+  /** Back-edge: the DataFrame an insight's result is materialized into. */
+  getDataFrameByInsight(insightId: UUID): Promise<DataFrameRead | null>;
+
+  /**
+   * Tiered DATA read for one artifact (a table or an insight result). This is
+   * the VALUE egress — the host implementation MUST route the returned payload
+   * through the privacy floor (./floor.ts). Returns column PROFILES only in
+   * v0.3 (the conservative floor until the perception assembler lands;
+   * see ./floor.ts). The reader exposes it so the data tool (./tools.ts) never
+   * reaches past the port for row data.
+   */
+  readDataProfile(node: NodeRef): Promise<DataReadResult>;
+
+  /**
+   * Open a project SOURCE file as text — the agent's BACKUP/verification path
+   * for the command vocabulary (the crafted guide in ./command-guide.ts is the
+   * PRIMARY reference; this lets the agent fall back to `commands.ts` when the
+   * guide is insufficient or suspected stale). Host-scoped to an allowlist of
+   * readable source files; returns `null` for anything not allowlisted.
+   */
+  readSource(file: string): Promise<string | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Data-read result (value egress shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-column profile — SHAPE, never raw rows. The floor-held default until the
+ * perception assembler can produce the tiered profile→obfuscated→real
+ * sample. `sensitivity` is the column's own classification (inherit-source key).
+ */
+export interface ColumnProfile {
+  name: string;
+  type: string;
+  sensitivity: "unclassified" | "sensitive" | "cleared";
+  /** Non-row statistics safe to surface at every tier (counts, null-rate). */
+  stats?: {
+    rowCount?: number;
+    nullCount?: number;
+    distinctCount?: number;
+  };
+}
+
+/**
+ * The result of a tiered data read. STRUCTURE (the column profiles' names/types/
+ * sensitivity) is always present and ungated. Whether the read is MASKED is the
+ * binary inherit-source decision (./floor.ts): any source column sensitive →
+ * masked. `sample` is reserved for the post-assembler tiered real/obfuscated rows;
+ * it is ALWAYS `undefined` in v0.3 (profiles-only).
+ */
+export interface DataReadResult {
+  node: NodeRef;
+  /** True when any contributing source column is sensitive (inherit-source). */
+  masked: boolean;
+  /** Per-column profiles — the only value data v0.3 emits. */
+  columns: ColumnProfile[];
+  /**
+   * Reserved seam: tiered row sample (real | obfuscated). Wires to the
+   * perception assembler when it lands; ALWAYS `undefined` until then.
+   */
+  sample?: never;
+}

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Read-layer contracts — the privacy-aware graph resolver.
+ *
+ * These tests pin the LOAD-BEARING contracts of the read layer against an
+ * in-memory fake GraphReader (a hand-built artifact graph). The fake stands in
+ * for the host's draft-scoped server seam; the apps/server integration test
+ * proves the SAME resolver against a real PGlite app + real draft overlay +
+ * real Field.sensitivity. Here we prove the resolver logic and the floor in
+ * isolation, where cause→effect is obvious.
+ *
+ * Contracts under test:
+ *   - readNeighborhood = invocation point + 1 hop, NOT the whole graph.
+ *   - readGraph / find navigate BEYOND one hop.
+ *   - readArtifact returns structure (the definition), ungated.
+ *   - readData masks (profiles-only) when a source column is sensitive; never
+ *     gates structure; emits NO raw rows and NO result-classification.
+ */
+
+import type {
+  DataSource,
+  DataTable,
+  Field,
+  Insight,
+  Visualization,
+} from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+
+import { applyFloor, isMaskedBySource } from "./floor.js";
+import { neighbors, search, traverse } from "./graph.js";
+import type {
+  DashboardRead,
+  DataFrameRead,
+  DataReadResult,
+  GraphReader,
+  NodeRef,
+} from "./port.js";
+import { createReadTools } from "./tools.js";
+
+// ---------------------------------------------------------------------------
+// A small fixed graph:
+//
+//   source(src1) ─owns→ table(tblOrders) ─reads→ insight(insRevenue) ─renders→ viz(vizBar) ─placed→ dashboard(dashMain)
+//
+// tblOrders has a sensitive `email` column and a cleared `amount` column.
+// A SECOND, fully-cleared table (tblPublic) feeds insight insPublic — used to
+// prove an unmasked read.
+// ---------------------------------------------------------------------------
+
+const FIELD_EMAIL: Field = {
+  id: "f-email",
+  name: "email",
+  tableId: "tblOrders",
+  type: "string",
+  sensitivity: "sensitive",
+};
+const FIELD_AMOUNT: Field = {
+  id: "f-amount",
+  name: "amount",
+  tableId: "tblOrders",
+  type: "number",
+  sensitivity: "cleared",
+};
+const FIELD_REGION: Field = {
+  id: "f-region",
+  name: "region",
+  tableId: "tblPublic",
+  type: "string",
+  sensitivity: "cleared",
+};
+
+const SRC: DataSource = {
+  id: "src1",
+  type: "rest",
+  name: "Orders API",
+  config: {} as DataSource["config"],
+  createdAt: 0,
+};
+const TBL_ORDERS: DataTable = {
+  id: "tblOrders",
+  dataSourceId: "src1",
+  name: "Orders",
+  table: "orders",
+  fields: [FIELD_EMAIL, FIELD_AMOUNT],
+  metrics: [],
+  createdAt: 0,
+};
+const TBL_PUBLIC: DataTable = {
+  id: "tblPublic",
+  dataSourceId: "src1",
+  name: "Regions",
+  table: "regions",
+  fields: [FIELD_REGION],
+  metrics: [],
+  createdAt: 0,
+};
+const INS_REVENUE: Insight = {
+  id: "insRevenue",
+  name: "Revenue by email",
+  baseTableId: "tblOrders",
+  selectedFields: ["f-email", "f-amount"],
+  metrics: [],
+  createdAt: 0,
+};
+const INS_PUBLIC: Insight = {
+  id: "insPublic",
+  name: "Regions list",
+  baseTableId: "tblPublic",
+  selectedFields: ["f-region"],
+  metrics: [],
+  createdAt: 0,
+};
+// Insight-on-insight composition: baseTableId holds an INSIGHT id, not a table.
+const INS_COMPOSED: Insight = {
+  id: "insComposed",
+  name: "Composed over revenue",
+  baseTableId: "insRevenue", // ← an insight id (the upstream source)
+  selectedFields: [],
+  metrics: [],
+  createdAt: 0,
+};
+const VIZ_BAR: Visualization = {
+  id: "vizBar",
+  insightId: "insRevenue",
+  name: "Revenue bar",
+  visualizationType: "barY",
+  spec: {} as Visualization["spec"],
+  createdAt: 0,
+};
+const DASH_MAIN: DashboardRead = {
+  id: "dashMain",
+  name: "Main dashboard",
+  items: [{ id: "item1", type: "visualization", visualizationId: "vizBar" }],
+};
+
+const DATAFRAME: DataFrameRead = {
+  id: "df1",
+  name: "Revenue result",
+  insightId: "insRevenue",
+  fieldIds: ["f-email", "f-amount"],
+};
+
+/** A fake reader over the fixed graph. `readDataProfile` mirrors the host: it
+ * resolves the artifact's source fields and runs them through `applyFloor`. */
+function makeReader(): GraphReader {
+  const tables = [TBL_ORDERS, TBL_PUBLIC];
+  const insights = [INS_REVENUE, INS_PUBLIC, INS_COMPOSED];
+  const vizzes = [VIZ_BAR];
+  const dashboards = [DASH_MAIN];
+
+  const sourceFieldsFor = (node: NodeRef): Field[] => {
+    if (node.kind === "dataTable")
+      return tables.find((t) => t.id === node.id)?.fields ?? [];
+    const ins = insights.find((i) => i.id === node.id);
+    if (!ins) return [];
+    const tbl = tables.find((t) => t.id === ins.baseTableId);
+    const byId = new Map((tbl?.fields ?? []).map((f) => [f.id, f]));
+    return (ins.selectedFields ?? [])
+      .map((id) => byId.get(id))
+      .filter((f): f is Field => f !== undefined);
+  };
+
+  return {
+    getDataSource: async (id) => (id === "src1" ? SRC : null),
+    getDataTable: async (id) => tables.find((t) => t.id === id) ?? null,
+    getDataFrameEntry: async (id) => (id === "df1" ? DATAFRAME : null),
+    getInsight: async (id) => insights.find((i) => i.id === id) ?? null,
+    getVisualization: async (id) => vizzes.find((v) => v.id === id) ?? null,
+    getDashboard: async (id) => dashboards.find((d) => d.id === id) ?? null,
+    listDataSources: async () => [SRC],
+    listDataTables: async (dataSourceId) =>
+      dataSourceId
+        ? tables.filter((t) => t.dataSourceId === dataSourceId)
+        : tables,
+    listDataFrames: async () => [DATAFRAME],
+    listInsights: async () => insights,
+    listVisualizations: async (insightId) =>
+      insightId ? vizzes.filter((v) => v.insightId === insightId) : vizzes,
+    listDashboards: async () => dashboards,
+    getDataFrameByInsight: async (insightId) =>
+      insightId === "insRevenue" ? DATAFRAME : null,
+    readDataProfile: async (node) =>
+      applyFloor(
+        node,
+        sourceFieldsFor(node).map((f) => ({
+          name: f.name,
+          type: f.type,
+          sensitivity: f.sensitivity,
+        })),
+      ),
+    readSource: async (file) =>
+      file === "apps/server/src/functions/commands.ts"
+        ? "// source text"
+        : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Neighborhood = invocation point + 1 hop (NOT the whole graph)
+// ---------------------------------------------------------------------------
+
+describe("readNeighborhood — ambient = invocation + 1 hop", () => {
+  it("returns only direct neighbors of the insight, both directions", async () => {
+    const reader = makeReader();
+    const hood = await neighbors(reader, { kind: "insight", id: "insRevenue" });
+    expect(hood).not.toBeNull();
+    expect(hood!.center.name).toBe("Revenue by email");
+
+    // downstream: base table + result dataframe (1 hop down).
+    const down = hood!.downstream.map((n) => n.ref.id).sort();
+    expect(down).toEqual(["df1", "tblOrders"]);
+    // upstream (1 hop up): the viz that renders it + the insight composed ON it
+    // (insComposed's base is insRevenue — the reverse insight-on-insight edge).
+    expect(hood!.upstream.map((n) => n.ref.id).sort()).toEqual([
+      "insComposed",
+      "vizBar",
+    ]);
+
+    // NOT the whole graph: the dashboard (2 hops up) is absent from neighbors.
+    const allIds = [...down, ...hood!.upstream.map((n) => n.ref.id)];
+    expect(allIds).not.toContain("dashMain");
+    expect(allIds).not.toContain("src1");
+  });
+
+  it("returns null for a missing invocation point", async () => {
+    const reader = makeReader();
+    expect(await neighbors(reader, { kind: "insight", id: "nope" })).toBeNull();
+  });
+
+  it("resolves a composed insight's base as an INSIGHT, not a dropped table edge", async () => {
+    const reader = makeReader();
+    const hood = await neighbors(reader, {
+      kind: "insight",
+      id: "insComposed",
+    });
+    // baseTableId is an insight id; the edge must resolve to that insight (down),
+    // never silently dropped by probing it as a non-existent table.
+    expect(
+      hood!.downstream.some(
+        (n) => n.ref.kind === "insight" && n.ref.id === "insRevenue",
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readGraph / find navigate BEYOND one hop
+// ---------------------------------------------------------------------------
+
+describe("readGraph / find — global reach beyond one hop", () => {
+  it("traverse reaches the dashboard from the insight at depth 2", async () => {
+    const reader = makeReader();
+    const reached = await traverse(
+      reader,
+      { kind: "insight", id: "insRevenue" },
+      2,
+    );
+    const dash = reached.find((r) => r.ref.id === "dashMain");
+    expect(dash).toBeDefined();
+    expect(dash!.depth).toBe(2); // insight → viz (1) → dashboard (2)
+  });
+
+  it("traverse at depth 0 returns only the origin", async () => {
+    const reader = makeReader();
+    const reached = await traverse(
+      reader,
+      { kind: "insight", id: "insRevenue" },
+      0,
+    );
+    expect(reached.map((r) => r.ref.id)).toEqual(["insRevenue"]);
+  });
+
+  it("find by name substring matches across kinds", async () => {
+    const reader = makeReader();
+    const hits = await search(reader, { name: "revenue" });
+    const ids = hits.map((h) => h.ref.id).sort();
+    // "Revenue by email" (insight), "Composed over revenue" (insight),
+    // "Revenue result" (dataFrame — now searchable), "Revenue bar" (viz).
+    expect(ids).toEqual(["df1", "insComposed", "insRevenue", "vizBar"]);
+  });
+
+  it("find by kind restricts the result set", async () => {
+    const reader = makeReader();
+    const hits = await search(reader, { kind: "dataTable" });
+    expect(hits.map((h) => h.ref.kind)).toEqual(["dataTable", "dataTable"]);
+  });
+
+  it("find by kind 'dataFrame' returns dataFrames (KindSchema accepts it)", async () => {
+    const reader = makeReader();
+    const hits = await search(reader, { kind: "dataFrame" });
+    expect(hits.map((h) => h.ref.id)).toEqual(["df1"]);
+  });
+
+  it("empty find lists every node (the ls)", async () => {
+    const reader = makeReader();
+    const hits = await search(reader, {});
+    // 1 source + 2 tables + 1 dataFrame + 3 insights + 1 viz + 1 dashboard = 9
+    expect(hits.length).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readArtifact returns structure (the definition), ungated
+// ---------------------------------------------------------------------------
+
+describe("readArtifact — structure, ungated", () => {
+  it("returns the insight's full definition (query shape)", async () => {
+    const reader = makeReader();
+    const { readArtifact } = createReadTools(reader);
+    const res = await readArtifact.execute("c", {
+      kind: "insight",
+      id: "insRevenue",
+    });
+    expect(res.details).toMatchObject({
+      kind: "insight",
+      definition: { id: "insRevenue", baseTableId: "tblOrders" },
+    });
+    // Structure is ungated even though the insight touches a sensitive column.
+    const def = (res.details as { definition: Insight }).definition;
+    expect(def.selectedFields).toEqual(["f-email", "f-amount"]);
+  });
+
+  it("reports not_found for a missing artifact", async () => {
+    const reader = makeReader();
+    const { readArtifact } = createReadTools(reader);
+    const res = await readArtifact.execute("c", {
+      kind: "dashboard",
+      id: "nope",
+    });
+    expect(res.details).toEqual({ error: "not_found" });
+  });
+});
+
+describe("read_source — allowlisted backup path", () => {
+  it("returns the command source for an allowlisted file", async () => {
+    const reader = makeReader();
+    const { readSource } = createReadTools(reader);
+    const res = await readSource.execute("c", {
+      file: "apps/server/src/functions/commands.ts",
+    });
+    expect(res.details).toMatchObject({
+      file: "apps/server/src/functions/commands.ts",
+    });
+    expect((res.details as { text: string }).text).toContain("source text");
+  });
+
+  it("refuses a non-allowlisted file", async () => {
+    const reader = makeReader();
+    const { readSource } = createReadTools(reader);
+    const res = await readSource.execute("c", { file: "/etc/passwd" });
+    expect(res.details).toEqual({ error: "not_readable" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readData — the FLOOR: binary inherit-source, profiles-only, never gates structure
+// ---------------------------------------------------------------------------
+
+describe("isMaskedBySource — the binary inherit-source decision", () => {
+  it("masks when ANY source field is sensitive", () => {
+    expect(isMaskedBySource([FIELD_AMOUNT, FIELD_EMAIL])).toBe(true);
+  });
+  it("masks when a field is unclassified (fail-closed)", () => {
+    expect(isMaskedBySource([{ sensitivity: "unclassified" }])).toBe(true);
+    expect(isMaskedBySource([{}])).toBe(true); // absent === unclassified
+  });
+  it("does NOT mask when every source field is cleared", () => {
+    expect(isMaskedBySource([FIELD_AMOUNT, FIELD_REGION])).toBe(false);
+  });
+});
+
+describe("applyFloor — fail-closed on incomplete resolution (forceMask)", () => {
+  const node: NodeRef = { kind: "insight", id: "x" };
+
+  it("masks a cleared field set when forceMask is set (couldn't enumerate source)", () => {
+    // The fail-open hazard: a host that can't walk an insight's full source chain
+    // resolves to an incomplete (here, empty/cleared) field set. forceMask makes
+    // the floor mask regardless — an unmasked-but-incomplete read is the leak.
+    expect(applyFloor(node, []).masked).toBe(false); // empty .some() is false…
+    expect(applyFloor(node, [], { forceMask: true }).masked).toBe(true); // …forced closed
+    expect(
+      applyFloor(
+        node,
+        [{ name: "a", type: "string", sensitivity: "cleared" }],
+        {
+          forceMask: true,
+        },
+      ).masked,
+    ).toBe(true);
+  });
+
+  it("forceMask can only make a read MORE restrictive, never less", () => {
+    // A sensitive field already masks; forceMask:false doesn't unmask it.
+    expect(
+      applyFloor(
+        node,
+        [{ name: "e", type: "string", sensitivity: "sensitive" }],
+        { forceMask: false },
+      ).masked,
+    ).toBe(true);
+  });
+});
+
+describe("readData — tiered data, floor-gated", () => {
+  it("masks an insight whose source has a sensitive column (table + insight)", async () => {
+    const reader = makeReader();
+    const { readData } = createReadTools(reader);
+
+    // Insight result (a viz reads its insight's result via this).
+    const insRes = await readData.execute("c", {
+      kind: "insight",
+      id: "insRevenue",
+    });
+    const ins = insRes.details as DataReadResult;
+    expect(ins.masked).toBe(true);
+    // Structure NEVER gated: column names/types/sensitivity always flow.
+    expect(ins.columns.map((c) => c.name).sort()).toEqual(["amount", "email"]);
+    expect(ins.columns.find((c) => c.name === "email")!.sensitivity).toBe(
+      "sensitive",
+    );
+    // Profiles-only: NO raw rows. (`sample` is the never-set seam.)
+    expect(ins.sample).toBeUndefined();
+
+    // Same masking applies reading the underlying TABLE directly.
+    const tblRes = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblOrders",
+    });
+    expect((tblRes.details as DataReadResult).masked).toBe(true);
+  });
+
+  it("does NOT mask a fully-cleared source, still profiles-only (no rows)", async () => {
+    const reader = makeReader();
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "insight",
+      id: "insPublic",
+    });
+    const data = res.details as DataReadResult;
+    expect(data.masked).toBe(false);
+    expect(data.columns.map((c) => c.name)).toEqual(["region"]);
+    // Even unmasked, v0.3 emits profiles-only — no raw sample until the perception assembler lands.
+    expect(data.sample).toBeUndefined();
+  });
+
+  it("masks a fully-cleared TABLE only when all its fields are cleared", async () => {
+    const reader = makeReader();
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblPublic",
+    });
+    expect((res.details as DataReadResult).masked).toBe(false);
+  });
+});

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -1,0 +1,348 @@
+/**
+ * The ~4 FIXED read tools — the assistant's perception surface.
+ *
+ * Built on `defineToolHandler` (the typed-tool seam) over an injected
+ * `GraphReader` (the host binds it to the draft-scoped server read path; see
+ * ./port.ts). This is NOT a query language — the agent calls these four fixed
+ * tools, and the resolver (./graph.ts) + floor (./floor.ts) do the work.
+ *
+ * INVARIANTS (restated from the resolver, enforced here at the tool boundary):
+ *   - STRUCTURE flows UNGATED; VALUES are floor-gated at the data sink.
+ *     readNeighborhood / readGraph / readArtifact return STRUCTURE only.
+ *     readData is the ONLY tool that returns value-shaped data, and it routes
+ *     through the floor (./floor.ts, via the port's readDataProfile).
+ *   - All reads go through the SERVER seam (the GraphReader port), against the
+ *     DRAFT-OVERLAY view — the host scopes the reader to the active draftId, so
+ *     the agent perceives its own in-progress edits. Tools never touch the DB.
+ *   - Ambient perception (readNeighborhood) = invocation point + 1 hop, NOT the
+ *     whole graph. readGraph/searchGraph are the on-demand global reach.
+ */
+
+import type { ArtifactKind } from "@dashframe/types";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { defineToolHandler, Type, type Static } from "../tool.js";
+
+import type { Neighborhood, ReachedNode, SearchHit } from "./graph.js";
+import { neighbors, search, summarize, traverse } from "./graph.js";
+import type {
+  DashboardRead,
+  DataReadResult,
+  GraphReader,
+  NodeRef,
+} from "./port.js";
+
+/**
+ * TypeBox enum for an artifact kind (shared across the tool schemas). The
+ * members are spelled out (not `.map()`-ed from an array) so TypeBox's `Static`
+ * inference narrows `kind` to the literal union rather than widening to string.
+ */
+const KindSchema = Type.Union(
+  [
+    Type.Literal("dataSource"),
+    Type.Literal("dataTable"),
+    Type.Literal("dataFrame"),
+    Type.Literal("insight"),
+    Type.Literal("visualization"),
+    Type.Literal("dashboard"),
+  ],
+  { description: "Artifact kind." },
+);
+
+/** A node reference param: { kind, id }. */
+const NodeRefSchema = Type.Object({
+  kind: KindSchema,
+  id: Type.String({ description: "Artifact id (UUID)." }),
+});
+
+function text(s: string) {
+  return { content: [{ type: "text" as const, text: s }] };
+}
+
+/**
+ * Build the four fixed read tools over a reader. The host calls this once with a
+ * reader already scoped to the active draft, and registers the result on the
+ * agent's tool set. Returned as a named record so the host can register exactly
+ * the perception surface it wants.
+ */
+export function createReadTools(reader: GraphReader) {
+  // -------------------------------------------------------------------------
+  // 1. readNeighborhood — AMBIENT perception: invocation point + 1 hop.
+  // -------------------------------------------------------------------------
+  const readNeighborhood = defineToolHandler<
+    typeof NodeRefSchema,
+    { neighborhood: Neighborhood } | { error: string }
+  >({
+    name: "read_neighborhood",
+    description:
+      "Ambient perception: the invocation point (the artifact the assistant " +
+      "was triggered from) plus its ONE-HOP neighbors, both directions. " +
+      "Returns STRUCTURE only (names, kinds, edges) — never data. This is the " +
+      "default local view; most intents are local. Use read_graph/find_nodes " +
+      "to reach beyond one hop.",
+    label: "Read neighborhood",
+    parameters: NodeRefSchema,
+    async execute(
+      _id,
+      params,
+    ): Promise<
+      AgentToolResult<{ neighborhood: Neighborhood } | { error: string }>
+    > {
+      const hood = await neighbors(reader, params as NodeRef);
+      if (hood === null) {
+        return {
+          ...text(`No artifact found for ${params.kind} ${params.id}.`),
+          details: { error: "not_found" },
+        };
+      }
+      const downNames = hood.downstream.map((n) => n.name).join(", ") || "none";
+      const upNames = hood.upstream.map((n) => n.name).join(", ") || "none";
+      return {
+        ...text(
+          `${hood.center.name} (${params.kind}). ` +
+            `Downstream: ${downNames}. Upstream: ${upNames}.`,
+        ),
+        details: { neighborhood: hood },
+      };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // 2a. readGraph — navigate on demand: bounded traversal from a node.
+  // -------------------------------------------------------------------------
+  const ReadGraphSchema = Type.Object({
+    from: NodeRefSchema,
+    depth: Type.Integer({
+      minimum: 0,
+      maximum: 6,
+      description: "Hops to traverse (clamped to 6).",
+    }),
+  });
+  const readGraph = defineToolHandler<
+    typeof ReadGraphSchema,
+    { reached: ReachedNode[] }
+  >({
+    name: "read_graph",
+    description:
+      "Navigate the artifact graph on demand: breadth-first from a node out to " +
+      "`depth` hops. Returns STRUCTURE only (reached nodes + their hop " +
+      "distance). The global-reach counterpart to read_neighborhood — use when " +
+      "the relevant artifact is beyond the ambient one-hop view.",
+    label: "Read graph",
+    parameters: ReadGraphSchema,
+    async execute(
+      _id,
+      params,
+    ): Promise<AgentToolResult<{ reached: ReachedNode[] }>> {
+      const reached = await traverse(
+        reader,
+        params.from as NodeRef,
+        params.depth,
+      );
+      return {
+        ...text(
+          `Reached ${reached.length} node(s) within ${params.depth} hop(s).`,
+        ),
+        details: { reached },
+      };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // 2b. findNodes — find by name / type / relationship (the grep+ls model).
+  // -------------------------------------------------------------------------
+  const FindSchema = Type.Object({
+    name: Type.Optional(
+      Type.String({ description: "Case-insensitive name substring." }),
+    ),
+    kind: Type.Optional(KindSchema),
+  });
+  const findNodes = defineToolHandler<typeof FindSchema, { hits: SearchHit[] }>(
+    {
+      name: "find_nodes",
+      description:
+        "Find artifacts across the whole graph by name substring and/or kind " +
+        "(any of dataSource, dataTable, dataFrame, insight, visualization, " +
+        "dashboard). STRUCTURE only. An empty query lists everything (the `ls`). " +
+        "Pair with read_graph to navigate from a hit.",
+      label: "Find nodes",
+      parameters: FindSchema,
+      async execute(
+        _id,
+        params,
+      ): Promise<AgentToolResult<{ hits: SearchHit[] }>> {
+        const q: { name?: string; kind?: NodeRef["kind"] } = {};
+        if (params.name !== undefined) q.name = params.name;
+        if (params.kind !== undefined) q.kind = params.kind;
+        const hits = await search(reader, q);
+        return {
+          ...text(
+            `${hits.length} match(es): ` +
+              (hits.map((h) => `${h.name} (${h.ref.kind})`).join(", ") ||
+                "none"),
+          ),
+          details: { hits },
+        };
+      },
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // 3. readArtifact — ONE artifact's full DEFINITION (structure, ungated).
+  // -------------------------------------------------------------------------
+  const readArtifact = defineToolHandler<
+    typeof NodeRefSchema,
+    { kind: ArtifactKind; definition: unknown } | { error: string }
+  >({
+    name: "read_artifact",
+    description:
+      "Read ONE artifact's full definition: an insight's query shape (source, " +
+      "selected fields, metrics, filters, sorts, joins), a visualization's " +
+      "encoding/spec, a dashboard's layout, a data source/table's config. " +
+      "STRUCTURE, UNGATED — never row data. Reads the DRAFT-OVERLAY view, so " +
+      "in-progress draft edits are visible.",
+    label: "Read artifact",
+    parameters: NodeRefSchema,
+    async execute(
+      _id,
+      params,
+    ): Promise<
+      AgentToolResult<
+        { kind: ArtifactKind; definition: unknown } | { error: string }
+      >
+    > {
+      const ref = params as NodeRef;
+      const definition = await readArtifactDefinition(reader, ref);
+      if (definition === null) {
+        return {
+          ...text(`No artifact found for ${ref.kind} ${ref.id}.`),
+          details: { error: "not_found" },
+        };
+      }
+      return {
+        ...text(`${ref.kind} definition for ${ref.id}.`),
+        details: { kind: ref.kind, definition },
+      };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. readData — TIERED data sample. Works on a TABLE or an INSIGHT RESULT.
+  //    The ONLY value-egress tool: routes through the floor (./floor.ts).
+  // -------------------------------------------------------------------------
+  const ReadDataSchema = Type.Object({
+    // Constrained to the two artifacts that HAVE data: a data table's rows, or
+    // an insight's computed result. (A viz reads its insight's result — the
+    // agent reads the insight here.)
+    kind: Type.Union([Type.Literal("dataTable"), Type.Literal("insight")], {
+      description: "Only dataTable or insight have a data sample.",
+    }),
+    id: Type.String({ description: "Artifact id (UUID)." }),
+  });
+  const readData = defineToolHandler<typeof ReadDataSchema, DataReadResult>({
+    name: "read_data",
+    description:
+      "Read a tiered DATA sample for a data table or an insight result. " +
+      "Column structure (names, types, sensitivity) always flows. VALUES are " +
+      "floor-gated: if any contributing SOURCE column is sensitive, the read " +
+      "is MASKED. In v0.3 every read returns column PROFILES only (shape/stats, " +
+      "never raw rows) — the conservative floor until the perception assembler " +
+      "lands; a masked read is the same profiles flagged masked.",
+    label: "Read data",
+    parameters: ReadDataSchema,
+    async execute(_id, params): Promise<AgentToolResult<DataReadResult>> {
+      const node: NodeRef = { kind: params.kind, id: params.id };
+      // The port's readDataProfile IS the floor-gated sink (host wires it to
+      // ./floor.applyFloor over the artifact's source fields). The tool never
+      // assembles value data itself — single egress boundary.
+      const result = await reader.readDataProfile(node);
+      const masked = result.masked ? " (MASKED — sensitive source)" : "";
+      return {
+        ...text(
+          `${result.columns.length} column profile(s) for ${params.kind} ` +
+            `${params.id}${masked}. No raw rows (profiles-only floor).`,
+        ),
+        details: result,
+      };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. readSource — BACKUP/verification: open an allowlisted project source file.
+  // -------------------------------------------------------------------------
+  const ReadSourceSchema = Type.Object({
+    file: Type.String({
+      description:
+        "Allowlisted project source path, e.g. " +
+        "apps/server/src/functions/commands.ts.",
+    }),
+  });
+  const readSource = defineToolHandler<
+    typeof ReadSourceSchema,
+    { file: string; text: string } | { error: string }
+  >({
+    name: "read_source",
+    description:
+      "Open an ALLOWLISTED project source file as text — the BACKUP path for the " +
+      "command vocabulary. The crafted command guide is the PRIMARY reference; " +
+      "use this to verify exact arg shapes against the source " +
+      "(apps/server/src/functions/commands.ts) when the guide is insufficient. " +
+      "Returns an error for any non-allowlisted file.",
+    label: "Read source",
+    parameters: ReadSourceSchema,
+    async execute(
+      _id,
+      params,
+    ): Promise<
+      AgentToolResult<{ file: string; text: string } | { error: string }>
+    > {
+      const source = await reader.readSource(params.file);
+      if (source === null) {
+        return {
+          ...text(`No readable source for "${params.file}" (not allowlisted).`),
+          details: { error: "not_readable" },
+        };
+      }
+      return {
+        ...text(`Source of ${params.file} (${source.length} chars).`),
+        details: { file: params.file, text: source },
+      };
+    },
+  });
+
+  return {
+    readNeighborhood,
+    readGraph,
+    findNodes,
+    readArtifact,
+    readData,
+    readSource,
+  };
+}
+
+/**
+ * Resolve a node to its full server-side definition (structure). Used by
+ * read_artifact. Each kind reads through the corresponding port method.
+ */
+async function readArtifactDefinition(
+  reader: GraphReader,
+  ref: NodeRef,
+): Promise<unknown | null> {
+  switch (ref.kind) {
+    case "dataSource":
+      return reader.getDataSource(ref.id);
+    case "dataTable":
+      return reader.getDataTable(ref.id);
+    case "dataFrame":
+      return reader.getDataFrameEntry(ref.id);
+    case "insight":
+      return reader.getInsight(ref.id);
+    case "visualization":
+      return reader.getVisualization(ref.id);
+    case "dashboard":
+      return reader.getDashboard(ref.id) as Promise<DashboardRead | null>;
+  }
+}
+
+export type ReadTools = ReturnType<typeof createReadTools>;
+export { summarize };
+export type { Static };


### PR DESCRIPTION
The assistant's READ layer: a privacy-aware graph resolver. The agent perceives the artifact graph through **four fixed read tools** built on `defineToolHandler`. **The floor lives in the resolver**: STRUCTURE (names, types, edges, definitions) flows ungated; VALUES pass the privacy floor.

## The four fixed tools (`packages/assistant/src/read`)
1. **read_neighborhood** — ambient perception: the invocation point + 1 hop, both directions. Structure only, ungated. The default local view (most intents are local), NOT the whole graph.
2. **read_graph** + **find_nodes** — navigate/search on demand. The global reach (grep+ls) the agent navigates to.
3. **read_artifact** — one artifact's full definition (insight query shape, viz encoding, dashboard layout, source/table config). Structure ungated; reads the **draft-overlay view** so the assistant sees its own in-progress edits.
4. **read_data** — tiered data sample for a table OR an insight result. Floor-gated.

## The floor-in-resolver model
Structure resolves freely through the `GraphReader` port; every value passes `floor.ts`, the single value-egress gate.

## The binary inherit-source rule
ONE rule, auditable at a glance: a column is sensitive or it isn't (`Field.sensitivity`; only `cleared` is unrestricted — `sensitive` and `unclassified` both restrict, fail-closed). `readData` **inherits source sensitivity**: if any contributing source column is sensitive, the whole read is MASKED. No result-classification, no k-anonymity (those are YW-283). The host resolves the *full* contributing set — base source (incl. insight-on-insight composition chains), join tables, and metric source tables — and `forceMask`s whenever a contributing column can't be enumerated (dangling ref, cycle), so the read can only ever become *more* restrictive, never less.

## The YW-134 / YW-283 seams
- Single value-egress boundary → the **YW-134** perception assembler. It isn't built yet, so `read_data` returns **profiles-only** (column stats/shape/type, never raw rows) as the conservative floor. The tiered profile→obfuscated→real sample plugs into the `applyFloor` seam when 134 lands (`DataReadResult.sample` is typed `never` until then).
- The definition-literal scrub (inlined `WHERE email='x'`) is **YW-283** — the inherit-source data-masking rule already covers the common case.

## Command vocabulary guide
`command-guide.ts` is the agent's **PRIMARY** reference (the crafted contract per `cmd()` command) for the next applyCommand work. A **freshness test** (`command-guide-freshness.test.ts`) flags drift against the live `COMMAND_PATHS` registry, in both directions. The agent can fall back to source via `readSource` (allowlisted to `commands.ts`).

## Boundary
`@dashframe/assistant` defines the `GraphReader` **port** (it cannot import the server — apps/server depends on the assistant). The **host adapter** (`apps/server/src/assistant-read-host.ts`) binds the port to the server read seam via `app.runHandler(path, args, tracked, { draftId })` — all reads route through the `withDraftSeam` draft-overlay view, **never raw DB**.

## Also: server read-seam hardening
The `rowTo*` converters coalesce a null `created_at` (the draft overlay returns null for a draft-created artifact) instead of crashing on `.getTime()` — surfaced by the first reader of draft-created artifacts.

## Stacking
Stacks on the YW-260 draft controller (#156). If #156 hasn't merged when this is reviewed, the cockpit handles merge order — this branch retargets/rebases onto main after #156 lands.

## Gate
Whole-graph `bun run typecheck` 46/46, lint + format clean, `bun run test` (264 server + 59 assistant). Local code-review (3 rounds, opus, security-focused): all MUSTs resolved — two fail-open holes in inherit-source resolution (missing metric/join/composition columns; dangling-table swallowed) found and fixed with isolating regression tests; final verdict SHIP, fail-closed confirmed across all hops.

Tracked internally as YW-280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the assistant's privacy-aware read layer: a `GraphReader` port, four fixed perception tools, a single value-egress floor (`applyFloor`), and a server-side host adapter that binds the port to the draft-overlay read seam. Also includes a command vocabulary guide with a CI freshness test, and null-safe `tsToMillis` coalescing for draft-created artifact timestamps.

- **Privacy floor**: Binary inherit-source masking — any contributing source column that is not `cleared` masks the entire data read; `forceMask` ensures resolution failures are fail-closed rather than fail-open.
- **Server hardening**: `tsToMillis` replaces `.getTime()` calls across all row converters so draft-created artifacts (whose `created_at` is NULL in the overlay) no longer crash on reads.
- **Command guide freshness**: A cross-package test asserts the hand-crafted guide's command names exactly equal `COMMAND_PATHS` keys, catching drift at CI.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the privacy floor is auditable and fail-closed, the draft-overlay invariants are well-tested, and the server hardening is correct.

The inherit-source masking logic, forceMask fail-closed path, and draft-overlay scoping are all backed by unit and integration tests against real PGlite. The two items noted are style and future-proofing nits with no current impact on correctness or security.

No files require special attention for merging; the two observations in tools.ts and assistant-read-host.ts are minor quality items that do not affect current behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/src/read/tools.ts | Defines the six perception tools over GraphReader; `readArtifactDefinition` switch is currently exhaustive but lacks the `never`-guard pattern used in `summarize()`, leaving a latent gap if ArtifactKind is extended. |
| apps/server/src/assistant-read-host.ts | Host adapter binding GraphReader to the draft-overlay seam; `resolveInsightSourceFields` performs two sequential `getDataTable` calls for the base-source probe — once to determine kind, once inside `addTableFields` — the already-fetched object could be reused. |
| packages/assistant/src/read/floor.ts | Single value-egress gate; binary inherit-source rule + forceMask fail-closed are clearly auditable; `sample?: never` correctly prevents premature row exposure. |
| packages/assistant/src/read/graph.ts | Structure navigation (neighbors, traverse, search) with correct `dataFrame` inclusion in search, exhaustive `never`-guard in `summarize()`, and proper cycle-safe traversal. |
| packages/assistant/src/read/port.ts | GraphReader port definition; clean separation of structure vs. value egress; `DataReadResult.sample?: never` correctly reserves the seam for the future perception assembler. |
| apps/server/src/functions/app-artifacts.ts | Introduces shared `tsToMillis` null-safe helper and applies it across all `rowTo*` converters, fixing the crash on draft-created artifacts. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(assistant): privacy-aware read laye..."](https://github.com/youhaowei/dashframe/commit/49bc7a378360eeb3f934cd10fd0240a0f93e995d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39470188)</sub>

<!-- /greptile_comment -->