### PR TITLE
[YW-292] fix(ui): purge off-token color from VirtualTable row highlights

### DIFF
--- a/packages/ui/src/components/VirtualTable.tsx
+++ b/packages/ui/src/components/VirtualTable.tsx
@@ -537,16 +537,16 @@ export function VirtualTable({
 
   const highlightHeaderStyles = {
     primary: "bg-palette-primary text-palette-primary-fg font-semibold",
-    base: "bg-blue-600 text-white font-semibold",
-    join: "bg-emerald-600 text-white font-semibold",
-    both: "bg-amber-500 text-white font-semibold",
+    base: "bg-palette-info text-palette-info-fg font-semibold",
+    join: "bg-palette-success text-palette-success-fg font-semibold",
+    both: "bg-palette-warning text-palette-warning-fg font-semibold",
   };
 
   const highlightCellStyles = {
     primary: "bg-palette-primary/15",
-    base: "bg-blue-500/10",
-    join: "bg-emerald-500/10",
-    both: "bg-amber-500/10",
+    base: "bg-palette-info/10",
+    join: "bg-palette-success/10",
+    both: "bg-palette-warning/10",
   };
 
   // Get row data by index


### PR DESCRIPTION
## Summary

- Replaces `bg-blue-600`, `bg-emerald-600`, `bg-amber-500`, `text-white` literals in `VirtualTable.tsx` with semantic palette tokens: `bg-palette-info/text-palette-info-fg` (base), `bg-palette-success/text-palette-success-fg` (join), `bg-palette-warning/text-palette-warning-fg` (both)
- Replaces `bg-blue-500/10`, `bg-emerald-500/10`, `bg-amber-500/10` cell tints with `bg-palette-info/10`, `bg-palette-success/10`, `bg-palette-warning/10`
- `ItemSelector.tsx` and `select.tsx` were already on-token — no changes needed

## Verified DoD

- No `bg-blue-*`/`emerald-*`/`amber-*`/`bg-white` literals remain in `VirtualTable.tsx`, `ItemSelector.tsx`, or `select.tsx`
- Palette tokens (`palette-info/success/warning`) confirmed present in `@wystack/ui` theme (used in badge, button, alert, progress, sonner)
- Typecheck: clean (0 errors)
- Lint: 0 errors (1 pre-existing warning in unrelated `select.tsx` field)

## Test plan

- [ ] Confirm row highlight colors render correctly in the table (base=info blue, join=success green, both=warning amber)
- [ ] Verify dark-mode contrast holds (palette tokens are dark-mode-safe by construction)

Tracked internally as YW-292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces hard-coded Tailwind color literals (`bg-blue-600`, `bg-emerald-600`, `bg-amber-500`, `text-white`, and their `/10` tint variants) in `VirtualTable.tsx` with semantic `@wystack/ui` palette tokens, aligning the file with the team's off-token color invariant.

- **Header highlight styles** (`base`, `join`, `both`) now use `bg-palette-info/text-palette-info-fg`, `bg-palette-success/text-palette-success-fg`, and `bg-palette-warning/text-palette-warning-fg` respectively — matching the same `bg-palette-*/text-palette-*-fg` pattern already established by the `primary` variant.
- **Cell tint styles** adopt `bg-palette-info/10`, `bg-palette-success/10`, and `bg-palette-warning/10`, consistent with the existing `bg-palette-primary/15` cell tint.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only class string literals change; no logic, props, or data flow is touched.

The change is limited to six Tailwind class strings inside two plain objects. All replacement tokens follow the identical bg-palette-*/text-palette-*-fg pattern already used by the unmodified primary variant in the same objects, confirming the token names are valid. No remaining off-token literals were found in the file, no ticket IDs appear in source, and the type checker is reported clean.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/VirtualTable.tsx | Six class strings in two style maps replaced with semantic palette tokens; no remaining off-token literals, no logic changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Column highlight config] --> B{highlight variant}
    B -->|primary| C["bg-palette-primary\ntext-palette-primary-fg\n— unchanged"]
    B -->|base| D["bg-palette-info\ntext-palette-info-fg\n— was bg-blue-600 text-white"]
    B -->|join| E["bg-palette-success\ntext-palette-success-fg\n— was bg-emerald-600 text-white"]
    B -->|both| F["bg-palette-warning\ntext-palette-warning-fg\n— was bg-amber-500 text-white"]
    C --> G[Header cell class]
    D --> G
    E --> G
    F --> G
    G --> H{cell vs header?}
    H -->|header| I[Full bg + fg text]
    H -->|data cell| J["bg-palette-*/10 tint\n— was bg-*-500/10"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Column highlight config] --> B{highlight variant}
    B -->|primary| C["bg-palette-primary\ntext-palette-primary-fg\n— unchanged"]
    B -->|base| D["bg-palette-info\ntext-palette-info-fg\n— was bg-blue-600 text-white"]
    B -->|join| E["bg-palette-success\ntext-palette-success-fg\n— was bg-emerald-600 text-white"]
    B -->|both| F["bg-palette-warning\ntext-palette-warning-fg\n— was bg-amber-500 text-white"]
    C --> G[Header cell class]
    D --> G
    E --> G
    F --> G
    G --> H{cell vs header?}
    H -->|header| I[Full bg + fg text]
    H -->|data cell| J["bg-palette-*/10 tint\n— was bg-*-500/10"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): purge off-token color from Virt..."](https://github.com/youhaowei/dashframe/commit/3bec346cec89eae26216415ed6237e1f0d88da61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39736217)</sub>

**Context used:**

- Context used - NO OFF-TOKEN COLOR (invariant). No raw hex/rgb/okl... ([source](greptile.json))

<!-- /greptile_comment -->