### PR TITLE
fix(engine): unique join aliases per join instance — fix two-joins-same-table column loss [YW-295]

### DIFF
--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -122,14 +122,38 @@ export function useInsightPagination({
     // Cache for later use
     resolvedTablesRef.current = { baseTable, joinedTables };
 
-    // Collect all fields from base + joined tables
+    // Collect all fields from base + joined tables.
+    // Iterate insight.joins (not joinedTables.values()) so two joins to the same
+    // rightTableId each contribute their fields.  For the second (and later) join
+    // to a given table, the SQL engine emits suffixed aliases (field_<uuid>_j{n})
+    // — mirror that here by using synthetic field IDs so columnDisplayNames and
+    // columnTypeMap are keyed on the SAME aliases DuckDB actually produces.
     const allFields: Field[] = [
       ...(baseTable.fields ?? []).filter((f) => !f.name.startsWith("_")),
     ];
-    for (const joinTable of joinedTables.values()) {
-      allFields.push(
-        ...(joinTable.fields ?? []).filter((f) => !f.name.startsWith("_")),
+    const joinInstanceCount = new Map<string, number>();
+    for (const join of insight.joins ?? []) {
+      const joinTable = joinedTables.get(join.rightTableId);
+      if (!joinTable) continue;
+      const instanceIndex = joinInstanceCount.get(join.rightTableId) ?? 0;
+      joinInstanceCount.set(join.rightTableId, instanceIndex + 1);
+      const visibleFields = (joinTable.fields ?? []).filter(
+        (f) => !f.name.startsWith("_"),
       );
+      if (instanceIndex === 0) {
+        // First join: use fields as-is (canonical aliases, no suffix)
+        allFields.push(...visibleFields);
+      } else {
+        // Repeat join: push synthetic Fields whose id encodes the instance index
+        // so fieldIdToColumnAlias produces the _j{n}-suffixed alias that matches
+        // the SQL column name DuckDB received from the join builder.
+        allFields.push(
+          ...visibleFields.map((f) => ({
+            ...f,
+            id: `${f.id}_j${instanceIndex}` as UUID,
+          })),
+        );
+      }
     }
 
     return { baseTable, joinedTables, allFields };

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -868,7 +868,7 @@ describe("buildInsightSQL — identifier quoting: embedded double-quotes in disp
 });
 
 // ---------------------------------------------------------------------------
-// YW-295: Two joins to the same table must produce distinct column aliases.
+// Two joins to the same table must produce distinct column aliases.
 //
 // Scenario: an orders table joined to a users table TWICE — once via
 // created_by → id (the creator) and once via approved_by → id (the approver).

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -866,3 +866,194 @@ describe("buildInsightSQL — identifier quoting: embedded double-quotes in disp
     expect(sql!).toMatch(/AS "my ""best"" sales table"/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// YW-295: Two joins to the same table must produce distinct column aliases.
+//
+// Scenario: an orders table joined to a users table TWICE — once via
+// created_by → id (the creator) and once via approved_by → id (the approver).
+// Both joins resolve the same DataTable and therefore the same Field UUIDs.
+// Without the fix, processSingleJoin emits `AS "field_<uuid>"` for every
+// non-key column of users on BOTH join passes, producing duplicate aliases in
+// the final SELECT.  DuckDB silently keeps the first occurrence, so the
+// approved_by-joined columns are unreachable (silent wrong results).
+//
+// The fix: the second join's non-key columns get `field_<uuid>_j1` aliases
+// (instance-suffixed) so each join instance has its own distinct alias.
+// ---------------------------------------------------------------------------
+
+describe("buildInsightSQL — two joins to the same table produce distinct column aliases", () => {
+  // Table IDs
+  const ORDERS_TABLE_ID = "10101010-1010-1010-1010-101010101010" as UUID;
+  const ORDERS_DF_ID = "20202020-2020-2020-2020-202020202020" as UUID;
+  const USERS_TABLE_ID = "30303030-3030-3030-3030-303030303030" as UUID;
+  const USERS_DF_ID = "40404040-4040-4040-4040-404040404040" as UUID;
+
+  // Orders fields
+  const O_ID_FIELD: Field = {
+    id: "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0" as UUID,
+    name: "Order ID",
+    tableId: ORDERS_TABLE_ID,
+    columnName: "id",
+    type: "string",
+  };
+  const O_CREATED_BY_FIELD: Field = {
+    id: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0" as UUID,
+    name: "Created By",
+    tableId: ORDERS_TABLE_ID,
+    columnName: "created_by",
+    type: "string",
+  };
+  const O_APPROVED_BY_FIELD: Field = {
+    id: "c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0" as UUID,
+    name: "Approved By",
+    tableId: ORDERS_TABLE_ID,
+    columnName: "approved_by",
+    type: "string",
+  };
+
+  // Users fields (same table joined twice)
+  const U_ID_FIELD: Field = {
+    id: "d0d0d0d0-d0d0-d0d0-d0d0-d0d0d0d0d0d0" as UUID,
+    name: "User ID",
+    tableId: USERS_TABLE_ID,
+    columnName: "id",
+    type: "string",
+  };
+  const U_NAME_FIELD: Field = {
+    id: "e0e0e0e0-e0e0-e0e0-e0e0-e0e0e0e0e0e0" as UUID,
+    name: "User Name",
+    tableId: USERS_TABLE_ID,
+    columnName: "name",
+    type: "string",
+  };
+  const U_EMAIL_FIELD: Field = {
+    id: "f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0" as UUID,
+    name: "User Email",
+    tableId: USERS_TABLE_ID,
+    columnName: "email",
+    type: "string",
+  };
+
+  const ordersTable: DataTable = {
+    id: ORDERS_TABLE_ID,
+    name: "orders",
+    dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+    table: "orders.csv",
+    fields: [O_ID_FIELD, O_CREATED_BY_FIELD, O_APPROVED_BY_FIELD],
+    metrics: [],
+    dataFrameId: ORDERS_DF_ID,
+    createdAt: 0,
+  };
+
+  const usersTable: DataTable = {
+    id: USERS_TABLE_ID,
+    name: "users",
+    dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+    table: "users.csv",
+    fields: [U_ID_FIELD, U_NAME_FIELD, U_EMAIL_FIELD],
+    metrics: [],
+    dataFrameId: USERS_DF_ID,
+    createdAt: 0,
+  };
+
+  // The insight: orders joined to users on created_by→id AND approved_by→id
+  const doubleJoinInsight: Insight = {
+    id: "50505050-5050-5050-5050-505050505050" as UUID,
+    name: "Orders with creator and approver",
+    baseTableId: ORDERS_TABLE_ID,
+    selectedFields: [],
+    metrics: [],
+    joins: [
+      {
+        type: "inner",
+        rightTableId: USERS_TABLE_ID,
+        leftKey: "created_by",
+        rightKey: "id",
+      },
+      {
+        type: "inner",
+        rightTableId: USERS_TABLE_ID,
+        leftKey: "approved_by",
+        rightKey: "id",
+      },
+    ],
+    createdAt: 0,
+  };
+
+  // Canonical alias for the first join's non-key user columns (no suffix)
+  const nameAliasJ0 = fieldIdToColumnAlias(U_NAME_FIELD.id);
+  const emailAliasJ0 = fieldIdToColumnAlias(U_EMAIL_FIELD.id);
+  // Suffixed aliases for the second join instance
+  const nameAliasJ1 = `${nameAliasJ0}_j1`;
+  const emailAliasJ1 = `${emailAliasJ0}_j1`;
+
+  it("emits NO duplicate column alias definition when the same table is joined twice", () => {
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+
+    // Count how many times each alias is DEFINED (i.e. appears after AS).
+    // Passthrough references ("alias" without AS) are not output column definitions
+    // and do not cause DuckDB to produce a duplicate output column.
+    const countDefinitions = (alias: string) => {
+      const pattern = new RegExp(`AS "${alias}"`, "g");
+      return (sql!.match(pattern) ?? []).length;
+    };
+
+    // First join's non-key columns: defined exactly once at the canonical alias
+    expect(countDefinitions(nameAliasJ0)).toBe(1);
+    expect(countDefinitions(emailAliasJ0)).toBe(1);
+
+    // Second join's non-key columns: defined at the suffixed alias — distinct
+    // from the first join's aliases so DuckDB cannot silently drop them.
+    expect(countDefinitions(nameAliasJ1)).toBe(1);
+    expect(countDefinitions(emailAliasJ1)).toBe(1);
+  });
+
+  it("includes BOTH join instances' non-key columns in the SELECT (approver columns are not shadowed)", () => {
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+
+    // First join (creator): name and email defined at canonical aliases
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ0}"`);
+
+    // Second join (approver): name and email defined at suffixed aliases — distinct
+    // from the first join's aliases, so DuckDB sees them as separate output columns
+    // and cannot silently discard them (the pre-fix bug: silent wrong results).
+    expect(sql!).toContain(`AS "${nameAliasJ1}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ1}"`);
+  });
+
+  it("single join to a table still emits the canonical (unsuffixed) alias — regression guard", () => {
+    // The fix must not break the common single-join case.
+    const firstJoin = doubleJoinInsight.joins![0]!;
+    const singleJoinInsight: Insight = {
+      ...doubleJoinInsight,
+      joins: [firstJoin],
+    };
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      singleJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    // Canonical alias (no suffix) is present
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ0}"`);
+    // No suffix alias should appear
+    expect(sql!).not.toContain(`"${nameAliasJ1}"`);
+    expect(sql!).not.toContain(`"${emailAliasJ1}"`);
+  });
+});

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -44,6 +44,19 @@ export function fieldIdToColumnAlias(fieldId: string): string {
 }
 
 /**
+ * Encode a join instance index into a field ID so two joins to the same table
+ * produce distinct column aliases.  index=0 → unchanged; index≥1 → `id_j{n}`.
+ * For SQL alias derivation inside the join builder only — never stored/compared.
+ */
+function joinInstanceFieldId(
+  fieldId: string,
+  joinInstanceIndex: number,
+): string {
+  if (joinInstanceIndex === 0) return fieldId;
+  return `${fieldId}_j${joinInstanceIndex}`;
+}
+
+/**
  * Convert a metric ID to a SQL-safe column alias.
  * Format: metric_<uuid_with_underscores>
  *
@@ -67,8 +80,11 @@ export function extractUUIDFromColumnAlias(columnAlias: string): string | null {
   const match = columnAlias.match(/^(?:field|metric)_(.+)$/);
   if (!match) return null;
 
-  // Convert underscores back to hyphens in UUID format
-  const uuidPart = match[1];
+  // Strip the join-instance suffix appended by joinInstanceFieldId (e.g. `_j1`,
+  // `_j2`).  These suffixes keep two joins to the same table from emitting
+  // duplicate SQL aliases; they must be removed before UUID reconstruction so
+  // callers (AxisSelectField, analyze, suggest-charts) get the real field ID.
+  const uuidPart = (match[1] ?? "").replace(/_j\d+$/, "");
   if (!uuidPart) return null;
   // UUID format: 8-4-4-4-12 characters
   // With underscores: 8_4_4_4_12
@@ -517,13 +533,21 @@ function buildJoinedSQL(
   let currentSQL = `(SELECT ${baseSelects.join(", ")} FROM ${baseDFTable} AS ${quoteIdentifier(baseDisplayName)})`;
   let currentFields = baseFields;
 
+  // Count prior instances per rightTableId so processSingleJoin can suffix
+  // aliases for repeat-joins and avoid duplicate column names in the SELECT.
+  const joinInstanceCount = new Map<UUID, number>();
+
   for (const join of insight.joins ?? []) {
+    const instanceIndex = joinInstanceCount.get(join.rightTableId) ?? 0;
+    joinInstanceCount.set(join.rightTableId, instanceIndex + 1);
+
     const joinResult = processSingleJoin(
       join,
       joinedTables,
       currentSQL,
       baseDisplayName,
       currentFields,
+      instanceIndex,
     );
 
     if (joinResult) {
@@ -531,6 +555,8 @@ function buildJoinedSQL(
       // Accumulate fields from all joined tables for subsequent joins.
       // `joinResult.allFields` excludes dropped right join-keys, so it is the
       // accurate set of columns actually present in `currentSQL`.
+      // For repeat-joins, allFields contains synthetic Fields with suffixed IDs
+      // so downstream alias derivations match the emitted SELECT.
       currentFields = joinResult.allFields;
     }
   }
@@ -551,6 +577,12 @@ interface JoinResult {
 /**
  * Process a single join and return the updated SQL with UUID-based column aliases.
  * Returns null if join is invalid.
+ *
+ * @param joinInstanceIndex How many times this rightTableId was joined BEFORE
+ *   this call (0 = first, 1 = second, …).  When > 0 the right-side non-key
+ *   column aliases are suffixed `_j{n}` so two joins to the same table emit
+ *   distinct SQL aliases.  Without this, DuckDB silently keeps the first alias
+ *   and the second join's columns are unreachable (silent wrong results).
  */
 function processSingleJoin(
   join: NonNullable<Insight["joins"]>[number],
@@ -558,6 +590,7 @@ function processSingleJoin(
   currentSQL: string,
   currentDisplayName: string,
   currentFields: Field[],
+  joinInstanceIndex: number,
 ): JoinResult | null {
   // Validate join table
   const joinTable = joinedTables.get(join.rightTableId);
@@ -589,28 +622,27 @@ function processSingleJoin(
 
   const rightColName = joinKeyField.columnName ?? joinKeyField.name;
 
-  // Build SELECT parts using UUID-based aliases
-  // For the left side, use the field alias (field_<uuid>) since it's already aliased
+  // Left side: passthrough existing aliases; field.id is stable (or already
+  // instance-suffixed from a prior repeat-join), so fieldIdToColumnAlias works.
   const leftKeyAlias = fieldIdToColumnAlias(currentKeyField.id);
   const baseSelects = currentFields.map((field) => {
     const alias = fieldIdToColumnAlias(field.id);
     return `"${alias}"`;
   });
 
-  // For the right side, select with UUID aliases (excluding join key to avoid duplication)
-  const joinSelects = joinFields
-    .filter((f) => {
-      const colName = f.columnName ?? f.name;
-      return colName !== rightColName;
-    })
-    .map((field) => {
-      const columnName = field.columnName ?? field.name;
-      return buildColumnSelectWithFieldId(
-        joinDisplayName,
-        columnName,
-        field.id,
-      );
-    });
+  // Right side: exclude the join key; suffix aliases for repeat-joins.
+  const nonKeyJoinFields = joinFields.filter(
+    (f) => (f.columnName ?? f.name) !== rightColName,
+  );
+  const joinSelects = nonKeyJoinFields.map((field) => {
+    const columnName = field.columnName ?? field.name;
+    const instanceId = joinInstanceFieldId(field.id, joinInstanceIndex);
+    return buildColumnSelectWithFieldId(
+      joinDisplayName,
+      columnName,
+      instanceId,
+    );
+  });
 
   const selectParts = [...baseSelects, ...joinSelects];
 
@@ -629,14 +661,19 @@ function processSingleJoin(
     ON "${leftKeyAlias}" = ${quoteIdentifier(joinDisplayName)}.${quoteIdentifier(rightColName)}
   )`;
 
-  // Combine all fields for subsequent joins (excluding duplicate join key)
-  const allFields = [
-    ...currentFields,
-    ...joinFields.filter((f) => {
-      const colName = f.columnName ?? f.name;
-      return colName !== rightColName;
-    }),
-  ];
+  // Combine fields for subsequent joins (excluding dropped right join-key).
+  // For repeat-joins, create synthetic Fields with instance-suffixed IDs so that
+  // subsequent join iterations see the correct suffixed aliases when building their
+  // SELECT pass-throughs (not the original from a prior join instance).
+  // Note: selectedFields / metrics / filters in the Insight model still reference
+  // the canonical (un-suffixed) field IDs — they map to the first join instance.
+  // Binding them to a specific join instance is out of scope for this fix.
+  const instanceFields = nonKeyJoinFields.map((f) => ({
+    ...f,
+    id: joinInstanceFieldId(f.id, joinInstanceIndex) as UUID,
+  }));
+
+  const allFields = [...currentFields, ...instanceFields];
 
   return { sql, allFields, displayName: joinDisplayName };
 }


### PR DESCRIPTION
Confirmed by the YW-237 adversarial audit (opus finder + verifier). Join-key-handling class.

## The bug
Two `InsightJoinConfig` entries with the same `rightTableId` (a legitimate double-join — e.g. orders→users on `created_by` AND `approved_by`) produced the same `field_<uuid>` alias for each join. DuckDB silently keeps the FIRST occurrence (verified @duckdb/node-api 1.5.3 — no crash), so the second join's columns are unreachable → **silent wrong results**.

## The fix
A join's instance index suffixes the alias derivation (`id_j{n}` for index≥1) so repeat-joins get distinct column aliases. The suffix is stripped before UUID reconstruction so stored ids are unaffected. The join Map in `useInsightPagination` is keyed per-instance so the two joins aren't collapsed.

## Verification
- New test: two joins to the same table → no duplicate alias, both column sets reachable.
- 46 engine SQL tests pass; whole-graph typecheck clean.

(This PR recovers complete-but-uncommitted work salvaged from a dead agent's worktree — verified sound before committing.)

Tracked internally as YW-295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-loss bug where two `InsightJoinConfig` entries pointing at the same `rightTableId` (a legitimate double-join, e.g. `orders→users` on both `created_by` and `approved_by`) produced identical `field_<uuid>` column aliases in the generated SQL, causing DuckDB to silently discard the second join's columns. The fix adds a per-`rightTableId` instance counter in both the SQL builder and the pagination hook, suffixing repeated-join aliases with `_j{n}` so each join instance emits unique output columns.

- **`insight-sql.ts`**: `joinInstanceFieldId` encodes the instance index into the field ID before alias derivation; `extractUUIDFromColumnAlias` strips the `_j\\d+` suffix before UUID reconstruction so existing consumers receive canonical field IDs.
- **`useInsightPagination.ts`**: mirrors the engine's instance counter so `columnDisplayNames` and `columnTypeMap` are keyed on the same suffixed aliases DuckDB actually produces.
- **`insight-sql.test.ts`**: three new tests cover alias uniqueness, column reachability for both join instances, and a single-join regression guard."
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core alias-deduplication logic is correct and well-tested, with no regressions on the single-join path.

The two-join deduplication and hook mirroring are implemented consistently. The intentional trade-off — extractUUIDFromColumnAlias permanently discarding the instance index — means filters, sorts, and axis selections on repeat-join columns will silently bind to the first join instance, leaving room for confusing UI behavior when users interact with the second join's columns.

A test for the extractUUIDFromColumnAlias round-trip with suffixed aliases would strengthen confidence in insight-sql.ts.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/engine/src/sql/insight-sql.ts | Adds join-instance suffix logic (`_j{n}`) to alias generation and introduces unconditional suffix stripping in `extractUUIDFromColumnAlias`; core alias deduplication is correct but all downstream UUID round-trips now lose the instance dimension. |
| packages/app/src/hooks/useInsightPagination.ts | Mirrors the engine's instance-index logic to ensure `columnDisplayNames` and `columnTypeMap` are keyed on the correct suffixed aliases; implementation is consistent with the SQL layer. |
| packages/engine/src/sql/insight-sql.test.ts | Adds 3 well-structured tests covering the double-join alias deduplication and regression guard; `extractUUIDFromColumnAlias` round-trip for suffixed aliases is not directly tested. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Hook as useInsightPagination
    participant Engine as insight-sql (buildJoinedSQL)
    participant DuckDB

    Hook->>Hook: fetch baseTable + joinedTables (parallel)
    Hook->>Hook: iterate insight.joins, track joinInstanceCount per rightTableId
    Note over Hook: join1 (rightTableId=C, instanceIndex=0) fields as-is
    Note over Hook: join2 (rightTableId=C, instanceIndex=1) synthetic IDs with _j1 suffix
    Hook->>Engine: buildInsightSQL(baseTable, joinedTables, insight)
    Engine->>Engine: "join1 instanceIndex=0 processSingleJoin"
    Note over Engine: nonKeyFields aliased as field_uuid (no suffix)
    Engine->>Engine: "join2 instanceIndex=1 processSingleJoin"
    Note over Engine: nonKeyFields aliased as field_uuid_j1 (suffixed)
    Engine->>DuckDB: SELECT field_e0, field_f0, field_e0_j1, field_f0_j1
    DuckDB-->>Hook: result rows with distinct aliases for both join instances
    Hook->>Hook: columnDisplayNames keyed on both canonical and suffixed aliases
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Hook as useInsightPagination
    participant Engine as insight-sql (buildJoinedSQL)
    participant DuckDB

    Hook->>Hook: fetch baseTable + joinedTables (parallel)
    Hook->>Hook: iterate insight.joins, track joinInstanceCount per rightTableId
    Note over Hook: join1 (rightTableId=C, instanceIndex=0) fields as-is
    Note over Hook: join2 (rightTableId=C, instanceIndex=1) synthetic IDs with _j1 suffix
    Hook->>Engine: buildInsightSQL(baseTable, joinedTables, insight)
    Engine->>Engine: "join1 instanceIndex=0 processSingleJoin"
    Note over Engine: nonKeyFields aliased as field_uuid (no suffix)
    Engine->>Engine: "join2 instanceIndex=1 processSingleJoin"
    Note over Engine: nonKeyFields aliased as field_uuid_j1 (suffixed)
    Engine->>DuckDB: SELECT field_e0, field_f0, field_e0_j1, field_f0_j1
    DuckDB-->>Hook: result rows with distinct aliases for both join instances
    Hook->>Hook: columnDisplayNames keyed on both canonical and suffixed aliases
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%3A83-87%0A**Repeat-join%20columns%20resolve%20to%20first%20instance%20in%20all%20downstream%20consumers**%0A%0A%60extractUUIDFromColumnAlias%60%20unconditionally%20strips%20%60_j%5Cd%2B%24%60%20before%20returning%20the%20field%20UUID.%20Every%20caller%20%E2%80%94%20%60AxisSelectField%60%2C%20%60analyze%60%2C%20%60suggest-charts%60%20%E2%80%94%20will%20receive%20the%20canonical%20first-join%20field%20ID%20for%20any%20repeat-join%20column%20alias%20%28e.g.%2C%20%60field_e0e0..._j1%60%20%E2%86%92%20%60e0e0...-...-...-...%60%29.%20This%20means%20any%20feature%20that%20writes%20back%20a%20%60fieldId%60%20derived%20from%20a%20suffixed%20alias%20%28a%20filter%2C%20a%20sort%2C%20a%20chart%20axis%29%20will%20silently%20target%20the%20first%20join%20instance%2C%20not%20the%20second.%20The%20code%20comment%20on%20line%20669%20acknowledges%20this%20as%20out%20of%20scope%2C%20but%20the%20limitation%20is%20invisible%20to%20callers%20of%20%60extractUUIDFromColumnAlias%60%3B%20a%20JSDoc%20note%20on%20the%20function%20itself%20would%20prevent%20future%20contributors%20from%20unknowingly%20relying%20on%20the%20round-trip%20being%20lossless.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%3A47-49%0ADoc%20comment%20typo%3A%20%60id_j%7Bn%7D%60%20should%20read%20%60%7BfieldId%7D_j%7Bn%7D%60%20%E2%80%94%20the%20full%20modified%20field%20ID%20is%20returned%2C%20not%20just%20%60id%60.%0A%0A%60%60%60suggestion%0A%20*%20Encode%20a%20join%20instance%20index%20into%20a%20field%20ID%20so%20two%20joins%20to%20the%20same%20table%0A%20*%20produce%20distinct%20column%20aliases.%20%20index%3D0%20%E2%86%92%20unchanged%3B%20index%E2%89%A51%20%E2%86%92%20%60%7BfieldId%7D_j%7Bn%7D%60.%0A%20*%20For%20SQL%20alias%20derivation%20inside%20the%20join%20builder%20only%20%E2%80%94%20never%20stored%2Fcompared.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.test.ts%3A866-870%0A**Missing%20test%20coverage%20for%20%60extractUUIDFromColumnAlias%60%20round-trip%20with%20suffixed%20aliases**%0A%0AThe%20three%20new%20tests%20validate%20SQL%20alias%20shape%20but%20none%20verify%20that%20%60extractUUIDFromColumnAlias%28%22field_e0e0e0e0_e0e0_e0e0_e0e0_e0e0e0e0e0e0_j1%22%29%60%20correctly%20returns%20the%20canonical%20UUID.%20Given%20that%20the%20stripping%20logic%20in%20%60extractUUIDFromColumnAlias%60%20is%20what%20downstream%20consumers%20%28axis%20selection%2C%20chart%20suggestion%29%20rely%20on%2C%20a%20direct%20unit%20test%20for%20the%20new%20%60_j%5Cd%2B%60%20branch%20would%20guard%20against%20a%20future%20regex%20regression%20silently%20breaking%20UUID%20extraction%20for%20all%20repeat-join%20columns.%0A%0A&repo=youhaowei%2Fdashframe&pr=162&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-295-duplicate-join-aliases%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-295-duplicate-join-aliases%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%3A83-87%0A**Repeat-join%20columns%20resolve%20to%20first%20instance%20in%20all%20downstream%20consumers**%0A%0A%60extractUUIDFromColumnAlias%60%20unconditionally%20strips%20%60_j%5Cd%2B%24%60%20before%20returning%20the%20field%20UUID.%20Every%20caller%20%E2%80%94%20%60AxisSelectField%60%2C%20%60analyze%60%2C%20%60suggest-charts%60%20%E2%80%94%20will%20receive%20the%20canonical%20first-join%20field%20ID%20for%20any%20repeat-join%20column%20alias%20%28e.g.%2C%20%60field_e0e0..._j1%60%20%E2%86%92%20%60e0e0...-...-...-...%60%29.%20This%20means%20any%20feature%20that%20writes%20back%20a%20%60fieldId%60%20derived%20from%20a%20suffixed%20alias%20%28a%20filter%2C%20a%20sort%2C%20a%20chart%20axis%29%20will%20silently%20target%20the%20first%20join%20instance%2C%20not%20the%20second.%20The%20code%20comment%20on%20line%20669%20acknowledges%20this%20as%20out%20of%20scope%2C%20but%20the%20limitation%20is%20invisible%20to%20callers%20of%20%60extractUUIDFromColumnAlias%60%3B%20a%20JSDoc%20note%20on%20the%20function%20itself%20would%20prevent%20future%20contributors%20from%20unknowingly%20relying%20on%20the%20round-trip%20being%20lossless.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%3A47-49%0ADoc%20comment%20typo%3A%20%60id_j%7Bn%7D%60%20should%20read%20%60%7BfieldId%7D_j%7Bn%7D%60%20%E2%80%94%20the%20full%20modified%20field%20ID%20is%20returned%2C%20not%20just%20%60id%60.%0A%0A%60%60%60suggestion%0A%20*%20Encode%20a%20join%20instance%20index%20into%20a%20field%20ID%20so%20two%20joins%20to%20the%20same%20table%0A%20*%20produce%20distinct%20column%20aliases.%20%20index%3D0%20%E2%86%92%20unchanged%3B%20index%E2%89%A51%20%E2%86%92%20%60%7BfieldId%7D_j%7Bn%7D%60.%0A%20*%20For%20SQL%20alias%20derivation%20inside%20the%20join%20builder%20only%20%E2%80%94%20never%20stored%2Fcompared.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.test.ts%3A866-870%0A**Missing%20test%20coverage%20for%20%60extractUUIDFromColumnAlias%60%20round-trip%20with%20suffixed%20aliases**%0A%0AThe%20three%20new%20tests%20validate%20SQL%20alias%20shape%20but%20none%20verify%20that%20%60extractUUIDFromColumnAlias%28%22field_e0e0e0e0_e0e0_e0e0_e0e0_e0e0e0e0e0e0_j1%22%29%60%20correctly%20returns%20the%20canonical%20UUID.%20Given%20that%20the%20stripping%20logic%20in%20%60extractUUIDFromColumnAlias%60%20is%20what%20downstream%20consumers%20%28axis%20selection%2C%20chart%20suggestion%29%20rely%20on%2C%20a%20direct%20unit%20test%20for%20the%20new%20%60_j%5Cd%2B%60%20branch%20would%20guard%20against%20a%20future%20regex%20regression%20silently%20breaking%20UUID%20extraction%20for%20all%20repeat-join%20columns.%0A%0A&repo=youhaowei%2Fdashframe&pr=162&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%3A83-87%0A**Repeat-join%20columns%20resolve%20to%20first%20instance%20in%20all%20downstream%20consumers**%0A%0A%60extractUUIDFromColumnAlias%60%20unconditionally%20strips%20%60_j%5Cd%2B%24%60%20before%20returning%20the%20field%20UUID.%20Every%20caller%20%E2%80%94%20%60AxisSelectField%60%2C%20%60analyze%60%2C%20%60suggest-charts%60%20%E2%80%94%20will%20receive%20the%20canonical%20first-join%20field%20ID%20for%20any%20repeat-join%20column%20alias%20%28e.g.%2C%20%60field_e0e0..._j1%60%20%E2%86%92%20%60e0e0...-...-...-...%60%29.%20This%20means%20any%20feature%20that%20writes%20back%20a%20%60fieldId%60%20derived%20from%20a%20suffixed%20alias%20%28a%20filter%2C%20a%20sort%2C%20a%20chart%20axis%29%20will%20silently%20target%20the%20first%20join%20instance%2C%20not%20the%20second.%20The%20code%20comment%20on%20line%20669%20acknowledges%20this%20as%20out%20of%20scope%2C%20but%20the%20limitation%20is%20invisible%20to%20callers%20of%20%60extractUUIDFromColumnAlias%60%3B%20a%20JSDoc%20note%20on%20the%20function%20itself%20would%20prevent%20future%20contributors%20from%20unknowingly%20relying%20on%20the%20round-trip%20being%20lossless.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.ts%3A47-49%0ADoc%20comment%20typo%3A%20%60id_j%7Bn%7D%60%20should%20read%20%60%7BfieldId%7D_j%7Bn%7D%60%20%E2%80%94%20the%20full%20modified%20field%20ID%20is%20returned%2C%20not%20just%20%60id%60.%0A%0A%60%60%60suggestion%0A%20*%20Encode%20a%20join%20instance%20index%20into%20a%20field%20ID%20so%20two%20joins%20to%20the%20same%20table%0A%20*%20produce%20distinct%20column%20aliases.%20%20index%3D0%20%E2%86%92%20unchanged%3B%20index%E2%89%A51%20%E2%86%92%20%60%7BfieldId%7D_j%7Bn%7D%60.%0A%20*%20For%20SQL%20alias%20derivation%20inside%20the%20join%20builder%20only%20%E2%80%94%20never%20stored%2Fcompared.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fengine%2Fsrc%2Fsql%2Finsight-sql.test.ts%3A866-870%0A**Missing%20test%20coverage%20for%20%60extractUUIDFromColumnAlias%60%20round-trip%20with%20suffixed%20aliases**%0A%0AThe%20three%20new%20tests%20validate%20SQL%20alias%20shape%20but%20none%20verify%20that%20%60extractUUIDFromColumnAlias%28%22field_e0e0e0e0_e0e0_e0e0_e0e0_e0e0e0e0e0e0_j1%22%29%60%20correctly%20returns%20the%20canonical%20UUID.%20Given%20that%20the%20stripping%20logic%20in%20%60extractUUIDFromColumnAlias%60%20is%20what%20downstream%20consumers%20%28axis%20selection%2C%20chart%20suggestion%29%20rely%20on%2C%20a%20direct%20unit%20test%20for%20the%20new%20%60_j%5Cd%2B%60%20branch%20would%20guard%20against%20a%20future%20regex%20regression%20silently%20breaking%20UUID%20extraction%20for%20all%20repeat-join%20columns.%0A%0A&pr=162&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/engine/src/sql/insight-sql.ts:83-87
**Repeat-join columns resolve to first instance in all downstream consumers**

`extractUUIDFromColumnAlias` unconditionally strips `_j\d+$` before returning the field UUID. Every caller — `AxisSelectField`, `analyze`, `suggest-charts` — will receive the canonical first-join field ID for any repeat-join column alias (e.g., `field_e0e0..._j1` → `e0e0...-...-...-...`). This means any feature that writes back a `fieldId` derived from a suffixed alias (a filter, a sort, a chart axis) will silently target the first join instance, not the second. The code comment on line 669 acknowledges this as out of scope, but the limitation is invisible to callers of `extractUUIDFromColumnAlias`; a JSDoc note on the function itself would prevent future contributors from unknowingly relying on the round-trip being lossless.

### Issue 2 of 3
packages/engine/src/sql/insight-sql.ts:47-49
Doc comment typo: `id_j{n}` should read `{fieldId}_j{n}` — the full modified field ID is returned, not just `id`.

```suggestion
 * Encode a join instance index into a field ID so two joins to the same table
 * produce distinct column aliases.  index=0 → unchanged; index≥1 → `{fieldId}_j{n}`.
 * For SQL alias derivation inside the join builder only — never stored/compared.
```

### Issue 3 of 3
packages/engine/src/sql/insight-sql.test.ts:866-870
**Missing test coverage for `extractUUIDFromColumnAlias` round-trip with suffixed aliases**

The three new tests validate SQL alias shape but none verify that `extractUUIDFromColumnAlias("field_e0e0e0e0_e0e0_e0e0_e0e0_e0e0e0e0e0e0_j1")` correctly returns the canonical UUID. Given that the stripping logic in `extractUUIDFromColumnAlias` is what downstream consumers (axis selection, chart suggestion) rely on, a direct unit test for the new `_j\d+` branch would guard against a future regex regression silently breaking UUID extraction for all repeat-join columns.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(engine): remove ticket ref from test..."](https://github.com/youhaowei/dashframe/commit/ff83ed1ab87770b532cdbbec63966270dff6d39d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39480954)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->