### PR TITLE
[YW-160] feat(security): Zod handler guards + ws:/wss: CSP for untrusted-client hardening

### DIFF
--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -392,3 +392,168 @@ describe("createInsight — atomic auto-draft dedup", () => {
     expect(rows.map((r) => r.name).sort()).toEqual(["orders", "orders (2)"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// patchDataTableArray — Zod discriminated-union guard at the handler boundary
+// ---------------------------------------------------------------------------
+//
+// Contract: the handler rejects malformed inputs with a structured error BEFORE
+// calling patchDataTableItems, so malformed JSONB payloads from any untrusted
+// client path never reach the helper.  The guard messages are distinct from the
+// helper's own throws — commenting the guard out makes these tests RED, proving
+// they exercise the guard, not the helper.
+//
+// The three DoD tests from the ticket spec:
+//   (1) mode=add without `value` → structured error
+//   (2) mode=update without `itemId` → structured error
+//   (3) mode=delete — valid path — passes (guard does not block legitimate calls)
+
+describe("patchDataTableArray — Zod guard rejects malformed inputs", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-patch-dt-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await createWyStack({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function call(path: string, args: unknown): Promise<unknown> {
+    const { result } = await app.call(path, args);
+    return result;
+  }
+
+  it("should reject mode=add with no value — guard fires before helper", async () => {
+    // mode=add requires value (object with id).  The guard emits a Zod v4
+    // structured error (JSON issues array, e.g. '...expected object...').
+    // The helper's own error "fields must be an object with an id" is never
+    // reached — and the guard message is structurally distinct from it.
+    //
+    // The guard runs before loadDataTable, so no real DB row is needed.
+    const dataTableId = crypto.randomUUID();
+    await expect(
+      call("patchDataTableArray", {
+        dataTableId,
+        kind: "fields",
+        mode: "add",
+        // value intentionally omitted
+      }),
+      // Zod v4 error.message is a JSON issues array: '[ { "expected": "object", ... } ]'
+      // Distinct from the helper's plain-English "fields must be an object with an id"
+    ).rejects.toThrow(/expected.*object/i);
+  });
+
+  it("should reject mode=update with no itemId — guard fires before helper", async () => {
+    // mode=update requires itemId.  Guard emits a Zod v4 structured error.
+    // The helper's "itemId is required for update" is never reached.
+    // Guard runs before loadDataTable — no real DB row needed.
+    const dataTableId = crypto.randomUUID();
+    await expect(
+      call("patchDataTableArray", {
+        dataTableId,
+        kind: "fields",
+        mode: "update",
+        value: { name: "renamed" },
+        // itemId intentionally omitted
+      }),
+      // Zod v4 error.message: '[ { "expected": "string", ... } ]'
+      // Distinct from helper's "itemId is required for update"
+    ).rejects.toThrow(/expected.*string/i);
+  });
+
+  it("should pass valid mode=delete with itemId through the guard", async () => {
+    // A well-formed delete passes the guard and reaches loadDataTable, which
+    // throws "not found" for a nonexistent row — domain error, not guard error.
+    const dataTableId = crypto.randomUUID();
+    const itemId = crypto.randomUUID();
+    await expect(
+      call("patchDataTableArray", {
+        dataTableId,
+        kind: "fields",
+        mode: "delete",
+        itemId,
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchInsight — Zod discriminated-union guard at the handler boundary
+// ---------------------------------------------------------------------------
+//
+// Same pattern: handler validates before calling patchInsightDefinition.
+// Guard messages are distinct from helper throws — these tests go RED without
+// the guard, proving they test the boundary, not the helper internals.
+
+describe("patchInsight — Zod guard rejects malformed inputs", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-patch-insight-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await createWyStack({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function call(path: string, args: unknown): Promise<unknown> {
+    const { result } = await app.call(path, args);
+    return result;
+  }
+
+  it("should reject mode=addMetric with no metric — guard fires before helper", async () => {
+    // mode=addMetric requires metric (record/object).  Guard emits a Zod v4
+    // structured error; the helper's "metric must include id, name, sourceTable,
+    // and aggregation" is never reached.
+    //
+    // The guard runs before loadInsight, so no real DB row is needed.
+    const id = crypto.randomUUID();
+    await expect(
+      call("patchInsight", {
+        id,
+        mode: "addMetric",
+        // metric intentionally omitted
+      }),
+      // Zod v4 error.message: '[ { "expected": "record", ... } ]'
+      // Distinct from helper's "metric must include id, name, sourceTable, and aggregation"
+    ).rejects.toThrow(/expected.*record/i);
+  });
+
+  it("should reject mode=addField with no fieldId — guard fires before helper", async () => {
+    // Guard runs before loadInsight — no real DB row needed.
+    const id = crypto.randomUUID();
+    await expect(
+      call("patchInsight", {
+        id,
+        mode: "addField",
+        // fieldId intentionally omitted
+      }),
+      // Zod v4 error.message: '[ { "expected": "string", ... } ]'
+      // Distinct from helper's "fieldId is required for addField"
+    ).rejects.toThrow(/expected.*string/i);
+  });
+
+  it("should reject an unsupported mode before reaching the helper", async () => {
+    // Zod discriminated union rejects an unrecognized discriminator value.
+    // Guard runs before loadInsight — no real DB row needed.
+    const id = crypto.randomUUID();
+    await expect(
+      call("patchInsight", {
+        id,
+        mode: "bogusMode",
+      }),
+      // Zod v4 error for invalid union discriminator uses code "invalid_union".
+    ).rejects.toThrow(/invalid_union/i);
+  });
+});

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -481,6 +481,20 @@ describe("patchDataTableArray — Zod guard rejects malformed inputs", () => {
       }),
     ).rejects.toThrow(/not found/i);
   });
+
+  it("should reject an unsupported mode before reaching the helper", async () => {
+    // Zod discriminated union rejects an unrecognized discriminator value.
+    // Guard runs before loadDataTable — no real DB row needed.
+    const dataTableId = crypto.randomUUID();
+    await expect(
+      call("patchDataTableArray", {
+        dataTableId,
+        kind: "fields",
+        mode: "bogusMode",
+      }),
+      // Zod v4 error for invalid union discriminator uses code "invalid_union".
+    ).rejects.toThrow(/invalid_union/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -29,6 +29,7 @@ import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { isSecretRef } from "@wystack/secret-vault";
 import type { FunctionContext } from "@wystack/server";
 import { mutation, query } from "@wystack/server";
+import { z } from "zod";
 
 import {
   applyCredentialField,
@@ -653,6 +654,27 @@ const removeDataTable = mutation({
   },
 });
 
+// Discriminated-union guard for patchDataTableArray mode inputs.
+// Guards the SINK — validates at the handler boundary before the helper call,
+// catching malformed payloads that arrive from any untrusted client path.
+const patchDataTableArrayArgsSchema = z.discriminatedUnion("mode", [
+  z.object({
+    mode: z.literal("add"),
+    value: z.object({ id: z.string().uuid() }).passthrough(),
+  }),
+  z.object({
+    mode: z.literal("update"),
+    itemId: z.string().uuid(),
+    // value is optional (partial patch object); the helper validates it is an
+    // object when present. The guard only enforces itemId is present and valid.
+    value: z.record(z.string(), z.unknown()).optional(),
+  }),
+  z.object({
+    mode: z.literal("delete"),
+    itemId: z.string().uuid(),
+  }),
+]);
+
 const patchDataTableArray = mutation({
   args: {
     dataTableId: uuid,
@@ -665,6 +687,14 @@ const patchDataTableArray = mutation({
     ctx,
     { dataTableId, kind, mode, itemId, value },
   ): Promise<{ ok: true }> => {
+    const parsed = patchDataTableArrayArgsSchema.safeParse({
+      mode,
+      itemId,
+      value,
+    });
+    if (!parsed.success) {
+      throw new Error(parsed.error.message);
+    }
     const table = await loadDataTable(ctx, dataTableId);
     if (kind !== "fields" && kind !== "metrics") {
       throw new Error(`Unsupported data table array ${kind}`);
@@ -920,6 +950,33 @@ const removeInsight = mutation({
   },
 });
 
+// Discriminated-union guard for patchInsight mode inputs.
+// Guards the SINK — validates at the handler boundary before the helper call,
+// catching malformed payloads that arrive from any untrusted client path.
+const patchInsightArgsSchema = z.discriminatedUnion("mode", [
+  z.object({
+    mode: z.literal("addMetric"),
+    metric: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    mode: z.literal("addField"),
+    fieldId: z.string().uuid(),
+  }),
+  z.object({
+    mode: z.literal("removeField"),
+    fieldId: z.string().uuid(),
+  }),
+  z.object({
+    mode: z.literal("updateMetric"),
+    metricId: z.string().uuid(),
+    updates: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    mode: z.literal("removeMetric"),
+    metricId: z.string().uuid(),
+  }),
+]);
+
 const patchInsight = mutation({
   args: {
     id: uuid,
@@ -930,6 +987,10 @@ const patchInsight = mutation({
     updates: jsonb.optional(),
   },
   handler: async (ctx, args): Promise<{ ok: true }> => {
+    const parsed = patchInsightArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      throw new Error(parsed.error.message);
+    }
     const current = await loadInsight(ctx, args.id);
     const { selectedFields, metrics } = patchInsightDefinition(current, args);
     await ctx.db

--- a/apps/web/lib/security-headers.test.ts
+++ b/apps/web/lib/security-headers.test.ts
@@ -157,6 +157,51 @@ describe("Security Headers", () => {
       expect(cspHeader?.value).toContain("http://127.0.0.1:4100");
     });
 
+    it("should include ws: WyStack host in connect-src when VITE_WYSTACK_URL uses http:", () => {
+      // Browser CSP treats ws:/wss: as distinct from http:/https:.  Both must be
+      // present so WebSocket connections to the WyStack server are allowed.
+      const headers = getSecurityHeaders({
+        VITE_WYSTACK_URL: "http://127.0.0.1:4100/api",
+      });
+      const cspHeader = headers.find(
+        (h) => h.key === "Content-Security-Policy",
+      );
+      const connectSrc = cspHeader?.value
+        .split(";")
+        .find((d) => d.trim().startsWith("connect-src"));
+
+      expect(connectSrc).toContain("http://127.0.0.1:4100");
+      expect(connectSrc).toContain("ws://127.0.0.1:4100");
+    });
+
+    it("should include wss: WyStack host in connect-src when VITE_WYSTACK_URL uses https:", () => {
+      const headers = getSecurityHeaders({
+        VITE_WYSTACK_URL: "https://example.com/api",
+      });
+      const cspHeader = headers.find(
+        (h) => h.key === "Content-Security-Policy",
+      );
+      const connectSrc = cspHeader?.value
+        .split(";")
+        .find((d) => d.trim().startsWith("connect-src"));
+
+      expect(connectSrc).toContain("https://example.com");
+      expect(connectSrc).toContain("wss://example.com");
+    });
+
+    it("should not include ws: or wss: entries in connect-src when VITE_WYSTACK_URL is absent", () => {
+      const headers = getSecurityHeaders({});
+      const cspHeader = headers.find(
+        (h) => h.key === "Content-Security-Policy",
+      );
+      const connectSrc = cspHeader?.value
+        .split(";")
+        .find((d) => d.trim().startsWith("connect-src"));
+
+      expect(connectSrc).not.toMatch(/\bws:\/\//);
+      expect(connectSrc).not.toMatch(/\bwss:\/\//);
+    });
+
     it("should include PostHog hosts in script-src and connect-src", () => {
       const headers = getSecurityHeaders();
       const cspHeader = headers.find(

--- a/apps/web/lib/security-headers.ts
+++ b/apps/web/lib/security-headers.ts
@@ -89,11 +89,21 @@ export function getSecurityHeaders(
     customPostHogHost ? customPostHogHost : null,
   ].filter(Boolean);
   let wystackHost: string | null = null;
+  let wystackWsHost: string | null = null;
   if (env.VITE_WYSTACK_URL) {
     try {
-      wystackHost = new URL(env.VITE_WYSTACK_URL).origin;
+      const url = new URL(env.VITE_WYSTACK_URL);
+      wystackHost = url.origin;
+      // Browser CSP treats ws: and wss: as distinct schemes from http:/https:.
+      // WyStack uses WebSocket for live invalidation; without a ws:/wss: entry
+      // in connect-src the browser blocks the connection (default-src 'self'
+      // won't match a cross-origin WS). Derive the WS-equivalent from the HTTP
+      // origin so both schemes are covered.
+      const wsScheme = url.protocol === "https:" ? "wss:" : "ws:";
+      wystackWsHost = `${wsScheme}//${url.host}`;
     } catch {
       wystackHost = null;
+      wystackWsHost = null;
     }
   }
 
@@ -217,6 +227,7 @@ export function getSecurityHeaders(
       "connect-src 'self' blob: https://cdn.jsdelivr.net",
       ...postHogHosts,
       wystackHost,
+      wystackWsHost,
     ]
       .filter(Boolean)
       .join(" "),


### PR DESCRIPTION
## Summary

- **Server-side input validation (a):** Adds Zod discriminated-union guards at the handler boundary of `patchDataTableArray` and `patchInsight` before their helper calls. Each mode arm enforces its required fields (`value.id` for add, `itemId` for update/delete; `metric`/`fieldId`/`metricId` per patchInsight mode). Unsupported modes are rejected immediately. Pattern mirrors `commands.ts` (`z.safeParse` + `throw new Error(parsed.error.message)`). Guards the SINK — JSONB args are untyped at the WyStack transport layer; validation must be at the point of use.

- **Production CSP ws:/wss: (b):** Derives the WebSocket-equivalent of `VITE_WYSTACK_URL` and adds it to `connect-src` alongside the existing HTTP origin. Browser CSP treats `ws:` and `wss:` as distinct schemes from `http:`/`https:` — without these entries, WyStack's WebSocket live-invalidation connections are blocked by the CSP `default-src 'self'` fallback in production.

## Test plan

- [ ] 6 guard-boundary tests in `app-artifacts.test.ts` — verified RED when each guard is disabled, GREEN when enabled (guard-specific error messages distinct from helper messages)
- [ ] 4 CSP WebSocket tests in `security-headers.test.ts` — `http://` → `ws://`, `https://` → `wss://`, same `host:port` preserved, no-URL negative case
- [ ] 285 server tests pass, 37 web tests pass, 48 typecheck tasks pass
- [ ] Code review (correctness, security, testing, QA lenses) — 1 MUST resolved (mode=update missing `value` field in schema), 1 SUGGEST resolved (unsupported-mode test bare assertion strengthened)

Tracked internally as YW-160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two independent security hardening changes: Zod discriminated-union guards at the handler boundary of `patchDataTableArray` and `patchInsight`, and `ws:`/`wss:` CSP entries for WyStack WebSocket connections in production.

- **Server-side input validation:** `patchDataTableArrayArgsSchema` and `patchInsightArgsSchema` use `z.discriminatedUnion` to reject malformed or unsupported `mode` payloads before any helper is invoked; 7 boundary tests (4 + 3) verify RED/GREEN behaviour with the guard removed.
- **CSP WebSocket fix:** `security-headers.ts` derives the `ws:`/`wss:` equivalent of `VITE_WYSTACK_URL` and inserts it into `connect-src` alongside the HTTP origin so browser CSP does not block WyStack's live-invalidation WebSocket in production; 3 targeted tests cover the `http→ws`, `https→wss`, and absent-URL cases.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are additive hardening with no functional regression risk.

The guard schemas correctly reject malformed payloads before any DB access, the CSP derivation is straightforward and well-tested, and there are no changes to existing business logic or data paths. The only finding is a misleading inline comment about the Zod v4 error format that does not affect runtime behaviour.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/server/src/functions/app-artifacts.ts | Adds Zod discriminated-union guards for patchDataTableArray and patchInsight; guards correctly validate required per-mode fields and throw on invalid inputs before reaching helpers. |
| apps/server/src/functions/app-artifacts.test.ts | Adds 7 guard-boundary tests for patchDataTableArray and patchInsight; test logic is sound but inline comments incorrectly describe ZodError.message as a v3-style JSON array rather than the v4 human-readable string. |
| apps/web/lib/security-headers.ts | Correctly derives the ws:/wss: equivalent of VITE_WYSTACK_URL and adds it to connect-src alongside the HTTP origin; handles missing URL gracefully. |
| apps/web/lib/security-headers.test.ts | Adds 3 focused CSP WebSocket tests covering http→ws, https→wss, and absent-URL cases; assertions are precise and well scoped to the connect-src directive. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Untrusted Client JSONB Payload] --> B[WyStack Transport Layer]
    B --> C{Handler boundary}
    C --> D[patchDataTableArrayArgsSchema.safeParse]
    C --> E[patchInsightArgsSchema.safeParse]
    D -->|invalid| F[throw Error - guard message]
    E -->|invalid| F
    D -->|valid mode=add/update/delete| G[loadDataTable]
    E -->|valid mode=addMetric/addField/etc| H[loadInsight]
    G --> I[patchDataTableItems helper]
    H --> J[patchInsightDefinition helper]
    I --> K[(DB write)]
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Untrusted Client JSONB Payload] --> B[WyStack Transport Layer]
    B --> C{Handler boundary}
    C --> D[patchDataTableArrayArgsSchema.safeParse]
    C --> E[patchInsightArgsSchema.safeParse]
    D -->|invalid| F[throw Error - guard message]
    E -->|invalid| F
    D -->|valid mode=add/update/delete| G[loadDataTable]
    E -->|valid mode=addMetric/addField/etc| H[loadInsight]
    G --> I[patchDataTableItems helper]
    H --> J[patchInsightDefinition helper]
    I --> K[(DB write)]
    J --> K
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/server/src/functions/app-artifacts.ts`, line 690-703 ([link](https://github.com/youhaowei/dashframe/blob/fbf72698f640d53e4f2e1d369aca1934c6fb6bc0/apps/server/src/functions/app-artifacts.ts#L690-L703)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Guard validates but discards the parsed output**

   `parsed.data` is computed but never used — the original destructured `mode`, `itemId`, and `value` (and the full `args` in `patchInsight`) are passed directly to the helpers. The guard correctly throws on invalid input, but the type-narrowed, Zod-coerced output is silently dropped. This means TypeScript cannot reason about which discriminated arm was matched, and any future coercion added to the schema (e.g. `.transform()` or `.default()`) would be silently ignored. The same pattern appears in the `patchInsight` handler at line 989–993. Using `parsed.data` (or a narrowed view of it) downstream would make the validation's intent self-enforcing.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/functions/app-artifacts.ts
   Line: 690-703

   Comment:
   **Guard validates but discards the parsed output**

   `parsed.data` is computed but never used — the original destructured `mode`, `itemId`, and `value` (and the full `args` in `patchInsight`) are passed directly to the helpers. The guard correctly throws on invalid input, but the type-narrowed, Zod-coerced output is silently dropped. This means TypeScript cannot reason about which discriminated arm was matched, and any future coercion added to the schema (e.g. `.transform()` or `.default()`) would be silently ignored. The same pattern appears in the `patchInsight` handler at line 989–993. Using `parsed.data` (or a narrowed view of it) downstream would make the validation's intent self-enforcing.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fapp-artifacts.ts%0ALine%3A%20690-703%0A%0AComment%3A%0A**Guard%20validates%20but%20discards%20the%20parsed%20output**%0A%0A%60parsed.data%60%20is%20computed%20but%20never%20used%20%E2%80%94%20the%20original%20destructured%20%60mode%60%2C%20%60itemId%60%2C%20and%20%60value%60%20%28and%20the%20full%20%60args%60%20in%20%60patchInsight%60%29%20are%20passed%20directly%20to%20the%20helpers.%20The%20guard%20correctly%20throws%20on%20invalid%20input%2C%20but%20the%20type-narrowed%2C%20Zod-coerced%20output%20is%20silently%20dropped.%20This%20means%20TypeScript%20cannot%20reason%20about%20which%20discriminated%20arm%20was%20matched%2C%20and%20any%20future%20coercion%20added%20to%20the%20schema%20%28e.g.%20%60.transform%28%29%60%20or%20%60.default%28%29%60%29%20would%20be%20silently%20ignored.%20The%20same%20pattern%20appears%20in%20the%20%60patchInsight%60%20handler%20at%20line%20989%E2%80%93993.%20Using%20%60parsed.data%60%20%28or%20a%20narrowed%20view%20of%20it%29%20downstream%20would%20make%20the%20validation's%20intent%20self-enforcing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-160-untrusted-client-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-160-untrusted-client-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fapp-artifacts.ts%0ALine%3A%20690-703%0A%0AComment%3A%0A**Guard%20validates%20but%20discards%20the%20parsed%20output**%0A%0A%60parsed.data%60%20is%20computed%20but%20never%20used%20%E2%80%94%20the%20original%20destructured%20%60mode%60%2C%20%60itemId%60%2C%20and%20%60value%60%20%28and%20the%20full%20%60args%60%20in%20%60patchInsight%60%29%20are%20passed%20directly%20to%20the%20helpers.%20The%20guard%20correctly%20throws%20on%20invalid%20input%2C%20but%20the%20type-narrowed%2C%20Zod-coerced%20output%20is%20silently%20dropped.%20This%20means%20TypeScript%20cannot%20reason%20about%20which%20discriminated%20arm%20was%20matched%2C%20and%20any%20future%20coercion%20added%20to%20the%20schema%20%28e.g.%20%60.transform%28%29%60%20or%20%60.default%28%29%60%29%20would%20be%20silently%20ignored.%20The%20same%20pattern%20appears%20in%20the%20%60patchInsight%60%20handler%20at%20line%20989%E2%80%93993.%20Using%20%60parsed.data%60%20%28or%20a%20narrowed%20view%20of%20it%29%20downstream%20would%20make%20the%20validation's%20intent%20self-enforcing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fapp-artifacts.ts%0ALine%3A%20690-703%0A%0AComment%3A%0A**Guard%20validates%20but%20discards%20the%20parsed%20output**%0A%0A%60parsed.data%60%20is%20computed%20but%20never%20used%20%E2%80%94%20the%20original%20destructured%20%60mode%60%2C%20%60itemId%60%2C%20and%20%60value%60%20%28and%20the%20full%20%60args%60%20in%20%60patchInsight%60%29%20are%20passed%20directly%20to%20the%20helpers.%20The%20guard%20correctly%20throws%20on%20invalid%20input%2C%20but%20the%20type-narrowed%2C%20Zod-coerced%20output%20is%20silently%20dropped.%20This%20means%20TypeScript%20cannot%20reason%20about%20which%20discriminated%20arm%20was%20matched%2C%20and%20any%20future%20coercion%20added%20to%20the%20schema%20%28e.g.%20%60.transform%28%29%60%20or%20%60.default%28%29%60%29%20would%20be%20silently%20ignored.%20The%20same%20pattern%20appears%20in%20the%20%60patchInsight%60%20handler%20at%20line%20989%E2%80%93993.%20Using%20%60parsed.data%60%20%28or%20a%20narrowed%20view%20of%20it%29%20downstream%20would%20make%20the%20validation's%20intent%20self-enforcing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(security): add unsupported-mode gua..."](https://github.com/youhaowei/dashframe/commit/f1e667d3031d788eefb5d26e5af592cdcd8990b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39862020)</sub>

<!-- /greptile_comment -->