### PR TITLE
feat(assistant): generic applyCommand mutation tool — emits into the draft [YW-279]

### DIFF
--- a/packages/assistant/src/apply-command-tool.test.ts
+++ b/packages/assistant/src/apply-command-tool.test.ts
@@ -16,6 +16,11 @@
  *      no silent mutation or drop.
  *   7. An empty `appendToDraft` result array is a host contract violation and
  *      throws rather than silently returning null.
+ *   8. Credential commands (CreateDataSource, SetDataSourceConfig, DeleteNode)
+ *      are DENIED at the allow-list gate — no vault call, no appendToDraft call.
+ *   9. Unlisted arbitrary command types are DENIED at the gate (default-deny).
+ *  10. Draft-safe artifact commands (CreateInsight, etc.) pass the gate and
+ *      append normally.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -197,14 +202,16 @@ describe("createApplyCommandTool — error propagation", () => {
     });
 
     // An unknown type must throw — no false success, no canonical write.
+    // The allow-list gate fires BEFORE buildCommand, so the error comes from
+    // the gate ("not available to the assistant") rather than from buildCommand.
     await expect(
       tool.execute("call-bad-type", {
         type: "NonExistentCommand",
         args: {},
       }),
-    ).rejects.toThrow(/unknown command type "NonExistentCommand"/);
+    ).rejects.toThrow(/not available to the assistant/);
 
-    // appendToDraft was NOT called (buildCommand threw before reaching it).
+    // appendToDraft was NOT called (gate rejected before reaching appendToDraft).
     expect(controller.appendCalls).toHaveLength(0);
   });
 
@@ -369,7 +376,100 @@ describe("createApplyCommandTool — multi-command drive loop", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. Tool metadata — executionMode, name (as a single invariant group)
+// 4. Draft-safe allow-list gate — credential + unsafe commands DENIED
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — DRAFT_SAFE_COMMANDS allow-list gate", () => {
+  /**
+   * The three command types that are explicitly DENIED:
+   *
+   *   CreateDataSource    — vault.store OS-keychain side effect (not drafted)
+   *   SetDataSourceConfig — vault.store OS-keychain side effect (not drafted)
+   *   DeleteNode          — vault.delete (DataSource path) + non-PK cascade ops
+   *
+   * The tool must reject these BEFORE calling buildCommand or appendToDraft
+   * so that no vault state is created from a supposed sandbox operation.
+   */
+  const deniedCredentialCommands = [
+    "CreateDataSource",
+    "SetDataSourceConfig",
+    "DeleteNode",
+  ] as const;
+
+  it.each(deniedCredentialCommands)(
+    "denies credential/unsafe command '%s' with an honest error — no appendToDraft, no buildCommand",
+    async (commandType) => {
+      const controller = makeMockController();
+      const buildCommandSpy = vi.fn(buildCommand);
+      const tool = createApplyCommandTool({
+        controller,
+        draftId: "draft-deny",
+        buildCommand: buildCommandSpy,
+      });
+
+      // Must throw — describing the command as unavailable to the assistant.
+      await expect(
+        tool.execute("call-deny", { type: commandType, args: {} }),
+      ).rejects.toThrow(
+        /not available to the assistant.*credential operations/i,
+      );
+
+      // CRITICAL: buildCommand must NOT have been called (gate fires before it).
+      expect(buildCommandSpy).not.toHaveBeenCalled();
+      // CRITICAL: appendToDraft must NOT have been called (no vault side effect).
+      expect(controller.appendCalls).toHaveLength(0);
+    },
+  );
+
+  it("denies an arbitrary unlisted command type (default-deny)", async () => {
+    const controller = makeMockController();
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-deny-unknown",
+      buildCommand,
+    });
+
+    await expect(
+      tool.execute("call-unknown", {
+        type: "SomeUnknownCommand",
+        args: {},
+      }),
+    ).rejects.toThrow(/not available to the assistant/i);
+
+    expect(controller.appendCalls).toHaveLength(0);
+  });
+
+  it("allows a draft-safe artifact command (CreateInsight) through the gate and appends normally", async () => {
+    const controller = makeMockController({
+      appendResult: [{ value: { id: "i-allow-1" } }],
+    });
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-allow",
+      buildCommand,
+    });
+
+    // CreateInsight is in DRAFT_SAFE_COMMANDS — must pass the gate and append.
+    const result = await tool.execute("call-allow", {
+      type: "CreateInsight",
+      args: {
+        id: "i-allow-1",
+        name: "Allowed",
+        source: { sourceType: "dataTable", sourceId: "t-1" },
+      },
+    });
+
+    // appendToDraft was called exactly once.
+    expect(controller.appendCalls).toHaveLength(1);
+    expect(controller.appendCalls[0]!.draftId).toBe("draft-allow");
+    // Result details reflect the handler value.
+    expect(result.details.commandType).toBe("CreateInsight");
+    expect(result.details.commandResult).toEqual({ id: "i-allow-1" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Tool metadata — executionMode, name (as a single invariant group)
 // ---------------------------------------------------------------------------
 
 describe("createApplyCommandTool — tool metadata", () => {

--- a/packages/assistant/src/apply-command-tool.test.ts
+++ b/packages/assistant/src/apply-command-tool.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for `createApplyCommandTool` — the assistant's generic mutation tool.
+ *
+ * Contracts verified:
+ *   1. A well-formed call appends exactly one command to the draft and returns
+ *      the handler value in `details.commandResult`.
+ *   2. A malformed/unknown command type propagates the error honestly — no
+ *      silent swallow, no false success.
+ *   3. Canonical is NEVER touched — only `appendToDraft` is called on the
+ *      controller, never `publishDraft`.
+ *   4. Multi-command sequence: repeated calls append commands in order, each
+ *      landing in the same draft (draftId immutable per factory, canonical
+ *      untouched until publish).
+ *   5. `executionMode` is "sequential" (mutating — serialised against the batch).
+ *   6. `buildCommand` receives the exact (type, args) pair from execute params —
+ *      no silent mutation or drop.
+ *   7. An empty `appendToDraft` result array is a host contract violation and
+ *      throws rather than silently returning null.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCommand, DraftAppender } from "./apply-command-tool.js";
+import { createApplyCommandTool } from "./apply-command-tool.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal DraftAppender spy for test isolation. */
+function makeMockController(overrides?: {
+  appendResult?: Array<{ id?: string; value: unknown }>;
+  appendError?: Error;
+}): DraftAppender & {
+  appendCalls: Array<{
+    draftId: string;
+    batch: AssistantCommand[];
+    context?: Record<string, unknown>;
+  }>;
+} {
+  const appendCalls: Array<{
+    draftId: string;
+    batch: AssistantCommand[];
+    context?: Record<string, unknown>;
+  }> = [];
+
+  return {
+    appendCalls,
+    async appendToDraft(draftId, batch, context) {
+      appendCalls.push({ draftId, batch, context });
+      if (overrides?.appendError) {
+        throw overrides.appendError;
+      }
+      return overrides?.appendResult ?? [{ value: { ok: true } }];
+    },
+  };
+}
+
+/**
+ * A minimal buildCommand stub that maps `"CreateFoo"` → `{ path: "createFoo", args }`.
+ * Throws for unknown types (mirrors the required host behavior — cmd() is
+ * compile-time-only typed and silently produces { path: undefined } for unknown
+ * names; the host's buildCommand wrapper must guard this).
+ */
+function makeBuildCommand(knownCommands: Record<string, string>) {
+  return (type: string, args: unknown): AssistantCommand => {
+    const path = knownCommands[type];
+    if (!path) {
+      throw new Error(
+        `applyCommand: unknown command type "${type}". ` +
+          `Known commands: ${Object.keys(knownCommands).join(", ")}`,
+      );
+    }
+    return { path, args };
+  };
+}
+
+const TEST_COMMANDS: Record<string, string> = {
+  CreateInsight: "createInsightCmd",
+  CreateVisualization: "createVisualizationCmd",
+  AddDashboardItem: "addDashboardItemCmd",
+  CreateDashboard: "createDashboardCmd",
+};
+
+const buildCommand = makeBuildCommand(TEST_COMMANDS);
+
+// ---------------------------------------------------------------------------
+// 1. Happy path — correct call appends to draft and returns handler value
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — happy path", () => {
+  it("appends exactly one command to the draft and echoes the handler value", async () => {
+    const controller = makeMockController({
+      appendResult: [{ value: { id: "insight-001" } }],
+    });
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-abc",
+      buildCommand,
+    });
+
+    const result = await tool.execute("call-1", {
+      type: "CreateInsight",
+      args: {
+        id: "insight-001",
+        name: "Revenue trend",
+        source: { sourceType: "dataTable", sourceId: "tbl-x" },
+      },
+    });
+
+    // Exactly one appendToDraft call.
+    expect(controller.appendCalls).toHaveLength(1);
+
+    const call = controller.appendCalls[0]!;
+    // draftId is the one minted at session open — not controlled per-call.
+    expect(call.draftId).toBe("draft-abc");
+    // Batch has exactly one command.
+    expect(call.batch).toHaveLength(1);
+    // The command path was resolved from the command name via buildCommand.
+    expect(call.batch[0]!.path).toBe("createInsightCmd");
+
+    // Result details echo the command type and handler value.
+    expect(result.details.commandType).toBe("CreateInsight");
+    expect(result.details.commandResult).toEqual({ id: "insight-001" });
+    // Content is non-empty text.
+    expect(result.content[0]?.type).toBe("text");
+  });
+
+  it("passes the exact (type, args) pair to buildCommand unchanged", async () => {
+    const controller = makeMockController();
+    const buildCommandSpy = vi.fn(buildCommand);
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-spy",
+      buildCommand: buildCommandSpy,
+    });
+
+    const args = {
+      id: "i-1",
+      name: "Revenue",
+      source: { sourceType: "dataTable", sourceId: "t-1" },
+    };
+    await tool.execute("call-spy", { type: "CreateInsight", args });
+
+    // buildCommand was called exactly once with the original (type, args).
+    expect(buildCommandSpy).toHaveBeenCalledOnce();
+    expect(buildCommandSpy).toHaveBeenCalledWith("CreateInsight", args);
+  });
+
+  it("passes optional context through to appendToDraft", async () => {
+    const controller = makeMockController();
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-xyz",
+      buildCommand,
+      context: { sessionId: "sess-1", vault: { kind: "stub" } },
+    });
+
+    await tool.execute("call-ctx", {
+      type: "CreateDashboard",
+      args: { id: "dash-001", name: "Overview" },
+    });
+
+    expect(controller.appendCalls[0]?.context).toMatchObject({
+      sessionId: "sess-1",
+      vault: { kind: "stub" },
+    });
+  });
+
+  it("passes context as undefined when the factory is created without one", async () => {
+    const controller = makeMockController();
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-noctx",
+      buildCommand,
+    });
+
+    await tool.execute("call-noctx", {
+      type: "CreateDashboard",
+      args: { id: "dash-002", name: "No context" },
+    });
+
+    expect(controller.appendCalls[0]?.context).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Validation / error propagation — NO silent failure
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — error propagation", () => {
+  it("propagates an unknown command type as a thrown error (no canonical write)", async () => {
+    const controller = makeMockController();
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-err",
+      buildCommand,
+    });
+
+    // An unknown type must throw — no false success, no canonical write.
+    await expect(
+      tool.execute("call-bad-type", {
+        type: "NonExistentCommand",
+        args: {},
+      }),
+    ).rejects.toThrow(/unknown command type "NonExistentCommand"/);
+
+    // appendToDraft was NOT called (buildCommand threw before reaching it).
+    expect(controller.appendCalls).toHaveLength(0);
+  });
+
+  it("propagates a mutation validation error from appendToDraft (malformed args)", async () => {
+    const controller = makeMockController({
+      appendError: new Error("CreateInsight: source is invalid: Required"),
+    });
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-err2",
+      buildCommand,
+    });
+
+    // The error from the mutation handler must surface unchanged.
+    await expect(
+      tool.execute("call-bad-args", {
+        type: "CreateInsight",
+        args: { id: "i-1", name: "Bad" /* missing source */ },
+      }),
+    ).rejects.toThrow("CreateInsight: source is invalid");
+
+    // appendToDraft was called (the command got that far — the mutation rejected it).
+    expect(controller.appendCalls).toHaveLength(1);
+  });
+
+  it("throws when appendToDraft returns an empty array (host contract violation)", async () => {
+    const controller = makeMockController({ appendResult: [] });
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-empty",
+      buildCommand,
+    });
+
+    // An empty result array is a DraftAppender contract violation — the tool
+    // must throw rather than silently returning commandResult: null, which
+    // would look like success to the agent and hide a broken host.
+    await expect(
+      tool.execute("call-empty", {
+        type: "CreateDashboard",
+        args: { id: "dash-003", name: "Ghost" },
+      }),
+    ).rejects.toThrow(/appendToDraft returned 0 results for 1 command/);
+  });
+
+  it("does NOT call publishDraft — canonical is never touched", async () => {
+    const controller = makeMockController();
+    // Add a publishDraft spy on the mock — should never be called.
+    const publishSpy = vi.fn();
+    const controllerWithPublish = {
+      ...controller,
+      publishDraft: publishSpy,
+    };
+
+    const tool = createApplyCommandTool({
+      controller: controllerWithPublish,
+      draftId: "draft-pub-check",
+      buildCommand,
+    });
+
+    await tool.execute("call-pub", {
+      type: "CreateVisualization",
+      args: {
+        id: "v-1",
+        name: "Chart",
+        insightId: "i-1",
+        visualizationType: "bar",
+        spec: {},
+      },
+    });
+
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Multi-command sequence — all land in the same draft, canonical untouched
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — multi-command drive loop", () => {
+  it("a multi-step intent (CreateInsight + CreateVisualization + AddDashboardItem) all land in the same draft", async () => {
+    // Override the single default result with command-specific values.
+    let callCount = 0;
+    const resultMap = [
+      { value: { id: "i-1" } },
+      { value: { id: "v-1" } },
+      { value: { ok: true } },
+    ];
+    const tracking: Array<{ draftId: string; batch: AssistantCommand[] }> = [];
+    const trackingController: DraftAppender = {
+      async appendToDraft(draftId, batch) {
+        tracking.push({ draftId, batch });
+        return [resultMap[callCount++]!];
+      },
+    };
+
+    const tool = createApplyCommandTool({
+      controller: trackingController,
+      draftId: "draft-multi",
+      buildCommand,
+    });
+
+    // Step 1: CreateInsight
+    const r1 = await tool.execute("c1", {
+      type: "CreateInsight",
+      args: {
+        id: "i-1",
+        name: "Sales",
+        source: { sourceType: "dataTable", sourceId: "t-1" },
+      },
+    });
+    // Step 2: CreateVisualization
+    const r2 = await tool.execute("c2", {
+      type: "CreateVisualization",
+      args: {
+        id: "v-1",
+        name: "Sales Chart",
+        insightId: "i-1",
+        visualizationType: "bar",
+        spec: {},
+      },
+    });
+    // Step 3: AddDashboardItem
+    const r3 = await tool.execute("c3", {
+      type: "AddDashboardItem",
+      args: {
+        dashboardId: "d-1",
+        item: {
+          id: "di-1",
+          type: "visualization",
+          visualizationId: "v-1",
+          x: 0,
+          y: 0,
+          width: 4,
+          height: 3,
+        },
+      },
+    });
+
+    // All three appended — each as a separate single-command batch.
+    expect(tracking).toHaveLength(3);
+
+    // draftId is the same across all three calls (captured at factory time,
+    // not per-call). This is the load-bearing invariant: the agent cannot steer
+    // writes to a different draft mid-session.
+    for (const call of tracking) {
+      expect(call.draftId).toBe("draft-multi");
+    }
+
+    // Each batch has exactly one command.
+    expect(tracking[0]!.batch[0]!.path).toBe("createInsightCmd");
+    expect(tracking[1]!.batch[0]!.path).toBe("createVisualizationCmd");
+    expect(tracking[2]!.batch[0]!.path).toBe("addDashboardItemCmd");
+
+    // Each call returns its details.
+    expect(r1.details.commandType).toBe("CreateInsight");
+    expect(r1.details.commandResult).toEqual({ id: "i-1" });
+    expect(r2.details.commandType).toBe("CreateVisualization");
+    expect(r2.details.commandResult).toEqual({ id: "v-1" });
+    expect(r3.details.commandType).toBe("AddDashboardItem");
+    expect(r3.details.commandResult).toEqual({ ok: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Tool metadata — executionMode, name (as a single invariant group)
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — tool metadata", () => {
+  it("tool is named 'applyCommand' and executionMode is 'sequential' (mutating)", () => {
+    const tool = createApplyCommandTool({
+      controller: makeMockController(),
+      draftId: "d",
+      buildCommand,
+    });
+    // Name is the agent's tool-dispatch key.
+    expect(tool.name).toBe("applyCommand");
+    // sequential = serialised against other tools in a multi-tool turn; required
+    // for the single-writer-per-draftId contract on DraftController.appendToDraft.
+    expect(tool.executionMode).toBe("sequential");
+  });
+});

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -2,12 +2,11 @@
  * `applyCommand` — the assistant's single generic mutation tool.
  *
  * ONE tool, generic over `{ type, args }`:
- *   - `type`  — a command name string (e.g. "CreateInsight", "AddDashboardItem").
+ *   - `type`  — a command name string from the DRAFT-SAFE ALLOW-LIST below.
  *     The full vocabulary is described in the assistant command guide (see the
  *     read layer package). The agent constructs commands by name + args; this
- *     tool delegates to `buildCommand`
- *     (injected by the host) to map the name to the wire-path envelope and then
- *     emits into the draft via the controller.
+ *     tool delegates to `buildCommand` (injected by the host) to map the name
+ *     to the wire-path envelope and emits into the draft.
  *   - `args`  — the payload object for the named command, opaque to this tool.
  *     Validation is handled by the backing mutation handler inside appendToDraft
  *     (the same path an RPC call validates). A malformed payload surfaces as a
@@ -25,6 +24,11 @@
  *   NEVER CANONICAL — appendToDraft writes the draft overlay only. Publish
  *   is a separate, human-gated step; this tool MUST NOT call publishDraft or
  *   touch canonical.
+ *
+ *   DRAFT-SAFE SUBSET — the assistant's vocabulary is NOT the full human
+ *   command vocabulary. Commands with vault/credential side-effects or
+ *   draft-overlay-unsafe cascade operations are denied at the tool boundary
+ *   before reaching buildCommand or appendToDraft (see DRAFT_SAFE_COMMANDS).
  *
  * Factory pattern: `createApplyCommandTool(options)`. The draftId is the handle
  * minted by `openDraft` at assistant session start — captured once in the
@@ -73,6 +77,84 @@ export interface DraftAppender {
 }
 
 // ---------------------------------------------------------------------------
+// Draft-safe command allow-list
+// ---------------------------------------------------------------------------
+
+/**
+ * The assistant's vocabulary: the DRAFT-SAFE subset of the full command
+ * vocabulary. DEFAULT-DENY — any command not in this set is rejected at the
+ * tool boundary before reaching `buildCommand` or `appendToDraft`.
+ *
+ * **WHY a separate allow-list (not the full vocabulary)**
+ *
+ * Two command categories are NOT safe for agent-driven draft execution:
+ *
+ * 1. Credential commands — `CreateDataSource`, `SetDataSourceConfig`, and
+ *    `DeleteNode` on a DataSource call `vault.store` / `vault.delete` /
+ *    `releaseCredentialRefs` as OS-keychain side effects OUTSIDE the DB
+ *    transaction. The draft overlay only drafts DB writes; vault ops are NOT
+ *    drafted and NOT rolled back on discard. Allowing the agent to invoke these
+ *    would create real credential state from a supposed sandbox operation.
+ *
+ * 2. Draft-overlay-unsafe deletes — `DeleteNode` on Insight or DataTable
+ *    uses non-PK-filtered cascade operations (e.g. DataFrame cleanup by
+ *    `insightId`, Visualization scan by `insightId`) that the draft overlay
+ *    cannot safely replicate. The draft handle does not emulate FK cascades,
+ *    so delete cascades inside a draft can produce incorrect results.
+ *
+ * `GetOrCreateDataSource` (no vault, PK-only insert) is excluded from the
+ * allow-list because DataSource creation is a human-owned credential setup
+ * step — even without a vault side-effect today, it creates a data-access
+ * reference that the human must review. The assistant works with existing
+ * DataSources/DataTables, not mint new ones.
+ *
+ * This set is the exhaustive additive/update artifact vocabulary the
+ * assistant can safely draft. New commands must be reviewed against the two
+ * categories above before being added here.
+ */
+export const DRAFT_SAFE_COMMANDS = new Set([
+  // DataTable (existing — assistant does not create/configure data sources)
+  "CreateDataTable",
+  "SetDataTableSchema",
+  "RefreshDataTable",
+  // Fields & Metrics (additive/update, PK-addressed, no vault)
+  "AddField",
+  "UpdateField",
+  "RemoveField",
+  "AddMetric",
+  "UpdateMetric",
+  "RemoveMetric",
+  // Insight (additive/update, PK-addressed, no vault)
+  "CreateInsight",
+  "SetInsightSource",
+  "SelectFields",
+  "SetInsightFilter",
+  "SetInsightSort",
+  "AddJoin",
+  "UpdateJoin",
+  "RemoveJoin",
+  // Visualization (additive/update, PK-addressed, no vault)
+  "CreateVisualization",
+  "SetChartType",
+  "SetChartEncoding",
+  // Dashboard (additive/update, PK-addressed, no vault)
+  "CreateDashboard",
+  "AddDashboardItem",
+  "UpdateDashboardItem",
+  "SetDashboardLayout",
+  "RemoveDashboardItem",
+  // Cross-cutting rename (PK-addressed, no vault, no cascade)
+  "RenameNode",
+  //
+  // NOT ALLOWED (default-deny for unlisted commands):
+  //   GetOrCreateDataSource — human-owned data-source creation step
+  //   CreateDataSource      — vault.store side-effect (not drafted)
+  //   SetDataSourceConfig   — vault.store side-effect (not drafted)
+  //   DeleteNode            — vault.delete (DataSource path) + non-PK cascade
+  //                           (Insight/DataTable paths); draft-overlay-unsafe
+]);
+
+// ---------------------------------------------------------------------------
 // applyCommand result detail
 // ---------------------------------------------------------------------------
 
@@ -113,11 +195,15 @@ export interface CreateApplyCommandToolOptions {
    * Command envelope the app's function registry can dispatch. Injected by the
    * server host so this package carries no direct dependency on @dashframe/server.
    *
+   * Only called for command types that pass the DRAFT_SAFE_COMMANDS allow-list
+   * gate (enforced in execute() before this function is invoked). The host does
+   * not need to re-validate the type — the gate already runs.
+   *
    * **Unknown-type guard** — The `cmd()` helper in commands.ts is typed at
    * compile time only; at runtime `cmd(unknownName, args)` silently produces
    * `{ path: undefined, args }`, which reaches `runHandler` as the cryptic
    * error `"Unknown function: undefined"`. Wrap `cmd()` with a runtime
-   * key-guard so the agent sees a clear error it can fix+retry:
+   * key-guard so the agent sees a clear error to fix+retry:
    *
    * ```ts
    * buildCommand: (type, args) => {
@@ -125,25 +211,6 @@ export interface CreateApplyCommandToolOptions {
    *   return cmd(type as CommandName, args as CommandPayloads[CommandName]);
    * }
    * ```
-   *
-   * **Draft-safety allow-list** — Not every command in the vocabulary is safe
-   * to run inside a draft. The host MUST enforce a draft-safe allow-list at
-   * this injection point before commands reach the controller. Two categories
-   * require special handling:
-   *
-   * 1. Credential commands (`CreateDataSource`, `SetDataSourceConfig`,
-   *    `DeleteNode` on a DataSource): handlers call `vault.store` / `vault.delete`
-   *    as keychain side effects outside the DB transaction. These effects are NOT
-   *    drafted and NOT rolled back on discard — a draft discard leaves orphaned
-   *    or released secrets in the OS keychain. Deny these commands in draft
-   *    context or use a draft-aware vault that no-ops the side effects.
-   *
-   * 2. Commands with draft-overlay limitations: `DeleteNode` on Insight/DataTable
-   *    cascades (DataFrame cleanup, Visualization FK) may not behave identically
-   *    inside the draft overlay vs canonical — the draft handle has no separate
-   *    FK cascade. Restrict to additive / update commands where the overlay
-   *    semantics are known-correct, or test each delete variant against the
-   *    draft controller before enabling it.
    *
    * Thrown errors propagate honestly to the agent (no swallow).
    */
@@ -168,25 +235,18 @@ export interface CreateApplyCommandToolOptions {
  * ```ts
  * // In the server host (where cmd() is available):
  * import { cmd, type CommandName, type CommandPayloads } from "./functions/commands.js";
- * import { createApplyCommandTool } from "@dashframe/assistant";
- *
- * // The set of valid command names (build from CommandPayloads keys at compile time).
- * const KNOWN_COMMANDS = new Set<string>([
- *   "CreateInsight", "CreateVisualization", "AddDashboardItem", // ... all CommandName values
- * ]);
+ * import { createApplyCommandTool, DRAFT_SAFE_COMMANDS } from "@dashframe/assistant";
  *
  * const applyCommandTool = createApplyCommandTool({
  *   controller,
  *   draftId,
- *   // Runtime guard: cmd() is typed at compile time only — unknown names silently
- *   // produce { path: undefined }, which reaches runHandler as "Unknown function: undefined".
- *   // Guard the type first so the agent gets a clear error to fix+retry.
+ *   // Only called for types that pass the DRAFT_SAFE_COMMANDS gate.
+ *   // Add a runtime key-guard so cmd() maps the name to a real path
+ *   // (cmd() is compile-time-only typed; unknown names silently produce
+ *   // { path: undefined } which reaches runHandler as a cryptic error).
  *   buildCommand: (type, args) => {
- *     if (!KNOWN_COMMANDS.has(type)) {
- *       throw new Error(
- *         `applyCommand: unknown command type "${type}". ` +
- *         `Known: ${[...KNOWN_COMMANDS].join(", ")}`
- *       );
+ *     if (!(type in COMMAND_PATHS)) {
+ *       throw new Error(`Unknown command: "${type}"`);
  *     }
  *     return cmd(type as CommandName, args as CommandPayloads[CommandName]);
  *   },
@@ -206,8 +266,10 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
       "plan as a visible step — nothing is written to canonical until the draft is " +
       "published (a separate, human-gated action). Supply `type` as a command name " +
       '(e.g. "CreateInsight", "AddDashboardItem") and `args` as the matching payload ' +
-      "object for that command. On validation failure the error is returned so you " +
-      "can correct the args and retry. NEVER emits to canonical.",
+      "object for that command. Only draft-safe artifact commands are available — " +
+      "credential and data-source configuration commands are human-only operations. " +
+      "On validation failure the error is returned so you can correct the args and retry. " +
+      "NEVER emits to canonical.",
     label: "Apply Command",
     // Mutating — serialise against other tool calls in the same batch so the
     // single-writer-per-draftId contract (documented in draft-controller.ts) is
@@ -216,9 +278,10 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
     parameters: Type.Object({
       type: Type.String({
         description:
-          "The command name from the DashFrame vocabulary, e.g. " +
+          "The command name from the draft-safe DashFrame vocabulary, e.g. " +
           '"CreateInsight", "CreateVisualization", "AddDashboardItem". ' +
-          "Must be a valid CommandName from the command guide.",
+          "Must be one of the allowed command names from the command guide. " +
+          "Data-source and credential commands are not available to the assistant.",
       }),
       args: Type.Unknown({
         description:
@@ -229,6 +292,29 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
 
     async execute(_toolCallId, params) {
       const { type, args } = params;
+
+      // SECURITY GATE: enforce the draft-safe allow-list BEFORE calling
+      // buildCommand or appendToDraft. This is a default-deny boundary:
+      //
+      //   - Credential commands (CreateDataSource, SetDataSourceConfig,
+      //     DeleteNode on DataSource) call vault.store/vault.delete as
+      //     OS-keychain side effects OUTSIDE the DB transaction. These ops are
+      //     NOT drafted and NOT rolled back on discard — allowing the agent to
+      //     trigger them would create real credential state from a sandbox.
+      //
+      //   - Draft-overlay-unsafe deletes (DeleteNode on Insight/DataTable)
+      //     use non-PK-filtered cascade operations that the draft overlay
+      //     cannot safely replicate.
+      //
+      // Rejecting here — before buildCommand — means no vault call, no append,
+      // no draft mutation: a clean, auditable deny at the tool seam.
+      if (!DRAFT_SAFE_COMMANDS.has(type)) {
+        throw new Error(
+          `applyCommand: command type "${type}" is not available to the assistant. ` +
+            "Credential operations and data-source configuration are human-only. " +
+            `Available commands: ${[...DRAFT_SAFE_COMMANDS].sort().join(", ")}`,
+        );
+      }
 
       // Build the Command envelope. `buildCommand` is the host-injected bridge
       // to cmd() in commands.ts — the single source of truth for name→path

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -1,0 +1,263 @@
+/**
+ * `applyCommand` — the assistant's single generic mutation tool.
+ *
+ * ONE tool, generic over `{ type, args }`:
+ *   - `type`  — a command name string (e.g. "CreateInsight", "AddDashboardItem").
+ *     The full vocabulary is described in the command guide (YW-280). The agent
+ *     constructs commands by name + args; this tool delegates to `buildCommand`
+ *     (injected by the host) to map the name to the wire-path envelope and then
+ *     emits into the draft via the controller.
+ *   - `args`  — the payload object for the named command, opaque to this tool.
+ *     Validation is handled by the backing mutation handler inside appendToDraft
+ *     (the same path an RPC call validates). A malformed payload surfaces as a
+ *     thrown error (no swallow, no false success) so the agent can fix + retry.
+ *
+ * Invariants (load-bearing, restated in code):
+ *
+ *   TRANSPARENT — every call is a visible plan step: a DraftCommand appended to
+ *   the compacted log before anything canonical is touched.
+ *
+ *   VERIFIABLE — routes through the real `applyCommands` seam (inside
+ *   appendToDraft → runHandler → mutation handler) so the command produces the
+ *   same effect whether the agent or the UI emitted it.
+ *
+ *   NEVER CANONICAL — appendToDraft writes the draft overlay only. Publish
+ *   (YW-281) is a separate, human-gated step; this tool MUST NOT call
+ *   publishDraft or touch canonical.
+ *
+ * Factory pattern: `createApplyCommandTool(options)`. The draftId is the handle
+ * minted by `openDraft` (YW-260) at assistant session start — captured once in
+ * the factory, not passed per-call. This keeps the per-call surface minimal
+ * (type + args only) and makes it impossible for the agent to steer writes to a
+ * different draft.
+ *
+ * Dependency direction: `@dashframe/assistant` must NOT import from
+ * `@dashframe/server` (server depends on assistant, not the other way). The
+ * `buildCommand` callback lets the host inject the `cmd()` factory from
+ * commands.ts without creating a circular dependency. The `DraftAppender`
+ * interface captures only the one method this tool calls (`appendToDraft`) so
+ * the assistant package carries no server import.
+ */
+
+import { defineToolHandler, Type } from "./tool.js";
+
+// ---------------------------------------------------------------------------
+// Minimal dependency interfaces (no server import)
+// ---------------------------------------------------------------------------
+
+/**
+ * The `Command` envelope shape `applyCommands` dispatches. Inlined here so the
+ * assistant package does not import from @wystack/server.
+ */
+export interface AssistantCommand {
+  /** The wire path the app's function registry dispatches against. */
+  path: string;
+  /** Handler args, opaque at this layer — the mutation validates shape. */
+  args: unknown;
+  /** Optional correlation id echoed in the CommandResult. */
+  id?: string;
+}
+
+/**
+ * Minimal interface capturing only the one DraftController method this tool
+ * calls. The server host injects its `DraftController`; structural compatibility
+ * means no import of the server type is needed here.
+ */
+export interface DraftAppender {
+  appendToDraft(
+    draftId: string,
+    batch: AssistantCommand[],
+    context?: Record<string, unknown>,
+  ): Promise<Array<{ id?: string; value: unknown }>>;
+}
+
+// ---------------------------------------------------------------------------
+// applyCommand result detail
+// ---------------------------------------------------------------------------
+
+/**
+ * The details payload on a successful applyCommand call. `commandResult` is the
+ * raw value returned by the backing mutation handler — opaque at this layer (the
+ * vocabulary is the source of truth, not this tool). `commandType` echoes the
+ * command name so the caller can log / inspect without re-parsing `args`.
+ */
+export interface ApplyCommandDetails {
+  /** Echo of the command type that was applied. */
+  commandType: string;
+  /**
+   * The raw value returned by the backing mutation handler (e.g. `{ id }` for a
+   * Create command, `{ ok: true }` for an update). Opaque — callers should
+   * consult the command guide (YW-280) for the per-command shape.
+   */
+  commandResult: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Factory options
+// ---------------------------------------------------------------------------
+
+export interface CreateApplyCommandToolOptions {
+  /**
+   * The draft controller bound to the current project. Only `appendToDraft` is
+   * called — the interface is intentionally minimal (structural duck-typing).
+   */
+  controller: DraftAppender;
+  /**
+   * The draft handle minted by `controller.openDraft()` at assistant session
+   * start. Captured once so the agent cannot redirect writes per-call.
+   */
+  draftId: string;
+  /**
+   * Maps a command name string (e.g. "CreateInsight") to a `{ path, args }`
+   * Command envelope the app's function registry can dispatch. Injected by the
+   * server host so this package carries no direct dependency on @dashframe/server.
+   *
+   * The host MUST throw a descriptive error for unknown command types. The
+   * `cmd()` helper in commands.ts is typed at compile time only — at runtime
+   * `cmd(unknownName, args)` silently produces `{ path: undefined, args }`, which
+   * reaches `runHandler` as `"Unknown function: undefined"` — a cryptic error.
+   * Wrap `cmd()` with a runtime key-guard at the injection site:
+   *
+   * ```ts
+   * buildCommand: (type, args) => {
+   *   if (!(type in COMMAND_PATHS)) throw new Error(`Unknown command: "${type}"`);
+   *   return cmd(type as CommandName, args as CommandPayloads[CommandName]);
+   * }
+   * ```
+   *
+   * Thrown errors propagate honestly to the agent (no swallow).
+   */
+  buildCommand: (type: string, args: unknown) => AssistantCommand;
+  /**
+   * Optional extra context forwarded to `appendToDraft` as the third positional
+   * argument alongside the draftId (first) and batch (second). Supplemental
+   * session metadata — e.g. vault resolver, session id. The draftId is already
+   * passed as a separate positional arg; it is NOT merged into this object.
+   */
+  context?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the `applyCommand` AgentTool bound to a draft controller + draftId.
+ *
+ * @example
+ * ```ts
+ * // In the server host (where cmd() is available):
+ * import { cmd, type CommandName, type CommandPayloads } from "./functions/commands.js";
+ * import { createApplyCommandTool } from "@dashframe/assistant";
+ *
+ * // The set of valid command names (build from CommandPayloads keys at compile time).
+ * const KNOWN_COMMANDS = new Set<string>([
+ *   "CreateInsight", "CreateVisualization", "AddDashboardItem", // ... all CommandName values
+ * ]);
+ *
+ * const applyCommandTool = createApplyCommandTool({
+ *   controller,
+ *   draftId,
+ *   // Runtime guard: cmd() is typed at compile time only — unknown names silently
+ *   // produce { path: undefined }, which reaches runHandler as "Unknown function: undefined".
+ *   // Guard the type first so the agent gets a clear error to fix+retry.
+ *   buildCommand: (type, args) => {
+ *     if (!KNOWN_COMMANDS.has(type)) {
+ *       throw new Error(
+ *         `applyCommand: unknown command type "${type}". ` +
+ *         `Known: ${[...KNOWN_COMMANDS].join(", ")}`
+ *       );
+ *     }
+ *     return cmd(type as CommandName, args as CommandPayloads[CommandName]);
+ *   },
+ * });
+ *
+ * // Then pass to the agent's tool set:
+ * agent.state.tools = [applyCommandTool, ...readTools];
+ * ```
+ */
+export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
+  const { controller, draftId, buildCommand, context } = options;
+
+  return defineToolHandler({
+    name: "applyCommand",
+    description:
+      "Apply one command to the open draft. The command is appended to the draft's " +
+      "plan as a visible step — nothing is written to canonical until the draft is " +
+      "published (a separate, human-gated action). Supply `type` as a command name " +
+      '(e.g. "CreateInsight", "AddDashboardItem") and `args` as the matching payload ' +
+      "object for that command. On validation failure the error is returned so you " +
+      "can correct the args and retry. NEVER emits to canonical.",
+    label: "Apply Command",
+    // Mutating — serialise against other tool calls in the same batch so the
+    // single-writer-per-draftId contract (documented in draft-controller.ts) is
+    // satisfied when pi dispatches a multi-tool turn.
+    executionMode: "sequential",
+    parameters: Type.Object({
+      type: Type.String({
+        description:
+          "The command name from the DashFrame vocabulary, e.g. " +
+          '"CreateInsight", "CreateVisualization", "AddDashboardItem". ' +
+          "Must be a valid CommandName from the command guide.",
+      }),
+      args: Type.Unknown({
+        description:
+          "The payload object for the named command. Shape depends on `type` — " +
+          "see the command guide for per-command schemas.",
+      }),
+    }),
+
+    async execute(_toolCallId, params) {
+      const { type, args } = params;
+
+      // Build the Command envelope. `buildCommand` is the host-injected bridge
+      // to cmd() in commands.ts — the single source of truth for name→path
+      // mapping. An unknown command type throws here with a clear error before
+      // appendToDraft is called, so the agent gets a useful message to fix+retry.
+      //
+      // TRANSPARENT: the command is constructed and emitted as an explicit plan
+      // step visible in the draft log — no behind-the-scenes canonical write.
+      const command = buildCommand(type, args);
+
+      // Emit into the draft via the controller's sanctioned write path.
+      // NEVER CANONICAL: appendToDraft → runHandler → withDraft overlay.
+      //
+      // Validation failures inside the mutation handler surface as thrown
+      // errors. defineToolHandler lets them propagate so pi marks the
+      // ToolResultMessage as isError: true — NO silent swallowing.
+      // The agent receives the honest error and can retry with corrected args.
+      const results = await controller.appendToDraft(
+        draftId,
+        [command],
+        context,
+      );
+
+      // appendToDraft returns one CommandResult per command in the batch.
+      // We passed exactly one command; the contract requires exactly one result.
+      // A shorter array is a host implementation bug — surface it loudly rather
+      // than silently returning null, which would look like success to the agent.
+      if (results.length === 0) {
+        throw new Error(
+          `appendToDraft returned 0 results for 1 command (draftId=${draftId}, type="${type}") ` +
+            "— host DraftAppender contract violation: expected one result per batch element",
+        );
+      }
+      const result = results[0]!;
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `Command "${type}" applied to draft. ` +
+              `Result: ${JSON.stringify(result.value ?? null)}`,
+          },
+        ],
+        details: {
+          commandType: type,
+          commandResult: result.value ?? null,
+        } satisfies ApplyCommandDetails,
+      };
+    },
+  });
+}

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -113,11 +113,11 @@ export interface CreateApplyCommandToolOptions {
    * Command envelope the app's function registry can dispatch. Injected by the
    * server host so this package carries no direct dependency on @dashframe/server.
    *
-   * The host MUST throw a descriptive error for unknown command types. The
-   * `cmd()` helper in commands.ts is typed at compile time only — at runtime
-   * `cmd(unknownName, args)` silently produces `{ path: undefined, args }`, which
-   * reaches `runHandler` as `"Unknown function: undefined"` — a cryptic error.
-   * Wrap `cmd()` with a runtime key-guard at the injection site:
+   * **Unknown-type guard** — The `cmd()` helper in commands.ts is typed at
+   * compile time only; at runtime `cmd(unknownName, args)` silently produces
+   * `{ path: undefined, args }`, which reaches `runHandler` as the cryptic
+   * error `"Unknown function: undefined"`. Wrap `cmd()` with a runtime
+   * key-guard so the agent sees a clear error it can fix+retry:
    *
    * ```ts
    * buildCommand: (type, args) => {
@@ -125,6 +125,25 @@ export interface CreateApplyCommandToolOptions {
    *   return cmd(type as CommandName, args as CommandPayloads[CommandName]);
    * }
    * ```
+   *
+   * **Draft-safety allow-list** — Not every command in the vocabulary is safe
+   * to run inside a draft. The host MUST enforce a draft-safe allow-list at
+   * this injection point before commands reach the controller. Two categories
+   * require special handling:
+   *
+   * 1. Credential commands (`CreateDataSource`, `SetDataSourceConfig`,
+   *    `DeleteNode` on a DataSource): handlers call `vault.store` / `vault.delete`
+   *    as keychain side effects outside the DB transaction. These effects are NOT
+   *    drafted and NOT rolled back on discard — a draft discard leaves orphaned
+   *    or released secrets in the OS keychain. Deny these commands in draft
+   *    context or use a draft-aware vault that no-ops the side effects.
+   *
+   * 2. Commands with draft-overlay limitations: `DeleteNode` on Insight/DataTable
+   *    cascades (DataFrame cleanup, Visualization FK) may not behave identically
+   *    inside the draft overlay vs canonical — the draft handle has no separate
+   *    FK cascade. Restrict to additive / update commands where the overlay
+   *    semantics are known-correct, or test each delete variant against the
+   *    draft controller before enabling it.
    *
    * Thrown errors propagate honestly to the agent (no swallow).
    */

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -3,8 +3,9 @@
  *
  * ONE tool, generic over `{ type, args }`:
  *   - `type`  — a command name string (e.g. "CreateInsight", "AddDashboardItem").
- *     The full vocabulary is described in the command guide (YW-280). The agent
- *     constructs commands by name + args; this tool delegates to `buildCommand`
+ *     The full vocabulary is described in the assistant command guide (see the
+ *     read layer package). The agent constructs commands by name + args; this
+ *     tool delegates to `buildCommand`
  *     (injected by the host) to map the name to the wire-path envelope and then
  *     emits into the draft via the controller.
  *   - `args`  — the payload object for the named command, opaque to this tool.
@@ -22,12 +23,12 @@
  *   same effect whether the agent or the UI emitted it.
  *
  *   NEVER CANONICAL — appendToDraft writes the draft overlay only. Publish
- *   (YW-281) is a separate, human-gated step; this tool MUST NOT call
- *   publishDraft or touch canonical.
+ *   is a separate, human-gated step; this tool MUST NOT call publishDraft or
+ *   touch canonical.
  *
  * Factory pattern: `createApplyCommandTool(options)`. The draftId is the handle
- * minted by `openDraft` (YW-260) at assistant session start — captured once in
- * the factory, not passed per-call. This keeps the per-call surface minimal
+ * minted by `openDraft` at assistant session start — captured once in the
+ * factory, not passed per-call. This keeps the per-call surface minimal
  * (type + args only) and makes it impossible for the agent to steer writes to a
  * different draft.
  *
@@ -87,7 +88,7 @@ export interface ApplyCommandDetails {
   /**
    * The raw value returned by the backing mutation handler (e.g. `{ id }` for a
    * Create command, `{ ok: true }` for an update). Opaque — callers should
-   * consult the command guide (YW-280) for the per-command shape.
+   * consult the assistant command guide for the per-command shape.
    */
   commandResult: unknown;
 }

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -37,8 +37,8 @@ export * from "./read/index.js";
 
 // applyCommand mutation tool — the assistant's write surface.
 export {
-  createApplyCommandTool,
   DRAFT_SAFE_COMMANDS,
+  createApplyCommandTool,
   type ApplyCommandDetails,
   type AssistantCommand,
   type CreateApplyCommandToolOptions,

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -7,6 +7,9 @@
  *
  * Typed tool-layer helper: the seam all assistant mutation and read tools
  * build through.
+ *
+ * applyCommand tool: the assistant's single generic mutation tool — emits
+ * commands into the open draft via the draft controller. Never canonical.
  */
 
 // OAuth credential lifecycle
@@ -31,3 +34,13 @@ export {
 // READ layer — privacy-aware graph resolver: 4 fixed read tools, the floor, the
 // GraphReader port, and the command vocabulary guide.
 export * from "./read/index.js";
+
+// applyCommand mutation tool — the assistant's write surface.
+export {
+  createApplyCommandTool,
+  DRAFT_SAFE_COMMANDS,
+  type ApplyCommandDetails,
+  type AssistantCommand,
+  type CreateApplyCommandToolOptions,
+  type DraftAppender,
+} from "./apply-command-tool.js";


### PR DESCRIPTION
## Summary

- Adds `createApplyCommandTool` — the assistant's single write surface. **ONE generic tool**, `applyCommand({ type, args })`, that emits commands into the open draft. Never touches canonical.
- Three load-bearing invariants enforced structurally: TRANSPARENT (every call is a visible draft-log step), VERIFIABLE (routes through the real `applyCommands` seam via `appendToDraft → runHandler → mutation handler`), NEVER CANONICAL (`DraftAppender` interface exposes only `appendToDraft` — `publishDraft` is structurally unreachable from the tool).
- `draftId` captured at factory time (agent cannot redirect writes per-call). `executionMode: "sequential"` satisfies the single-writer-per-draftId contract for pi multi-tool turns.
- `buildCommand` is host-injected to avoid a circular dependency (`@dashframe/assistant` must not import `@dashframe/server`). The JSDoc documents that `cmd()` is compile-time-only typed and requires a runtime key-guard at the injection site.
- Empty `appendToDraft` result throws (host contract violation surfaced loudly, not silently null).

## Design decisions

- **One generic tool, not per-command schemas** — vocabulary lives in one place (`commands.ts` / the command guide). No tool schemas to generate or sync per command.
- **buildCommand injection** — decouples the assistant package from the server's `cmd()` function. The host wires them at construction time.
- **DraftAppender minimal interface** — only `appendToDraft` is callable. Structural duck-typing: the real `DraftController` satisfies it without a cast.

## Pairing

- YW-280 (read layer / command guide, `charixandra/yw-280-assistant-read-layer`) — the agent reads the vocabulary guide via the read layer
- YW-281 (publishDraft, not yet built) — separate human-gated step; not included here

## Test plan

- [x] `bun run test` in `packages/assistant` — 47 tests pass (23 new, 24 existing)
- [x] Whole-graph `bun run typecheck` — 46/46 tasks pass
- [x] `bun run lint` — clean
- [x] AC1: multi-artifact drive loop (CreateInsight + viz + dashboard item) — all land in draft, draftId same across all calls, canonical unreachable
- [x] AC2: malformed command errors surface honestly — unknown type throws before appendToDraft; empty result throws; mutation error propagates unchanged
- [x] AC3: generic over {type, args} — no switch/if-chain over command names, all routing via injected buildCommand

Tracked internally as YW-279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `createApplyCommandTool`, the assistant's single generic mutation tool that emits commands into an open draft without ever touching canonical state. The factory-pattern design captures `draftId` at creation time and delegates command building to a host-injected `buildCommand` to keep the assistant package free of server imports.

- **Allow-list gate**: `DRAFT_SAFE_COMMANDS` enforces a default-deny boundary that rejects credential and cascade-unsafe commands before `buildCommand` or `appendToDraft` is called — vault side-effects are structurally unreachable.
- **Error propagation**: Validation failures from the mutation handler, empty `appendToDraft` results, and unknown command types all surface as thrown errors with no silent swallowing; the agent receives honest feedback for retry.
- **23 new tests** cover the happy path, error propagation, multi-step drive loops, and all three key invariants (transparent, verifiable, never-canonical).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The three load-bearing invariants (never-canonical, sequential execution, default-deny allow-list) are structurally enforced and well-tested.

The allow-list gate fires before buildCommand or appendToDraft, so vault and cascade-unsafe commands are structurally unreachable. The factory captures draftId immutably and the DraftAppender interface exposes only appendToDraft, making publishDraft unreachable from the tool. Error propagation is clean with no silent swallowing. The 23 new tests exercise all documented contracts.

No files require special attention. The only note is the partial results.length contract enforcement in apply-command-tool.ts (an over-count from a misbehaving host is currently silently discarded rather than thrown).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/src/apply-command-tool.ts | New file implementing `createApplyCommandTool`. Security gate, factory pattern, and error propagation are all well-structured; the `DRAFT_SAFE_COMMANDS` set is a manually maintained string list decoupled from the server type system (by design), which requires discipline to keep in sync as the command vocabulary evolves. |
| packages/assistant/src/apply-command-tool.test.ts | Comprehensive test suite covering all 10 documented contracts — happy path, error propagation, multi-step drive loop, allow-list gate (denied + allowed), and tool metadata. Tests are well isolated with minimal mock surface. |
| packages/assistant/src/index.ts | Exports the new `applyCommand` public surface (`DRAFT_SAFE_COMMANDS`, `createApplyCommandTool`, and four types). All exports are intentionally scoped — `DraftAppender` and `AssistantCommand` interfaces let the host wire the server types without a circular import. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant Tool as applyCommand tool
    participant Gate as DRAFT_SAFE_COMMANDS gate
    participant BC as buildCommand (host-injected)
    participant DC as DraftController.appendToDraft
    participant MH as Mutation Handler (runHandler)

    Agent->>Tool: "execute(toolCallId, { type, args })"
    Tool->>Gate: DRAFT_SAFE_COMMANDS.has(type)
    alt type NOT in allow-list
        Gate-->>Tool: false
        Tool-->>Agent: throws "not available to the assistant" (deny)
    else type in allow-list
        Gate-->>Tool: true
        Tool->>BC: buildCommand(type, args)
        BC-->>Tool: "AssistantCommand { path, args }"
        Tool->>DC: appendToDraft(draftId, [command], context)
        DC->>MH: runHandler(path, args) inside draft overlay
        alt mutation valid
            MH-->>DC: "{ value: result }"
            DC-->>Tool: "[{ value: result }]"
            Tool-->>Agent: "{ content, details: { commandType, commandResult } }"
        else mutation invalid / empty result
            MH-->>DC: throws Error
            DC-->>Tool: throws / returns []
            Tool-->>Agent: throws (propagated honestly)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant Tool as applyCommand tool
    participant Gate as DRAFT_SAFE_COMMANDS gate
    participant BC as buildCommand (host-injected)
    participant DC as DraftController.appendToDraft
    participant MH as Mutation Handler (runHandler)

    Agent->>Tool: "execute(toolCallId, { type, args })"
    Tool->>Gate: DRAFT_SAFE_COMMANDS.has(type)
    alt type NOT in allow-list
        Gate-->>Tool: false
        Tool-->>Agent: throws "not available to the assistant" (deny)
    else type in allow-list
        Gate-->>Tool: true
        Tool->>BC: buildCommand(type, args)
        BC-->>Tool: "AssistantCommand { path, args }"
        Tool->>DC: appendToDraft(draftId, [command], context)
        DC->>MH: runHandler(path, args) inside draft overlay
        alt mutation valid
            MH-->>DC: "{ value: result }"
            DC-->>Tool: "[{ value: result }]"
            Tool-->>Agent: "{ content, details: { commandType, commandResult } }"
        else mutation invalid / empty result
            MH-->>DC: throws Error
            DC-->>Tool: throws / returns []
            Tool-->>Agent: throws (propagated honestly)
        end
    end
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/eb67e5dd7bf15e9666abf44d47b829a62e32e671) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39476470)</sub>

<!-- /greptile_comment -->