### PR TITLE
[YW-303] Stabilize group/cache key generation in compute-preview + hook async state

### DIFF
--- a/packages/app/src/hooks/useDataFrameData.test.tsx
+++ b/packages/app/src/hooks/useDataFrameData.test.tsx
@@ -732,6 +732,81 @@ describe("useDataFrameData", () => {
     });
   });
 
+  describe("stale-state guard (input change mid-flight)", () => {
+    it("discards in-flight result from A when dataFrameId changes to B before A resolves", async () => {
+      // A resolves slowly; B resolves fast.
+      // After B settles, releasing A must not overwrite B's data.
+      let resolveA!: (value: unknown) => void;
+      const slowLoadA = new Promise((res) => {
+        resolveA = res;
+      });
+
+      const rowsA = [{ id: "a", name: "Alpha" }];
+      const rowsB = [{ id: "b", name: "Beta" }];
+
+      const dfA = {
+        id: "df-a",
+        load: vi.fn().mockReturnValue(
+          slowLoadA.then(() => ({
+            limit: vi.fn().mockReturnThis(),
+            sql: vi.fn().mockResolvedValue("SELECT * FROM a"),
+          })),
+        ),
+      };
+      const dfB = {
+        id: "df-b",
+        load: vi.fn().mockResolvedValue({
+          limit: vi.fn().mockReturnThis(),
+          sql: vi.fn().mockResolvedValue("SELECT * FROM b"),
+        }),
+      };
+
+      mockGetDataFrame.mockImplementation((id: string) => {
+        if (id === "df-a") return Promise.resolve(dfA);
+        if (id === "df-b") return Promise.resolve(dfB);
+        return Promise.resolve(null);
+      });
+
+      // Route by SQL so the guard is observable: if A's stale continuation
+      // were allowed to run, it would call query("SELECT * FROM a") and write
+      // rowsA, failing the final toEqual(rowsB) assertion.
+      mockQuery.mockImplementation((sql: string) => {
+        if (sql.includes("FROM a"))
+          return Promise.resolve(createMockQueryResult(rowsA));
+        return Promise.resolve(createMockQueryResult(rowsB));
+      });
+
+      const { result, rerender } = renderHook(
+        ({ id }) => useDataFrameData(id),
+        { initialProps: { id: "df-a" as string } },
+      );
+
+      // A's getDataFrame resolves immediately but A's load() is stuck in slowLoadA.
+      // Switch to B before A's load resolves.
+      rerender({ id: "df-b" });
+
+      // Wait for B to settle (B loads instantly).
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // B's data should be present.
+      expect(result.current.data?.rows).toEqual(rowsB);
+
+      // Now release A's slow load. A must not overwrite B's state.
+      await act(async () => {
+        resolveA(undefined);
+      });
+
+      // Give the event loop a few cycles to let A's continuation run.
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Still B's data — A's stale result was discarded.
+      expect(result.current.data?.rows).toEqual(rowsB);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
   describe("hook stability", () => {
     it("should return stable reload function reference", async () => {
       const mockRows = [{ id: 1 }];

--- a/packages/app/src/hooks/useDataFrameData.ts
+++ b/packages/app/src/hooks/useDataFrameData.ts
@@ -128,6 +128,13 @@ export function useDataFrameData(
       isDuckDBLoading ||
       skip
     ) {
+      // Bump the token even on the skip path. If the hook flips to skipped /
+      // no-id while a prior load is in flight (e.g. dataFrameId cleared or
+      // skip toggled true on a mounted component), incrementing here means the
+      // in-flight load's token check (currentLoadCount === loadCountRef.current)
+      // now fails, so its resolved-but-stale result is discarded instead of
+      // landing over the skipped state.
+      ++loadCountRef.current;
       return;
     }
 

--- a/packages/app/src/hooks/useDataFrameData.ts
+++ b/packages/app/src/hooks/useDataFrameData.ts
@@ -131,19 +131,22 @@ export function useDataFrameData(
       return;
     }
 
-    const dataFrame = await getDataFrame(dataFrameId);
-    if (!dataFrame) {
-      setError(`DataFrame not found: ${dataFrameId}`);
-      setData(null);
-      setIsLoading(false);
-      return;
-    }
-
-    // Increment load count to track this specific load operation
+    // Capture the generation token BEFORE the first await so that any
+    // in-flight request from a superseded dataFrameId can be discarded.
     const currentLoadCount = ++loadCountRef.current;
 
     setIsLoading(true);
     setError(null);
+
+    const dataFrame = await getDataFrame(dataFrameId);
+    if (!dataFrame) {
+      if (currentLoadCount === loadCountRef.current) {
+        setError(`DataFrame not found: ${dataFrameId}`);
+        setData(null);
+        setIsLoading(false);
+      }
+      return;
+    }
 
     try {
       // Wait for any existing load of this DataFrame to complete (mutex)

--- a/packages/app/src/hooks/useDataFramePagination.ts
+++ b/packages/app/src/hooks/useDataFramePagination.ts
@@ -2,7 +2,7 @@ import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame, useDataFrames } from "@dashframe/core";
 import type { UUID } from "@dashframe/types";
 import type { FetchDataParams, FetchDataResult } from "@dashframe/ui";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Hook for paginated DataFrame queries via DuckDB
@@ -38,6 +38,10 @@ export function useDataFramePagination(dataFrameId: UUID | undefined) {
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Generation counter: incremented on every effect run so stale async
+  // completions from a superseded dataFrameId never overwrite current state.
+  const genRef = useRef(0);
+
   // Fetch total count and column info on mount
   useEffect(() => {
     if (!dataFrameId || !connection || !isInitialized || isDuckDBLoading) {
@@ -45,9 +49,14 @@ export function useDataFramePagination(dataFrameId: UUID | undefined) {
       return;
     }
 
+    // Capture token before the first await — any earlier in-flight init that
+    // resolves after this point will see a stale token and discard its results.
+    const gen = ++genRef.current;
+
     const init = async () => {
       try {
         const dataFrame = await getDataFrame(dataFrameId);
+        if (gen !== genRef.current) return; // superseded
         if (!dataFrame) {
           setError(`DataFrame not found: ${dataFrameId}`);
           setIsReady(false);
@@ -56,32 +65,41 @@ export function useDataFramePagination(dataFrameId: UUID | undefined) {
 
         // Load table into DuckDB and get count
         const queryBuilder = await dataFrame.load(connection);
+        if (gen !== genRef.current) return; // superseded
 
         // Get total count
         const countSql = `SELECT COUNT(*) as count FROM (${await queryBuilder.sql()})`;
         const countResult = await connection.query(countSql);
+        if (gen !== genRef.current) return; // superseded
         const count = Number(countResult.toArray()[0]?.count ?? 0);
         setTotalCount(count);
 
         // Get column info from first row
         const previewSql = await queryBuilder.limit(1).sql();
         const previewResult = await connection.query(previewSql);
+        if (gen !== genRef.current) return; // superseded
         const rows = previewResult.toArray() as Record<string, unknown>[];
 
         if (rows.length > 0) {
           const cols = Object.keys(rows[0]!)
             .filter((key) => !key.startsWith("_"))
             .map((name) => ({ name }));
-          requestAnimationFrame(() => setColumns(cols));
+          requestAnimationFrame(() => {
+            if (gen !== genRef.current) return; // superseded inside rAF
+            setColumns(cols);
+          });
         }
 
         requestAnimationFrame(() => {
+          if (gen !== genRef.current) return; // superseded inside rAF
           setIsReady(true);
           setError(null);
         });
       } catch (err) {
         console.error("Failed to initialize DataFrame pagination:", err);
+        if (gen !== genRef.current) return; // superseded
         requestAnimationFrame(() => {
+          if (gen !== genRef.current) return; // superseded inside rAF
           setError(err instanceof Error ? err.message : "Failed to initialize");
           setIsReady(false);
         });

--- a/packages/app/src/hooks/useDataFramePagination.ts
+++ b/packages/app/src/hooks/useDataFramePagination.ts
@@ -45,6 +45,12 @@ export function useDataFramePagination(dataFrameId: UUID | undefined) {
   // Fetch total count and column info on mount
   useEffect(() => {
     if (!dataFrameId || !connection || !isInitialized || isDuckDBLoading) {
+      // Bump the token on the skip path too. If the hook flips to skipped /
+      // no-id while a prior init is in flight (dataFrameId cleared, or DuckDB
+      // goes unavailable on a mounted component), incrementing here invalidates
+      // that in-flight init's gen check so its stale result is discarded
+      // instead of landing over the now-skipped state.
+      ++genRef.current;
       requestAnimationFrame(() => setIsReady(false));
       return;
     }

--- a/packages/app/src/hooks/useInsightPagination.test.tsx
+++ b/packages/app/src/hooks/useInsightPagination.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for useInsightPagination hook — stale-state guard
+ *
+ * The critical invariant: when the insight config changes (or the hook is
+ * re-rendered with a new insight) before the previous async init completes,
+ * only the NEW config's data (totalCount, isReady) must be exposed.  The
+ * previous in-flight init must detect it was superseded and discard its
+ * results without calling setState.
+ *
+ * Contract under test:
+ *   render with insight A (slow init) → re-render with insight B (fast init)
+ *   → B settles first → release A → only B's count/readiness is visible; A's
+ *   data never surfaces.
+ */
+import type { DataTable, Insight } from "@dashframe/types";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useInsightPagination } from "./useInsightPagination";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockConnection, mockUseDuckDB } = vi.hoisted(() => {
+  const query = vi.fn();
+  return {
+    mockConnection: { query },
+    mockUseDuckDB: vi.fn(),
+  };
+});
+
+vi.mock("@/components/providers/DuckDBProvider", () => ({
+  useDuckDB: () => mockUseDuckDB(),
+}));
+
+const { mockGetDataFrame, mockGetDataTable } = vi.hoisted(() => ({
+  mockGetDataFrame: vi.fn(),
+  mockGetDataTable: vi.fn(),
+}));
+
+vi.mock("@dashframe/core", () => ({
+  getDataFrame: mockGetDataFrame,
+  getDataTable: mockGetDataTable,
+}));
+
+const { mockBuildInsightSQL, mockEnsureTableLoaded } = vi.hoisted(() => ({
+  mockBuildInsightSQL: vi.fn(),
+  mockEnsureTableLoaded: vi.fn(),
+}));
+
+vi.mock("@dashframe/engine-browser", () => ({
+  ensureTableLoaded: (...args: unknown[]) => mockEnsureTableLoaded(...args),
+  buildInsightSQL: (...args: unknown[]) => mockBuildInsightSQL(...args),
+  fieldIdToColumnAlias: (id: string) => `field_${id.replace(/-/g, "_")}`,
+  metricIdToColumnAlias: (id: string) => `metric_${id.replace(/-/g, "_")}`,
+}));
+
+// engine exports used by the hook at import time
+vi.mock("@dashframe/engine", () => ({
+  buildInsightSQL: (...args: unknown[]) => mockBuildInsightSQL(...args),
+  fieldIdToColumnAlias: (id: string) => `field_${id.replace(/-/g, "_")}`,
+  metricIdToColumnAlias: (id: string) => `metric_${id.replace(/-/g, "_")}`,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeInsight(id: string, tableId: string): Insight {
+  return {
+    id,
+    name: `Insight ${id}`,
+    baseTableId: tableId,
+    selectedFields: [],
+    metrics: [],
+    createdAt: 0,
+  };
+}
+
+function makeDataTable(id: string, dfId: string): DataTable {
+  return {
+    id,
+    name: `Table ${id}`,
+    dataSourceId: "ds-1",
+    table: `tbl_${id}`,
+    dataFrameId: dfId,
+    fields: [],
+    metrics: [],
+    createdAt: 0,
+  };
+}
+
+function makeDataFrame(id: string) {
+  return {
+    id,
+    storage: { type: "indexeddb" as const, key: `df_${id}` },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useInsightPagination — stale-state guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockUseDuckDB.mockReturnValue({
+      connection: mockConnection,
+      isInitialized: true,
+      isLoading: false,
+    });
+
+    mockEnsureTableLoaded.mockResolvedValue(undefined);
+  });
+
+  it("discards A's in-flight init when insight changes to B before A resolves", async () => {
+    // Insight A's resolveTables (getDataTable) is artificially slow.
+    // Insight B resolves instantly.
+    // After B settles, releasing A must NOT overwrite totalCount or isReady.
+    const tableA = makeDataTable("tbl-a", "df-a");
+    const tableB = makeDataTable("tbl-b", "df-b");
+    const dfA = makeDataFrame("df-a");
+    const dfB = makeDataFrame("df-b");
+    const insightA = makeInsight("ins-a", "tbl-a");
+    const insightB = makeInsight("ins-b", "tbl-b");
+
+    let resolveTableA!: (value: DataTable) => void;
+    const slowTableAPromise = new Promise<DataTable>((res) => {
+      resolveTableA = res;
+    });
+
+    mockGetDataTable.mockImplementation((id: string) => {
+      if (id === "tbl-a") return slowTableAPromise;
+      if (id === "tbl-b") return Promise.resolve(tableB);
+      return Promise.resolve(null);
+    });
+
+    mockGetDataFrame.mockImplementation((id: string) => {
+      if (id === "df-a") return Promise.resolve(dfA);
+      if (id === "df-b") return Promise.resolve(dfB);
+      return Promise.resolve(null);
+    });
+
+    // B's count SQL returns 42; A's would return 99 (should never be seen)
+    mockBuildInsightSQL.mockImplementation(
+      (_baseTable: DataTable, _joinedTables: unknown, insight: Insight) => {
+        return insight.id === "ins-b"
+          ? "SELECT 1 FROM tbl_b"
+          : "SELECT 1 FROM tbl_a";
+      },
+    );
+
+    mockConnection.query = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes("tbl_b")) {
+        return Promise.resolve({
+          toArray: () => [{ count: BigInt(42) }],
+        });
+      }
+      // A's queries — should never reach here in the guarded scenario
+      return Promise.resolve({
+        toArray: () => [{ count: BigInt(99) }],
+      });
+    });
+
+    const { result, rerender } = renderHook(
+      ({ insight }: { insight: Insight }) => useInsightPagination({ insight }),
+      { initialProps: { insight: insightA } },
+    );
+
+    // A's init is stuck at getDataTable("tbl-a"). Switch to B immediately.
+    rerender({ insight: insightB });
+
+    // Wait for B to settle fully.
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+
+    expect(result.current.totalCount).toBe(42);
+
+    // Now release A's slow getDataTable — A's continuation must be discarded.
+    await act(async () => {
+      resolveTableA(tableA);
+    });
+
+    // Give the event loop time to let A's continuation run if it weren't guarded.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // B's state must be intact — A's stale result was discarded.
+    expect(result.current.totalCount).toBe(42);
+    expect(result.current.isReady).toBe(true);
+  });
+});

--- a/packages/app/src/hooks/useInsightPagination.test.tsx
+++ b/packages/app/src/hooks/useInsightPagination.test.tsx
@@ -143,14 +143,14 @@ describe("useInsightPagination — stale-state guard", () => {
       return Promise.resolve(null);
     });
 
-    // B's count SQL returns 42; A's would return 99 (should never be seen)
-    mockBuildInsightSQL.mockImplementation(
-      (_baseTable: DataTable, _joinedTables: unknown, insight: Insight) => {
-        return insight.id === "ins-b"
-          ? "SELECT 1 FROM tbl_b"
-          : "SELECT 1 FROM tbl_a";
-      },
-    );
+    // Discriminate the built SQL on the BASE TABLE actually passed in (not the
+    // insight id), so a fetchData that reads a corrupted resolvedTablesRef
+    // (holding A's table) is detectable: it would build SQL against tbl_a.
+    mockBuildInsightSQL.mockImplementation((baseTable: DataTable) => {
+      return baseTable.id === "tbl-b"
+        ? "SELECT 1 FROM tbl_b"
+        : "SELECT 1 FROM tbl_a";
+    });
 
     mockConnection.query = vi.fn().mockImplementation((sql: string) => {
       if (sql.includes("tbl_b")) {
@@ -190,6 +190,23 @@ describe("useInsightPagination — stale-state guard", () => {
     // B's state must be intact — A's stale result was discarded.
     expect(result.current.totalCount).toBe(42);
     expect(result.current.isReady).toBe(true);
+
+    // Cache-corruption guard: A's released init must NOT have written its tables
+    // into resolvedTablesRef (the cache write is now behind the gen check). A
+    // subsequent fetchData reuses that cache, so it must build SQL against B's
+    // table (tbl_b), never A's (tbl_a). Without the gen-guarded cache write, A's
+    // resolveTables side-effect would have overwritten the ref and fetchData
+    // would query tbl_a here.
+    const queriedSqls: string[] = [];
+    mockConnection.query = vi.fn().mockImplementation((sql: string) => {
+      queriedSqls.push(sql);
+      return Promise.resolve({ toArray: () => [] });
+    });
+    await act(async () => {
+      await result.current.fetchData({ offset: 0, limit: 10 });
+    });
+    expect(queriedSqls.some((sql) => sql.includes("tbl_b"))).toBe(true);
+    expect(queriedSqls.some((sql) => sql.includes("tbl_a"))).toBe(false);
   });
 
   it("discards an in-flight init when `enabled` flips false before it resolves", async () => {

--- a/packages/app/src/hooks/useInsightPagination.test.tsx
+++ b/packages/app/src/hooks/useInsightPagination.test.tsx
@@ -191,4 +191,51 @@ describe("useInsightPagination — stale-state guard", () => {
     expect(result.current.totalCount).toBe(42);
     expect(result.current.isReady).toBe(true);
   });
+
+  it("discards an in-flight init when `enabled` flips false before it resolves", async () => {
+    // Reachable path: VisualizationDisplay passes `enabled: !!insightForView`,
+    // so a mounted component can flip enabled true→false while an init is in
+    // flight (the insight clears). The skip branch must invalidate the
+    // in-flight init's generation token so its stale count/readiness never land.
+    const tableA = makeDataTable("tbl-a", "df-a");
+    const dfA = makeDataFrame("df-a");
+    const insightA = makeInsight("ins-a", "tbl-a");
+
+    let resolveTableA!: (value: DataTable) => void;
+    const slowTableAPromise = new Promise<DataTable>((res) => {
+      resolveTableA = res;
+    });
+
+    mockGetDataTable.mockImplementation((id: string) =>
+      id === "tbl-a" ? slowTableAPromise : Promise.resolve(null),
+    );
+    mockGetDataFrame.mockImplementation((id: string) =>
+      id === "df-a" ? Promise.resolve(dfA) : Promise.resolve(null),
+    );
+    mockBuildInsightSQL.mockReturnValue("SELECT 1 FROM tbl_a");
+    // If A's init were ever allowed to complete, it would set count=99 / ready.
+    mockConnection.query = vi.fn().mockResolvedValue({
+      toArray: () => [{ count: BigInt(99) }],
+    });
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useInsightPagination({ insight: insightA, enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    // A's init is stuck at getDataTable("tbl-a"). Disable the hook mid-flight.
+    rerender({ enabled: false });
+
+    // Release A's slow getDataTable — its continuation must be discarded
+    // because the !enabled re-render bumped the generation token.
+    await act(async () => {
+      resolveTableA(tableA);
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The disabled hook must expose neither A's count nor a ready state.
+    expect(result.current.totalCount).toBe(0);
+    expect(result.current.isReady).toBe(false);
+  });
 });

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -236,6 +236,7 @@ export function useInsightPagination({
     // resolves after this point will see a stale token and discard its results.
     const gen = ++genRef.current;
 
+    // eslint-disable-next-line sonarjs/cognitive-complexity -- defensive stale-state guards (gen checks) after every await legitimately raise complexity; extracting further would obscure the guard pattern
     const init = async () => {
       try {
         // Resolve tables

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -88,6 +88,10 @@ export function useInsightPagination({
   const [error, setError] = useState<string | null>(null);
   const [resolvedFields, setResolvedFields] = useState<Field[]>([]);
 
+  // Generation counter: incremented on every init effect run so stale async
+  // completions from a superseded insight config never overwrite current state.
+  const genRef = useRef(0);
+
   // Cache resolved tables to avoid re-fetching
   const resolvedTablesRef = useRef<{
     baseTable: DataTable | null;
@@ -185,7 +189,9 @@ export function useInsightPagination({
 
       const baseDataFrame = await getDataFrame(baseTable.dataFrameId);
       if (!baseDataFrame) {
-        setError(`Base DataFrame not found: ${baseTable.dataFrameId}`);
+        // Do not call setError here — loadDataFrames has no access to the
+        // caller's generation token. The caller (init) checks the token after
+        // awaiting this function and emits the error there.
         return false;
       }
 
@@ -226,10 +232,15 @@ export function useInsightPagination({
       return;
     }
 
+    // Capture token before the first await — any earlier in-flight init that
+    // resolves after this point will see a stale token and discard its results.
+    const gen = ++genRef.current;
+
     const init = async () => {
       try {
         // Resolve tables
         const { baseTable, joinedTables, allFields } = await resolveTables();
+        if (gen !== genRef.current) return; // superseded
         if (!baseTable) {
           setError("Base table not found");
           setIsReady(false);
@@ -239,9 +250,13 @@ export function useInsightPagination({
         // Store resolved fields for display name mapping
         setResolvedFields(allFields);
 
-        // Load DataFrames into DuckDB
+        // Load DataFrames into DuckDB.
+        // Error messages from failed loads are emitted HERE (after the gen check)
+        // rather than inside loadDataFrames, which has no access to the gen token.
         const loaded = await loadDataFrames(baseTable, joinedTables);
+        if (gen !== genRef.current) return; // superseded
         if (!loaded) {
+          setError(`Failed to load DataFrames for table: ${baseTable.id}`);
           setIsReady(false);
           return;
         }
@@ -272,6 +287,7 @@ export function useInsightPagination({
         // Execute count query
         const countQuery = `SELECT COUNT(*) as count FROM (${countSQL})`;
         const countResult = await connection.query(countQuery);
+        if (gen !== genRef.current) return; // superseded
         const count = Number(countResult.toArray()[0]?.count ?? 0);
         setTotalCount(count);
 
@@ -284,6 +300,7 @@ export function useInsightPagination({
 
         if (previewSQL) {
           const previewResult = await connection.query(previewSQL);
+          if (gen !== genRef.current) return; // superseded
           const rows = previewResult.toArray() as Record<string, unknown>[];
 
           if (rows.length > 0) {
@@ -291,6 +308,7 @@ export function useInsightPagination({
               .filter((key) => !key.startsWith("_"))
               .map((name) => ({ name }));
             requestAnimationFrame(() => {
+              if (gen !== genRef.current) return; // superseded inside rAF
               setColumns(cols);
               setFieldCount(cols.length);
             });
@@ -298,12 +316,15 @@ export function useInsightPagination({
         }
 
         requestAnimationFrame(() => {
+          if (gen !== genRef.current) return; // superseded inside rAF
           setIsReady(true);
           setError(null);
         });
       } catch (err) {
         console.error("Failed to initialize insight pagination:", err);
+        if (gen !== genRef.current) return; // superseded
         requestAnimationFrame(() => {
+          if (gen !== genRef.current) return; // superseded inside rAF
           setError(err instanceof Error ? err.message : "Failed to initialize");
           setIsReady(false);
         });

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -123,8 +123,12 @@ export function useInsightPagination({
       }
     });
 
-    // Cache for later use
-    resolvedTablesRef.current = { baseTable, joinedTables };
+    // NOTE: the cache write (resolvedTablesRef.current = ...) is intentionally
+    // NOT done here. Writing the cache inside resolveTables() — before any
+    // generation check — would allow a stale init for insight A to overwrite
+    // the cache after insight B's init has already populated it, corrupting
+    // subsequent fetchData calls with A's table references.
+    // The caller (init) writes the cache after its generation check passes.
 
     // Collect all fields from base + joined tables
     const allFields: Field[] = [
@@ -247,6 +251,10 @@ export function useInsightPagination({
           setIsReady(false);
           return;
         }
+
+        // Write the table cache AFTER the gen check so a stale init for insight A
+        // cannot overwrite the cache that a faster init for insight B already set.
+        resolvedTablesRef.current = { baseTable, joinedTables };
 
         // Store resolved fields for display name mapping
         setResolvedFields(allFields);

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -226,12 +226,20 @@ export function useInsightPagination({
 
   // Initialize: resolve tables, load DataFrames, get count
   useEffect(() => {
-    // Skip initialization if hook is disabled (lazy loading optimization)
+    // Skip initialization if hook is disabled (lazy loading optimization).
+    // Bump the token on this path too: if `enabled` flips false while a prior
+    // init is in flight (e.g. the insight clears on a mounted VisualizationDisplay),
+    // incrementing here invalidates that in-flight init's gen check so its stale
+    // result is discarded instead of landing over the now-disabled state.
     if (!enabled) {
+      ++genRef.current;
       return;
     }
 
     if (!connection || !isInitialized || isDuckDBLoading) {
+      // Same rationale for the not-ready path: bump so an in-flight init from a
+      // moment when DuckDB WAS ready cannot land after it goes unavailable.
+      ++genRef.current;
       requestAnimationFrame(() => setIsReady(false));
       return;
     }

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -256,13 +256,17 @@ export function useInsightView(
   // from superseded configs can discard their setState calls rather than
   // overwriting the state that a newer config already wrote.
   //
-  // Updated synchronously during render (not inside an effect) so it always
-  // reflects the latest configKey at the time any async continuation resumes.
-  // This is safe because configKey is derived from stable primitives (insightId,
-  // joinsKey, effectiveFiltersKey) and does not change between renders unless
-  // the insight config genuinely changed.
+  // Updated inside a useEffect (declared before the createView effect so it
+  // runs first each render) rather than synchronously during render, which
+  // avoids the react-compiler lint rule against ref mutation during render.
+  // By the time any async continuation from a prior render resumes, this
+  // effect has already fired and the ref reflects the current configKey.
   const currentConfigKeyRef = useRef<string | null>(configKey);
-  currentConfigKeyRef.current = configKey;
+  // Sync the ref to the current configKey after every render. Declared before
+  // the createView effect so React fires this first when both deps change.
+  useEffect(() => {
+    currentConfigKeyRef.current = configKey;
+  });
 
   // Check module-level cache for existing view (survives Strict Mode remounts)
   const cachedView = configKey
@@ -365,6 +369,7 @@ export function useInsightView(
     // buildViewSQLOptions — so only filters are snapshotted here.
     const snapshotEffectiveFilters = effectiveParams?.filters ?? null;
 
+    // eslint-disable-next-line sonarjs/cognitive-complexity -- defensive stale-state guards (currentConfigKeyRef checks) after every await legitimately raise complexity; extracting further would obscure the guard pattern
     const createView = async () => {
       try {
         // Double-check cache in case another effect already created it

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -15,7 +15,7 @@ import type {
   InsightMetric,
   UUID,
 } from "@dashframe/types";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Check whether a DataFrame can be served to the native chart engine.
@@ -252,6 +252,18 @@ export function useInsightView(
     ? `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`
     : null;
 
+  // Track the most recently rendered configKey so in-flight createView calls
+  // from superseded configs can discard their setState calls rather than
+  // overwriting the state that a newer config already wrote.
+  //
+  // Updated synchronously during render (not inside an effect) so it always
+  // reflects the latest configKey at the time any async continuation resumes.
+  // This is safe because configKey is derived from stable primitives (insightId,
+  // joinsKey, effectiveFiltersKey) and does not change between renders unless
+  // the insight config genuinely changed.
+  const currentConfigKeyRef = useRef<string | null>(configKey);
+  currentConfigKeyRef.current = configKey;
+
   // Check module-level cache for existing view (survives Strict Mode remounts)
   const cachedView = configKey
     ? (createdViewsCache.get(configKey) ?? null)
@@ -369,18 +381,20 @@ export function useInsightView(
         // Get base table
         const baseTable = await getDataTable(baseTableId);
         if (!baseTable || !baseTable.dataFrameId) {
+          pendingRequests.delete(configKey);
+          if (currentConfigKeyRef.current !== configKey) return;
           setError("Base table not found");
           setResolvedViewName(null);
-          pendingRequests.delete(configKey);
           return;
         }
 
         // Ensure base DataFrame is loaded
         const baseDataFrame = await getDataFrame(baseTable.dataFrameId);
         if (!baseDataFrame) {
+          pendingRequests.delete(configKey);
+          if (currentConfigKeyRef.current !== configKey) return;
           setError("Base DataFrame not found");
           setResolvedViewName(null);
-          pendingRequests.delete(configKey);
           return;
         }
 
@@ -461,9 +475,10 @@ export function useInsightView(
         );
 
         if (!sql) {
+          pendingRequests.delete(configKey);
+          if (currentConfigKeyRef.current !== configKey) return;
           setError("Failed to build SQL for insight view");
           setResolvedViewName(null);
-          pendingRequests.delete(configKey);
           return;
         }
 
@@ -500,15 +515,21 @@ export function useInsightView(
         });
         pendingRequests.delete(configKey);
 
+        // Guard: if the component has moved on to a different configKey while
+        // this async path was in-flight, discard these results. The newer
+        // config's createView will (or already did) set the correct state.
+        if (currentConfigKeyRef.current !== configKey) return;
+
         setResolvedViewName(newViewName);
         setResolvedConfigKey(configKey);
         setNativeCapable(allNativeCapable);
         setError(null);
       } catch (err) {
         console.error("[useInsightView] Failed to create view:", err);
+        pendingRequests.delete(configKey);
+        if (currentConfigKeyRef.current !== configKey) return;
         setError(err instanceof Error ? err.message : "Failed to create view");
         setResolvedViewName(null);
-        pendingRequests.delete(configKey);
       }
     };
 

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -15,7 +15,7 @@ import type {
   InsightMetric,
   UUID,
 } from "@dashframe/types";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Check whether a DataFrame can be served to the native chart engine.
@@ -256,15 +256,25 @@ export function useInsightView(
   // from superseded configs can discard their setState calls rather than
   // overwriting the state that a newer config already wrote.
   //
-  // Updated inside a useEffect (declared before the createView effect so it
-  // runs first each render) rather than synchronously during render, which
-  // avoids the react-compiler lint rule against ref mutation during render.
-  // By the time any async continuation from a prior render resumes, this
-  // effect has already fired and the ref reflects the current configKey.
+  // Synced in a useLayoutEffect (NOT a passive useEffect): layout effects
+  // flush synchronously inside React's commit phase, before control returns to
+  // the event loop. A passive useEffect runs in a later macrotask, leaving a
+  // window where config B has committed but the ref still holds A — an
+  // in-flight createView for A whose promise resolves as a microtask in that
+  // window would read currentConfigKeyRef.current === A, pass its own guard,
+  // and write A's resolvedViewName/nativeCapable over B's. useLayoutEffect
+  // closes that window because no microtask continuation can interleave before
+  // the ref is updated. (This package is the Electron/web renderer — no SSR —
+  // so the layout-effect SSR warning does not apply; VisualizationDisplay in
+  // the same package already uses useLayoutEffect.)
+  //
+  // React always flushes layout effects before passive effects, so this runs
+  // before the createView (passive) effect each render regardless of source
+  // ordering — the ref reflects the current configKey before createView reads
+  // it. Updating the ref here rather than during render also satisfies the
+  // react-compiler lint rule against ref mutation during render.
   const currentConfigKeyRef = useRef<string | null>(configKey);
-  // Sync the ref to the current configKey after every render. Declared before
-  // the createView effect so React fires this first when both deps change.
-  useEffect(() => {
+  useLayoutEffect(() => {
     currentConfigKeyRef.current = configKey;
   });
 


### PR DESCRIPTION
## Summary

- **compute-preview.ts (Findings 1 + 2)**: Both the group-key collision fix (type-tagged tuple encoding) and the silent field-drop fix (`columnName ?? name` fallback) were already on `main` via PR #105. No changes needed.
- **Finding 3 — stale async state in 4 hooks**: Generation tokens / render-synchronous config-key refs added to `useDataFrameData`, `useDataFramePagination`, `useInsightPagination`, and `useInsightView`. Every `setState` call after an `await` is now guarded — including all error / early-return paths. An in-flight promise from a superseded input can no longer overwrite state written by the current input.
- **Tests**: stale-state guard test for `useDataFrameData` (SQL-discriminated mock so the assertion is non-vacuous); new `useInsightPagination.test.tsx` with the A→B succession test from the DoD.

Tracked internally as YW-303.

## Changes

| File | What changed |
|------|-------------|
| `useDataFrameData.ts` | Token captured before first `await`; "not found" early-return guarded |
| `useDataFramePagination.ts` | `genRef` + guards on all `setState` calls including rAF callbacks |
| `useInsightPagination.ts` | Same `genRef` pattern; `loadDataFrames` no longer calls `setError` directly (caller emits error after gen check) |
| `useInsightView.ts` | `currentConfigKeyRef` (render-synchronous); all four error paths in `createView` now guarded |
| `useDataFrameData.test.tsx` | Stale-state guard test; SQL-discriminated `mockQuery` |
| `useInsightPagination.test.tsx` | **New** — stale-state guard test (count=42 vs 99) |

## Test plan

- [x] `bun run test` in `packages/app` — 518/518 pass
- [x] Code-review (local): error-path guards, vacuity of new tests, TypeScript
- [x] QA (local): verified all setState-after-await sites are guarded; both new tests are non-vacuous (would fail without the guard)
- [ ] CI green (Waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes stale async state in four data-fetching hooks by adding generation-token guards (`genRef`/`currentConfigKeyRef`) so that `setState` calls from superseded in-flight requests are discarded before landing. Two new non-vacuous tests cover the A→B succession scenario for `useDataFrameData` and `useInsightPagination`.

- **`useDataFrameData`**: generation token now captured before the first `await`, and the skip path bumps the counter to invalidate any concurrent load.
- **`useDataFramePagination` / `useInsightPagination`**: `genRef` guards added after every `await` and inside every `requestAnimationFrame` callback; `useInsightPagination`'s `resolvedTablesRef` cache write is now also behind the gen check to prevent stale table references from poisoning `fetchData`.
- **`useInsightView`**: uses a render-synchronous `currentConfigKeyRef` updated via `useLayoutEffect` (before the passive `createView` effect reads it); all four error paths and the success block are guarded.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all setState-after-await sites are guarded, the two new tests are non-vacuous, and no custom rules are violated in the changed files.

The guard pattern is applied consistently: token captured before the first await, bumped on every skip path, and checked after every subsequent await including inside rAF callbacks. The useInsightView mechanism (useLayoutEffect-synced ref) is correctly reasoned — layout effects flush before passive effects so the ref is always current when createView reads it. The only pre-existing gap (expensive DuckDB side-effects executing before the final success guard in useInsightView) was already flagged in prior review and is unchanged by this PR.

useInsightView.ts warrants a follow-up for the missing intermediate guards between the join-load await block and the SQL check, but this is a pre-existing gap outside the scope of this PR's changes.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/hooks/useDataFrameData.ts | Token now captured before first `await`; skip path bumps the counter to invalidate in-flight loads. All setState calls after async boundaries are correctly guarded. |
| packages/app/src/hooks/useDataFramePagination.ts | Adds `genRef` with guards after every await, including inside rAF callbacks. Skip path bumps gen to invalidate in-flight inits. Pattern is consistent throughout. |
| packages/app/src/hooks/useInsightPagination.ts | Adds `genRef` with guards after every await point including rAF callbacks; cache write moved after gen check to prevent stale table reference corruption in fetchData; loadDataFrames error now emitted by caller after gen check passes. |
| packages/app/src/hooks/useInsightView.ts | Uses `currentConfigKeyRef` synced via `useLayoutEffect` for render-synchronous guard; guards placed at all four error paths and the success block. Pre-existing gap: no guard between `await Promise.all(joinLoadPromises)` and the `!sql` check means expensive DuckDB side-effects still execute for superseded configs (flagged in prior review). |
| packages/app/src/hooks/useDataFrameData.test.tsx | New SQL-discriminated stale-state test using slow/fast DataFrame mocks is non-vacuous — would fail without the guard. |
| packages/app/src/hooks/useInsightPagination.test.tsx | New test file with two non-vacuous guard scenarios: A→B insight succession (count=42 vs 99 discriminator) and enabled→false mid-flight flip. Also validates cache-corruption path via fetchData SQL inspection. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as React Render
    participant LE as useLayoutEffect
    participant PE as useEffect (createView/init)
    participant Async as Async Operations
    participant State as React State

    Note over R,State: Config A → Config B succession

    R->>LE: Render with config A
    LE->>LE: "currentConfigKeyRef = A (or gen = N)"
    PE->>Async: Start async init/createView for A
    Async->>Async: await getDataFrame / getDataTable...

    R->>LE: Re-render with config B
    LE->>LE: "currentConfigKeyRef = B (or ++gen → N+1)"
    PE->>Async: Start async init/createView for B
    Async->>State: B resolves fast → setState(B data)

    Async->>Async: A resolves (slow)
    Async->>Async: Guard: currentRef ≠ A ? return
    Note over Async,State: A's setState discarded ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as React Render
    participant LE as useLayoutEffect
    participant PE as useEffect (createView/init)
    participant Async as Async Operations
    participant State as React State

    Note over R,State: Config A → Config B succession

    R->>LE: Render with config A
    LE->>LE: "currentConfigKeyRef = A (or gen = N)"
    PE->>Async: Start async init/createView for A
    Async->>Async: await getDataFrame / getDataTable...

    R->>LE: Re-render with config B
    LE->>LE: "currentConfigKeyRef = B (or ++gen → N+1)"
    PE->>Async: Start async init/createView for B
    Async->>State: B resolves fast → setState(B data)

    Async->>Async: A resolves (slow)
    Async->>Async: Guard: currentRef ≠ A ? return
    Note over Async,State: A's setState discarded ✓
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/app/src/hooks/useInsightView.ts`, line 408-521 ([link](https://github.com/youhaowei/dashframe/blob/ecc7d81df5afc865e2170e2b9f612944125d4e46/packages/app/src/hooks/useInsightView.ts#L408-L521)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale request still executes expensive DuckDB work before the guard fires**

   The gen guard (`currentConfigKeyRef.current !== configKey`) is only checked at the error-path early returns and the final success block (line 521). Between `await Promise.all(joinLoadPromises)` and the success guard, a superseded request will still run `ensureTableLoaded` for every DataFrame, optionally `uploadArrowTable` for each, and `CREATE OR REPLACE VIEW` in both DuckDB-WASM and the native connector — all before realising it is stale. While the final state-write guard prevents incorrect React state, the DuckDB side-effects (view creation, Arrow uploads) happen unconditionally for stale requests. For configurations that change rapidly this could cause measurable latency and orphaned views accumulating in DuckDB memory.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/hooks/useInsightView.ts
   Line: 408-521

   Comment:
   **Stale request still executes expensive DuckDB work before the guard fires**

   The gen guard (`currentConfigKeyRef.current !== configKey`) is only checked at the error-path early returns and the final success block (line 521). Between `await Promise.all(joinLoadPromises)` and the success guard, a superseded request will still run `ensureTableLoaded` for every DataFrame, optionally `uploadArrowTable` for each, and `CREATE OR REPLACE VIEW` in both DuckDB-WASM and the native connector — all before realising it is stale. While the final state-write guard prevents incorrect React state, the DuckDB side-effects (view creation, Arrow uploads) happen unconditionally for stale requests. For configurations that change rapidly this could cause measurable latency and orphaned views accumulating in DuckDB memory.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20408-521%0A%0AComment%3A%0A**Stale%20request%20still%20executes%20expensive%20DuckDB%20work%20before%20the%20guard%20fires**%0A%0AThe%20gen%20guard%20%28%60currentConfigKeyRef.current%20!%3D%3D%20configKey%60%29%20is%20only%20checked%20at%20the%20error-path%20early%20returns%20and%20the%20final%20success%20block%20%28line%20521%29.%20Between%20%60await%20Promise.all%28joinLoadPromises%29%60%20and%20the%20success%20guard%2C%20a%20superseded%20request%20will%20still%20run%20%60ensureTableLoaded%60%20for%20every%20DataFrame%2C%20optionally%20%60uploadArrowTable%60%20for%20each%2C%20and%20%60CREATE%20OR%20REPLACE%20VIEW%60%20in%20both%20DuckDB-WASM%20and%20the%20native%20connector%20%E2%80%94%20all%20before%20realising%20it%20is%20stale.%20While%20the%20final%20state-write%20guard%20prevents%20incorrect%20React%20state%2C%20the%20DuckDB%20side-effects%20%28view%20creation%2C%20Arrow%20uploads%29%20happen%20unconditionally%20for%20stale%20requests.%20For%20configurations%20that%20change%20rapidly%20this%20could%20cause%20measurable%20latency%20and%20orphaned%20views%20accumulating%20in%20DuckDB%20memory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-303-stabilize-compute-preview-keys%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-303-stabilize-compute-preview-keys%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20408-521%0A%0AComment%3A%0A**Stale%20request%20still%20executes%20expensive%20DuckDB%20work%20before%20the%20guard%20fires**%0A%0AThe%20gen%20guard%20%28%60currentConfigKeyRef.current%20!%3D%3D%20configKey%60%29%20is%20only%20checked%20at%20the%20error-path%20early%20returns%20and%20the%20final%20success%20block%20%28line%20521%29.%20Between%20%60await%20Promise.all%28joinLoadPromises%29%60%20and%20the%20success%20guard%2C%20a%20superseded%20request%20will%20still%20run%20%60ensureTableLoaded%60%20for%20every%20DataFrame%2C%20optionally%20%60uploadArrowTable%60%20for%20each%2C%20and%20%60CREATE%20OR%20REPLACE%20VIEW%60%20in%20both%20DuckDB-WASM%20and%20the%20native%20connector%20%E2%80%94%20all%20before%20realising%20it%20is%20stale.%20While%20the%20final%20state-write%20guard%20prevents%20incorrect%20React%20state%2C%20the%20DuckDB%20side-effects%20%28view%20creation%2C%20Arrow%20uploads%29%20happen%20unconditionally%20for%20stale%20requests.%20For%20configurations%20that%20change%20rapidly%20this%20could%20cause%20measurable%20latency%20and%20orphaned%20views%20accumulating%20in%20DuckDB%20memory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20408-521%0A%0AComment%3A%0A**Stale%20request%20still%20executes%20expensive%20DuckDB%20work%20before%20the%20guard%20fires**%0A%0AThe%20gen%20guard%20%28%60currentConfigKeyRef.current%20!%3D%3D%20configKey%60%29%20is%20only%20checked%20at%20the%20error-path%20early%20returns%20and%20the%20final%20success%20block%20%28line%20521%29.%20Between%20%60await%20Promise.all%28joinLoadPromises%29%60%20and%20the%20success%20guard%2C%20a%20superseded%20request%20will%20still%20run%20%60ensureTableLoaded%60%20for%20every%20DataFrame%2C%20optionally%20%60uploadArrowTable%60%20for%20each%2C%20and%20%60CREATE%20OR%20REPLACE%20VIEW%60%20in%20both%20DuckDB-WASM%20and%20the%20native%20connector%20%E2%80%94%20all%20before%20realising%20it%20is%20stale.%20While%20the%20final%20state-write%20guard%20prevents%20incorrect%20React%20state%2C%20the%20DuckDB%20side-effects%20%28view%20creation%2C%20Arrow%20uploads%29%20happen%20unconditionally%20for%20stale%20requests.%20For%20configurations%20that%20change%20rapidly%20this%20could%20cause%20measurable%20latency%20and%20orphaned%20views%20accumulating%20in%20DuckDB%20memory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/app/src/hooks/useInsightView.ts`, line 368-536 ([link](https://github.com/youhaowei/dashframe/blob/ecc7d81df5afc865e2170e2b9f612944125d4e46/packages/app/src/hooks/useInsightView.ts#L368-L536)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No automated test for `useInsightView` stale-state guard**

   The three other hooks changed in this PR (`useDataFrameData`, `useDataFramePagination`, `useInsightPagination`) each have a corresponding non-vacuous stale-state guard test. `useInsightView` has the most complex async path (join resolution → DataFrames loading → DuckDB view creation → native connector view creation) and uses a different guard mechanism (`currentConfigKeyRef` vs `genRef`), but no test exercises the A→B succession scenario. Consider adding a test analogous to the `useInsightPagination` suite to make the guard machine-verifiable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/hooks/useInsightView.ts
   Line: 368-536

   Comment:
   **No automated test for `useInsightView` stale-state guard**

   The three other hooks changed in this PR (`useDataFrameData`, `useDataFramePagination`, `useInsightPagination`) each have a corresponding non-vacuous stale-state guard test. `useInsightView` has the most complex async path (join resolution → DataFrames loading → DuckDB view creation → native connector view creation) and uses a different guard mechanism (`currentConfigKeyRef` vs `genRef`), but no test exercises the A→B succession scenario. Consider adding a test analogous to the `useInsightPagination` suite to make the guard machine-verifiable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20368-536%0A%0AComment%3A%0A**No%20automated%20test%20for%20%60useInsightView%60%20stale-state%20guard**%0A%0AThe%20three%20other%20hooks%20changed%20in%20this%20PR%20%28%60useDataFrameData%60%2C%20%60useDataFramePagination%60%2C%20%60useInsightPagination%60%29%20each%20have%20a%20corresponding%20non-vacuous%20stale-state%20guard%20test.%20%60useInsightView%60%20has%20the%20most%20complex%20async%20path%20%28join%20resolution%20%E2%86%92%20DataFrames%20loading%20%E2%86%92%20DuckDB%20view%20creation%20%E2%86%92%20native%20connector%20view%20creation%29%20and%20uses%20a%20different%20guard%20mechanism%20%28%60currentConfigKeyRef%60%20vs%20%60genRef%60%29%2C%20but%20no%20test%20exercises%20the%20A%E2%86%92B%20succession%20scenario.%20Consider%20adding%20a%20test%20analogous%20to%20the%20%60useInsightPagination%60%20suite%20to%20make%20the%20guard%20machine-verifiable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-303-stabilize-compute-preview-keys%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-303-stabilize-compute-preview-keys%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20368-536%0A%0AComment%3A%0A**No%20automated%20test%20for%20%60useInsightView%60%20stale-state%20guard**%0A%0AThe%20three%20other%20hooks%20changed%20in%20this%20PR%20%28%60useDataFrameData%60%2C%20%60useDataFramePagination%60%2C%20%60useInsightPagination%60%29%20each%20have%20a%20corresponding%20non-vacuous%20stale-state%20guard%20test.%20%60useInsightView%60%20has%20the%20most%20complex%20async%20path%20%28join%20resolution%20%E2%86%92%20DataFrames%20loading%20%E2%86%92%20DuckDB%20view%20creation%20%E2%86%92%20native%20connector%20view%20creation%29%20and%20uses%20a%20different%20guard%20mechanism%20%28%60currentConfigKeyRef%60%20vs%20%60genRef%60%29%2C%20but%20no%20test%20exercises%20the%20A%E2%86%92B%20succession%20scenario.%20Consider%20adding%20a%20test%20analogous%20to%20the%20%60useInsightPagination%60%20suite%20to%20make%20the%20guard%20machine-verifiable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightView.ts%0ALine%3A%20368-536%0A%0AComment%3A%0A**No%20automated%20test%20for%20%60useInsightView%60%20stale-state%20guard**%0A%0AThe%20three%20other%20hooks%20changed%20in%20this%20PR%20%28%60useDataFrameData%60%2C%20%60useDataFramePagination%60%2C%20%60useInsightPagination%60%29%20each%20have%20a%20corresponding%20non-vacuous%20stale-state%20guard%20test.%20%60useInsightView%60%20has%20the%20most%20complex%20async%20path%20%28join%20resolution%20%E2%86%92%20DataFrames%20loading%20%E2%86%92%20DuckDB%20view%20creation%20%E2%86%92%20native%20connector%20view%20creation%29%20and%20uses%20a%20different%20guard%20mechanism%20%28%60currentConfigKeyRef%60%20vs%20%60genRef%60%29%2C%20but%20no%20test%20exercises%20the%20A%E2%86%92B%20succession%20scenario.%20Consider%20adding%20a%20test%20analogous%20to%20the%20%60useInsightPagination%60%20suite%20to%20make%20the%20guard%20machine-verifiable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["test(hooks): assert resolved-table cache..."](https://github.com/youhaowei/dashframe/commit/b3d039b5a37d665bc418007606753624b13ec2ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39856862)</sub>

<!-- /greptile_comment -->