### PR TITLE
fix(server): release prior SecretRef on credential clear/rotate [YW-301]

### DIFF
--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -426,14 +426,26 @@ const setDataSourceConfig = mutation({
       .first()) as DataSourceRow | undefined;
     if (!current) throw new Error(`Data source ${id} not found`);
     const config = { ...((current.config ?? {}) as DataSourceConfig) };
+    // Sink guard FIRST: callers may not sneak credential keys in via `extra`.
+    // This validation must run BEFORE applyCredentialField, because a clear/rotate
+    // releases the prior vault ref (an irreversible keychain side-effect). If the
+    // guard threw after the release, a rejected request would have already deleted
+    // the live secret while the DB row still pointed at it — a dangling ref.
+    // Validation before side-effects keeps a rejected write fully consistent.
+    if (isRecord(extra) && ("apiKey" in extra || "connectionString" in extra)) {
+      throw new Error(
+        "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, not extra",
+      );
+    }
     // store non-empty (replaces any existing ref with a fresh one) / clear-on-empty
-    // (deletes the config key so hasApiKey reads false) / leave-on-undefined.
+    // (releases the prior vault ref + deletes the config key so hasApiKey reads false)
+    // / leave-on-undefined.
     // applyCredentialField is the single choke point; a real store fails closed when
-    // no vault is injected. Orphaned old refs (on replace or clear) are not deleted
-    // from the vault here — the same deferred cleanup as rotation; the locator is
-    // dropped from config so the data-plane resolver stops using it, and the
-    // plaintext-never-at-rest invariant is unaffected.
-    // In preview mode vault writes are skipped (keychain is not transactional).
+    // no vault is injected. The prior vault ref (on replace or clear) is released
+    // inside applyCredentialField after the new ref is stored (rotate) or before
+    // the key is dropped (clear). The release fires only once the store/validation
+    // above has succeeded.
+    // In preview mode vault writes and releases are skipped (keychain is not transactional).
     await applyCredentialField(
       config,
       "apiKey",
@@ -450,14 +462,8 @@ const setDataSourceConfig = mutation({
       `connectionString-${id}`,
       preview,
     );
-    // Sink guard: callers may not sneak credential keys in via `extra`.
+    // Merge non-credential keys from `extra` into the config (guarded above).
     if (isRecord(extra)) {
-      if ("apiKey" in extra || "connectionString" in extra) {
-        throw new Error(
-          "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, not extra",
-        );
-      }
-      // Merge non-credential keys into the config.
       Object.assign(config, extra);
     }
     await ctx.db.from(dataSources).where(eq("id", id)).update({ config });

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -109,13 +109,19 @@ export async function storeCredential(
 
 /**
  * Release every `SecretRef` present in a `DataSourceConfig` from the vault.
- * Called before a data-source row is deleted so the mapping row and backend
- * blob do not accumulate as permanent orphans in the OS keychain.
+ * Called in three places: (1) before a data-source row is deleted, (2) when a
+ * credential field is cleared (CLEAR branch in {@link applyCredentialField}),
+ * (3) when a credential is overwritten with a new value (ROTATE branch). In all
+ * cases the goal is to avoid orphaned keychain blobs + mapping rows.
+ *
+ * Callers may pass a full config or a single-field slice
+ * (`{ [field]: prior }`); only fields that satisfy {@link isSecretRef} are
+ * included in the delete batch, so an absent or non-ref field is always a no-op.
  *
  * **Vault-absent policy (fail-closed consistency):** `storeCredential` throws
  * when no vault is injected, so a config holding a real `SecretRef` could only
  * have been written with a vault present. If that same vault is absent at
- * delete time — which would be a server mis-configuration — we throw rather
+ * release time — which would be a server mis-configuration — we throw rather
  * than silently leaving an orphan. This keeps the invariant symmetric: the
  * fail-closed store implies a fail-closed delete.
  *
@@ -162,17 +168,37 @@ export async function releaseCredentialRefs(
  * Apply an inbound credential value to a config slice, in place. Three-way:
  *
  *   - `undefined` → leave the existing config key untouched (not part of this write).
- *   - `""`        → CLEAR the credential: delete the key so `hasApiKey` reads false.
+ *   - `""`        → CLEAR the credential: release the prior vault ref (if any),
+ *                   then delete the key so `hasApiKey` reads false.
  *                   (Empty string is an explicit "remove it", never a stored value —
- *                   storing it would make `vault.has(ref)` lie.) The old vault ref
- *                   is orphaned, not deleted — same deferred cleanup as rotation.
- *   - non-empty   → store via the vault and write the returned `SecretRef`.
+ *                   storing it would make `vault.has(ref)` lie.)
+ *   - non-empty   → store via the vault and write the returned `SecretRef`, then
+ *                   release the prior ref so the old keychain blob + mapping row
+ *                   do not accumulate as permanent orphans (rotate path).
+ *
+ * **Release ordering (rotate):** the new ref is stored first, then the old one is
+ * released. This way a failure mid-rotate does not orphan the newly-stored secret;
+ * the worst-case outcome is that the old secret lingers until the next successful
+ * rotate (idempotent cleanup, same as the delete-path guarantee).
+ *
+ * **Preview-mode guard:** vault deletes are keychain side-effects outside the DB
+ * transaction. In preview mode the transaction rolls back, so neither the new store
+ * nor a release of the old ref should touch the keychain. The clear and rotate
+ * release calls are skipped when `preview` is `true`, mirroring the guard that the
+ * DeleteNode / removeDataSource paths apply via `modeFromCtx()`.
+ *
+ * **Vault-absent (clear):** `storeCredential` throws on vault-absent + non-empty
+ * plaintext, so a real `SecretRef` in `config[field]` could only have been written
+ * with a vault present. A clear with no vault and no prior ref is therefore a valid
+ * no-op. `releaseCredentialRefs` early-returns when no `isSecretRef` value is found,
+ * so passing a single-field slice is always safe for an already-absent field.
  *
  * The vault-absent refusal lives in {@link storeCredential}, so a clear (`""`) or
- * an untouched field (`undefined`) does NOT require a vault — only a real store does.
+ * an untouched field (`undefined`) with no prior ref does NOT require a vault.
  *
  * @param preview When `true` (preview-mode execution) the vault write is skipped
  *   and a no-op placeholder ref is stored instead. See {@link storeCredential}.
+ *   Vault releases are also skipped in preview mode.
  */
 export async function applyCredentialField(
   config: DataSourceConfig,
@@ -184,10 +210,22 @@ export async function applyCredentialField(
 ): Promise<void> {
   if (value === undefined) return; // not part of this write
   if (value.length === 0) {
+    // CLEAR branch: release the prior vault ref before dropping the config key.
+    // Only attempted in commit mode — preview transactions roll back and must not
+    // produce keychain side-effects.
+    if (!preview) {
+      await releaseCredentialRefs({ [field]: config[field] }, vault);
+    }
     delete config[field]; // explicit clear
     return;
   }
+  // ROTATE branch: capture prior ref before overwriting, store new first,
+  // then release old (store-new-then-release-old preserves the new secret on failure).
+  const prior = config[field];
   config[field] = await storeCredential(vault, value, locatorHint, preview);
+  if (!preview) {
+    await releaseCredentialRefs({ [field]: prior }, vault);
+  }
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -1189,4 +1189,343 @@ describe("vault lifecycle — preview mode skips vault delete", () => {
       false,
     );
   });
+
+  // Preview-mode guard for the CLEAR and ROTATE branches in applyCredentialField.
+  // The `!preview` guard in applyCredentialField must prevent vault.delete() from firing
+  // in preview mode for SetDataSourceConfig, just as it does for DeleteNode.
+  // These tests use the spy on vault.delete() already set up by this describe's beforeEach.
+
+  it("preview mode — SetDataSourceConfig with apiKey clear never calls vault.delete() (prior ref survives)", async () => {
+    // Arrange: commit a credentialed source so a real SecretRef is live.
+    const id = crypto.randomUUID();
+    await commitApp.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Preview Clear Guard",
+      apiKey: "do-not-release-on-preview-clear",
+    });
+    const configBefore = await readConfig(db, id);
+    const apiKeyRef = configBefore!["apiKey"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    const deleteCountBefore = deleteCallCount;
+
+    // Act: preview a SetDataSourceConfig that clears the apiKey (empty string).
+    // The transaction rolls back, so the DB row is unchanged. More importantly,
+    // the CLEAR branch in applyCredentialField must not call vault.delete() in preview.
+    await buildPreviewDiff(
+      previewApp,
+      db,
+      [cmd("SetDataSourceConfig", { id, apiKey: "" })],
+      { vault },
+    );
+
+    // Assert: the guard fired — vault.delete() was never called during preview.
+    expect(deleteCallCount).toBe(deleteCountBefore);
+    // The canonical row still holds the original ref (rollback preserved it)...
+    const configAfter = await readConfig(db, id);
+    expect(configAfter!["apiKey"]).toBe(apiKeyRef);
+    // ...and the credential is still resolvable (NOT orphaned by the preview clear).
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+  });
+
+  it("preview mode — SetDataSourceConfig with apiKey rotate never calls vault.delete() (prior ref survives)", async () => {
+    // Arrange: commit a credentialed source so a real SecretRef is live.
+    const id = crypto.randomUUID();
+    await commitApp.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Preview Rotate Guard",
+      apiKey: "do-not-release-on-preview-rotate",
+    });
+    const configBefore = await readConfig(db, id);
+    const apiKeyRef = configBefore!["apiKey"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    const deleteCountBefore = deleteCallCount;
+
+    // Act: preview a SetDataSourceConfig that rotates the apiKey to a new value.
+    // The ROTATE branch in applyCredentialField must not call vault.delete() in preview.
+    await buildPreviewDiff(
+      previewApp,
+      db,
+      [cmd("SetDataSourceConfig", { id, apiKey: "rotated-preview-value" })],
+      { vault },
+    );
+
+    // Assert: the guard fired — vault.delete() was never called during preview.
+    expect(deleteCallCount).toBe(deleteCountBefore);
+    // The canonical row still holds the original ref (rollback preserved it)...
+    const configAfter = await readConfig(db, id);
+    expect(configAfter!["apiKey"]).toBe(apiKeyRef);
+    // ...and the credential is still resolvable (NOT orphaned by the preview rotate).
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clear/rotate branches release prior SecretRef (applyCredentialField)
+// ---------------------------------------------------------------------------
+//
+// AC1: store → clear → old ref no longer in vault (vault.has false) + config key absent.
+// AC2: store → rotate → old ref released, new ref resolves (vault.has new=true, old=false).
+// AC3: vault-absent clear with no prior ref is a no-op (no throw).
+//
+// The fix lives in applyCredentialField (utils.ts): CLEAR captures the prior ref,
+// calls releaseCredentialRefs({[field]: prior}, vault) BEFORE deleting the key;
+// ROTATE stores the new ref first, THEN releases the old one (store-new-then-release-old
+// preserves the new secret on mid-rotate failure). Both skipped in preview mode.
+// ---------------------------------------------------------------------------
+
+describe("vault lifecycle: clear releases prior SecretRef (AC1)", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  let vault: SecretVault;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-vault-clear-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault } = makeTestVault());
+    const rawApp = await createWyStack({ db, functions });
+    app = {
+      ...rawApp,
+      async call(path, args, ctx) {
+        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("AC1 — store credential → clear it → old SecretRef is released from vault and config key is absent", async () => {
+    // Arrange: create a source with an apiKey so a real SecretRef is minted.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Clear Me",
+      apiKey: "clear-this-secret",
+    });
+    const configBefore = await readConfig(db, id);
+    const oldRef = configBefore!["apiKey"] as string;
+    expect(isSecretRef(oldRef)).toBe(true);
+    expect(await vault.has(oldRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: clear the credential by passing an empty string.
+    await app.call("setDataSourceConfig", { id, apiKey: "" });
+
+    // Assert AC1a: the old ref is no longer in the vault.
+    expect(await vault.has(oldRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+    // Assert AC1b: the config key is absent (not just null/undefined in jsonb).
+    const configAfter = await readConfig(db, id);
+    expect(configAfter!["apiKey"]).toBeUndefined();
+  });
+
+  it("a rejected clear (extra-key sink-guard fires) does NOT release the prior ref — validation runs before the irreversible vault.delete", async () => {
+    // Regression: the sink-guard that rejects credential keys in `extra` must run
+    // BEFORE applyCredentialField does the vault release. Otherwise a request that
+    // clears apiKey AND smuggles apiKey via `extra` would delete the live secret,
+    // then throw — leaving the surviving DB row pointing at a now-dead ref.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Reject Me",
+      apiKey: "must-survive-a-rejected-write",
+    });
+    const configBefore = await readConfig(db, id);
+    const oldRef = configBefore!["apiKey"] as string;
+    expect(isSecretRef(oldRef)).toBe(true);
+    expect(await vault.has(oldRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: clear apiKey while illegally smuggling apiKey through `extra`.
+    await expect(
+      app.call("setDataSourceConfig", {
+        id,
+        apiKey: "",
+        extra: { apiKey: "sneaky" },
+      }),
+    ).rejects.toThrow(/typed credential fields/i);
+
+    // Assert: the guard rejected before any release fired — the prior ref is intact
+    // and the DB row still references it (consistent, no dangling pointer).
+    expect(await vault.has(oldRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    const configAfter = await readConfig(db, id);
+    expect(configAfter!["apiKey"]).toBe(oldRef);
+  });
+
+  it("clearing apiKey releases ONLY the apiKey ref — the connectionString sibling stays live in the vault", async () => {
+    // Single-field scope: applyCredentialField passes { [field]: prior } to
+    // releaseCredentialRefs, so clearing one credential must not touch the other.
+    // This is the regression fence for the single-field slice — a full-config
+    // release would wrongly delete the sibling's vault entry.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "postgres",
+      name: "Both Creds",
+      apiKey: "the-api-key",
+      connectionString: "postgresql://u:p@h/db",
+    });
+    const configBefore = await readConfig(db, id);
+    const apiKeyRef = configBefore!["apiKey"] as string;
+    const csRef = configBefore!["connectionString"] as string;
+    expect(isSecretRef(apiKeyRef)).toBe(true);
+    expect(isSecretRef(csRef)).toBe(true);
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    expect(await vault.has(csRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: clear ONLY apiKey.
+    await app.call("setDataSourceConfig", { id, apiKey: "" });
+
+    // Assert: apiKey ref released, connectionString ref untouched (vault + config).
+    expect(await vault.has(apiKeyRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+    expect(await vault.has(csRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+    const configAfter = await readConfig(db, id);
+    expect(configAfter!["apiKey"]).toBeUndefined();
+    expect(configAfter!["connectionString"]).toBe(csRef);
+  });
+});
+
+describe("vault lifecycle: rotate releases prior SecretRef (AC2)", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  let vault: SecretVault;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-vault-rotate-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault } = makeTestVault());
+    const rawApp = await createWyStack({ db, functions });
+    app = {
+      ...rawApp,
+      async call(path, args, ctx) {
+        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      },
+      async runHandler(path, args, tracked, ctx) {
+        return rawApp.runHandler(path, args, tracked, {
+          ...(ctx ?? {}),
+          vault,
+        });
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("AC2 — store credential → rotate to new value → old ref released, new ref resolves", async () => {
+    // Arrange: create a source with an initial apiKey.
+    const id = crypto.randomUUID();
+    await app.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Rotate Me",
+      apiKey: "original-secret",
+    });
+    const configBefore = await readConfig(db, id);
+    const oldRef = configBefore!["apiKey"] as string;
+    expect(isSecretRef(oldRef)).toBe(true);
+    expect(await vault.has(oldRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+
+    // Act: rotate to a new credential value.
+    await app.call("setDataSourceConfig", { id, apiKey: "rotated-secret" });
+
+    // Assert AC2a: old ref is released from the vault.
+    expect(await vault.has(oldRef as Parameters<typeof vault.has>[0])).toBe(
+      false,
+    );
+    // Assert AC2b: the new ref is live and distinct from the old one.
+    const configAfter = await readConfig(db, id);
+    const newRef = configAfter!["apiKey"] as string;
+    expect(isSecretRef(newRef)).toBe(true);
+    expect(newRef).not.toBe(oldRef);
+    expect(await vault.has(newRef as Parameters<typeof vault.has>[0])).toBe(
+      true,
+    );
+  });
+});
+
+describe("vault lifecycle: vault-absent clear is a no-op (AC3)", () => {
+  // AC3 unit anchor: the underlying releaseCredentialRefs early-return semantics.
+  it("AC3 unit — releaseCredentialRefs with no prior ref and no vault does not throw (early-return)", async () => {
+    // releaseCredentialRefs early-returns when refs.length === 0, so no vault is
+    // consulted. This pins the primitive that applyCredentialField relies on for AC3.
+    await expect(
+      releaseCredentialRefs({ apiKey: undefined }, undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  // AC3 end-to-end: applyCredentialField with value="" on a source with no prior
+  // credential, no vault injected. The full path: handler → applyCredentialField →
+  // CLEAR branch → releaseCredentialRefs({apiKey: undefined}, undefined) → early-return.
+  it("AC3 e2e — setDataSourceConfig with apiKey clear on a no-credential source succeeds with no vault injected", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dashframe-vault-ac3-"));
+    const db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    // No vault injected — this is a vault-absent server.
+    const app = await createWyStack({ db, functions });
+
+    try {
+      // Arrange: create a source with no credential (allowed without vault).
+      const id = crypto.randomUUID();
+      await app.call("createDataSource", {
+        id,
+        type: "csv",
+        name: "AC3 Source",
+      });
+      const configBefore = await readConfig(db, id);
+      expect(configBefore!["apiKey"]).toBeUndefined(); // confirm no prior ref
+
+      // Act: clear the (already-absent) apiKey with no vault. Must not throw.
+      await expect(
+        app.call("setDataSourceConfig", { id, apiKey: "" }),
+      ).resolves.toBeDefined();
+
+      // Assert: config still has no apiKey (clear on absent field is a no-op).
+      const configAfter = await readConfig(db, id);
+      expect(configAfter!["apiKey"]).toBeUndefined();
+    } finally {
+      await db.$client.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`applyCredentialField` (`apps/server/src/functions/utils.ts`) dropped or overwrote a credential's `SecretRef` in config without releasing the prior vault secret on the **clear** and **rotate** paths — leaving an orphaned keychain blob + mapping row. This mirrors the DELETE-path release (`releaseCredentialRefs` / `vault.delete`) that #156-era YW-268 already shipped, applied to the two sibling sinks.

## Changes

- **CLEAR branch** (credential → empty, ref dropped): release the prior ref **before** dropping it from config.
- **ROTATE branch** (credential overwritten): store the **new** ref first, **then** release the old (store-new-then-release-old, so a mid-rotate failure can't orphan the newly-stored secret).
- **Preview-mode guard**: both release calls are skipped when `preview` is true — keychain deletes are side-effects outside the rollback-able DB transaction, mirroring the DeleteNode/removeDataSource guard.
- Release is scoped to a **single-field slice** (`{ [field]: prior }`) so clearing `apiKey` never touches the `connectionString` sibling.
- Vault-absent + no real ref stays a no-op via `releaseCredentialRefs`' `isSecretRef` early-return.

## Verified DoD (the 3 ACs as tests)

- **AC1** — store → clear → old `SecretRef` no longer resolves (`vault.has(oldRef)` false) + config key absent.
- **AC2** — store → rotate → old ref released, new ref resolves.
- **AC3** — vault-absent clear with no prior ref is a no-op (no throw) — unit + end-to-end.
- Plus **preview-mode regression guards** for clear and rotate (`vault.delete` must not fire on a previewed `SetDataSourceConfig`).

Local gate: full-graph typecheck (46 tasks, 0 errors), lint (clean), format (clean), `@dashframe/server` tests 277/277 pass.

Tracked internally as YW-301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the vault-orphan gap for the **clear** and **rotate** paths in `applyCredentialField`: the prior `SecretRef` is now released before the config key is dropped (CLEAR) or after the new ref is stored (ROTATE), mirroring the delete-path cleanup already in place. The sink guard in `setDataSourceConfig` is also moved before the `applyCredentialField` calls so a validation failure can no longer fire after an irreversible keychain side-effect.

- **`utils.ts`**: `applyCredentialField` now captures the prior ref, releases it via a single-field `releaseCredentialRefs` slice (so clearing `apiKey` cannot touch `connectionString`), and skips the release in preview mode where the DB transaction rolls back.
- **`commands.ts`**: The credential-key sink guard is hoisted above the two `applyCredentialField` calls, preventing a rejected write from reaching the vault at all.
- **`vault-control-plane.test.ts`**: 343 lines of new tests cover AC1 (clear releases prior ref), AC2 (rotate releases old / new ref lives), AC3 (vault-absent no-op), and preview-mode regression guards for both CLEAR and ROTATE branches; no ticket IDs remain in source.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to releasing prior vault refs on clear/rotate, the sink-guard reordering is strictly defensive, and the known store-new-then-release-old trade-off is intentional and documented.

The three changed files are tightly coupled and all changes are consistent: the release logic is correctly gated on !preview, scoped to a single-field slice to avoid cross-credential interference, and ordered to favour the new entry over the old on mid-rotate failure. The moved sink guard eliminates the only path where a validation rejection could follow a vault side-effect. Test coverage directly exercises each acceptance criterion. No new correctness gaps were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/utils.ts | Adds CLEAR and ROTATE vault-release logic to `applyCredentialField`: captures prior ref, releases it (skipping in preview mode), scoped to a single-field slice to avoid touching sibling credentials. Logic and documentation are correct. |
| apps/server/src/functions/commands.ts | Moves the credential-key sink guard to run before `applyCredentialField` calls, preventing the guard from throwing after a vault release has already fired; the reordering is correct and well-motivated. |
| apps/server/src/functions/vault-control-plane.test.ts | Adds 343 lines of targeted tests covering AC1 (clear releases prior ref), AC2 (rotate releases old ref, new ref lives), AC3 (vault-absent clear is a no-op), and preview-mode guards for both CLEAR and ROTATE branches. No ticket IDs in source. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(server): release prior SecretRef on ..."](https://github.com/youhaowei/dashframe/commit/ea49845d81f02a352eb09a5d2c28f516c52e2e89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39740337)</sub>

<!-- /greptile_comment -->