### PR TITLE
fix(app): clear insight-view error on config-switch to a cached config [YW-296]

### DIFF
--- a/packages/app/src/hooks/useInsightView.test.tsx
+++ b/packages/app/src/hooks/useInsightView.test.tsx
@@ -541,6 +541,69 @@ describe("useInsightView", () => {
       expect(result.current.isReady).toBe(true);
     });
 
+    it("should clear error when config-key switches to an already-cached config", async () => {
+      // Regression: config A fails (error set) → switch to config B which is
+      // already in createdViewsCache → effect returns early on the cache hit
+      // and never calls setError(null). Without the fix, the stale A error
+      // persists and VisualizationDisplay stays stuck on the error state even
+      // though config B has a valid cached view.
+
+      const insightA = createMockInsight({
+        id: "insight-error-a",
+        baseTableId: "table-error-a",
+      });
+
+      const insightB = createMockInsight({
+        id: "insight-cached-b",
+        baseTableId: "table-cached-b",
+      });
+
+      const tableB = createMockDataTable({
+        id: "table-cached-b",
+        dataFrameId: "df-cached-b",
+      });
+      const dfB = createMockDataFrame("df-cached-b");
+
+      // Prime config B into the cache before config A fails:
+      // First mount insight B → success → unmount → cache hit guaranteed.
+      mockGetDataTable.mockResolvedValue(tableB);
+      mockGetDataFrame.mockResolvedValue(dfB);
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
+      mockQuery.mockResolvedValue(undefined);
+
+      const { result: primeResult, unmount: primeUnmount } = renderHook(() =>
+        useInsightView(insightB),
+      );
+      await waitFor(() => {
+        expect(primeResult.current.isReady).toBe(true);
+      });
+      primeUnmount();
+
+      // Now mount insight A and make it fail so error is set.
+      mockGetDataTable.mockResolvedValue(null); // base table missing → error
+      const { result, rerender } = renderHook(
+        ({ insight }: { insight: typeof insightA | typeof insightB }) =>
+          useInsightView(insight),
+        { initialProps: { insight: insightA } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.error).toBe("Base table not found");
+      });
+      expect(result.current.isReady).toBe(false);
+
+      // Switch to config B — already in cache, effect short-circuits at early-return.
+      // The stale error from A must NOT persist.
+      rerender({ insight: insightB });
+
+      await waitFor(() => {
+        expect(result.current.isReady).toBe(true);
+      });
+      expect(result.current.error).toBeNull();
+      expect(result.current.viewName).toBe("insight_view_insight_cached_b");
+    });
+
     it("should create new view when joins change", async () => {
       const insightNoJoins = createMockInsight({
         id: "insight-joins-change",

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -297,6 +297,13 @@ export function useInsightView(
       ? cachedView.nativeCapable
       : nativeCapable;
 
+  // Clear stale error when configKey changes to one already in the cache.
+  // The cache-hit path returns early before createView runs, so setError(null)
+  // in createView's success path never fires on a cache-switch. A prior error
+  // from config A must not bleed into a successful cached config B.
+  const errorForCurrentKey =
+    cachedView && resolvedConfigKey !== configKey ? null : error;
+
   const prerequisitesReady =
     Boolean(connection) &&
     isInitialized &&
@@ -532,8 +539,8 @@ export function useInsightView(
     viewName,
     /** Whether the view is ready to be queried */
     isReady,
-    /** Error message if view creation failed */
-    error,
+    /** Error message if view creation failed, or null when the current config is clean. */
+    error: errorForCurrentKey,
     /**
      * Whether all DataFrames for this insight were successfully uploaded to
      * the native engine. `false` means at least one DataFrame uses remote


### PR DESCRIPTION
## Summary

- **Bug**: When \`configKey\` changes to a key already in \`createdViewsCache\`, the \`useEffect\` in \`useInsightView\` returns early at the cache-hit guard before \`createView\` runs — so \`setError(null)\` in \`createView\`'s success path never fires. A prior error from config A leaked into config B, leaving \`VisualizationDisplay\` stuck on the "Failed to load visualization data" error state even though config B had a valid cached view and was fully ready to render.
- **Fix**: Compute \`errorForCurrentKey\` alongside the existing per-configKey recomputation for \`nativeCapable\` and \`viewName\`. When \`cachedView\` is present and \`resolvedConfigKey !== configKey\`, \`errorForCurrentKey\` is \`null\` — mirroring the established pattern the authors used for the other two derived values.
- **Test**: New regression test: config A fails (error set) → config B is already in cache → switch to B → assert \`error\` is null and \`viewName\` is the B view name.

Tracked internally as YW-296.

## Test plan

- [x] All app tests pass (\`bun run test\` — 511 tests, all green)
- [x] Whole-graph typecheck passes (\`bun run typecheck\` — 46/46 tasks)
- [x] New test "should clear error when config-key switches to an already-cached config" passes
- [x] Existing cache behavior tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where a stale error from a failed insight config (A) leaked into a subsequently-displayed cached config (B), leaving `VisualizationDisplay` stuck on the error state even though config B was fully ready. The fix mirrors the existing `nativeCapableForCurrentKey` pattern to derive `errorForCurrentKey` at render time, returning `null` when a cached view exists for the incoming `configKey` but `resolvedConfigKey` hasn't yet been advanced to it.

- **Core fix** (`useInsightView.ts`): adds a render-time `errorForCurrentKey` computation that short-circuits to `null` on a cache-hit config switch, preventing the stale error from the previous config bleeding through.
- **Regression test** (`useInsightView.test.tsx`): primes config B into cache, drives config A to fail (sets error), then switches to B and asserts `error` is null and `viewName` is B's view — covering the exact failure scenario described in the bug report.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a 7-line derived-value addition that follows the codebase's established pattern, backed by a direct regression test for the exact failure scenario.

The fix is minimal and isolated to render-time derivation with no side effects. The condition `cachedView && resolvedConfigKey !== configKey` correctly identifies the cache-hit transition case without affecting the normal (non-cached) path, initial mounts, or re-renders on the same configKey. All edge cases (null configKey, rapid switches, returning to a failed config) behave correctly. The new test exercises the exact bug scenario and the existing test suite covers regressions.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/hooks/useInsightView.ts | Adds `errorForCurrentKey` derived value that returns null when a cached view exists for the current configKey but state hasn't been synced yet — mirrors the existing `nativeCapableForCurrentKey` pattern correctly. |
| packages/app/src/hooks/useInsightView.test.tsx | Adds a targeted regression test that primes a config into the cache, fails a second config, switches back to the cached one, and asserts the error is cleared — matches the described bug scenario precisely. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as VisualizationDisplay
    participant H as useInsightView
    participant Cache as createdViewsCache
    participant Effect as useEffect

    Note over UI,Effect: Config A (fails)
    UI->>H: render(insightA)
    H->>Effect: "trigger (configKey=A)"
    Effect->>Cache: has(A)? → false
    Effect->>Effect: createView(A) → setError("Base table not found")
    H-->>UI: "error="Base table not found", isReady=false"

    Note over UI,Effect: Switch to Config B (already cached)
    UI->>H: render(insightB)
    H->>Cache: "get(configKey=B) → cachedView (exists)"
    Note over H: resolvedConfigKey≠configKey AND cachedView present
    H->>H: "errorForCurrentKey = null  ← FIX"
    H->>Effect: "trigger (configKey=B)"
    Effect->>Cache: has(B)? → true → early return (no setError call)
    H-->>UI: "error=null, isReady=true ✓"

    Note over UI,Effect: Without fix
    H->>H: "errorForCurrentKey = error = "Base table not found" (stale)"
    H-->>UI: "error="Base table not found", isReady=true (stuck on error state)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as VisualizationDisplay
    participant H as useInsightView
    participant Cache as createdViewsCache
    participant Effect as useEffect

    Note over UI,Effect: Config A (fails)
    UI->>H: render(insightA)
    H->>Effect: "trigger (configKey=A)"
    Effect->>Cache: has(A)? → false
    Effect->>Effect: createView(A) → setError("Base table not found")
    H-->>UI: "error="Base table not found", isReady=false"

    Note over UI,Effect: Switch to Config B (already cached)
    UI->>H: render(insightB)
    H->>Cache: "get(configKey=B) → cachedView (exists)"
    Note over H: resolvedConfigKey≠configKey AND cachedView present
    H->>H: "errorForCurrentKey = null  ← FIX"
    H->>Effect: "trigger (configKey=B)"
    Effect->>Cache: has(B)? → true → early return (no setError call)
    H-->>UI: "error=null, isReady=true ✓"

    Note over UI,Effect: Without fix
    H->>H: "errorForCurrentKey = error = "Base table not found" (stale)"
    H-->>UI: "error="Base table not found", isReady=true (stuck on error state)"
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(app): clear insight-view error on co..."](https://github.com/youhaowei/dashframe/commit/e82bfe044064c9a30009ea7ebbaa3e3205bdc729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39479165)</sub>

<!-- /greptile_comment -->