### PR TITLE
[YW-304] fix(ui): lock no-regression invariant for render+compute seam

### DIFF
--- a/packages/app/src/components/visualizations/VisualizationDisplay.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Tests for VisualizationDisplay — saved-insight-params forwarded to pagination
+ * when no cell overrides are present (YW-304, Finding 1).
+ *
+ * Contract: when `overrides` is absent, `useInsightPagination` must receive
+ * effectiveParams that carry the insight's own filters/sorts so the table
+ * row count reflects the saved insight configuration.
+ *
+ * F1 scope: VisualizationDisplay.tsx only.
+ */
+import type { Insight, Visualization } from "@dashframe/types";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VisualizationDisplay } from "./VisualizationDisplay";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockUseInsightPagination } = vi.hoisted(() => ({
+  mockUseInsightPagination: vi.fn(),
+}));
+
+vi.mock("@/hooks/useInsightPagination", () => ({
+  useInsightPagination: (opts: unknown) => mockUseInsightPagination(opts),
+}));
+
+const { mockUseInsightView } = vi.hoisted(() => ({
+  mockUseInsightView: vi.fn(),
+}));
+
+vi.mock("@/hooks/useInsightView", () => ({
+  useInsightView: () => mockUseInsightView(),
+}));
+
+const { mockUseChartEngine } = vi.hoisted(() => ({
+  mockUseChartEngine: vi.fn(),
+}));
+
+vi.mock("@/components/providers/ChartEngineProvider", () => ({
+  useChartEngine: () => mockUseChartEngine(),
+}));
+
+const { mockUseDuckDBContext } = vi.hoisted(() => ({
+  mockUseDuckDBContext: vi.fn(),
+}));
+
+vi.mock("@/components/providers/DuckDBProvider", () => ({
+  useDuckDBContext: () => mockUseDuckDBContext(),
+}));
+
+const { mockUseVisualizations, mockUseInsights, mockUseDataTables } =
+  vi.hoisted(() => ({
+    mockUseVisualizations: vi.fn(),
+    mockUseInsights: vi.fn(),
+    mockUseDataTables: vi.fn(),
+  }));
+
+vi.mock("@dashframe/core", () => ({
+  useVisualizations: () => mockUseVisualizations(),
+  useInsights: () => mockUseInsights(),
+  useDataTables: () => mockUseDataTables(),
+}));
+
+vi.mock("@dashframe/engine", () => ({
+  resolveEffectiveParams: vi.fn((filters, sorts, _limit, overrides) => ({
+    filters: overrides?.filters ?? filters ?? [],
+    sorts: overrides?.sorts ?? sorts ?? [],
+    limit: overrides?.limit,
+  })),
+  resolveEncodingToSql: vi.fn().mockReturnValue({}),
+  getMetricDisplayLabel: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("@dashframe/types", () => ({
+  parseEncoding: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@dashframe/ui", () => ({
+  VirtualTable: () => null,
+}));
+
+vi.mock("@dashframe/visualization", () => ({
+  Chart: () => null,
+  VisualizationProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+  useVisualization: vi.fn().mockReturnValue({ error: null }),
+}));
+
+vi.mock("@wystack/ui", () => ({
+  ErrorState: () => null,
+  Spinner: () => null,
+  Surface: ({ children }: { children: React.ReactNode }) => children,
+  Toggle: () => null,
+}));
+
+vi.mock("@wystack/ui-icons", () => ({
+  ChartIcon: () => null,
+  LayersIcon: () => null,
+  TableIcon: () => null,
+}));
+
+vi.mock("./EngineUnavailableState", () => ({
+  EngineUnavailableState: () => null,
+}));
+
+// ── Shared fixtures ──────────────────────────────────────────────────────────
+
+const savedFilter = {
+  field: "status",
+  operator: "eq" as const,
+  value: "active",
+};
+
+const savedSort = { field: "created_at", direction: "desc" as const };
+
+const insight: Insight = {
+  id: "ins-1",
+  name: "Active Orders",
+  baseTableId: "t1",
+  selectedFields: [],
+  metrics: [],
+  joins: [],
+  filters: [savedFilter],
+  sorts: [savedSort],
+  createdAt: 0,
+} as unknown as Insight;
+
+const viz: Visualization = {
+  id: "viz-1",
+  name: "Orders Chart",
+  insightId: "ins-1",
+  visualizationType: "bar",
+  encoding: {},
+  createdAt: 0,
+} as unknown as Visualization;
+
+function setupCommonMocks(currentInsight = insight, currentViz = viz) {
+  mockUseChartEngine.mockReturnValue({ engineError: null });
+  mockUseDuckDBContext.mockReturnValue({ db: null, connection: null });
+  mockUseVisualizations.mockReturnValue({
+    data: [currentViz],
+    isLoading: false,
+  });
+  mockUseInsights.mockReturnValue({ data: [currentInsight] });
+  mockUseDataTables.mockReturnValue({ data: [] });
+  mockUseInsightView.mockReturnValue({
+    viewName: "v_ins1",
+    isReady: true,
+    error: null,
+    nativeCapable: true,
+  });
+  mockUseInsightPagination.mockReturnValue({
+    fetchData: vi.fn(),
+    totalCount: 5,
+    columns: [],
+    isReady: true,
+    columnDisplayNames: {},
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("VisualizationDisplay — saved params forwarded when overrides absent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupCommonMocks();
+  });
+
+  it("forwards the insight's saved filters to useInsightPagination via effectiveParams when no overrides prop", () => {
+    render(<VisualizationDisplay visualizationId="viz-1" />);
+
+    // useInsightPagination must have been called
+    expect(mockUseInsightPagination).toHaveBeenCalled();
+
+    const callOpts = mockUseInsightPagination.mock.calls[0]?.[0];
+    // effectiveParams must be present and carry the saved filter
+    expect(callOpts).toBeDefined();
+    expect(callOpts.effectiveParams).toBeDefined();
+    expect(callOpts.effectiveParams.filters).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "status" })]),
+    );
+  });
+
+  it("forwards the insight's saved sorts to useInsightPagination via effectiveParams when no overrides prop", () => {
+    render(<VisualizationDisplay visualizationId="viz-1" />);
+
+    const callOpts = mockUseInsightPagination.mock.calls[0]?.[0];
+    expect(callOpts?.effectiveParams?.sorts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: "created_at" }),
+      ]),
+    );
+  });
+
+  it("effectiveParams carries empty arrays (not undefined) when insight has no filters/sorts", () => {
+    // An insight with no filters/sorts should still produce effectiveParams
+    // with empty arrays — so buildInsightSQL doesn't fall through to a
+    // missing-param branch.
+    const bareInsight: Insight = {
+      ...insight,
+      id: "ins-bare",
+      filters: undefined,
+      sorts: undefined,
+    };
+    const bareViz: Visualization = {
+      ...viz,
+      id: "viz-bare",
+      insightId: "ins-bare",
+    };
+    setupCommonMocks(bareInsight, bareViz);
+
+    render(<VisualizationDisplay visualizationId="viz-bare" />);
+
+    const callOpts = mockUseInsightPagination.mock.calls[0]?.[0];
+    expect(callOpts?.effectiveParams).toBeDefined();
+    expect(Array.isArray(callOpts?.effectiveParams?.filters)).toBe(true);
+    expect(Array.isArray(callOpts?.effectiveParams?.sorts)).toBe(true);
+  });
+});

--- a/packages/app/src/components/visualizations/VisualizationDisplay.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.test.tsx
@@ -1,12 +1,12 @@
 /**
  * Tests for VisualizationDisplay — saved-insight-params forwarded to pagination
- * when no cell overrides are present (YW-304, Finding 1).
+ * when no cell overrides are present.
  *
  * Contract: when `overrides` is absent, `useInsightPagination` must receive
  * effectiveParams that carry the insight's own filters/sorts so the table
  * row count reflects the saved insight configuration.
  *
- * F1 scope: VisualizationDisplay.tsx only.
+ * Scope: VisualizationDisplay.tsx only (pagination effectiveParams invariant).
  */
 import type { Insight, Visualization } from "@dashframe/types";
 import { render } from "@testing-library/react";

--- a/packages/app/src/components/visualizations/VisualizationDisplay.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.test.tsx
@@ -215,4 +215,28 @@ describe("VisualizationDisplay — saved params forwarded when overrides absent"
     expect(Array.isArray(callOpts?.effectiveParams?.filters)).toBe(true);
     expect(Array.isArray(callOpts?.effectiveParams?.sorts)).toBe(true);
   });
+
+  it("when overrides are present, paginationEffectiveParams merges them into effectiveParams for pagination", () => {
+    // Regression: paginationEffectiveParams is always computed from resolveEffectiveParams
+    // with overrides forwarded — this path verifies the override is merged (not lost).
+    const overrideFilter = {
+      field: "region",
+      operator: "eq" as const,
+      value: "west",
+    };
+    const overrides = { filters: [overrideFilter] };
+
+    render(
+      <VisualizationDisplay
+        visualizationId="viz-1"
+        overrides={overrides as never}
+      />,
+    );
+
+    const callOpts = mockUseInsightPagination.mock.calls[0]?.[0];
+    // The override filter should reach useInsightPagination (mock merges overrides.filters ?? insight.filters)
+    expect(callOpts?.effectiveParams?.filters).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: "region" })]),
+    );
+  });
 });

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -129,12 +129,11 @@ export function VisualizationDisplay({
   // IMPORTANT: this is intentionally the minimal structural shape
   // (id, name, baseTableId, joins) — exactly as the pre-override path.  It must
   // NOT carry selectedFields/metrics/filters/sorts: this surface renders the
-  // RAW model view (vgplot computes aggregations from raw rows via the encoding),
-  // and useInsightPagination below queries the same raw model. Adding
-  // metrics/selectedFields here would make pagination emit aggregated/metric
-  // columns that don't exist in the raw model view the chart queries, breaking
-  // chart column resolution.  Cell overrides are layered separately via
-  // effectiveParams, which is undefined unless `overrides` is present.
+  // RAW model view (vgplot computes aggregations from raw rows via the encoding).
+  // Adding metrics/selectedFields here would make the chart view emit aggregated
+  // columns that break chart column resolution.  Cell overrides are layered
+  // separately via effectiveParams (useInsightView) / paginationEffectiveParams
+  // (useInsightPagination), neither of which mutates this object.
   const insightForView: Insight | null = useMemo(() => {
     if (!insight) return null;
     return {
@@ -145,11 +144,9 @@ export function VisualizationDisplay({
     } as Insight;
   }, [insight]);
 
-  // Resolve the effective params for this cell = insight defaults ⊕ overrides.
-  // Only computed when overrides are present.  When absent, both hooks get
-  // `effectiveParams: undefined` and follow the exact pre-override path
-  // (no-override no-regression).  The insight's own filters/sorts come from the
-  // raw server `insight` object, not `insightForView` (which is kept minimal).
+  // Resolve the effective params for useInsightView (chart).
+  // Only computed when overrides are present — the chart view is pre-filtered
+  // only when the dashboard cell has overrides.
   const effectiveParams = useMemo(
     () =>
       overrides && insight
@@ -157,6 +154,24 @@ export function VisualizationDisplay({
             insight.filters,
             insight.sorts,
             undefined, // insight-level limit (not stored on Insight type yet)
+            overrides,
+          )
+        : undefined,
+    [insight, overrides],
+  );
+
+  // Resolve effective params for useInsightPagination (table).
+  // When overrides are present, these are identical to `effectiveParams` above.
+  // When absent, we still forward the insight's own filters/sorts so the table
+  // reflects the saved insight config — without this the stripped `insightForView`
+  // (which has no filters/sorts) would silently drop them from buildInsightSQL.
+  const paginationEffectiveParams = useMemo(
+    () =>
+      insight
+        ? resolveEffectiveParams(
+            insight.filters,
+            insight.sorts,
+            undefined,
             overrides,
           )
         : undefined,
@@ -184,10 +199,10 @@ export function VisualizationDisplay({
   });
 
   // Use insight pagination for table data (queries DuckDB directly).
-  // When overrides are present, effectiveParams carries the merged filter/sort/limit
-  // and buildInsightSQL replaces the insight's own params with them.
-  // When absent, effectiveParams is undefined and buildInsightSQL reads
-  // insight.filters/sorts natively — byte-identical to the pre-override path.
+  // paginationEffectiveParams always carries the insight's own filters/sorts
+  // (merging in cell overrides when present), so buildInsightSQL receives them
+  // even when `overrides` is absent. Without this, the stripped `insightForView`
+  // (which has no filters/sorts) would silently drop the saved insight config.
   const {
     fetchData,
     totalCount,
@@ -198,7 +213,7 @@ export function VisualizationDisplay({
     insight: insightForView ?? ({} as Insight),
     showModelPreview: false, // Apply full insight transformations
     enabled: !!insightForView, // Only enable when we have an insight
-    effectiveParams,
+    effectiveParams: paginationEffectiveParams,
   });
 
   // Helper to calculate visible rows from container dimensions

--- a/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
@@ -161,6 +161,32 @@ describe("VisualizationPreview — (b) view-creation error branch", () => {
     expect(screen.getByTestId("custom-fallback")).not.toBeNull();
     expect(screen.queryByText("Failed to load")).toBeNull();
   });
+
+  it("does NOT show stale error from prior insight while the new insight is loading", () => {
+    // Regression: after the guard reorder (error before loading), a stale error
+    // from insight A can persist in useInsightView while insight B is loading
+    // (isLoadingInsight=true). The `!isLoadingInsight` guard prevents the stale
+    // error from surfacing as "Failed to load" during the transition.
+    //
+    // Simulate: component re-rendered for a new visualization/insight.
+    // isLoadingInsight=true (new insight fetch in flight).
+    // error is still set from the prior insight's view-creation failure.
+    mockUseInsight.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseDataTables.mockReturnValue({ data: [] });
+    mockUseInsightView.mockReturnValue({
+      viewName: null,
+      isReady: false,
+      error: "stale error from prior insight A",
+    });
+
+    const { container } = render(
+      <VisualizationPreview visualization={visualization} />,
+    );
+
+    // Must show spinner, NOT the stale error UI
+    expect(screen.queryByText("Failed to load")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
 });
 
 // ── (c) Encoding missing — distinct text, not spinner ───────────────────────

--- a/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
@@ -1,14 +1,15 @@
 /**
- * Tests for VisualizationPreview terminal-state routing (YW-304).
+ * Tests for VisualizationPreview terminal-state routing.
  *
  * Three branch contracts:
  * (a) Loading — spinner is shown while insight or view is not yet ready.
  * (b) View-creation error — terminal/error UI is shown (not spinner) even when
- *     `isReady` is false, which previously spun forever due to guard ordering.
+ *     `isReady` is false (guard ordering bug: error must be checked before
+ *     the loading guard to avoid an indefinite spinner).
  * (c) Missing encoding — "Encoding missing" text is shown (not spinner) when
  *     `resolvedEncoding` has no x/y channel after the view is ready.
  *
- * F2 scope: VisualizationPreview.tsx only.
+ * Scope: VisualizationPreview.tsx only.
  */
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Tests for VisualizationPreview terminal-state routing (YW-304).
+ *
+ * Three branch contracts:
+ * (a) Loading — spinner is shown while insight or view is not yet ready.
+ * (b) View-creation error — terminal/error UI is shown (not spinner) even when
+ *     `isReady` is false, which previously spun forever due to guard ordering.
+ * (c) Missing encoding — "Encoding missing" text is shown (not spinner) when
+ *     `resolvedEncoding` has no x/y channel after the view is ready.
+ *
+ * F2 scope: VisualizationPreview.tsx only.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { VisualizationPreview } from "./VisualizationPreview";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockUseInsightView } = vi.hoisted(() => ({
+  mockUseInsightView: vi.fn(),
+}));
+
+vi.mock("@/hooks/useInsightView", () => ({
+  useInsightView: () => mockUseInsightView(),
+}));
+
+const { mockUseInsight, mockUseDataTables } = vi.hoisted(() => ({
+  mockUseInsight: vi.fn(),
+  mockUseDataTables: vi.fn(),
+}));
+
+vi.mock("@dashframe/core", () => ({
+  useInsight: () => mockUseInsight(),
+  useDataTables: () => mockUseDataTables(),
+}));
+
+vi.mock("@dashframe/engine", () => ({
+  resolveEncodingToSql: vi.fn().mockReturnValue({}),
+}));
+
+// Chart is a heavy dependency — stub it out so tests focus on guard logic.
+vi.mock("@dashframe/visualization", () => ({
+  Chart: () => <div data-testid="chart" />,
+}));
+
+// ── Shared fixture ───────────────────────────────────────────────────────────
+
+const visualization = {
+  id: "viz-1",
+  name: "Test Chart",
+  insightId: "ins-1",
+  visualizationType: "bar",
+  encoding: { x: "field:f1", y: "metric:m1" },
+  createdAt: 0,
+} as unknown as import("@dashframe/types").Visualization;
+
+const insight = {
+  id: "ins-1",
+  name: "Test",
+  baseTableId: "t1",
+  selectedFields: [],
+  metrics: [],
+  joins: [],
+  createdAt: 0,
+} as unknown as import("@dashframe/types").Insight;
+
+const dataTable = {
+  id: "t1",
+  name: "Test",
+  dataSourceId: "ds1",
+  table: "test",
+  fields: [],
+  metrics: [],
+  createdAt: 0,
+} as unknown as import("@dashframe/types").DataTable;
+
+function setDataReady() {
+  mockUseInsight.mockReturnValue({ data: insight, isLoading: false });
+  mockUseDataTables.mockReturnValue({ data: [dataTable] });
+}
+
+// ── (a) Loading — spinner while insight or view not ready ────────────────────
+
+describe("VisualizationPreview — (a) loading branch", () => {
+  it("renders a spinner while insight is still loading", () => {
+    mockUseInsight.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseDataTables.mockReturnValue({ data: [] });
+    mockUseInsightView.mockReturnValue({
+      viewName: null,
+      isReady: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <VisualizationPreview visualization={visualization} />,
+    );
+
+    // Spinner is rendered — no error text, no chart
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(screen.queryByText("Failed to load")).toBeNull();
+    expect(screen.queryByText("Encoding missing")).toBeNull();
+    expect(screen.queryByTestId("chart")).toBeNull();
+  });
+
+  it("renders a spinner when insight loaded but view is not yet ready (no error)", () => {
+    setDataReady();
+    mockUseInsightView.mockReturnValue({
+      viewName: null,
+      isReady: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <VisualizationPreview visualization={visualization} />,
+    );
+
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(screen.queryByText("Failed to load")).toBeNull();
+  });
+});
+
+// ── (b) View-creation error — terminal UI, not spinner ───────────────────────
+
+describe("VisualizationPreview — (b) view-creation error branch", () => {
+  it("shows terminal error UI (not spinner) when error is set with isReady=false", () => {
+    // This was the bug: isReady=false + error → loading guard fired before error
+    // guard, resulting in indefinite spinner.
+    setDataReady();
+    mockUseInsightView.mockReturnValue({
+      viewName: null,
+      isReady: false,
+      error: "View creation failed: loopback 500",
+    });
+
+    const { container } = render(
+      <VisualizationPreview visualization={visualization} />,
+    );
+
+    // Must show terminal text, not a spinner
+    expect(screen.getByText("Failed to load")).not.toBeNull();
+    // No spinner SVG visible
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("passes fallback through when caller provides one and error occurs", () => {
+    setDataReady();
+    mockUseInsightView.mockReturnValue({
+      viewName: null,
+      isReady: false,
+      error: "some error",
+    });
+
+    render(
+      <VisualizationPreview
+        visualization={visualization}
+        fallback={<span data-testid="custom-fallback">custom</span>}
+      />,
+    );
+
+    expect(screen.getByTestId("custom-fallback")).not.toBeNull();
+    expect(screen.queryByText("Failed to load")).toBeNull();
+  });
+
+  it("default fallback (null) — renders inline 'Failed to load' text for error state", () => {
+    setDataReady();
+    mockUseInsightView.mockReturnValue({
+      viewName: null,
+      isReady: false,
+      error: "view failed",
+    });
+
+    // No fallback prop → default null → fallback ?? <inline div> renders the inline text
+    render(<VisualizationPreview visualization={visualization} />);
+
+    expect(screen.getByText("Failed to load")).not.toBeNull();
+  });
+});
+
+// ── (c) Encoding missing — distinct text, not spinner ───────────────────────
+
+describe("VisualizationPreview — (c) encoding-missing branch", () => {
+  it("shows 'Encoding missing' text (not spinner) when resolvedEncoding has no x/y", () => {
+    // resolveEncodingToSql is already mocked to return {} (no x/y)
+    setDataReady();
+    mockUseInsightView.mockReturnValue({
+      viewName: "v_ins1",
+      isReady: true,
+      error: null,
+    });
+
+    const vizNoEncoding = {
+      ...visualization,
+      encoding: {},
+    } as unknown as import("@dashframe/types").Visualization;
+
+    const { container } = render(
+      <VisualizationPreview visualization={vizNoEncoding} />,
+    );
+
+    expect(screen.getByText("Encoding missing")).not.toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+    expect(screen.queryByTestId("chart")).toBeNull();
+  });
+});

--- a/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
@@ -160,20 +160,6 @@ describe("VisualizationPreview — (b) view-creation error branch", () => {
     expect(screen.getByTestId("custom-fallback")).not.toBeNull();
     expect(screen.queryByText("Failed to load")).toBeNull();
   });
-
-  it("default fallback (null) — renders inline 'Failed to load' text for error state", () => {
-    setDataReady();
-    mockUseInsightView.mockReturnValue({
-      viewName: null,
-      isReady: false,
-      error: "view failed",
-    });
-
-    // No fallback prop → default null → fallback ?? <inline div> renders the inline text
-    render(<VisualizationPreview visualization={visualization} />);
-
-    expect(screen.getByText("Failed to load")).not.toBeNull();
-  });
 });
 
 // ── (c) Encoding missing — distinct text, not spinner ───────────────────────

--- a/packages/app/src/components/visualizations/VisualizationPreview.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.tsx
@@ -86,7 +86,13 @@ export function VisualizationPreview({
 
   // Error state — checked BEFORE the loading guard so that view-creation errors
   // that leave `isReady=false` reach a terminal UI instead of spinning forever.
-  if (error) {
+  //
+  // Guard: `!isLoadingInsight` prevents stale-error bleed-through. When the
+  // visualization prop changes to a new insight that is still loading, the prior
+  // useInsightView error persists briefly (the hook resets it only when
+  // createView succeeds). Without this guard, a stale error from insight A
+  // would flash "Failed to load" while insight B is being fetched.
+  if (!isLoadingInsight && error) {
     return (
       fallback ?? (
         <div className="flex h-full w-full items-center justify-center bg-neutral-bg-muted/50 text-xs text-neutral-fg-subtle">
@@ -97,7 +103,8 @@ export function VisualizationPreview({
   }
 
   // Loading state — waiting for insight data or view creation.
-  // Only reached when there is no error.
+  // Only reached when there is no error (or isLoadingInsight is true, in which
+  // case any prior error is stale and the spinner is the correct state).
   if (isLoadingInsight || !isReady || !viewName) {
     return <PreviewLoading />;
   }

--- a/packages/app/src/components/visualizations/VisualizationPreview.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.tsx
@@ -38,7 +38,7 @@ interface VisualizationPreviewProps {
 export function VisualizationPreview({
   visualization,
   height = PREVIEW_HEIGHT,
-  fallback = <PreviewLoading />,
+  fallback = null,
 }: VisualizationPreviewProps) {
   // Fetch the insight for this visualization
   const { data: insight, isLoading: isLoadingInsight } = useInsight(
@@ -84,12 +84,8 @@ export function VisualizationPreview({
     };
   }, [visualization.encoding, dataTable, insight]);
 
-  // Loading state - waiting for insight data or view creation
-  if (isLoadingInsight || !isReady || !viewName) {
-    return <PreviewLoading />;
-  }
-
-  // Error state - show fallback if view creation failed
+  // Error state — checked BEFORE the loading guard so that view-creation errors
+  // that leave `isReady=false` reach a terminal UI instead of spinning forever.
   if (error) {
     return (
       fallback ?? (
@@ -100,11 +96,18 @@ export function VisualizationPreview({
     );
   }
 
+  // Loading state — waiting for insight data or view creation.
+  // Only reached when there is no error.
+  if (isLoadingInsight || !isReady || !viewName) {
+    return <PreviewLoading />;
+  }
+
   // Check if encoding has required data channels (x or y)
   // Visualizations created before the encoding fix may be missing these
   const hasValidEncoding = resolvedEncoding.x || resolvedEncoding.y;
 
-  // Show fallback for visualizations with missing encoding (legacy data)
+  // Show distinct terminal UI for missing encoding — callers that omit `fallback`
+  // get the inline "Encoding missing" text here, not a spinner.
   if (!hasValidEncoding) {
     return (
       fallback ?? (


### PR DESCRIPTION
## Summary

- **F1 (VisualizationDisplay):** saved insight `filters`/`sorts` were silently dropped when no cell overrides were present. `insightForView` is intentionally stripped (no filters/sorts) for chart-mode; `effectiveParams` was only built when overrides existed. Fix: introduce `paginationEffectiveParams` that always forwards `insight.filters/sorts` (merging cell overrides when present) and pass it to `useInsightPagination`. The shared `effectiveParams` feeding `useInsightView` (chart-mode) is unchanged.

- **F2 (VisualizationPreview):** two terminal-state bugs: (a) default `fallback` was `<PreviewLoading />` so callers omitting it got a spinner for error/encoding-missing states — defaulted to `null`. (b) loading guard executed before error guard, so view errors with `isReady=false` spun forever — error check moved before loading guard.

- **F3 (tests):** `VisualizationDisplay.test.tsx` (3 tests: F1 pagination effectiveParams invariant) and `VisualizationPreview.test.tsx` (6 branch tests: loading spinner × 2, error terminal UI × 3, encoding-missing × 1). The compute-combined-fields multi-join tests were already added by YW-305 (#170). The no-selectedFields+no-metrics "baseline-identical" AC for compute-preview is stale — source already grand-totals unconditionally, existing test at line 348 covers this; not duplicated.

## Premise notes

- **YW-303 (#168):** added the aspirational comments about "insight.filters/sorts natively" but didn't fix the code — the bug was real and unfixed.
- **YW-305 (#170):** added all compute-combined-fields multi-join collision tests (F3 first half) — not duplicated here.
- **F3 compute-preview AC stale:** `computeInsightPreview` with no selectedFields/no metrics always returns a grand-total (1 row), not a pass-through (N rows). The existing test at line 348 already locks this behavior.

## Test plan

- [x] `VisualizationPreview.test.tsx` — 6 branch tests pass
- [x] `VisualizationDisplay.test.tsx` — 3 effectiveParams invariant tests pass
- [x] Full `packages/app` test suite: 534/534 pass
- [x] Full turbo typecheck: 48/48 tasks pass
- [ ] CI green (in progress)

Tracked internally as YW-304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes two distinct bugs in the visualization layer and adds test coverage for both. The fix is narrow and well-scoped: only `VisualizationDisplay.tsx` and `VisualizationPreview.tsx` are touched, and each change is tightly paired with its test file.

- **F1 (VisualizationDisplay):** introduces `paginationEffectiveParams`, a separate memo that always forwards `insight.filters/sorts` to `useInsightPagination` — even when no cell overrides exist — so the stripped `insightForView` object (which deliberately omits filters/sorts to keep chart column resolution intact) no longer causes them to be silently dropped from the table SQL.
- **F2 (VisualizationPreview):** swaps the error guard before the loading guard (preventing an indefinite spinner when `isReady=false && error`) and changes the default `fallback` from `<PreviewLoading />` to `null`, allowing terminal error/encoding-missing states to surface their own distinct UI instead of always showing a spinner.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both fixes are additive and narrowly scoped; the no-override chart path is explicitly unchanged.

The two production changes are targeted: a new memo that unconditionally forwards saved insight params to the pagination hook, and a guard-order swap in the preview component. Neither touches shared infrastructure, and each is backed by dedicated tests that lock the corrected behavior.

VisualizationDisplay.test.tsx and VisualizationPreview.test.tsx still contain YW-304 in their top-level doc blocks, which the repo's check-no-ticket-refs.mjs CI gate will reject.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/components/visualizations/VisualizationDisplay.tsx | Adds `paginationEffectiveParams` memo that unconditionally forwards `insight.filters/sorts` (plus any cell overrides) to `useInsightPagination`, fixing silent filter/sort loss when `overrides` is absent. The chart-mode `effectiveParams` path is unchanged. |
| packages/app/src/components/visualizations/VisualizationPreview.tsx | Reorders error guard before loading guard and changes `fallback` default from `<PreviewLoading />` to `null`, fixing indefinite spinners on view-creation errors and missing-encoding states. |
| packages/app/src/components/visualizations/VisualizationDisplay.test.tsx | New test file with 4 tests covering the `paginationEffectiveParams` invariant: saved filters forwarded, saved sorts forwarded, empty-arrays baseline, and override-merge path. All mocks use `vi.hoisted` correctly. |
| packages/app/src/components/visualizations/VisualizationPreview.test.tsx | New test file with 6 tests covering the three terminal-state branches: loading spinner (×2), view-creation error terminal UI (×3, including stale-error bleed-through guard), and encoding-missing text. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(viz): guard stale error from prior i..."](https://github.com/youhaowei/dashframe/commit/6e8351946164773dd602687af8b79019a2d1a920) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39896373)</sub>

<!-- /greptile_comment -->