### PR TITLE
[YW-299] feat(connector): Postgres/SQL data-source connector

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@dashframe/assistant": "workspace:*",
     "@dashframe/connector-notion": "workspace:*",
+    "@dashframe/connector-postgres": "workspace:*",
     "@dashframe/engine": "workspace:*",
     "@dashframe/engine-server": "workspace:*",
     "@dashframe/server-core": "workspace:*",

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1,4 +1,5 @@
 import { makeNotionConnector } from "@dashframe/connector-notion";
+import { makePostgresConnector } from "@dashframe/connector-postgres";
 // The canonical bound-resolver type — aliased for readability at the mint site.
 import type { SecretResolver as BoundSecretResolver } from "@dashframe/engine";
 import { schema } from "@dashframe/server-core";
@@ -1193,6 +1194,119 @@ const queryNotionDatabase = mutation({
   },
 });
 
+// ============================================================================
+// Postgres connector factory — mirrors notionConnectorFor.
+// postgresConnectorFor is the single seam where a postgres connector is
+// created from a DataSource id. Both postgres data-plane routes go through it.
+// ============================================================================
+
+/**
+ * Build a Postgres connector for a DataSource: read the row, verify it's a
+ * postgres source, mint a bound resolver from the stored connectionString ref,
+ * and construct the connector.
+ *
+ * @throws when the row is missing, not a postgres source, or has no valid ref
+ */
+async function postgresConnectorFor(
+  ctx: FunctionContext,
+  dataSourceId: UUID,
+): Promise<ReturnType<typeof makePostgresConnector>> {
+  const vault = vaultFromCtx(ctx);
+  const row = (await ctx.db
+    .from(dataSources)
+    .where(eq("id", dataSourceId))
+    .first()) as DataSourceRow | undefined;
+  if (!row) throw new Error(`DataSource ${dataSourceId} not found`);
+  if (row.kind !== "postgres") {
+    throw new Error(`DataSource ${dataSourceId} is not a postgres source`);
+  }
+  const config = (row.config ?? {}) as DataSourceConfig;
+  // connectionString holds the SecretRef (same vault slot as Notion's apiKey).
+  const auth = mintBoundResolver(
+    vault,
+    config.connectionString,
+    `DataSource(${dataSourceId})`,
+  );
+  // connectionStringRef is for introspection only; the bound `auth` resolver
+  // is the actual credential source. Pass the ref as-is — never coerce to "".
+  return makePostgresConnector(auth, {
+    connectionStringRef: config.connectionString,
+    defaultSchema: config.defaultSchema,
+  });
+}
+
+// ============================================================================
+// Postgres data-plane routes — server-side connector calls via bound resolver.
+// postgresConnectorFor is the only place postgres connectors are constructed.
+// ============================================================================
+
+/**
+ * Serializable result of a Postgres query — raw Arrow IPC buffer (base64) +
+ * field ids + field definitions. The renderer materializes the browser
+ * DataFrame from this; no plaintext and no live DataFrame crosses the boundary.
+ */
+type PostgresQueryResult = {
+  arrowBuffer: string;
+  fieldIds: string[];
+  fields: Field[];
+  rowCount: number;
+};
+
+/**
+ * listPostgresTables — connect to Postgres and list tables/views in the
+ * configured schema.
+ *
+ * Resolves the credential via the vault; the handler has no plaintext in scope.
+ * Accepts the DataSource id — the ref is read from the row, never from the client.
+ */
+const listPostgresTables = mutation({
+  args: { dataSourceId: uuid },
+  handler: async (
+    ctx,
+    { dataSourceId },
+  ): Promise<{ id: string; title: string }[]> => {
+    const connector = await postgresConnectorFor(ctx, dataSourceId);
+    const tables = await connector.connect();
+    return tables.map((t) => ({ id: t.id, title: t.name }));
+  },
+});
+
+/**
+ * queryPostgresTable — fetch rows from a Postgres table or run a SELECT
+ * server-side and return a serializable result the renderer can materialize.
+ *
+ * The credential resolves via the bound resolver inside `connector.query`; the
+ * handler has no plaintext in scope and the client receives only data.
+ * The connector enforces read-only at both layers (allowlist + SET SESSION).
+ */
+const queryPostgresTable = mutation({
+  args: {
+    dataSourceId: uuid,
+    /** "schema.table" ref from listPostgresTables, or a user SELECT statement */
+    databaseId: text,
+    tableId: uuid,
+    /** Optional cap on rows fetched for the preview. */
+    limit: int.optional(),
+  },
+  handler: async (
+    ctx,
+    { dataSourceId, databaseId, tableId, limit },
+  ): Promise<PostgresQueryResult> => {
+    const connector = await postgresConnectorFor(ctx, dataSourceId);
+    const pagination =
+      limit !== undefined && Number.isInteger(limit) && limit > 0
+        ? { pagination: { offset: 0, limit } }
+        : undefined;
+    const result = await connector.query(databaseId, tableId, pagination);
+    return {
+      arrowBuffer: result.arrowBuffer,
+      fieldIds: result.fieldIds,
+      fields: result.fields,
+      rowCount: result.rowCount,
+    };
+  },
+});
+
 export const appArtifactFunctions = {
   listDataSources,
   getDataSource,
@@ -1228,4 +1342,7 @@ export const appArtifactFunctions = {
   // Notion data-plane routes (auth-blind via bound resolver)
   listNotionDatabases,
   queryNotionDatabase,
+  // Postgres data-plane routes (auth-blind via bound resolver)
+  listPostgresTables,
+  queryPostgresTable,
 };

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1229,9 +1229,14 @@ async function postgresConnectorFor(
   );
   // connectionStringRef is for introspection only; the bound `auth` resolver
   // is the actual credential source. Pass the ref as-is — never coerce to "".
+  //
+  // Sink guard: defaultSchema flows into quoteIdentifier() in connect(); verify
+  // it's a string before passing it through (config is an untyped JSON blob).
+  const defaultSchema =
+    typeof config.defaultSchema === "string" ? config.defaultSchema : undefined;
   return makePostgresConnector(auth, {
     connectionStringRef: config.connectionString,
-    defaultSchema: config.defaultSchema,
+    defaultSchema,
   });
 }
 

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -19,6 +19,8 @@ export type DataSourceConfig = {
   apiKey?: string;
   /** SecretRef for the connection string (format: `secret:<uuid>`). Never plaintext. */
   connectionString?: string;
+  /** Optional non-credential config for Postgres: default schema to list (default: "public"). */
+  defaultSchema?: string;
 };
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
       "dependencies": {
         "@dashframe/assistant": "workspace:*",
         "@dashframe/connector-notion": "workspace:*",
+        "@dashframe/connector-postgres": "workspace:*",
         "@dashframe/engine": "workspace:*",
         "@dashframe/engine-server": "workspace:*",
         "@dashframe/server-core": "workspace:*",
@@ -379,6 +380,7 @@
       "dependencies": {
         "@dashframe/connector-local": "workspace:*",
         "@dashframe/connector-notion": "workspace:*",
+        "@dashframe/connector-postgres": "workspace:*",
         "@dashframe/core": "workspace:*",
         "@dashframe/csv": "workspace:*",
         "@dashframe/engine": "workspace:*",
@@ -495,6 +497,22 @@
         "@dashframe/engine-browser": "workspace:*",
         "@notionhq/client": "^2.2.0",
         "apache-arrow": "^21.1.0",
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.0.16",
+        "@wystack/secret-vault": "workspace:*",
+        "typescript": "^5.6.0",
+        "vitest": "^4.0.16",
+      },
+    },
+    "packages/connector-postgres": {
+      "name": "@dashframe/connector-postgres",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dashframe/engine": "workspace:*",
+        "@types/pg": "^8.11.11",
+        "apache-arrow": "^21.1.0",
+        "pg": "^8.13.3",
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.16",
@@ -913,6 +931,8 @@
     "@dashframe/connector-local": ["@dashframe/connector-local@workspace:packages/connector-local"],
 
     "@dashframe/connector-notion": ["@dashframe/connector-notion@workspace:packages/connector-notion"],
+
+    "@dashframe/connector-postgres": ["@dashframe/connector-postgres@workspace:packages/connector-postgres"],
 
     "@dashframe/connector-rest": ["@dashframe/connector-rest@workspace:packages/connector-rest"],
 
@@ -1671,6 +1691,8 @@
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@types/papaparse": ["@types/papaparse@5.3.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-T3VuKMC2H0lgsjI9buTB3uuKj3EMD2eap1MOuEQuBQ44EnDx/IkGhU6EwiTf9zG3za4SKlmwKAImdDKdNnCsXg=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
@@ -3026,6 +3048,22 @@
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
+    "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -3057,6 +3095,14 @@
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "posthog-js": ["posthog-js@1.372.9", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.28.3", "@posthog/types": "1.372.9", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-qFhTxxrONCO4YBubuEp6/f3beRPku8OqgfHwpSro/XcDU0oPXMVyvsXGUnxhjaq4PvQb79PwvquAX0/HIGcnWg=="],
 
@@ -3560,6 +3606,8 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
@@ -3615,6 +3663,8 @@
     "@dashframe/connector-local/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@dashframe/connector-notion/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@dashframe/connector-postgres/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@dashframe/connector-rest/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -3759,6 +3809,8 @@
     "@types/node-fetch/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "@types/papaparse/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
+
+    "@types/pg/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
     "@types/responselike/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
 
@@ -4057,6 +4109,8 @@
     "@types/node-fetch/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/papaparse/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/responselike/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@dashframe/connector-local": "workspace:*",
     "@dashframe/connector-notion": "workspace:*",
+    "@dashframe/connector-postgres": "workspace:*",
     "@dashframe/core": "workspace:*",
     "@dashframe/csv": "workspace:*",
     "@dashframe/engine": "workspace:*",

--- a/packages/app/src/components/data-sources/AddConnectionPanel.tsx
+++ b/packages/app/src/components/data-sources/AddConnectionPanel.tsx
@@ -23,6 +23,11 @@ export interface AddConnectionPanelProps {
   ) => void;
   /** Whether to show Notion connector (feature flag) */
   showNotion?: boolean;
+  /**
+   * Whether to show Postgres connector (feature flag, default false).
+   * Hidden until the renderer-side connect UI is complete.
+   */
+  showPostgres?: boolean;
 }
 
 /**
@@ -43,9 +48,13 @@ export function AddConnectionPanel({
   onFileSelect,
   onConnect,
   showNotion = false,
+  showPostgres = false,
 }: AddConnectionPanelProps) {
   // Get connectors from registry with feature flags
-  const connectors = useMemo(() => getConnectors({ showNotion }), [showNotion]);
+  const connectors = useMemo(
+    () => getConnectors({ showNotion, showPostgres }),
+    [showNotion, showPostgres],
+  );
 
   return (
     <div className="space-y-6">

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -46,6 +46,11 @@ export interface DataPickerContentProps {
    */
   showNotion?: boolean;
   /**
+   * Whether to show Postgres connection option (connect UI not yet wired)
+   * @default false
+   */
+  showPostgres?: boolean;
+  /**
    * Whether to show insights section (requires onInsightSelect to be provided)
    * @default true
    */
@@ -69,6 +74,7 @@ export function DataPickerContent({
   excludeTableIds = [],
   onCancel,
   showNotion = false,
+  showPostgres = false,
   showInsights = true,
 }: DataPickerContentProps) {
   const { data: dataSources = [] } = useDataSources();
@@ -274,6 +280,7 @@ export function DataPickerContent({
               onFileSelect={handleFileSelect}
               onConnect={handleConnect}
               showNotion={showNotion}
+              showPostgres={showPostgres}
             />
           </SectionList>
         )}

--- a/packages/app/src/components/providers/ConnectorSetup.tsx
+++ b/packages/app/src/components/providers/ConnectorSetup.tsx
@@ -19,6 +19,7 @@
 import { registerConnector } from "@/lib/connectors/registry";
 import { localFileConnector } from "@dashframe/connector-local";
 import { makeNotionConnector } from "@dashframe/connector-notion";
+import { makePostgresConnector } from "@dashframe/connector-postgres";
 
 // The Notion connector instance here is registered for static metadata only
 // (id, name, icon, form fields). connect()/query() are never called from the
@@ -32,10 +33,23 @@ const notionConnectorForRegistry = makeNotionConnector(() => {
   );
 });
 
+// The Postgres connector instance here is registered for static metadata only
+// (id, name, icon, form fields). connect()/query() go through server mutations
+// (listPostgresTables / queryPostgresTable). The resolver throws if called from
+// the renderer — that would be a bug. pg is dynamically imported in the
+// connector so this registration is safe in a browser context.
+const postgresConnectorForRegistry = makePostgresConnector(() => {
+  throw new Error(
+    "[connector-registry] connect()/query() must not be called from the renderer — " +
+      "use the WyStack server mutations instead.",
+  );
+}, {});
+
 // Register connectors at module scope — synchronous, before any render.
 // getConnectorById() calls from any component on first render will resolve.
 registerConnector(localFileConnector);
 registerConnector(notionConnectorForRegistry);
+registerConnector(postgresConnectorForRegistry);
 
 /**
  * Renders nothing. Import side-effect (module-scope registration above) is

--- a/packages/app/src/lib/connectors/registry.ts
+++ b/packages/app/src/lib/connectors/registry.ts
@@ -121,6 +121,14 @@ export function clearConnectorRegistry(): void {
 export interface GetConnectorsOptions {
   /** Show Notion connector (default: false for feature flag control) */
   showNotion?: boolean;
+  /**
+   * Show Postgres connector (default: false).
+   *
+   * Postgres is registered for static metadata and server-side query routing
+   * but the renderer-side connect() flow is not yet wired. Keep hidden until
+   * the connect UI is complete.
+   */
+  showPostgres?: boolean;
   /** Filter by source type */
   sourceType?: "file" | "remote-api";
 }
@@ -133,6 +141,11 @@ export function getConnectors(options?: GetConnectorsOptions): AnyConnector[] {
   return Array.from(connectorMap.values()).filter((connector) => {
     // Feature flag: Notion
     if (connector.id === "notion" && !(options?.showNotion ?? false)) {
+      return false;
+    }
+
+    // Feature flag: Postgres (connect UI not yet wired)
+    if (connector.id === "postgres" && !(options?.showPostgres ?? false)) {
       return false;
     }
 

--- a/packages/connector-postgres/package.json
+++ b/packages/connector-postgres/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@dashframe/connector-postgres",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc -w -p tsconfig.json --preserveWatchOutput",
+    "lint": "eslint src",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@dashframe/engine": "workspace:*",
+    "@types/pg": "^8.11.11",
+    "apache-arrow": "^21.1.0",
+    "pg": "^8.13.3"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.16",
+    "@wystack/secret-vault": "workspace:*",
+    "typescript": "^5.6.0",
+    "vitest": "^4.0.16"
+  }
+}

--- a/packages/connector-postgres/src/__exploit.realpg.test.ts
+++ b/packages/connector-postgres/src/__exploit.realpg.test.ts
@@ -1,0 +1,124 @@
+/**
+ * REAL-PG integration test for the multi-statement read-only bypass.
+ *
+ * The unit suite (connector.test.ts) uses a spy that cannot speak the pg wire
+ * protocol — it can verify the call SHAPE (queryMode:"extended") but not that
+ * Postgres actually rejects multi-statement SQL. This suite closes that gap by
+ * driving the ACTUAL PostgresConnector against a live Postgres, proving the
+ * `SELECT 1; BEGIN READ WRITE; CREATE TABLE ...` bypass is rejected at Parse
+ * (error 42601 "cannot insert multiple commands into a prepared statement")
+ * and that no write side-effect occurs.
+ *
+ * Empirically discriminating (verified against PG 15.18):
+ *   - OLD `client.query(sql, [])` → bypass ACCEPTED, pwned table created.
+ *   - NEW `client.query({ text, queryMode: "extended" })` → rejected (42601).
+ *
+ * Auto-skips when PG_DSN is absent (so CI without a database stays green).
+ * To run locally:
+ *   PG_DSN=postgresql://postgres@127.0.0.1:5432/postgres \
+ *     bun run --cwd packages/connector-postgres vitest run __exploit.realpg
+ */
+import type { SecretResolver } from "@dashframe/engine";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { makePostgresConnector } from "./connector.js";
+
+const DSN = process.env["PG_DSN"];
+const suite = DSN ? describe : describe.skip;
+
+// Real resolver — yields the live DSN into the auth callback scope.
+const realResolver: SecretResolver = (use) => use(DSN ?? "");
+
+// A direct admin client (bypasses the connector) to assert side-effects.
+async function adminQuery(
+  sql: string,
+): Promise<{ rows: Record<string, unknown>[] }> {
+  const { default: pg } = await import("pg");
+  const c = new pg.Client({ connectionString: DSN });
+  await c.connect();
+  try {
+    const r = await c.query(sql);
+    return { rows: r.rows as Record<string, unknown>[] };
+  } finally {
+    await c.end();
+  }
+}
+
+suite("REAL-PG: multi-statement read-only bypass is closed", () => {
+  beforeAll(async () => {
+    await adminQuery("DROP TABLE IF EXISTS pwned");
+    await adminQuery("DROP TABLE IF EXISTS exploit_src");
+    await adminQuery(
+      "CREATE TABLE exploit_src (id int PRIMARY KEY, name text)",
+    );
+    await adminQuery("INSERT INTO exploit_src VALUES (1, 'alice'), (2, 'bob')");
+  });
+
+  afterAll(async () => {
+    await adminQuery("DROP TABLE IF EXISTS pwned");
+    await adminQuery("DROP TABLE IF EXISTS exploit_src");
+  });
+
+  it("legit SELECT works (sanity — the happy path is intact)", async () => {
+    const connector = makePostgresConnector(realResolver, {
+      defaultSchema: "public",
+    });
+    const result = await connector.query(
+      "SELECT id, name FROM exploit_src ORDER BY id",
+      crypto.randomUUID(),
+    );
+    expect(result.rowCount).toBe(2);
+  });
+
+  it("EXPLOIT: multi-statement BEGIN READ WRITE + CREATE TABLE is REJECTED by PG", async () => {
+    const connector = makePostgresConnector(realResolver, {
+      defaultSchema: "public",
+    });
+    // The classic bypass: first statement passes the SELECT-prefix allowlist,
+    // then explicit BEGIN READ WRITE overrides the session read-only default,
+    // then a DDL write. On the simple protocol PG would run all of these.
+    const exploit =
+      "SELECT 1; COMMIT; BEGIN READ WRITE; CREATE TABLE pwned (x int); COMMIT";
+
+    let threw = false;
+    let message = "";
+    try {
+      await connector.query(exploit, crypto.randomUUID());
+    } catch (e) {
+      threw = true;
+      message = e instanceof Error ? e.message : String(e);
+    }
+
+    // PG must reject multi-command text in the extended protocol.
+    expect(threw).toBe(true);
+    expect(message.toLowerCase()).toContain("cannot insert multiple commands");
+
+    // And the side-effect table must NOT exist.
+    const check = await adminQuery(
+      "SELECT to_regclass('public.pwned') IS NOT NULL AS exists",
+    );
+    expect(check.rows[0]?.["exists"]).toBe(false);
+  });
+
+  it("EXPLOIT 2: even a bare two-statement SELECT;CREATE is rejected", async () => {
+    const connector = makePostgresConnector(realResolver, {
+      defaultSchema: "public",
+    });
+    const exploit = "SELECT 1; CREATE TABLE pwned (x int)";
+    let threw = false;
+    let message = "";
+    try {
+      await connector.query(exploit, crypto.randomUUID());
+    } catch (e) {
+      threw = true;
+      message = e instanceof Error ? e.message : String(e);
+    }
+    expect(threw).toBe(true);
+    // Discriminate: it must fail for the multi-statement guard, not an
+    // unrelated syntax/permission error.
+    expect(message.toLowerCase()).toContain("cannot insert multiple commands");
+    const check = await adminQuery(
+      "SELECT to_regclass('public.pwned') IS NOT NULL AS exists",
+    );
+    expect(check.rows[0]?.["exists"]).toBe(false);
+  });
+});

--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -520,6 +520,88 @@ describe("AC5 — Arrow output shape matches registry contract", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Pagination pushdown — table-ref path emits LIMIT/OFFSET into the SQL
+// ---------------------------------------------------------------------------
+
+describe("pagination pushdown (table-ref path)", () => {
+  it("pushes LIMIT $1 OFFSET $2 into the SQL with bound params when limit is set", async () => {
+    const spyClient = makeSpyClient([{ id: 1 }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    // "public.users" is a table ref (one dot, no spaces) → fetchTable path.
+    await connector.query("public.users", crypto.randomUUID(), {
+      pagination: { offset: 20, limit: 50 },
+    });
+
+    const calls = spyClient.spy.mock.calls as SpyCall[];
+    const fetchCall = calls.find((c) =>
+      spyCallText(c).toUpperCase().startsWith("SELECT * FROM"),
+    );
+    expect(fetchCall).toBeDefined();
+    // Emitted SQL carries the bound window, NOT a literal.
+    expect(spyCallText(fetchCall!)).toContain("LIMIT $1 OFFSET $2");
+    // limit/offset are passed as value params (no interpolation).
+    expect(fetchCall![1]).toEqual([50, 20]);
+  });
+
+  it("emits a plain SELECT (no LIMIT) when no pagination is requested", async () => {
+    const spyClient = makeSpyClient([{ id: 1 }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await connector.query("public.users", crypto.randomUUID());
+
+    const calls = spyClient.spy.mock.calls as SpyCall[];
+    const fetchCall = calls.find((c) =>
+      spyCallText(c).toUpperCase().startsWith("SELECT * FROM"),
+    );
+    expect(fetchCall).toBeDefined();
+    expect(spyCallText(fetchCall!)).not.toContain("LIMIT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Arrow-reserved column names are dropped before serialization
+// ---------------------------------------------------------------------------
+
+describe("reserved column names (Arrow safety)", () => {
+  it("drops __proto__/constructor/prototype columns before building Arrow", async () => {
+    // A row whose keys include Arrow-hostile names alongside a real column.
+    // Build with defineProperty so `__proto__` is an OWN ENUMERABLE key (an
+    // object literal `{ __proto__: ... }` would set the prototype instead).
+    const row: Record<string, unknown> = { id: 1 };
+    for (const k of ["__proto__", "constructor", "prototype"]) {
+      Object.defineProperty(row, k, {
+        value: "danger",
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    const rows = [row];
+    const spyClient = makeSpyClient(rows);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    // Must not throw (unfiltered, these crash tableFromArrays).
+    const result = await connector.query(
+      "SELECT * FROM weird",
+      crypto.randomUUID(),
+    );
+
+    const fieldNames = result.fields.map((f) => f.name);
+    expect(fieldNames).toContain("id");
+    expect(fieldNames).not.toContain("__proto__");
+    expect(fieldNames).not.toContain("constructor");
+    expect(fieldNames).not.toContain("prototype");
+
+    // The Arrow buffer must deserialize and expose only the safe column.
+    const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+    const table = tableFromIPC(bytes);
+    const colNames = table.schema.fields.map((f) => f.name);
+    expect(colNames).toEqual(["id"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Static metadata
 // ---------------------------------------------------------------------------
 

--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -19,7 +19,7 @@ import {
 } from "@wystack/secret-vault";
 import { tableFromIPC } from "apache-arrow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PgClientLike } from "./connector.js";
+import type { PgClientLike, PgQueryConfig } from "./connector.js";
 import {
   PostgresConnector,
   assertReadOnlyQuery,
@@ -55,10 +55,18 @@ function makeBoundResolver(
 // Returns a PgClientLike whose query() calls are tracked via a vi.fn() spy.
 // The first query is assumed to be the read-only SET statement; subsequent
 // calls return the rows passed to the factory.
+//
+// query() accepts either a string or a PgQueryConfig object — normalize to
+// extract the text in both cases.
 // ---------------------------------------------------------------------------
 
 interface SpyClient extends PgClientLike {
   spy: ReturnType<typeof vi.fn>;
+}
+
+/** Extract the SQL text from either call form (string | PgQueryConfig). */
+function callText(arg: string | PgQueryConfig): string {
+  return typeof arg === "string" ? arg : arg.text;
 }
 
 function makeSpyClient(dataRows: Record<string, unknown>[] = []): SpyClient {
@@ -68,8 +76,9 @@ function makeSpyClient(dataRows: Record<string, unknown>[] = []): SpyClient {
   //   1. SET SESSION CHARACTERISTICS... (returns empty rows)
   //   2. SET search_path TO ... (returns empty rows — for listTablesInSchema)
   //   3. Any other query (returns dataRows)
-  spy.mockImplementation((text: string) => {
-    const upper = String(text).toUpperCase().trim();
+  // The first arg may be a string OR a PgQueryConfig object (when queryMode is set).
+  spy.mockImplementation((arg: string | PgQueryConfig) => {
+    const upper = callText(arg).toUpperCase().trim();
     if (upper.startsWith("SET")) {
       return Promise.resolve({ rows: [] });
     }
@@ -227,10 +236,8 @@ describe("AC1 — non-SELECT rejected at allowlist, before any client.query", ()
       connector.query("DROP TABLE foo", crypto.randomUUID()),
     ).rejects.toThrow(/non-SELECT query rejected/i);
 
-    // The SET SESSION ... statement was issued (Layer 1), but no data query.
-    // Verify zero data queries were made (spy calls = only the SET statement).
-    // Because the allowlist runs BEFORE the auth/client path, even the SET
-    // statement must NOT have been called.
+    // The allowlist check runs BEFORE the auth/client path is entered —
+    // so even the SET SESSION statement is never issued. Zero pg calls total.
     expect(spyClient.spy).not.toHaveBeenCalled();
   });
 
@@ -250,6 +257,13 @@ describe("AC1 — non-SELECT rejected at allowlist, before any client.query", ()
 // AC2 — First query on every connection is the read-only SET statement
 // ---------------------------------------------------------------------------
 
+// Normalize spy call first arg — may be a string or a PgQueryConfig object.
+type SpyCall = [string | PgQueryConfig, ...unknown[]];
+
+function spyCallText(c: SpyCall): string {
+  return callText(c[0]);
+}
+
 describe("AC2 — SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY is first query", () => {
   it("issues the read-only SET before any query in connect()", async () => {
     const spyClient = makeSpyClient([{ table_name: "users" }]);
@@ -257,9 +271,9 @@ describe("AC2 — SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY is first 
 
     await connector.connect();
 
-    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    const calls = spyClient.spy.mock.calls as SpyCall[];
     expect(calls.length).toBeGreaterThanOrEqual(1);
-    expect(calls[0]?.[0].toUpperCase()).toBe(
+    expect(spyCallText(calls[0]!).toUpperCase()).toBe(
       "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
     );
   });
@@ -270,15 +284,15 @@ describe("AC2 — SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY is first 
 
     await connector.query("SELECT * FROM users", crypto.randomUUID());
 
-    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    const calls = spyClient.spy.mock.calls as SpyCall[];
     // Connection setup: SET SESSION CHARACTERISTICS + SET statement_timeout + data query.
     expect(calls.length).toBeGreaterThanOrEqual(3);
-    expect(calls[0]?.[0].toUpperCase()).toBe(
+    expect(spyCallText(calls[0]!).toUpperCase()).toBe(
       "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
     );
     // The SELECT must come AFTER both SET statements.
     const selectIdx = calls.findIndex((c) =>
-      c[0]?.toUpperCase().includes("SELECT"),
+      spyCallText(c).toUpperCase().includes("SELECT"),
     );
     expect(selectIdx).toBeGreaterThan(0);
   });
@@ -289,29 +303,33 @@ describe("AC2 — SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY is first 
 
     await connector.query("SELECT * FROM users", crypto.randomUUID());
 
-    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    const calls = spyClient.spy.mock.calls as SpyCall[];
     // Second call (index 1) must be the statement_timeout guard.
-    expect(calls[1]?.[0].toUpperCase()).toContain("STATEMENT_TIMEOUT");
+    expect(spyCallText(calls[1]!).toUpperCase()).toContain("STATEMENT_TIMEOUT");
   });
 
-  it("sends user SQL via extended query protocol (empty params array)", async () => {
-    // The extended query protocol forces Postgres to reject multi-statement SQL
-    // during Parse — closing the `SELECT 1; BEGIN READ WRITE; …` bypass.
-    // The mock spy can't actually reject multi-statement, but we verify the
-    // empty-params contract so that real pg uses the Parse/Bind/Execute path.
+  it("sends user SQL via extended query protocol (queryMode: 'extended')", async () => {
+    // `queryMode: "extended"` forces node-postgres onto the Parse/Bind/Execute
+    // path. Postgres rejects multi-statement SQL during Parse in that path,
+    // closing the `SELECT 1; BEGIN READ WRITE; …` bypass.
+    // The spy can't enforce the wire-level rejection, but we verify that the
+    // config object with queryMode is what reaches pg — not a bare string call.
     const spyClient = makeSpyClient([{ n: 1 }]);
     const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
 
     await connector.query("SELECT 1 AS n", crypto.randomUUID());
 
-    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
-    // Find the SELECT call.
+    const calls = spyClient.spy.mock.calls as SpyCall[];
+    // Find the SELECT call — it's the config-object form.
     const selectCall = calls.find((c) =>
-      c[0]?.toUpperCase().startsWith("SELECT"),
+      spyCallText(c).toUpperCase().startsWith("SELECT"),
     );
     expect(selectCall).toBeDefined();
-    // Must be called with an empty params array — this is the extended protocol signal.
-    expect(selectCall?.[1]).toEqual([]);
+    // First arg must be a PgQueryConfig object with queryMode: "extended".
+    const arg = selectCall![0];
+    expect(typeof arg).toBe("object");
+    expect((arg as PgQueryConfig).queryMode).toBe("extended");
+    expect((arg as PgQueryConfig).text).toBe("SELECT 1 AS n");
   });
 });
 
@@ -614,8 +632,8 @@ describe("read-only guard: allowlisted queries pass through to pg", () => {
 
   it("SELECT query reaches pg after SET SESSION", async () => {
     await connector.query("SELECT count(*) FROM users", crypto.randomUUID());
-    const calls = spyClient.spy.mock.calls as Array<[string]>;
-    const queries = calls.map((c) => c[0].toUpperCase());
+    const calls = spyClient.spy.mock.calls as SpyCall[];
+    const queries = calls.map((c) => spyCallText(c).toUpperCase());
     expect(queries[0]).toContain("SET SESSION CHARACTERISTICS");
     expect(queries.some((q) => q.includes("SELECT"))).toBe(true);
   });

--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -1,0 +1,633 @@
+/**
+ * PostgresConnector tests
+ *
+ * Pattern: makePostgresConnector(auth, config) — the connector is auth-blind.
+ * For vault tests we build a TestBackend vault and mint a bound resolver.
+ * For pg interaction tests we subclass PostgresConnector and inject a spy
+ * client via overriding createClient() — no real pg connection needed.
+ *
+ * WARNING: TestBackend / InMemoryMappingStore / SecretRegistry / SecretVault
+ * are CI/dev-only doubles — NEVER import these in production or renderer code.
+ */
+
+import type { SecretResolver } from "@dashframe/engine";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
+import { tableFromIPC } from "apache-arrow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PgClientLike } from "./connector.js";
+import {
+  PostgresConnector,
+  assertReadOnlyQuery,
+  listTablesInSchema,
+  makePostgresConnector,
+} from "./connector.js";
+import type { PostgresConnectorConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Vault factory
+// ---------------------------------------------------------------------------
+
+async function makeTestVaultWithSecret(plaintext: string) {
+  const backend = new TestBackend();
+  const registry = new SecretRegistry();
+  registry.register("test", backend, { fallback: true });
+  registry.setClassDefault("connector-key", "test");
+  const vault = new SecretVault(registry, new InMemoryMappingStore());
+  const ref = await vault.store(plaintext, { class: "connector-key" });
+  return { vault, ref };
+}
+
+function makeBoundResolver(
+  vault: SecretVault,
+  ref: Awaited<ReturnType<SecretVault["store"]>>,
+): SecretResolver {
+  return (use) => vault.withSecret(ref, use);
+}
+
+// ---------------------------------------------------------------------------
+// Spy client builder
+//
+// Returns a PgClientLike whose query() calls are tracked via a vi.fn() spy.
+// The first query is assumed to be the read-only SET statement; subsequent
+// calls return the rows passed to the factory.
+// ---------------------------------------------------------------------------
+
+interface SpyClient extends PgClientLike {
+  spy: ReturnType<typeof vi.fn>;
+}
+
+function makeSpyClient(dataRows: Record<string, unknown>[] = []): SpyClient {
+  const spy = vi.fn();
+
+  // The spy handles three call shapes:
+  //   1. SET SESSION CHARACTERISTICS... (returns empty rows)
+  //   2. SET search_path TO ... (returns empty rows — for listTablesInSchema)
+  //   3. Any other query (returns dataRows)
+  spy.mockImplementation((text: string) => {
+    const upper = String(text).toUpperCase().trim();
+    if (upper.startsWith("SET")) {
+      return Promise.resolve({ rows: [] });
+    }
+    return Promise.resolve({ rows: dataRows });
+  });
+
+  return {
+    spy,
+    query: spy as unknown as PgClientLike["query"],
+    end: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Injectable subclass
+//
+// Overrides createClient to inject a spy client without touching real pg.
+// ---------------------------------------------------------------------------
+
+class TestPostgresConnector extends PostgresConnector {
+  #clientToInject: PgClientLike | null = null;
+
+  injectClient(client: PgClientLike): void {
+    this.#clientToInject = client;
+  }
+
+  protected override async createClient(_dsn: string): Promise<PgClientLike> {
+    if (this.#clientToInject) {
+      return this.#clientToInject;
+    }
+    throw new Error("TestPostgresConnector: no client injected");
+  }
+}
+
+function makeTestConnector(
+  auth: SecretResolver,
+  config: PostgresConnectorConfig,
+  client: PgClientLike,
+): TestPostgresConnector {
+  const connector = new TestPostgresConnector(auth, config);
+  connector.injectClient(client);
+  return connector;
+}
+
+// Simple noop resolver — yields a non-empty DSN so fail-closed doesn't fire.
+const testDsn = "postgres://user:pass@localhost:5432/testdb";
+const noopDsnResolver: SecretResolver = (use) => use(testDsn);
+const emptyDsnResolver: SecretResolver = (use) => use("");
+
+const baseConfig: PostgresConnectorConfig = {
+  connectionStringRef: "secret:00000000-0000-0000-0000-000000000001",
+  defaultSchema: "public",
+};
+
+// ---------------------------------------------------------------------------
+// Unit: assertReadOnlyQuery
+// ---------------------------------------------------------------------------
+
+describe("assertReadOnlyQuery", () => {
+  it("accepts SELECT", () => {
+    expect(() => assertReadOnlyQuery("SELECT * FROM foo")).not.toThrow();
+  });
+
+  it("accepts WITH (CTE)", () => {
+    expect(() =>
+      assertReadOnlyQuery("WITH cte AS (SELECT 1) SELECT * FROM cte"),
+    ).not.toThrow();
+  });
+
+  it("accepts EXPLAIN", () => {
+    expect(() => assertReadOnlyQuery("EXPLAIN SELECT 1")).not.toThrow();
+  });
+
+  it("accepts TABLE shorthand", () => {
+    expect(() => assertReadOnlyQuery("TABLE foo")).not.toThrow();
+  });
+
+  it("accepts SELECT after leading line comment", () => {
+    expect(() =>
+      assertReadOnlyQuery("-- fetch all\nSELECT * FROM foo"),
+    ).not.toThrow();
+  });
+
+  it("accepts SELECT after leading block comment", () => {
+    expect(() =>
+      assertReadOnlyQuery("/* get rows */ SELECT * FROM foo"),
+    ).not.toThrow();
+  });
+
+  it("is case-insensitive", () => {
+    expect(() => assertReadOnlyQuery("select * from foo")).not.toThrow();
+    expect(() => assertReadOnlyQuery("Select 1")).not.toThrow();
+  });
+
+  it("rejects DROP", () => {
+    expect(() => assertReadOnlyQuery("DROP TABLE foo")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("rejects INSERT", () => {
+    expect(() => assertReadOnlyQuery("INSERT INTO foo VALUES (1)")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("rejects UPDATE", () => {
+    expect(() => assertReadOnlyQuery("UPDATE foo SET x=1")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("rejects DELETE", () => {
+    expect(() => assertReadOnlyQuery("DELETE FROM foo")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("rejects CREATE", () => {
+    expect(() => assertReadOnlyQuery("CREATE TABLE foo (id int)")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("does NOT match SELECT token inside a DROP (keyword-anywhere trap)", () => {
+    // "DROP TABLE select_log" — first token is DROP, not SELECT.
+    expect(() => assertReadOnlyQuery("DROP TABLE select_log")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("rejects empty/whitespace-only input", () => {
+    expect(() => assertReadOnlyQuery("   ")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+
+  it("rejects DROP after leading comment (comment-bypass attempt)", () => {
+    expect(() => assertReadOnlyQuery("-- SELECT\nDROP TABLE foo")).toThrow(
+      /non-SELECT query rejected/i,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 — Non-SELECT is rejected BEFORE client.query is called
+// ---------------------------------------------------------------------------
+
+describe("AC1 — non-SELECT rejected at allowlist, before any client.query", () => {
+  it("throws for DROP TABLE before any pg query call", async () => {
+    const spyClient = makeSpyClient();
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await expect(
+      connector.query("DROP TABLE foo", crypto.randomUUID()),
+    ).rejects.toThrow(/non-SELECT query rejected/i);
+
+    // The SET SESSION ... statement was issued (Layer 1), but no data query.
+    // Verify zero data queries were made (spy calls = only the SET statement).
+    // Because the allowlist runs BEFORE the auth/client path, even the SET
+    // statement must NOT have been called.
+    expect(spyClient.spy).not.toHaveBeenCalled();
+  });
+
+  it("throws for INSERT before any pg query call", async () => {
+    const spyClient = makeSpyClient();
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await expect(
+      connector.query("INSERT INTO foo VALUES (1)", crypto.randomUUID()),
+    ).rejects.toThrow(/non-SELECT query rejected/i);
+
+    expect(spyClient.spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2 — First query on every connection is the read-only SET statement
+// ---------------------------------------------------------------------------
+
+describe("AC2 — SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY is first query", () => {
+  it("issues the read-only SET before any query in connect()", async () => {
+    const spyClient = makeSpyClient([{ table_name: "users" }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await connector.connect();
+
+    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(calls[0]?.[0].toUpperCase()).toBe(
+      "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+    );
+  });
+
+  it("issues the read-only SET before the data query in query()", async () => {
+    const spyClient = makeSpyClient([{ id: 1, name: "Alice" }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await connector.query("SELECT * FROM users", crypto.randomUUID());
+
+    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    // Connection setup: SET SESSION CHARACTERISTICS + SET statement_timeout + data query.
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+    expect(calls[0]?.[0].toUpperCase()).toBe(
+      "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+    );
+    // The SELECT must come AFTER both SET statements.
+    const selectIdx = calls.findIndex((c) =>
+      c[0]?.toUpperCase().includes("SELECT"),
+    );
+    expect(selectIdx).toBeGreaterThan(0);
+  });
+
+  it("issues SET statement_timeout immediately after the read-only SET", async () => {
+    const spyClient = makeSpyClient([{ id: 1, name: "Alice" }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await connector.query("SELECT * FROM users", crypto.randomUUID());
+
+    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    // Second call (index 1) must be the statement_timeout guard.
+    expect(calls[1]?.[0].toUpperCase()).toContain("STATEMENT_TIMEOUT");
+  });
+
+  it("sends user SQL via extended query protocol (empty params array)", async () => {
+    // The extended query protocol forces Postgres to reject multi-statement SQL
+    // during Parse — closing the `SELECT 1; BEGIN READ WRITE; …` bypass.
+    // The mock spy can't actually reject multi-statement, but we verify the
+    // empty-params contract so that real pg uses the Parse/Bind/Execute path.
+    const spyClient = makeSpyClient([{ n: 1 }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    await connector.query("SELECT 1 AS n", crypto.randomUUID());
+
+    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    // Find the SELECT call.
+    const selectCall = calls.find((c) =>
+      c[0]?.toUpperCase().startsWith("SELECT"),
+    );
+    expect(selectCall).toBeDefined();
+    // Must be called with an empty params array — this is the extended protocol signal.
+    expect(selectCall?.[1]).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3 — Credential never plaintext in config
+// ---------------------------------------------------------------------------
+
+describe("AC3 — credential never plaintext in config", () => {
+  it("config stores a SecretRef string, never a postgres:// DSN", () => {
+    const plainDsn = "postgres://user:pass@host:5432/db";
+    const config: PostgresConnectorConfig = {
+      connectionStringRef: "secret:00000000-0000-0000-0000-000000000002",
+    };
+
+    const connector = makePostgresConnector(noopDsnResolver, config);
+
+    // Inspect all enumerable and own non-enumerable properties on the instance.
+    // The plaintext DSN must NOT appear as any property value.
+    const proto = Object.getPrototypeOf(connector) as object;
+    const ownKeys = [
+      ...Object.getOwnPropertyNames(connector),
+      ...Object.getOwnPropertyNames(proto),
+    ];
+    for (const key of ownKeys) {
+      try {
+        const val = (connector as unknown as Record<string, unknown>)[key];
+        if (typeof val === "string") {
+          expect(val).not.toBe(plainDsn);
+          expect(val).not.toContain("postgres://");
+        }
+      } catch {
+        // Private fields / accessors may throw — that's fine.
+      }
+    }
+
+    // connectionStringRef must be a SecretRef pattern or omitted.
+    // (We set it explicitly, so check it's the ref we gave.)
+    const configRef = config.connectionStringRef;
+    expect(configRef).toMatch(/^secret:/);
+    expect(configRef).not.toContain("postgres://");
+  });
+
+  it("fail-closed: empty DSN from resolver throws before creating a client", async () => {
+    const spyClient = makeSpyClient();
+    const connector = makeTestConnector(
+      emptyDsnResolver,
+      baseConfig,
+      spyClient,
+    );
+
+    await expect(connector.connect()).rejects.toThrow(/fail-closed/i);
+    // The spy client was never reached.
+    expect(spyClient.spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4 — Identifier quoting: double-quote in schema name is escaped
+// ---------------------------------------------------------------------------
+
+describe("AC4 — identifier quoting", () => {
+  it("quotes a schema name containing a double-quote in SET search_path", async () => {
+    const evilSchema = 'public"injection';
+    const spyClient = makeSpyClient([]);
+
+    // Call listTablesInSchema directly to isolate the quoting path.
+    await listTablesInSchema(spyClient, evilSchema);
+
+    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+
+    // First call is SET search_path — the schema must be double-quoted with
+    // the embedded " doubled: "public""injection"
+    const setCall = calls.find((c) => String(c[0]).includes("search_path"));
+    expect(setCall).toBeDefined();
+    const setQuery = String(setCall?.[0] ?? "");
+    expect(setQuery).toContain('"public""injection"');
+    // Must NOT contain the raw unescaped name.
+    expect(setQuery).not.toContain(`'${evilSchema}'`);
+
+    // Second call is the information_schema SELECT — schema passed as $1 value.
+    const selectCall = calls.find((c) =>
+      String(c[0]).toLowerCase().includes("information_schema"),
+    );
+    expect(selectCall).toBeDefined();
+    // The schema value must appear as the $1 parameter array entry, not
+    // interpolated into the SQL text.
+    const paramValues = selectCall?.[1] as unknown[];
+    expect(paramValues).toBeDefined();
+    expect(paramValues?.[0]).toBe(evilSchema);
+
+    // The SQL text itself must NOT contain the unquoted evil schema.
+    const selectQuery = String(selectCall?.[0] ?? "");
+    expect(selectQuery).toContain("$1");
+    expect(selectQuery).not.toContain(evilSchema);
+  });
+
+  it("quotes table name with double-quote when fetching by table ref", async () => {
+    const spyClient = makeSpyClient([{ id: 1, name: "Alice" }]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    // Trigger the table-ref path: "schema.table" format.
+    await connector.query('public.my"table', crypto.randomUUID());
+
+    const calls = spyClient.spy.mock.calls as Array<[string, ...unknown[]]>;
+    const fetchCall = calls.find((c) =>
+      String(c[0]).toUpperCase().startsWith("SELECT * FROM"),
+    );
+    expect(fetchCall).toBeDefined();
+    // Table name "my"table" must be quoted as "my""table"
+    expect(String(fetchCall?.[0] ?? "")).toContain('"my""table"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5 — Arrow output shape matches registry contract
+// ---------------------------------------------------------------------------
+
+describe("AC5 — Arrow output shape matches registry contract", () => {
+  it("returns arrowBuffer (base64), fieldIds, fields, rowCount for a two-column result", async () => {
+    const tableId = crypto.randomUUID();
+    const testRows = [
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ];
+    const spyClient = makeSpyClient(testRows);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query("SELECT * FROM users", tableId);
+
+    // Shape contract
+    expect(typeof result.arrowBuffer).toBe("string");
+    expect(Array.isArray(result.fieldIds)).toBe(true);
+    expect(Array.isArray(result.fields)).toBe(true);
+    expect(result.rowCount).toBe(2);
+
+    // fieldIds and fields must be aligned.
+    expect(result.fieldIds).toHaveLength(result.fields.length);
+
+    // Deserialize Arrow buffer and verify column names.
+    const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+    const table = tableFromIPC(bytes);
+    const colNames = table.schema.fields.map((f) => f.name);
+
+    // Both "id" and "name" columns must be present.
+    const fieldNames = result.fields.map((f) => f.name);
+    for (const name of fieldNames) {
+      expect(colNames).toContain(name);
+    }
+    expect(table.numRows).toBe(2);
+  });
+
+  it("returns rowCount = 0 for an empty result set", async () => {
+    const spyClient = makeSpyClient([]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT * FROM empty",
+      crypto.randomUUID(),
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.fields).toHaveLength(0);
+    expect(result.fieldIds).toHaveLength(0);
+    // arrowBuffer should still be a valid base64 string (empty Arrow table).
+    expect(typeof result.arrowBuffer).toBe("string");
+    expect(result.arrowBuffer.length).toBeGreaterThan(0);
+  });
+
+  it("returns correct rowCount for connect() listing tables", async () => {
+    const spyClient = makeSpyClient([
+      { table_name: "users" },
+      { table_name: "orders" },
+    ]);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const databases = await connector.connect();
+
+    expect(databases).toHaveLength(2);
+    expect(databases[0]).toEqual({
+      id: "public.users",
+      name: "users",
+    });
+    expect(databases[1]).toEqual({
+      id: "public.orders",
+      name: "orders",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Static metadata
+// ---------------------------------------------------------------------------
+
+describe("static metadata", () => {
+  const c = makePostgresConnector(noopDsnResolver, baseConfig);
+
+  it("has id = 'postgres'", () => {
+    expect(c.id).toBe("postgres");
+  });
+
+  it("has sourceType = 'remote-api'", () => {
+    expect(c.sourceType).toBe("remote-api");
+  });
+
+  it("is an instance of PostgresConnector", () => {
+    expect(c).toBeInstanceOf(PostgresConnector);
+  });
+
+  it("getFormFields includes connectionString and defaultSchema", () => {
+    const fields = c.getFormFields();
+    const names = fields.map((f) => f.name);
+    expect(names).toContain("connectionString");
+    expect(names).toContain("defaultSchema");
+  });
+
+  it("validate() fails when connectionString is absent", () => {
+    const result = c.validate({});
+    expect(result.valid).toBe(false);
+    expect(result.errors?.["connectionString"]).toBeTruthy();
+  });
+
+  it("validate() passes when connectionString is present", () => {
+    const result = c.validate({
+      connectionString: "postgres://user:pass@host:5432/db",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vault round-trip: SecretResolver wired to real vault
+// ---------------------------------------------------------------------------
+
+describe("vault round-trip: bound resolver from real SecretVault", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves DSN from vault and passes it to createClient", async () => {
+    const plainDsn = "postgres://vault-user:vault-pass@host:5432/testdb";
+    const { vault, ref } = await makeTestVaultWithSecret(plainDsn);
+    const auth = makeBoundResolver(vault, ref);
+
+    let capturedDsn: string | undefined;
+
+    class CapturingConnector extends PostgresConnector {
+      protected override async createClient(
+        dsn: string,
+      ): Promise<PgClientLike> {
+        capturedDsn = dsn;
+        // Return a spy client to avoid real pg call.
+        const spyClient = makeSpyClient([]);
+        return spyClient;
+      }
+    }
+
+    const config: PostgresConnectorConfig = {
+      connectionStringRef: ref,
+    };
+    const connector = new CapturingConnector(auth, config);
+    await connector.connect();
+
+    expect(capturedDsn).toBe(plainDsn);
+    // The plaintext DSN only appeared inside createClient — not on the connector.
+    expect(
+      (connector as unknown as Record<string, unknown>)["dsn"],
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed: resolver throws
+// ---------------------------------------------------------------------------
+
+describe("fail-closed: resolver failure", () => {
+  it("throws before constructing a client when the resolver rejects", async () => {
+    const failResolver: SecretResolver = async (_use) => {
+      throw new Error("vault unavailable");
+    };
+    const spyClient = makeSpyClient();
+    const connector = makeTestConnector(failResolver, baseConfig, spyClient);
+
+    await expect(connector.connect()).rejects.toThrow(/vault unavailable/i);
+    expect(spyClient.spy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read-only guard wired end-to-end
+// ---------------------------------------------------------------------------
+
+describe("read-only guard: allowlisted queries pass through to pg", () => {
+  let spyClient: SpyClient;
+  let connector: TestPostgresConnector;
+
+  beforeEach(() => {
+    spyClient = makeSpyClient([{ count: 42 }]);
+    connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+  });
+
+  it("SELECT query reaches pg after SET SESSION", async () => {
+    await connector.query("SELECT count(*) FROM users", crypto.randomUUID());
+    const calls = spyClient.spy.mock.calls as Array<[string]>;
+    const queries = calls.map((c) => c[0].toUpperCase());
+    expect(queries[0]).toContain("SET SESSION CHARACTERISTICS");
+    expect(queries.some((q) => q.includes("SELECT"))).toBe(true);
+  });
+
+  it("WITH query passes the allowlist", async () => {
+    spyClient = makeSpyClient([{ n: 1 }]);
+    connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+    await expect(
+      connector.query(
+        "WITH cte AS (SELECT 1 AS n) SELECT * FROM cte",
+        crypto.randomUUID(),
+      ),
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -122,12 +122,20 @@ export function assertReadOnlyQuery(sql: string): void {
  * Minimal interface for a pg Client used by this connector.
  * Keeps the seam narrow — only the two methods we call are required.
  */
+/** Config-object form — used when setting queryMode. */
+export interface PgQueryConfig {
+  text: string;
+  queryMode?: "extended" | "simple";
+  values?: unknown[];
+}
+
 export interface PgClientLike {
   query(text: string): Promise<{ rows: Record<string, unknown>[] }>;
   query(
     text: string,
     values: unknown[],
   ): Promise<{ rows: Record<string, unknown>[] }>;
+  query(config: PgQueryConfig): Promise<{ rows: Record<string, unknown>[] }>;
   end(): Promise<void>;
 }
 
@@ -427,17 +435,21 @@ export class PostgresConnector extends RemoteApiConnector {
  * interpolation of any user value. The text has already passed the allowlist
  * check (Layer 2) and runs on the read-only connection (Layer 1).
  *
- * The empty `[]` params array forces the pg extended query protocol (Parse →
- * Bind → Execute). Postgres rejects multi-statement SQL during Parse in this
- * protocol, closing the `SELECT 1; BEGIN READ WRITE; …` bypass that would
- * otherwise let an explicit transaction override the session-level read-only
- * default set by SET SESSION CHARACTERISTICS.
+ * `queryMode: "extended"` forces node-postgres onto the extended query
+ * protocol (Parse → Bind → Execute). Postgres rejects multi-statement SQL
+ * during Parse in this protocol, closing the `SELECT 1; BEGIN READ WRITE; …`
+ * bypass that would otherwise let an explicit transaction override the
+ * session-level read-only default set by SET SESSION CHARACTERISTICS.
+ *
+ * Note: passing an empty values array `[]` does NOT achieve this — pg checks
+ * `values.length > 0` in requiresPreparation(), so `[]` stays on the simple
+ * protocol. The `queryMode` field in the config object is the correct opt-in.
  */
 async function runUserQuery(
   client: PgClientLike,
   sql: string,
 ): Promise<Record<string, unknown>[]> {
-  const result = await client.query(sql, []);
+  const result = await client.query({ text: sql, queryMode: "extended" });
   return result.rows;
 }
 

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -72,7 +72,6 @@ import type { PostgresConnectorConfig } from "./types.js";
  */
 function stripLeadingComments(sql: string): string {
   let s = sql.trimStart();
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     if (s.startsWith("--")) {
       const nl = s.indexOf("\n");
@@ -349,14 +348,21 @@ export class PostgresConnector extends RemoteApiConnector {
     tableId: UUID,
     options?: QueryOptions,
   ): Promise<ConnectorQueryResult> {
-    const schema = this.#config.defaultSchema ?? "public";
-
     // Determine if databaseId is a "schema.table" reference (from connect())
     // or a raw user SQL statement. This check happens BEFORE auth/client
     // construction: a non-SELECT user query is rejected immediately (Layer 2
     // fast-fail) with zero client.query calls — the error surfaces without
     // touching the wire or the vault.
-    const isTableRef = /^[^(\s;]+\.[^(\s;]+$/.test(databaseId.trim());
+    // A "schema.table" ref (from connect()) has exactly one dot and no spaces,
+    // semicolons, or parentheses — it cannot be a SQL statement.
+    // A raw SQL statement always contains at least one space (e.g. "SELECT …").
+    const trimmed = databaseId.trim();
+    const dotIdx = trimmed.indexOf(".");
+    const isTableRef =
+      dotIdx > 0 &&
+      !trimmed.includes(" ") &&
+      !trimmed.includes(";") &&
+      !trimmed.includes("(");
 
     if (!isTableRef) {
       // Layer 2 allowlist — runs BEFORE #withClient (zero network side-effects).
@@ -367,10 +373,9 @@ export class PostgresConnector extends RemoteApiConnector {
       let rows: Record<string, unknown>[];
 
       if (isTableRef) {
-        // Table reference — split on the first dot.
-        const dotIdx = databaseId.indexOf(".");
-        const refSchema = databaseId.slice(0, dotIdx);
-        const refTable = databaseId.slice(dotIdx + 1);
+        // Table reference — split on the pre-computed dot index.
+        const refSchema = trimmed.slice(0, dotIdx);
+        const refTable = trimmed.slice(dotIdx + 1);
         // Sink 2: both parts quoted via quoteIdentifier().
         rows = await fetchTable(client, refSchema, refTable);
       } else {

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -1,0 +1,470 @@
+/**
+ * PostgresConnector — read-only Postgres data-source connector.
+ *
+ * Auth-blind: the connector is constructed with a bound SecretResolver
+ * pre-bound to the DataSource's credential ref. Data methods (connect, query)
+ * carry NO credential arguments — the pipeline call site has no vault, ref,
+ * or plaintext in scope (enforced by type).
+ *
+ * Security contracts — ALL MANDATORY:
+ *
+ * 1. Read-only, two layers:
+ *    Layer 1 (hard guard): SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY
+ *    sets the default transaction mode. In addition, user queries are sent via
+ *    the extended query protocol (empty params array) which causes Postgres to
+ *    reject multi-statement SQL at the Parse phase — preventing the
+ *    `SELECT 1; BEGIN READ WRITE; CREATE TABLE …` bypass.
+ *    Layer 2 (fast-fail): A regex allowlist rejects any user-supplied query
+ *    whose first non-comment, non-whitespace token is not SELECT/WITH/EXPLAIN/
+ *    TABLE — before touching the wire.
+ *
+ * DEPLOYMENT REQUIREMENT — least-privilege role:
+ *    The DSN MUST use a Postgres role that holds only SELECT grants on the
+ *    target schemas. The connector cannot enforce this. Using a superuser or
+ *    a role with WRITE/DDL grants breaks the read-only guarantee regardless of
+ *    the connector's guards — `pg_read_file`, `dblink`, and similar superuser
+ *    functions bypass all statement-level controls.
+ *
+ * 2. Credential never plaintext in config: the DSN is resolved inside
+ *    this.auth(async dsn => { ... }). The pg Client is constructed and closed
+ *    inside the callback scope; the plaintext DSN never escapes.
+ *
+ * 3. SQL sink guards:
+ *    Sink 1 — connection string assembled only inside auth callback.
+ *    Sink 2 — schema/table identifiers quoted via quoteIdentifier(); values
+ *             passed as $1/$2 parameters to information_schema queries.
+ *    Sink 3 — user query sent with ZERO string interpolation.
+ *
+ * 4. Fail-closed: if the resolver yields empty, throw before constructing
+ *    a client (no unauthenticated connection opened).
+ *
+ * pg is a Node-only package — all imports are dynamic (inside the auth
+ * callback) so this module is safe to import in the renderer for static
+ * metadata (id/name/icon/getFormFields) without pulling in Node APIs.
+ */
+
+import type {
+  ConnectorQueryResult,
+  Field,
+  FormField,
+  QueryOptions,
+  RemoteDatabase,
+  SecretResolver,
+  UUID,
+  ValidationResult,
+} from "@dashframe/engine";
+import {
+  RemoteApiConnector,
+  createFieldsFromColumns,
+  inferStringColumnType,
+  quoteIdentifier,
+} from "@dashframe/engine";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+import type { PostgresConnectorConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Read-only guard (Layer 2 — fast-fail allowlist)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip leading SQL line comments (-- ...) and block comments (/* ... *\/).
+ * Iterative — no regex backtracking on arbitrary input.
+ */
+function stripLeadingComments(sql: string): string {
+  let s = sql.trimStart();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (s.startsWith("--")) {
+      const nl = s.indexOf("\n");
+      s = nl === -1 ? "" : s.slice(nl + 1).trimStart();
+    } else if (s.startsWith("/*")) {
+      const end = s.indexOf("*/");
+      if (end === -1) {
+        s = "";
+      } else {
+        s = s.slice(end + 2).trimStart();
+      }
+    } else {
+      break;
+    }
+  }
+  return s;
+}
+
+/**
+ * Assert that a user-supplied SQL string's first token is an allowlisted
+ * read-only keyword: SELECT, WITH, EXPLAIN, or TABLE.
+ *
+ * The check is Layer 2 (fast-fail at the surface). Layer 1 (SET SESSION
+ * CHARACTERISTICS AS TRANSACTION READ ONLY) is the load-bearing guard.
+ *
+ * @throws if the first token is not on the allowlist.
+ */
+export function assertReadOnlyQuery(sql: string): void {
+  const stripped = stripLeadingComments(sql);
+  // Match the first word token, case-insensitive.
+  const match = /^([A-Za-z]+)(?:\s|$|;|\()/u.exec(stripped);
+  const first = match?.[1]?.toUpperCase() ?? "";
+  const allowed = new Set(["SELECT", "WITH", "EXPLAIN", "TABLE"]);
+  if (!allowed.has(first)) {
+    throw new Error(
+      `[PostgresConnector] Non-SELECT query rejected (first token: "${first || "(empty)"}"). ` +
+        `Only SELECT / WITH / EXPLAIN / TABLE statements are allowed. ` +
+        `This connector is read-only.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client abstraction (injectable for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for a pg Client used by this connector.
+ * Keeps the seam narrow — only the two methods we call are required.
+ */
+export interface PgClientLike {
+  query(text: string): Promise<{ rows: Record<string, unknown>[] }>;
+  query(
+    text: string,
+    values: unknown[],
+  ): Promise<{ rows: Record<string, unknown>[] }>;
+  end(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Introspection helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * List tables and views in the given schema using information_schema.
+ *
+ * Sink 2 compliance:
+ *   - schema name appears as a $1 PARAMETER VALUE in the WHERE clause.
+ *   - schema name is also used as an identifier in SET search_path — it is
+ *     quoted via quoteIdentifier() before interpolation.
+ *   - No user input is ever concatenated raw into SQL text.
+ */
+export async function listTablesInSchema(
+  client: PgClientLike,
+  schema: string,
+): Promise<string[]> {
+  // Set search_path for this session — schema name as a quoted identifier.
+  await client.query(`SET search_path TO ${quoteIdentifier(schema)}`);
+
+  // Query information_schema: schema name as a $1 value parameter.
+  const result = await client.query(
+    `SELECT table_name
+     FROM information_schema.tables
+     WHERE table_schema = $1
+       AND table_type IN ('BASE TABLE', 'VIEW')
+     ORDER BY table_name`,
+    [schema],
+  );
+
+  return result.rows.map((row) => String(row["table_name"] ?? ""));
+}
+
+// ---------------------------------------------------------------------------
+// Field inference from rows
+// ---------------------------------------------------------------------------
+
+function inferFieldsFromRows(
+  rows: Record<string, unknown>[],
+  tableId: UUID,
+): Field[] {
+  const columnNames = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      columnNames.add(key);
+    }
+  }
+
+  const columns = [...columnNames].map((name) => {
+    let type: ReturnType<typeof inferStringColumnType> = "unknown";
+    for (const row of rows) {
+      const v = row[name];
+      if (v !== null && v !== undefined) {
+        type = inferStringColumnType(String(v));
+        break;
+      }
+    }
+    return { name, type };
+  });
+
+  return createFieldsFromColumns(columns, tableId);
+}
+
+// ---------------------------------------------------------------------------
+// Connector
+// ---------------------------------------------------------------------------
+
+/**
+ * PostgresConnector — read-only, auth-blind Postgres source connector.
+ *
+ * Constructed via {@link makePostgresConnector} with a bound SecretResolver
+ * and declarative config. Call `connect()` and `query()` with no credential
+ * arguments — the pipeline call site has no vault, ref, or plaintext in scope.
+ *
+ * pg is dynamically imported inside the auth callback to avoid pulling the
+ * Node-only `pg` package into the renderer bundle (the renderer imports this
+ * module for static metadata only and never calls connect/query).
+ */
+export class PostgresConnector extends RemoteApiConnector {
+  readonly id = "postgres";
+  readonly name = "PostgreSQL";
+  readonly description = "Connect to a PostgreSQL database (read-only).";
+  readonly icon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.657 4.03 3 9 3s9-1.343 9-3V5"/><path d="M3 12c0 1.657 4.03 3 9 3s9-1.343 9-3"/></svg>`;
+
+  readonly #config: PostgresConnectorConfig;
+
+  /**
+   * Overridable client factory — enables test subclasses to inject a spy/stub
+   * without dynamic-importing the real pg package. The default implementation
+   * dynamically imports pg, constructs a Client, and connects it.
+   *
+   * @param dsn - Plaintext DSN, valid only within the auth callback scope.
+   */
+  protected async createClient(dsn: string): Promise<PgClientLike> {
+    // Dynamic import: keeps pg out of the renderer bundle. The renderer imports
+    // this class for static metadata (id/name/icon/getFormFields) and never
+    // calls createClient — so pg is never evaluated in a browser context.
+    const { default: pg } = await import("pg");
+    const client = new pg.Client({ connectionString: dsn });
+    await client.connect();
+    return client as unknown as PgClientLike;
+  }
+
+  constructor(auth: SecretResolver, config: PostgresConnectorConfig) {
+    super(auth);
+    this.#config = config;
+  }
+
+  /**
+   * Open a read-only pg client scoped to the auth callback.
+   *
+   * The DSN plaintext is consumed here and NEVER escapes this method.
+   * Layer 1 read-only guard is applied first: SET SESSION CHARACTERISTICS AS
+   * TRANSACTION READ ONLY is the very first query executed on every connection.
+   * If the resolver yields an empty DSN, we throw before constructing the client
+   * (fail-closed).
+   */
+  async #withClient<T>(use: (client: PgClientLike) => Promise<T>): Promise<T> {
+    return this.auth(async (dsn) => {
+      // Fail-closed: a connectionStringRef implies the credential is required.
+      if (!dsn) {
+        throw new Error(
+          "[PostgresConnector] connectionStringRef is configured but the " +
+            "secret resolver returned no DSN — refusing to open a connection " +
+            "(fail-closed).",
+        );
+      }
+
+      // Sink 1: DSN is used only here, inside the auth callback. The client is
+      // constructed with the DSN and closed before the callback returns.
+      const client = await this.createClient(dsn);
+
+      try {
+        // Layer 1 — hard read-only guard. This is the FIRST query on every
+        // connection — before any introspection or user query.
+        await client.query(
+          "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+        );
+        // Bound statement execution time. Protects against pg_sleep() and
+        // other long-running queries (DoS mitigation — no user-facing timeout).
+        await client.query("SET statement_timeout = '30s'");
+        return await use(client);
+      } finally {
+        // Ensure the client is closed even on error — DSN never escapes.
+        await client.end().catch(() => {
+          // Swallow end() errors: the caller's error takes priority.
+        });
+      }
+    });
+  }
+
+  getFormFields(): FormField[] {
+    return [
+      {
+        name: "connectionString",
+        label: "Connection String",
+        type: "password",
+        placeholder: "postgres://user:password@host:5432/dbname",
+        hint: "Stored securely in the vault. Never exposed in config.",
+        required: true,
+      },
+      {
+        name: "defaultSchema",
+        label: "Default Schema",
+        type: "text",
+        placeholder: "public",
+        hint: "Schema to list tables from (default: public).",
+      },
+    ];
+  }
+
+  validate(formData: Record<string, unknown>): ValidationResult {
+    const cs = formData["connectionString"] as string | undefined;
+    if (!cs) {
+      return {
+        valid: false,
+        errors: { connectionString: "Connection string is required." },
+      };
+    }
+    return { valid: true };
+  }
+
+  /**
+   * Connect to the Postgres database and list tables/views in the configured
+   * schema. Returns one RemoteDatabase entry per table/view.
+   *
+   * Credentials are resolved via `this.auth` — no credential argument.
+   */
+  async connect(): Promise<RemoteDatabase[]> {
+    const schema = this.#config.defaultSchema ?? "public";
+    return this.#withClient(async (client) => {
+      const tables = await listTablesInSchema(client, schema);
+      return tables.map((table) => ({
+        id: `${schema}.${table}`,
+        name: table,
+      }));
+    });
+  }
+
+  /**
+   * Query the Postgres database and return a serializable Arrow IPC result.
+   *
+   * `databaseId` is either a fully-qualified table name ("schema.table" from
+   * connect()) or a user-supplied SELECT statement. User-supplied SQL is
+   * validated by the Layer 2 allowlist before hitting the wire.
+   *
+   * Returns Arrow IPC bytes (base64) + fieldIds + fields — NOT a live DataFrame.
+   * The renderer materializes the browser DataFrame from arrowBuffer after it
+   * crosses the IPC boundary.
+   *
+   * Credentials are resolved via `this.auth` — no credential argument.
+   */
+  async query(
+    databaseId: string,
+    tableId: UUID,
+    options?: QueryOptions,
+  ): Promise<ConnectorQueryResult> {
+    const schema = this.#config.defaultSchema ?? "public";
+
+    // Determine if databaseId is a "schema.table" reference (from connect())
+    // or a raw user SQL statement. This check happens BEFORE auth/client
+    // construction: a non-SELECT user query is rejected immediately (Layer 2
+    // fast-fail) with zero client.query calls — the error surfaces without
+    // touching the wire or the vault.
+    const isTableRef = /^[^(\s;]+\.[^(\s;]+$/.test(databaseId.trim());
+
+    if (!isTableRef) {
+      // Layer 2 allowlist — runs BEFORE #withClient (zero network side-effects).
+      assertReadOnlyQuery(databaseId);
+    }
+
+    return this.#withClient(async (client) => {
+      let rows: Record<string, unknown>[];
+
+      if (isTableRef) {
+        // Table reference — split on the first dot.
+        const dotIdx = databaseId.indexOf(".");
+        const refSchema = databaseId.slice(0, dotIdx);
+        const refTable = databaseId.slice(dotIdx + 1);
+        // Sink 2: both parts quoted via quoteIdentifier().
+        rows = await fetchTable(client, refSchema, refTable);
+      } else {
+        // User-supplied SQL — allowlist already passed above; send with zero interpolation.
+        // Sink 3: query sent with zero interpolation.
+        rows = await runUserQuery(client, databaseId);
+      }
+
+      // Apply pagination window if requested.
+      const limit = options?.pagination?.limit;
+      const offset = options?.pagination?.offset ?? 0;
+      const slicedRows =
+        limit !== undefined ? rows.slice(offset, offset + limit) : rows;
+
+      // Infer fields from rows.
+      const fields = inferFieldsFromRows(slicedRows, tableId);
+
+      // Build Arrow column arrays from the inferred field set.
+      const columnArrays: Record<string, unknown[]> = Object.create(
+        null,
+      ) as Record<string, unknown[]>;
+      for (const field of fields) {
+        const colName = field.columnName ?? field.name;
+        columnArrays[colName] = slicedRows.map((r) => r[colName] ?? null);
+      }
+
+      const arrowTable = tableFromArrays(columnArrays);
+      const ipcBuffer = tableToIPC(arrowTable);
+      const base64 = Buffer.from(ipcBuffer).toString("base64");
+
+      return {
+        arrowBuffer: base64,
+        fieldIds: fields.map((f) => f.id),
+        fields,
+        rowCount: slicedRows.length,
+      };
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (after class definition to keep the class block clean)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a user-supplied SELECT and return its rows.
+ *
+ * Sink 3 compliance: the query text is sent as-is, with NO string
+ * interpolation of any user value. The text has already passed the allowlist
+ * check (Layer 2) and runs on the read-only connection (Layer 1).
+ *
+ * The empty `[]` params array forces the pg extended query protocol (Parse →
+ * Bind → Execute). Postgres rejects multi-statement SQL during Parse in this
+ * protocol, closing the `SELECT 1; BEGIN READ WRITE; …` bypass that would
+ * otherwise let an explicit transaction override the session-level read-only
+ * default set by SET SESSION CHARACTERISTICS.
+ */
+async function runUserQuery(
+  client: PgClientLike,
+  sql: string,
+): Promise<Record<string, unknown>[]> {
+  const result = await client.query(sql, []);
+  return result.rows;
+}
+
+/**
+ * Fetch all rows of a named table (schema-qualified).
+ * Used when databaseId is a table name rather than a raw SELECT statement.
+ *
+ * Sink 2 compliance: schema and table are both quoted via quoteIdentifier().
+ */
+async function fetchTable(
+  client: PgClientLike,
+  schema: string,
+  table: string,
+): Promise<Record<string, unknown>[]> {
+  const sql = `SELECT * FROM ${quoteIdentifier(schema)}.${quoteIdentifier(table)}`;
+  const result = await client.query(sql);
+  return result.rows;
+}
+
+/**
+ * Factory — mint a PostgresConnector bound to the given SecretResolver and config.
+ *
+ * This is the single construction site for PostgresConnector. The server-layer
+ * connector factory calls this after minting the bound resolver from
+ * `vault.withSecret.bind(vault, ref)`.
+ *
+ * @param auth   - SecretResolver pre-bound to this DataSource's credential ref
+ * @param config - Postgres config (connectionStringRef, optional defaultSchema)
+ */
+export function makePostgresConnector(
+  auth: SecretResolver,
+  config: PostgresConnectorConfig,
+): PostgresConnector {
+  return new PostgresConnector(auth, config);
+}

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -176,6 +176,23 @@ export async function listTablesInSchema(
 // Field inference from rows
 // ---------------------------------------------------------------------------
 
+/**
+ * Column names that must never reach `apache-arrow`'s `tableFromArrays`: they
+ * corrupt Arrow's column iteration. Verified against apache-arrow 21.1.0: a
+ * `__proto__` column does NOT throw — it silently makes Arrow drop the sibling
+ * real columns from the built table (e.g. `{__proto__:[…], id:[…]}` → schema
+ * with zero fields). `constructor`/`prototype` pass through as ordinary columns
+ * but are never legitimate data-column names. A Postgres column can technically
+ * be named any of these (identifiers are quoted), so all three are dropped
+ * before inference and serialization — fail-safe, mirroring the REST
+ * connector's DANGEROUS_KEYS.
+ */
+const DANGEROUS_COLUMN_NAMES = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 function inferFieldsFromRows(
   rows: Record<string, unknown>[],
   tableId: UUID,
@@ -183,6 +200,7 @@ function inferFieldsFromRows(
   const columnNames = new Set<string>();
   for (const row of rows) {
     for (const key of Object.keys(row)) {
+      if (DANGEROUS_COLUMN_NAMES.has(key)) continue; // never a real column
       columnNames.add(key);
     }
   }
@@ -377,6 +395,15 @@ export class PostgresConnector extends RemoteApiConnector {
       assertReadOnlyQuery(databaseId);
     }
 
+    const limit = options?.pagination?.limit;
+    const offset = options?.pagination?.offset ?? 0;
+
+    // The table-ref path pushes LIMIT/OFFSET into SQL, so it is already
+    // windowed by the DB. The user-SQL path is NOT (see below) and is sliced
+    // in-process as a backstop. INVARIANT: pushdown and in-process slice are
+    // mutually exclusive — exactly one applies a given window, never both.
+    const pushedDown = isTableRef && limit !== undefined;
+
     return this.#withClient(async (client) => {
       let rows: Record<string, unknown>[];
 
@@ -384,19 +411,25 @@ export class PostgresConnector extends RemoteApiConnector {
         // Table reference — split on the pre-computed dot index.
         const refSchema = trimmed.slice(0, dotIdx);
         const refTable = trimmed.slice(dotIdx + 1);
-        // Sink 2: both parts quoted via quoteIdentifier().
-        rows = await fetchTable(client, refSchema, refTable);
+        // Sink 2: both parts quoted via quoteIdentifier(). Pagination is pushed
+        // down into the SQL (LIMIT/OFFSET) so we never materialize a full table.
+        rows = await fetchTable(client, refSchema, refTable, limit, offset);
       } else {
-        // User-supplied SQL — allowlist already passed above; send with zero interpolation.
-        // Sink 3: query sent with zero interpolation.
+        // User-supplied SQL — allowlist already passed above; send with zero
+        // interpolation. We deliberately do NOT wrap user SQL to inject
+        // LIMIT/OFFSET: wrapping (`SELECT * FROM (<user sql>) ...`) would (1)
+        // re-interpolate user text, breaking the Sink 3 zero-interpolation
+        // contract, and (2) break legal allowlisted forms like `EXPLAIN …`,
+        // `TABLE …`, and trailing-`;` queries. The user authored this query and
+        // can bound it; statement_timeout + the post-fetch slice are backstops.
         rows = await runUserQuery(client, databaseId);
       }
 
-      // Apply pagination window if requested.
-      const limit = options?.pagination?.limit;
-      const offset = options?.pagination?.offset ?? 0;
+      // Slice only when the window was NOT already pushed into SQL.
       const slicedRows =
-        limit !== undefined ? rows.slice(offset, offset + limit) : rows;
+        !pushedDown && limit !== undefined
+          ? rows.slice(offset, offset + limit)
+          : rows;
 
       // Infer fields from rows.
       const fields = inferFieldsFromRows(slicedRows, tableId);
@@ -454,18 +487,34 @@ async function runUserQuery(
 }
 
 /**
- * Fetch all rows of a named table (schema-qualified).
- * Used when databaseId is a table name rather than a raw SELECT statement.
+ * Fetch rows of a named table (schema-qualified), with LIMIT/OFFSET pushed
+ * into the SQL when a pagination window is requested.
  *
- * Sink 2 compliance: schema and table are both quoted via quoteIdentifier().
+ * Sink 2 compliance: schema and table are both quoted via quoteIdentifier();
+ * limit/offset are bound as `$1`/`$2` parameter VALUES (never interpolated).
+ *
+ * Pushdown matters because this is the system-generated table-preview path: a
+ * preview with `limit: 50` must NOT pull an unbounded table into Node memory
+ * and slice afterward. When `limit` is undefined, the plain SELECT is emitted
+ * unchanged (full-table behavior preserved for callers that want every row).
  */
 async function fetchTable(
   client: PgClientLike,
   schema: string,
   table: string,
+  limit?: number,
+  offset = 0,
 ): Promise<Record<string, unknown>[]> {
-  const sql = `SELECT * FROM ${quoteIdentifier(schema)}.${quoteIdentifier(table)}`;
-  const result = await client.query(sql);
+  const base = `SELECT * FROM ${quoteIdentifier(schema)}.${quoteIdentifier(table)}`;
+  if (limit === undefined) {
+    const result = await client.query(base);
+    return result.rows;
+  }
+  // Bound window: limit/offset as $1/$2 value parameters → extended protocol.
+  const result = await client.query(`${base} LIMIT $1 OFFSET $2`, [
+    limit,
+    offset,
+  ]);
   return result.rows;
 }
 

--- a/packages/connector-postgres/src/index.ts
+++ b/packages/connector-postgres/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  PostgresConnector,
+  assertReadOnlyQuery,
+  listTablesInSchema,
+  makePostgresConnector,
+} from "./connector.js";
+export type { PgClientLike } from "./connector.js";
+export type { PostgresConnectorConfig } from "./types.js";

--- a/packages/connector-postgres/src/types.ts
+++ b/packages/connector-postgres/src/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Config for PostgresConnector.
+ *
+ * Credential is stored as a SecretRef — never plaintext.
+ * The DSN (host/port/db/user/password as a single connection string) lives in
+ * SecretVault and is resolved server-side via the bound SecretResolver.
+ */
+export interface PostgresConnectorConfig {
+  /**
+   * SecretRef pointing to the plaintext DSN in the vault.
+   * Format: "secret:<uuid>". Never a raw postgres:// string.
+   * Optional: when omitted, the bound SecretResolver provides the credential.
+   * Present only to surface the ref in config introspection endpoints.
+   */
+  connectionStringRef?: string;
+
+  /**
+   * Optional default schema to introspect for table/view listing.
+   * Defaults to "public" when omitted.
+   */
+  defaultSchema?: string;
+}

--- a/packages/connector-postgres/tsconfig.json
+++ b/packages/connector-postgres/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  }
+}

--- a/packages/connector-postgres/vitest.config.ts
+++ b/packages/connector-postgres/vitest.config.ts
@@ -1,0 +1,30 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "**/*.test.{ts,tsx}",
+        "**/__tests__/**",
+        "**/node_modules/**",
+        "**/dist/**",
+      ],
+    },
+  },
+  resolve: {
+    alias: {
+      "@dashframe/engine": path.resolve(__dirname, "../engine/src"),
+      "@wystack/secret-vault": path.resolve(
+        __dirname,
+        "../../libs/wystack/packages/secret-vault/src/index.ts",
+      ),
+    },
+  },
+});

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -103,11 +103,13 @@ export function assertFieldMapNoCollision(
 }
 
 /**
- * Keys that must never become column names. They mutate object prototypes
- * (`__proto__`) or, even when stored on a null-prototype object, crash
- * `apache-arrow`'s `tableFromArrays` (it recurses on these names). A REST source
- * cannot have a legitimate data column named any of these, so they are dropped
- * from every row before inference/serialization — fail-safe, not fail-loud.
+ * Keys that must never become column names. They corrupt `apache-arrow`'s
+ * column iteration: verified against apache-arrow 21.1.0, a `__proto__` column
+ * does NOT throw — it silently makes Arrow drop the sibling real columns from
+ * the built table. `constructor`/`prototype` pass through but are never
+ * legitimate column names. A REST source cannot have a legitimate data column
+ * named any of these, so they are dropped from every row before
+ * inference/serialization — fail-safe, not fail-loud.
  */
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 


### PR DESCRIPTION
## Summary

- Adds `@dashframe/connector-postgres` — a read-only Postgres data-source connector mirroring `connector-rest` structure
- `PostgresConnector extends RemoteApiConnector`, `id = "postgres"`, auth-blind (no credential arg on `connect()`/`query()`)
- Two server-side mutations added to `app-artifacts.ts`: `listPostgresTables`, `queryPostgresTable`
- Registered in `ConnectorSetup.tsx` with a throwing renderer resolver (static metadata only)

Tracked internally as YW-299.

## Security architecture — needs-human review

The ticket spec described Layer 1 (`SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY`) as "the hard guard that rejects DML/DDL at the protocol level." **This is false.** That GUC sets the *default* transaction mode — an explicit `BEGIN READ WRITE` overrides it. This was empirically proven against Postgres 15.18 during the local review gate: `SELECT 1; COMMIT; BEGIN READ WRITE; CREATE TABLE pwned(...)` landed a write.

**What the PR actually ships:**

1. **Extended query protocol**: User SQL is sent as `client.query(sql, [])` — the empty params array forces Postgres to use Parse/Bind/Execute. Postgres rejects multi-statement SQL during Parse in this protocol, closing the `SELECT 1; BEGIN READ WRITE; …` bypass. This is a real code-level guard.
2. **`SET statement_timeout = '30s'`**: Bounds `pg_sleep()` and similar long-running DoS vectors.
3. **Deployment requirement documented in the connector docstring**: The DSN *must* use a Postgres role with only SELECT grants. `pg_read_file`, `dblink`, and superuser functions bypass all statement-level controls — there is no code guard for these.

The connector's read-only guarantee is strong when deployed with a least-privilege role. Without that operational requirement being met, the code-level guards are defense-in-depth, not a hard boundary. **This needs explicit owner acknowledgment before merge** — either update the spec to reflect the actual security model (operational floor + code guards), or scope down the ticket's promise.

## Test plan

- [x] 38 connector tests — all 5 ACs covered:
  - AC1: non-SELECT query rejected before any `client.query` call (0 spy calls on rejection)
  - AC2: `SET SESSION CHARACTERISTICS` is first call; `SET statement_timeout` is second; extended-protocol params contract (`[]`)
  - AC3: `connectionStringRef` is a SecretRef, never a DSN; fail-closed on empty resolver
  - AC4: `quoteIdentifier` escapes embedded `"` in schema/table; `$1` param for introspection values
  - AC5: `arrowBuffer`/`fieldIds`/`fields`/`rowCount` shape + Arrow deserialization
- [x] Full-graph typecheck: 48/48 tasks
- [x] Full-graph tests: 42/42 tasks (309 tests total, 271 server + 38 connector)
- [x] Local `code-review --effort high`: security BLOCK resolved (extended protocol + statement_timeout + deployment doc); correctness SHIP; api-contract SHIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `@dashframe/connector-postgres`, a read-only Postgres data-source connector that mirrors the existing `connector-rest` and `connector-notion` structure. Two server-side mutations (`listPostgresTables`, `queryPostgresTable`) are wired through a bound `SecretResolver` so no plaintext DSN ever reaches the call site.

- **Security architecture**: Two independent read-only guards — Layer 1 (`SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY`) and Layer 2 (keyword allowlist + extended query protocol via `queryMode: "extended"`, confirmed supported since pg 8.10.0 and used here at 8.22.0). An integration exploit test empirically validates that the multi-statement `BEGIN READ WRITE` bypass is rejected at Parse phase.
- **SQL sink protection**: Schema/table identifiers are always passed through `quoteIdentifier()`; user queries are sent with zero string interpolation; pagination limit/offset for the table-ref path is pushed down as `$1`/`$2` bind parameters, not concatenated.
- **Renderer safety**: `pg` is dynamically imported inside the auth callback, keeping Node-only code out of the browser bundle; the renderer-side connector instance uses a throwing resolver and the `showPostgres` feature flag remains `false` until the connect UI is complete.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The new connector is safe to merge — the two read-only guards are independently load-bearing, all SQL sinks are parameterized or identifier-quoted, credentials never escape the auth callback, and the feature flag keeps the UI hidden until the connect flow is wired.

The two comments are minor quality observations: a redundant SET search_path round trip in listTablesInSchema and a usability edge case where nested block comments in user SQL produce a false rejection. Neither affects correctness or security. The exploit integration test empirically validates the key security property. All other paths — credential isolation, SQL sink guarding, Arrow serialization, and registry gating — are well-structured and consistent with existing codebase patterns.

No files require special attention. The only reviewer action needed is deciding whether to strip the redundant SET search_path TO call in listTablesInSchema before merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/connector-postgres/src/connector.ts | Core connector implementation — security guards (extended protocol, Layer 1/2), quoteIdentifier sink protection, and Arrow serialization all look correct. Minor: SET search_path in listTablesInSchema is redundant; nested block comments produce false rejections. |
| apps/server/src/functions/app-artifacts.ts | New Postgres mutations mirror Notion pattern correctly — auth-blind via bound resolver, defaultSchema validated as string before passing through, limit bounds checked before constructing pagination. |
| packages/connector-postgres/src/connector.test.ts | Comprehensive 38-test suite covering all 5 ACs; AC1 comment contradiction noted in previous thread was fixed in 705232bd. |
| packages/connector-postgres/src/__exploit.realpg.test.ts | Integration test that empirically validates extended-protocol multi-statement rejection and write side-effect absence; auto-skips without PG_DSN so CI remains green. |
| packages/app/src/components/providers/ConnectorSetup.tsx | Postgres connector registered with a throwing renderer resolver for static metadata only; dynamic pg import prevents Node-only code entering the browser bundle. |
| packages/app/src/lib/connectors/registry.ts | Feature-flag gating for postgres connector (showPostgres defaults false) mirrors existing Notion pattern correctly. |
| packages/connector-rest/src/connector.ts | Only change is updating the DANGEROUS_KEYS comment to include the empirically verified apache-arrow 21.1.0 behavior (silent column drop, not throw). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Browser/Renderer
    participant Mutation as Server Mutation
    participant ConnectorFactory as postgresConnectorFor
    participant Vault as SecretVault
    participant Connector as PostgresConnector
    participant PG as Postgres DB

    Client->>Mutation: queryPostgresTable(dataSourceId, databaseId, tableId, limit)
    Mutation->>ConnectorFactory: postgresConnectorFor(ctx, dataSourceId)
    ConnectorFactory->>Vault: mintBoundResolver(vault, connectionString ref)
    ConnectorFactory-->>Mutation: connector (bound resolver, no DSN)

    alt databaseId is user SQL
        Mutation->>Connector: "connector.query(databaseId, tableId, {limit})"
        Connector->>Connector: assertReadOnlyQuery(sql) [Layer 2 allowlist]
        Connector->>Vault: this.auth(callback) resolves DSN
        Vault-->>Connector: plaintext DSN (callback scope only)
        Connector->>PG: SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY
        Connector->>PG: "SET statement_timeout = 30s"
        Connector->>PG: "query({text: sql, queryMode: extended}) [extended protocol]"
        PG-->>Connector: rows
    else databaseId is schema.table ref
        Connector->>PG: "SELECT * FROM schema.table LIMIT $1 OFFSET $2"
        PG-->>Connector: rows
    end

    Connector->>Connector: inferFieldsFromRows then Arrow IPC base64
    Connector-->>Mutation: arrowBuffer, fieldIds, fields, rowCount
    Mutation-->>Client: PostgresQueryResult (no DSN, no live DataFrame)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Browser/Renderer
    participant Mutation as Server Mutation
    participant ConnectorFactory as postgresConnectorFor
    participant Vault as SecretVault
    participant Connector as PostgresConnector
    participant PG as Postgres DB

    Client->>Mutation: queryPostgresTable(dataSourceId, databaseId, tableId, limit)
    Mutation->>ConnectorFactory: postgresConnectorFor(ctx, dataSourceId)
    ConnectorFactory->>Vault: mintBoundResolver(vault, connectionString ref)
    ConnectorFactory-->>Mutation: connector (bound resolver, no DSN)

    alt databaseId is user SQL
        Mutation->>Connector: "connector.query(databaseId, tableId, {limit})"
        Connector->>Connector: assertReadOnlyQuery(sql) [Layer 2 allowlist]
        Connector->>Vault: this.auth(callback) resolves DSN
        Vault-->>Connector: plaintext DSN (callback scope only)
        Connector->>PG: SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY
        Connector->>PG: "SET statement_timeout = 30s"
        Connector->>PG: "query({text: sql, queryMode: extended}) [extended protocol]"
        PG-->>Connector: rows
    else databaseId is schema.table ref
        Connector->>PG: "SELECT * FROM schema.table LIMIT $1 OFFSET $2"
        PG-->>Connector: rows
    end

    Connector->>Connector: inferFieldsFromRows then Arrow IPC base64
    Connector-->>Mutation: arrowBuffer, fieldIds, fields, rowCount
    Mutation-->>Client: PostgresQueryResult (no DSN, no live DataFrame)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(connector-postgres): pagination push..."](https://github.com/youhaowei/dashframe/commit/e8aea190daf235aed6f02e08abdd2be7ab3d81b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39739322)</sub>

<!-- /greptile_comment -->