### PR TITLE
fix(app): tag Date in group-key encoding to prevent string collision [YW-294]

### DIFF
--- a/packages/app/src/lib/insights/compute-preview.test.ts
+++ b/packages/app/src/lib/insights/compute-preview.test.ts
@@ -197,6 +197,96 @@ describe("groupRowsBy — field without columnName", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Date values (DuckDB TIMESTAMP/DATE columns surface as JS Date objects)
+// ---------------------------------------------------------------------------
+
+describe("groupRowsBy — Date vs string collision", () => {
+  it("keeps a Date and its ISO-string representation as SEPARATE groups", () => {
+    // JSON.stringify(new Date("2024-01-01T00:00:00.000Z")) ===
+    // JSON.stringify("2024-01-01T00:00:00.000Z")  → both produce the same
+    // JSON bytes, so without a type tag the two rows would merge into one group.
+    const col = field({ id: "f1", name: "ts", columnName: "ts" });
+    const dt = table([col]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { ts: new Date("2024-01-01T00:00:00.000Z") }, // Date object
+      { ts: "2024-01-01T00:00:00.000Z" }, // equal ISO string
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    // Must be 2 distinct groups, not 1 merged group
+    expect(result.rowCount).toBe(2);
+    expect(result.dataFrame.rows).toHaveLength(2);
+  });
+
+  it("keeps two different Date values in separate groups", () => {
+    const col = field({ id: "f1", name: "ts", columnName: "ts" });
+    const dt = table([col]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { ts: new Date("2024-01-01T00:00:00.000Z") },
+      { ts: new Date("2024-06-15T12:00:00.000Z") },
+      { ts: new Date("2024-01-01T00:00:00.000Z") }, // duplicate of first
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(2);
+  });
+
+  it("keeps a Date distinct from null", () => {
+    const col = field({ id: "f1", name: "ts", columnName: "ts" });
+    const dt = table([col]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { ts: new Date("2024-01-01T00:00:00.000Z") },
+      { ts: null },
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(2);
+  });
+
+  it("keeps Invalid Date distinct from null and from a valid Date", () => {
+    // new Date("not-a-date").getTime() === NaN; JSON.stringify(NaN) === "null"
+    // so without a guard, ["d", NaN] serializes to ["d",null] — all invalid
+    // dates would collapse and differ silently from actual null. The encoder
+    // uses a dedicated ["d-invalid"] tag to keep injectivity intact.
+    const col = field({ id: "f1", name: "ts", columnName: "ts" });
+    const dt = table([col]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { ts: new Date("not-a-date") }, // Invalid Date
+      { ts: null },
+      { ts: new Date("2024-01-01T00:00:00.000Z") }, // valid Date
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    // Must be 3 distinct groups — Invalid Date must not merge with null or valid Date
+    expect(result.rowCount).toBe(3);
+  });
+
+  it("groups all Invalid Date rows together (same sentinel)", () => {
+    // Two different Invalid Date instances share the ["d-invalid"] sentinel —
+    // both are unusable values and should form one group, not two.
+    const col = field({ id: "f1", name: "ts", columnName: "ts" });
+    const dt = table([col]);
+    const ins = insight(["f1"]);
+
+    const data = frame([
+      { ts: new Date("bad1") },
+      { ts: new Date("bad2") }, // different string, same NaN result
+    ]);
+
+    const result = computeInsightPreview(ins, dt, data, 50);
+    expect(result.rowCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // BigInt values (DuckDB BIGINT columns surface as JS bigint)
 // ---------------------------------------------------------------------------
 

--- a/packages/app/src/lib/insights/compute-preview.ts
+++ b/packages/app/src/lib/insights/compute-preview.ts
@@ -126,8 +126,8 @@ function groupRowsBy(
     //
     // The encoding is a TOTAL, injective function over every value DuckDB
     // can produce (string, finite number, bigint, boolean, null/undefined,
-    // non-finite number). Two distinct values must never share a key; no
-    // value may throw. Type tags prevent cross-type collisions (e.g. the
+    // non-finite number, Date). Two distinct values must never share a key;
+    // no value may throw. Type tags prevent cross-type collisions (e.g. the
     // string "1" vs the number 1 vs the bigint 1n each produce distinct keys).
     //
     // Tags:
@@ -135,6 +135,12 @@ function groupRowsBy(
     //   ["num", str]       — non-finite numbers: "NaN", "Infinity", "-Infinity"
     //                        (JSON.stringify coerces these to null otherwise)
     //   ["bigint", str]    — BigInt values (JSON.stringify THROWS on bigint)
+    //   ["d", ms]          — valid Date objects: epoch milliseconds (a number)
+    //                        (JSON.stringify(date) === JSON.stringify(date.toISOString())
+    //                        so without a tag, a Date and its ISO string share a key)
+    //   ["d-invalid"]      — Invalid Date (getTime() returns NaN; JSON.stringify
+    //                        serializes NaN as null, which would collide with ["d",null]
+    //                        if not given its own tag)
     //   ["v", value]       — everything else: string, finite number, boolean
     //
     // Column lookup: field.columnName ?? field.name (codebase convention,
@@ -146,6 +152,11 @@ function groupRowsBy(
       if (typeof value === "bigint") return ["bigint", value.toString()];
       if (typeof value === "number" && !isFinite(value)) {
         return ["num", String(value)]; // "NaN", "Infinity", "-Infinity"
+      }
+      if (value instanceof Date) {
+        const ms = value.getTime();
+        // JSON.stringify coerces NaN to null — guard to keep injectivity intact
+        return isNaN(ms) ? ["d-invalid"] : ["d", ms];
       }
       return ["v", value];
     });


### PR DESCRIPTION
## Summary

- `groupRowsBy` in `compute-preview.ts` uses `JSON.stringify` on typed tuples to build collision-resistant group keys. `Date` objects fell into the `["v", value]` catch-all branch, but `JSON.stringify(new Date("2024-01-01T00:00:00.000Z"))` produces output byte-identical to `JSON.stringify("2024-01-01T00:00:00.000Z")` — so a TIMESTAMP/DATE row and a row carrying the equal ISO string silently merged into one group, corrupting aggregation counts and metric values. DuckDB-WASM materialises TIMESTAMP/DATE columns as JS `Date` objects via `.toArray()`, making this reachable in production.

- Fix adds a `["d", ms]` tag (using `getTime()` — a number — so the tag+payload is structurally distinct from `["v", <string>]`). Also adds a `["d-invalid"]` sentinel for `Invalid Date` (`getTime() === NaN`): `JSON.stringify(NaN)` coerces to `null`, which would have collapsed all invalid-Date rows into a `["d",null]` phantom group without this guard.

- Adds 5 tests to `compute-preview.test.ts`: Date/ISO-string collision (primary regression), Date/Date deduplication, Date/null cross-tag, Invalid Date isolation from null and valid Date, and Invalid Date–Invalid Date grouping. The comment enumeration in `groupRowsBy` is updated to list both new tags.

Tracked internally as YW-294.

## Test plan

- [ ] `bun run turbo test --filter=@dashframe/app` — 515 tests pass (5 new Date tests green)
- [ ] `bun run turbo typecheck` — 46/46 tasks pass
- [ ] `bun run turbo lint --filter=@dashframe/app` — clean
- [ ] `bun run format:check` — clean
- [ ] Verify: `JSON.stringify([["v", new Date("2024-01-01T00:00:00.000Z")]]) === JSON.stringify([["v", "2024-01-01T00:00:00.000Z"]])` returns `true` on baseline, `false` after fix (the Date now produces `[["d",1704067200000]]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent group-key collision in `groupRowsBy` where `JSON.stringify` produces byte-identical output for a `Date` object and its ISO-8601 string equivalent, causing DuckDB TIMESTAMP/DATE rows to merge incorrectly with string-typed rows during aggregation.

- **`compute-preview.ts`**: Inserts a `Date instanceof` branch before the catch-all `["v", value]` return; valid Dates are tagged `["d", ms]` (epoch ms as a finite number), and `Invalid Date` gets a dedicated `["d-invalid"]` sentinel to prevent the secondary `NaN → null` JSON coercion collision.
- **`compute-preview.test.ts`**: Five new focused tests cover the primary regression (Date vs ISO-string), same-timestamp dedup, Date vs null, Invalid Date vs null and valid Date, and Invalid Date–Invalid Date grouping.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the Date-value branch of the group-key encoder and does not touch any other code paths.

The fix correctly resolves the JSON serialization collision between Date objects and ISO strings, the NaN-guard for Invalid Date is precise, and all five new tests exercise the exact failure modes described in the PR. No custom rules are violated in the changed source files.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/lib/insights/compute-preview.ts | Adds a `["d", ms]` tag for valid Date objects and a `["d-invalid"]` sentinel for invalid Dates in the group-key encoder, closing the JSON serialization collision between Date objects and their ISO-string equivalents. Logic is sound and guard for NaN epoch is correct. |
| packages/app/src/lib/insights/compute-preview.test.ts | Adds 5 regression tests for the Date encoding fix: Date/ISO-string collision, Date/Date deduplication, Date/null isolation, Invalid Date vs null and valid Date, and Invalid Date–Invalid Date grouping. Covers all enumerated edge cases from the PR description. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Row value from DuckDB column] --> B{value == null?}
    B -- yes --> C["['null']"]
    B -- no --> D{typeof bigint?}
    D -- yes --> E["['bigint', str]"]
    D -- no --> F{typeof number && !isFinite?}
    F -- yes --> G["['num', str]\n'NaN'/'Infinity'/'-Infinity'"]
    F -- no --> H{instanceof Date?}
    H -- yes --> I{isNaN getTime?}
    I -- yes --> J["['d-invalid']\nInvalid Date sentinel"]
    I -- no --> K["['d', ms]\nEpoch milliseconds"]
    H -- no --> L["['v', value]\nstring / finite number / boolean"]
    C & E & G & J & K & L --> M[JSON.stringify keyParts]
    M --> N[Group key string]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Row value from DuckDB column] --> B{value == null?}
    B -- yes --> C["['null']"]
    B -- no --> D{typeof bigint?}
    D -- yes --> E["['bigint', str]"]
    D -- no --> F{typeof number && !isFinite?}
    F -- yes --> G["['num', str]\n'NaN'/'Infinity'/'-Infinity'"]
    F -- no --> H{instanceof Date?}
    H -- yes --> I{isNaN getTime?}
    I -- yes --> J["['d-invalid']\nInvalid Date sentinel"]
    I -- no --> K["['d', ms]\nEpoch milliseconds"]
    H -- no --> L["['v', value]\nstring / finite number / boolean"]
    C & E & G & J & K & L --> M[JSON.stringify keyParts]
    M --> N[Group key string]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(app): tag Date in group-key encoding..."](https://github.com/youhaowei/dashframe/commit/657d22d0bac202b61f5f07a6a1a974c65dae49d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39478714)</sub>

<!-- /greptile_comment -->