### PR TITLE
[YW-298] feat(connector-rest): SSRF private-host guard + assistant REST-config guide

### DIFF
--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -704,6 +704,43 @@ describe("command vocabulary", () => {
       expect(stored["connectionString"]).toBeUndefined();
     });
 
+    it("SetDataSourceConfig extra: a REST connector config shape lands in config unstripped", async () => {
+      // The assistant authors a REST data source by writing the declarative
+      // connector config through `extra`. None of these keys are credentials, so
+      // the sink guard must let the whole REST shape through to config — only the
+      // typed apiKey/connectionString fields are rejected from `extra`.
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", { id: sourceId, type: "rest", name: "GitHub" }),
+      );
+      await commit(
+        cmd("SetDataSourceConfig", {
+          id: sourceId,
+          extra: {
+            endpoint: "https://api.github.com/users",
+            method: "GET",
+            authRef: "secret-ref-123",
+            pagination: "cursor",
+            rowPath: "data",
+            fieldMap: { login: "username" },
+          } as Record<string, unknown>,
+        }),
+      );
+      const [row] = await sourcesById(sourceId);
+      const stored = row?.config as Record<string, unknown>;
+      expect(stored["endpoint"]).toBe("https://api.github.com/users");
+      expect(stored["method"]).toBe("GET");
+      // authRef is a SecretRef (an opaque id), NOT a plaintext credential — it is
+      // a reference the agent may author; it carries no secret value.
+      expect(stored["authRef"]).toBe("secret-ref-123");
+      expect(stored["pagination"]).toBe("cursor");
+      expect(stored["rowPath"]).toBe("data");
+      expect(stored["fieldMap"]).toEqual({ login: "username" });
+      // No credential slots were touched.
+      expect(stored["apiKey"]).toBeUndefined();
+      expect(stored["connectionString"]).toBeUndefined();
+    });
+
     it("should throw on UpdateField with a missing fieldId", async () => {
       const sourceId = id();
       const tableId = id();

--- a/bun.lock
+++ b/bun.lock
@@ -528,6 +528,7 @@
         "@dashframe/engine": "workspace:*",
         "@wystack/secret-vault": "workspace:*",
         "apache-arrow": "^21.1.0",
+        "ipaddr.js": "2.4.0",
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.16",
@@ -2552,7 +2553,7 @@
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+    "ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -3989,6 +3990,8 @@
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "protobufjs/@types/node": ["@types/node@24.9.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg=="],
+
+    "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "radix-ui/@radix-ui/react-label": ["@radix-ui/react-label@2.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ=="],
 

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -30,7 +30,7 @@ export interface CommandGuideEntry {
   name: string;
   /** Logical group for navigation. */
   group:
-    | "dataSource"
+    | "connector"
     | "dataTable"
     | "field"
     | "metric"
@@ -52,17 +52,33 @@ export interface CommandGuideEntry {
  * COMMAND_PATHS).
  */
 export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
-  // --- DataSource ---
+  // --- Connector (data-source authoring) ---
+  //
+  // A connector KIND (file, notion, rest, postgres) is first-party shipped code.
+  // A connector CONFIG is per-source declarative data in DataSource.config — the
+  // pair below authors that config. A REST source, for example, is a DataSource
+  // of type "rest" whose config holds { endpoint, method, authRef, pagination,
+  // rowPath, fieldMap }; no new connector kind is registered.
+  //
+  // ASSISTANT SCOPE (today): these are HUMAN-ONLY operations. They are NOT in the
+  // applyCommand draft-safe allow-list — the assistant works with EXISTING data
+  // sources, it does not mint or configure them. Data-source creation is a
+  // human-owned trust step (a new data-access reference the human must review),
+  // and credential writes hit the OS keychain outside the draft transaction.
+  // These entries document the config CONTRACT (so the agent can read a source's
+  // shape); they are not an instruction that the agent may emit them.
   {
     name: "GetOrCreateDataSource",
-    group: "dataSource",
+    group: "connector",
     summary: "Idempotent upsert of a data source by client-minted id.",
     args: { id: "UUID", type: "connector id", name: "display name" },
-    notes: "Safe to retry — finds existing by PK or inserts. No credentials.",
+    notes:
+      "Human-only (not draft-safe). Safe to retry — finds existing by PK or " +
+      "inserts. No credentials.",
   },
   {
     name: "CreateDataSource",
-    group: "dataSource",
+    group: "connector",
     summary: "Create a data source, storing any credentials in the vault.",
     args: {
       id: "UUID",
@@ -71,19 +87,30 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
       "apiKey?": "secret",
       "connectionString?": "secret",
     },
-    notes: "Credentials go to the vault; never echoed back on read.",
+    notes:
+      "Human-only (not draft-safe — vault side-effect + trust step). " +
+      "Credentials go to the vault; never echoed back on read. For a REST " +
+      'source: type "rest", then SetDataSourceConfig writes the endpoint config.',
   },
   {
     name: "SetDataSourceConfig",
-    group: "dataSource",
+    group: "connector",
     summary: "Replace a data source's credential + non-credential config.",
     args: {
       id: "UUID",
       "apiKey?": "secret",
       "connectionString?": "secret",
-      "extra?": "non-credential settings",
+      "extra?": "non-credential connector config (e.g. REST endpoint settings)",
     },
-    notes: "`extra` must NOT contain apiKey/connectionString (rejected).",
+    notes:
+      "Human-only (not draft-safe). `extra` carries the declarative connector " +
+      "config and must NOT contain apiKey/connectionString (rejected — use the " +
+      "typed credential fields). REST config shape: { endpoint, method, " +
+      "authRef (a SecretRef id, never a plaintext secret), pagination " +
+      "(offset|cursor|page-number|link-header), rowPath, fieldMap }. The REST " +
+      "connector rejects a private/internal endpoint host at the fetch sink and " +
+      "at config-form validation (SSRF guard); authRef must not be bypassed for " +
+      "authenticated sources.",
   },
   // --- DataTable ---
   {

--- a/packages/connector-rest/package.json
+++ b/packages/connector-rest/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@dashframe/engine": "workspace:*",
     "@wystack/secret-vault": "workspace:*",
-    "apache-arrow": "^21.1.0"
+    "apache-arrow": "^21.1.0",
+    "ipaddr.js": "2.4.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.16",

--- a/packages/connector-rest/src/connector.test.ts
+++ b/packages/connector-rest/src/connector.test.ts
@@ -190,7 +190,74 @@ describe("RestConnector", () => {
       const result = c.validate({ endpoint: "https://api.example.com/data" });
       expect(result.valid).toBe(true);
     });
+
+    // SSRF sink-guard: the endpoint URL is the attack vector. validate() must
+    // reject a private/loopback/link-local host regardless of who authored it.
+    // http:// (not https://) is deliberate — an internal/metadata target is
+    // typically plain-http; these are rejected-by-design fixtures, not real
+    // connection targets.
+    /* eslint-disable sonarjs/no-clear-text-protocols -- SSRF fixtures: internal http targets that validate() must reject. */
+    it.each([
+      ["http://10.0.0.1/data", "RFC-1918 private"],
+      ["http://192.168.1.1/data", "RFC-1918 private"],
+      ["http://127.0.0.1:8080/admin", "loopback"],
+      ["http://localhost/data", "loopback hostname"],
+      ["http://169.254.169.254/latest/meta-data/", "cloud metadata"],
+      ["http://[::1]/data", "IPv6 loopback"],
+      // IPv4-mapped IPv6: URL.hostname normalizes this to ::ffff:a9fe:a9fe (hex),
+      // which a dotted-form-only classifier would let through to cloud metadata.
+      // This fixture goes through the real validate() → URL → isPrivateHost path.
+      [
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+        "IPv4-mapped metadata",
+      ],
+      ["http://[::ffff:10.0.0.1]/data", "IPv4-mapped private"],
+    ])("rejects a private/internal endpoint: %s (%s)", (endpoint) => {
+      const result = c.validate({ endpoint });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.["endpoint"]).toBeTruthy();
+    });
+    /* eslint-enable sonarjs/no-clear-text-protocols */
+
+    it("passes for a public IP-literal URL", () => {
+      const result = c.validate({ endpoint: "https://8.8.8.8/api" });
+      expect(result.valid).toBe(true);
+    });
   });
+
+  // -------------------------------------------------------------------------
+  // SSRF guard at the FETCH SINK (the authoritative guard — validate() is
+  // form-side UX; this is what every authoring path inherits)
+  // -------------------------------------------------------------------------
+
+  /* eslint-disable sonarjs/no-clear-text-protocols -- SSRF fixtures: internal http targets the fetch sink must refuse. */
+  describe("fetch-sink SSRF guard", () => {
+    it("query() refuses a private endpoint BEFORE any fetch", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(noopResolver, {
+        // IPv4-mapped form URL.hostname normalizes to ::ffff:a9fe:a9fe — the
+        // cloud-metadata SSRF target. The fetch sink must reject it.
+        endpoint: "http://[::ffff:169.254.169.254]/latest/meta-data/",
+      });
+      await expect(c.query("db", crypto.randomUUID())).rejects.toThrow(
+        /private\/internal|SSRF/i,
+      );
+      // The guard fires before the network call — fetch is never invoked.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("connect() refuses a loopback endpoint BEFORE any fetch", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "http://127.0.0.1:9200/_cluster/health",
+      });
+      await expect(c.connect()).rejects.toThrow(/private\/internal|SSRF/i);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+  /* eslint-enable sonarjs/no-clear-text-protocols */
 
   // -------------------------------------------------------------------------
   // 1. Offset pagination

--- a/packages/connector-rest/src/connector.test.ts
+++ b/packages/connector-rest/src/connector.test.ts
@@ -58,13 +58,21 @@ function makeBoundResolver(
 /** Build a minimal Response-like object for vi.stubGlobal('fetch', ...) */
 function makeResponse(
   body: unknown,
-  opts: { ok?: boolean; status?: number; linkHeader?: string } = {},
+  opts: {
+    ok?: boolean;
+    status?: number;
+    linkHeader?: string;
+    location?: string;
+  } = {},
 ): Response {
   const ok = opts.ok ?? true;
   const status = opts.status ?? 200;
   const headers = new Map<string, string>();
   if (opts.linkHeader) {
     headers.set("link", opts.linkHeader);
+  }
+  if (opts.location) {
+    headers.set("location", opts.location);
   }
   return {
     ok,
@@ -255,6 +263,144 @@ describe("RestConnector", () => {
       });
       await expect(c.connect()).rejects.toThrow(/private\/internal|SSRF/i);
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("refuses a redirect from a public endpoint to a private host", async () => {
+      // A public endpoint 30x-redirects to cloud metadata. We follow redirects
+      // manually (redirect:"manual") and re-validate each Location — the private
+      // hop must be refused. The mock returns the 302; the connector resolves
+      // and re-checks the target itself.
+      const mockFetch = vi.fn().mockResolvedValueOnce(
+        makeResponse(null, {
+          status: 302,
+          location: "http://169.254.169.254/latest/meta-data/",
+        }),
+      );
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+      await expect(c.query("db", crypto.randomUUID())).rejects.toThrow(
+        /private\/internal|SSRF/i,
+      );
+      // The public first hop was fetched; the private redirect target was NOT.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]?.[0]).toBe("https://api.example.com/data");
+    });
+
+    it("follows a redirect to another public host", async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeResponse(null, {
+            status: 302,
+            location: "https://cdn.example.com/data",
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }]));
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(noopResolver, {
+        endpoint: "https://api.example.com/data",
+      });
+      const result = await c.query("db", crypto.randomUUID());
+      expect(result.fields.length).toBeGreaterThan(0);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]?.[0]).toBe("https://cdn.example.com/data");
+    });
+
+    it("drops the Authorization header on a cross-host redirect (no credential leak)", async () => {
+      // The first (configured) host carries the vault Bearer token; a redirect
+      // to a DIFFERENT public host must NOT forward it. Uses a real vault +
+      // bound resolver so an actual token is present — noopResolver would make
+      // this test blind (no token to leak).
+      const { vault, ref } =
+        await makeTestVaultWithSecret("super-secret-token");
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeResponse(null, {
+            status: 302,
+            location: "https://other.example.net/data",
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }]));
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(makeBoundResolver(vault, ref), {
+        endpoint: "https://api.example.com/data",
+        authRef: ref,
+      });
+      await c.query("db", crypto.randomUUID());
+
+      const firstHeaders = mockFetch.mock.calls[0]?.[1]?.headers as Record<
+        string,
+        string
+      >;
+      const secondHeaders = mockFetch.mock.calls[1]?.[1]?.headers as Record<
+        string,
+        string
+      >;
+      // The configured host got the credential…
+      expect(firstHeaders?.["Authorization"]).toBe("Bearer super-secret-token");
+      // …the cross-host redirect target did NOT.
+      expect(secondHeaders?.["Authorization"]).toBeUndefined();
+    });
+
+    it("keeps the Authorization header on a same-host scheme upgrade", async () => {
+      const { vault, ref } =
+        await makeTestVaultWithSecret("super-secret-token");
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          // http→https on the SAME host: a credential-preserving upgrade.
+          makeResponse(null, {
+            status: 302,
+            location: "https://api.example.com/data",
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }]));
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(makeBoundResolver(vault, ref), {
+        // http→https same-host upgrade keeps auth (covered by the block-level
+        // no-clear-text-protocols disable above).
+        endpoint: "http://api.example.com/data",
+        authRef: ref,
+      });
+      await c.query("db", crypto.randomUUID());
+
+      const secondHeaders = mockFetch.mock.calls[1]?.[1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(secondHeaders?.["Authorization"]).toBe(
+        "Bearer super-secret-token",
+      );
+    });
+
+    it("drops the Authorization header on a same-host scheme DOWNGRADE (https→http)", async () => {
+      // https→http on the same host re-sends the Bearer over cleartext — drop it.
+      const { vault, ref } =
+        await makeTestVaultWithSecret("super-secret-token");
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeResponse(null, {
+            status: 302,
+            location: "http://api.example.com/data",
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse([{ id: 1 }]));
+      vi.stubGlobal("fetch", mockFetch);
+      const c = makeRestConnector(makeBoundResolver(vault, ref), {
+        endpoint: "https://api.example.com/data",
+        authRef: ref,
+      });
+      await c.query("db", crypto.randomUUID());
+
+      const secondHeaders = mockFetch.mock.calls[1]?.[1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(secondHeaders?.["Authorization"]).toBeUndefined();
     });
   });
   /* eslint-enable sonarjs/no-clear-text-protocols */

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -36,11 +36,33 @@ import {
   parseStringValueByType,
 } from "@dashframe/engine";
 import { tableFromArrays, tableToIPC } from "apache-arrow";
+import { isPrivateHost } from "./private-host.js";
 import type { RestConnectorConfig } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * SSRF sink-guard for a fetch URL: throw unless the URL parses and its host is
+ * public. Shared by the fetch sink (`fetchPage`) and surfaced through
+ * `validate()` for the config form. Guard the sink, not the provenance — every
+ * fetch inherits this regardless of how the endpoint was authored.
+ */
+function assertPublicUrl(url: string): void {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    throw new Error(`[RestConnector] Invalid URL: ${url}`);
+  }
+  if (isPrivateHost(host)) {
+    throw new Error(
+      `[RestConnector] Endpoint host "${host}" is private/internal — ` +
+        "refusing to fetch (SSRF guard).",
+    );
+  }
+}
 
 /**
  * Traverse a dot-path in `data` and return the value at that path, or
@@ -254,6 +276,14 @@ async function fetchPage(
   method: string,
   headers: Record<string, string>,
 ): Promise<{ data: unknown; response: Response }> {
+  // SSRF sink-guard: this is the single fetch choke point — every pagination
+  // strategy and connect() route through here. Reject a private/loopback/
+  // link-local host BEFORE the request leaves the process, so the guard covers
+  // the initial endpoint and every paginated/redirect-resolved URL regardless of
+  // who authored the config. Guarding here (the sink) rather than only at form
+  // validation means a config persisted by any path — UI form, assistant, direct
+  // wire call — cannot reach an internal host.
+  assertPublicUrl(url);
   const response = await fetch(url, { method, headers });
   if (!response.ok) {
     throw new Error(
@@ -658,12 +688,32 @@ export class RestConnector extends RemoteApiConnector {
       };
     }
 
+    let parsed: URL;
     try {
-      new URL(endpoint);
+      parsed = new URL(endpoint);
     } catch {
       return {
         valid: false,
         errors: { endpoint: "Endpoint must be a valid URL." },
+      };
+    }
+
+    // SSRF check, form-side: reject endpoints addressing a private, loopback,
+    // link-local, or reserved host (RFC-1918, 127/8, 169.254/16 cloud-metadata,
+    // ::1, fc00::/7, fe80::/10, 0.0.0.0) so the config form surfaces the error
+    // early. This is UX — the AUTHORITATIVE guard is at the fetch sink
+    // (`fetchPage` → `assertPublicUrl`), which every fetch routes through
+    // regardless of how the endpoint was authored. (DNS-rebinding — a public
+    // hostname resolving to a private IP at fetch time — is a separate fetch-time
+    // concern; this synchronous check covers literal hosts.)
+    if (isPrivateHost(parsed.hostname)) {
+      return {
+        valid: false,
+        errors: {
+          endpoint:
+            "Endpoint must be a public host — private, loopback, and " +
+            "link-local addresses are not allowed.",
+        },
       };
     }
 

--- a/packages/connector-rest/src/connector.ts
+++ b/packages/connector-rest/src/connector.ts
@@ -268,30 +268,130 @@ function coercePageSize(value: unknown, fallback: number): number {
   return Math.floor(n);
 }
 
+/** Max redirect hops followed manually, matching `fetch`'s default cap of 20. */
+const MAX_REDIRECTS = 20;
+
+/** Header names dropped when a redirect crosses to a different host (credential-leak guard). */
+const SENSITIVE_HEADERS = new Set(["authorization", "cookie"]);
+
+/** Remove credential-bearing headers (case-insensitive) — used on a cross-host redirect. */
+function stripSensitiveHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (!SENSITIVE_HEADERS.has(k.toLowerCase())) out[k] = v;
+  }
+  return out;
+}
+
+/** One leg of a manual redirect chain: the next URL, method, and headers to use. */
+interface RedirectStep {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+}
+
 /**
- * Perform a single HTTP request. Throws on non-ok status.
+ * Resolve a 3xx response into the next request leg. Throws if the redirect is
+ * malformed (no/invalid Location).
+ *
+ * Applies two guards:
+ *  - Credential-leak: drops Authorization/Cookie when the target HOST differs
+ *    (a same-host scheme upgrade http→https keeps them, matching curl/browser).
+ *  - Method downgrade: 301/302/303 switch the follow-up to GET.
+ *
+ * The SSRF host check is NOT here — it runs in `fetchPage` before every fetch,
+ * so the resolved URL is re-validated at the top of the next loop iteration.
+ */
+function resolveRedirect(
+  response: Response,
+  current: RedirectStep,
+): RedirectStep {
+  const location = response.headers.get("Location");
+  if (!location) {
+    throw new Error(
+      `[RestConnector] HTTP ${response.status} redirect with no Location — ${current.url}`,
+    );
+  }
+  let resolved: URL;
+  try {
+    resolved = new URL(location, current.url);
+  } catch {
+    throw new Error(
+      `[RestConnector] redirect Location "${location}" is not a valid URL — ${current.url}`,
+    );
+  }
+  const from = new URL(current.url);
+  // Drop credentials when the redirect crosses to a different HOST, OR downgrades
+  // the scheme https→http (re-sending the Bearer over cleartext to an on-path
+  // observer). A same-host upgrade http→https keeps them, matching curl/browser.
+  const crossHost = resolved.hostname !== from.hostname;
+  const schemeDowngrade =
+    from.protocol === "https:" && resolved.protocol === "http:";
+  const dropCredentials = crossHost || schemeDowngrade;
+  const downgradeToGet =
+    response.status === 301 ||
+    response.status === 302 ||
+    response.status === 303;
+  return {
+    url: resolved.toString(),
+    method: downgradeToGet ? "GET" : current.method,
+    headers: dropCredentials
+      ? stripSensitiveHeaders(current.headers)
+      : current.headers,
+  };
+}
+
+/**
+ * Perform a single HTTP request, following redirects MANUALLY. Throws on non-ok
+ * status.
+ *
+ * SSRF sink-guard: this is the single fetch choke point — every pagination
+ * strategy and connect() route through here. The host is re-validated before
+ * EVERY hop, so the guard covers the initial endpoint, paginated URLs, AND
+ * redirect targets, regardless of how the config was authored (UI form,
+ * assistant, direct wire call).
+ *
+ * Why manual redirects (`redirect: "manual"`):
+ *  - A configured PUBLIC endpoint can 30x-redirect to a PRIVATE host (e.g.
+ *    `http://169.254.169.254/` cloud metadata). Auto-following (`fetch`'s
+ *    default) would reach the internal host and bypass the guard — the SSRF
+ *    vector is the host actually reached, not just the configured one. We
+ *    re-run `assertPublicUrl` on each resolved `Location` before following it.
+ *  - Going manual means WE own the cross-origin credential-stripping the
+ *    platform does on auto-follow (see `resolveRedirect`): the vault Bearer
+ *    token must not cross to a different host.
  */
 async function fetchPage(
   url: string,
   method: string,
   headers: Record<string, string>,
 ): Promise<{ data: unknown; response: Response }> {
-  // SSRF sink-guard: this is the single fetch choke point — every pagination
-  // strategy and connect() route through here. Reject a private/loopback/
-  // link-local host BEFORE the request leaves the process, so the guard covers
-  // the initial endpoint and every paginated/redirect-resolved URL regardless of
-  // who authored the config. Guarding here (the sink) rather than only at form
-  // validation means a config persisted by any path — UI form, assistant, direct
-  // wire call — cannot reach an internal host.
-  assertPublicUrl(url);
-  const response = await fetch(url, { method, headers });
-  if (!response.ok) {
-    throw new Error(
-      `[RestConnector] HTTP ${response.status} ${response.statusText} — ${url}`,
-    );
+  let step: RedirectStep = { url, method, headers };
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    assertPublicUrl(step.url);
+    const response = await fetch(step.url, {
+      method: step.method,
+      headers: step.headers,
+      redirect: "manual",
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      step = resolveRedirect(response, step);
+      continue;
+    }
+    if (!response.ok) {
+      throw new Error(
+        `[RestConnector] HTTP ${response.status} ${response.statusText} — ${step.url}`,
+      );
+    }
+    const data: unknown = await response.json();
+    return { data, response };
   }
-  const data: unknown = await response.json();
-  return { data, response };
+  throw new Error(
+    `[RestConnector] too many redirects (>${MAX_REDIRECTS}) — ${url}`,
+  );
 }
 
 // The `budget` arg threaded through pagination is a max-rows count: pagination

--- a/packages/connector-rest/src/private-host.test.ts
+++ b/packages/connector-rest/src/private-host.test.ts
@@ -64,6 +64,11 @@ describe("isPrivateHost (SSRF sink-guard)", () => {
       ["LOCALHOST"],
       ["ip6-localhost"],
       ["ip6-loopback"],
+      // Rooted FQDN form: new URL("http://localhost./").hostname === "localhost."
+      ["localhost."],
+      // Multi-trailing-dot — `new URL()` accepts these; resolvers collapse them.
+      ["localhost.."],
+      ["localhost..."],
     ])("blocks %s", (host) => {
       expect(isPrivateHost(host)).toBe(true);
     });
@@ -110,6 +115,9 @@ describe("isPrivateHost (SSRF sink-guard)", () => {
       ["http://[0:0:0:0:0:ffff:127.0.0.1]/", "IPv4-mapped loopback (expanded)"],
       ["http://[::10.0.0.1]/", "IPv4-compatible private (deprecated)"],
       ["http://2130706433/", "integer IPv4 → 127.0.0.1"],
+      ["http://0177.0.0.1/", "octal IPv4 → 127.0.0.1"],
+      ["http://0x7f.0.0.1/", "hex IPv4 → 127.0.0.1"],
+      ["http://localhost./", "rooted-FQDN localhost (trailing dot)"],
     ])("blocks %s (%s)", (url) => {
       expect(isPrivateHost(new URL(url).hostname)).toBe(true);
     });

--- a/packages/connector-rest/src/private-host.test.ts
+++ b/packages/connector-rest/src/private-host.test.ts
@@ -1,0 +1,126 @@
+/**
+ * SSRF host-guard tests.
+ *
+ * The contract under test: `isPrivateHost` returns true for any host that
+ * addresses a private, loopback, link-local, or reserved destination, and false
+ * for a public host. This is the sink-guard for connector URL validation — the
+ * test pins each blocked range so a future edit cannot silently re-open one.
+ */
+/* eslint-disable sonarjs/no-hardcoded-ip --
+ * Hardcoded IP literals are intrinsic to this file: it tests an IP-range
+ * classifier, so each blocked/allowed range MUST be asserted by literal. These
+ * are test fixtures, never a runtime connection target. */
+import { describe, expect, it } from "vitest";
+
+import { isPrivateHost } from "./private-host.js";
+
+describe("isPrivateHost (SSRF sink-guard)", () => {
+  describe("rejects private / loopback / link-local IPv4", () => {
+    it.each([
+      ["10.0.0.1", "RFC-1918 10/8"],
+      ["10.255.255.255", "RFC-1918 10/8 upper"],
+      ["172.16.0.1", "RFC-1918 172.16/12 lower"],
+      ["172.31.255.255", "RFC-1918 172.16/12 upper"],
+      ["192.168.0.1", "RFC-1918 192.168/16"],
+      ["127.0.0.1", "loopback 127/8"],
+      ["127.255.255.255", "loopback 127/8 upper"],
+      ["169.254.169.254", "link-local cloud metadata"],
+      ["0.0.0.0", "unspecified / loopback bypass"],
+    ])("blocks %s (%s)", (host) => {
+      expect(isPrivateHost(host)).toBe(true);
+    });
+  });
+
+  describe("rejects loopback / link-local / unique-local IPv6", () => {
+    it.each([
+      ["::1", "loopback"],
+      ["::", "unspecified"],
+      ["fe80::1", "link-local fe80::/10"],
+      ["febf::1", "link-local fe80::/10 upper"],
+      ["fc00::1", "unique-local fc00::/7 lower"],
+      ["fdff::1", "unique-local fc00::/7 upper"],
+      ["::ffff:10.0.0.1", "IPv4-mapped private (dotted form)"],
+      ["::ffff:192.168.1.1", "IPv4-mapped private 192.168 (dotted form)"],
+      // The HEX-compressed forms are what URL.hostname actually emits for an
+      // IPv4-mapped literal — these are the real attack surface. A regex
+      // classifier matching only the dotted form let these through (cloud
+      // metadata at 169.254.169.254 reachable as ::ffff:a9fe:a9fe).
+      ["::ffff:a00:1", "IPv4-mapped 10.0.0.1 (hex, URL-normalized)"],
+      ["::ffff:a9fe:a9fe", "IPv4-mapped 169.254.169.254 metadata (hex)"],
+      ["::ffff:7f00:1", "IPv4-mapped 127.0.0.1 loopback (hex)"],
+      ["::ffff:c0a8:101", "IPv4-mapped 192.168.1.1 (hex)"],
+      // Deprecated IPv4-compatible (::/96) embeds an IPv4 destination too.
+      ["::a00:1", "IPv4-compatible 10.0.0.1 (deprecated ::/96)"],
+      // CGNAT shared address space (100.64/10).
+      ["100.64.0.1", "carrier-grade NAT 100.64/10"],
+    ])("blocks %s (%s)", (host) => {
+      expect(isPrivateHost(host)).toBe(true);
+    });
+  });
+
+  describe("rejects loopback hostnames", () => {
+    it.each([
+      ["localhost"],
+      ["LOCALHOST"],
+      ["ip6-localhost"],
+      ["ip6-loopback"],
+    ])("blocks %s", (host) => {
+      expect(isPrivateHost(host)).toBe(true);
+    });
+  });
+
+  describe("allows public hosts", () => {
+    it.each([
+      ["api.example.com", "DNS hostname"],
+      ["8.8.8.8", "public IPv4"],
+      ["1.1.1.1", "public IPv4"],
+      ["172.15.0.1", "just below the 172.16/12 range"],
+      ["172.32.0.1", "just above the 172.16/12 range"],
+      ["192.169.0.1", "adjacent to 192.168/16"],
+      ["2606:4700:4700::1111", "public IPv6 (Cloudflare)"],
+      ["::ffff:8.8.8.8", "IPv4-mapped public"],
+    ])("allows %s (%s)", (host) => {
+      expect(isPrivateHost(host)).toBe(false);
+    });
+  });
+
+  it("treats an empty host as non-public (rejected)", () => {
+    expect(isPrivateHost("")).toBe(true);
+    expect(isPrivateHost("   ")).toBe(true);
+  });
+
+  it("tolerates a bracketed IPv6 literal", () => {
+    expect(isPrivateHost("[::1]")).toBe(true);
+    expect(isPrivateHost("[2606:4700:4700::1111]")).toBe(false);
+  });
+
+  // End-to-end through the real production path: the connector feeds
+  // `new URL(endpoint).hostname` to isPrivateHost, NOT the raw literal. URL
+  // normalizes IPv4-mapped/compatible and integer/octal IPv4 forms — these
+  // assertions pin the classifier against what URL actually emits (the dotted
+  // literal a unit test feeds it never appears in production).
+  describe("via new URL().hostname (the production code path)", () => {
+    /* eslint-disable sonarjs/no-clear-text-protocols -- SSRF fixtures: internal http targets the classifier must reject; plain http is the realistic attacker form. */
+    it.each([
+      ["http://[::ffff:10.0.0.1]/data", "IPv4-mapped private"],
+      [
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+        "metadata via mapped",
+      ],
+      ["http://[0:0:0:0:0:ffff:127.0.0.1]/", "IPv4-mapped loopback (expanded)"],
+      ["http://[::10.0.0.1]/", "IPv4-compatible private (deprecated)"],
+      ["http://2130706433/", "integer IPv4 → 127.0.0.1"],
+    ])("blocks %s (%s)", (url) => {
+      expect(isPrivateHost(new URL(url).hostname)).toBe(true);
+    });
+
+    it.each([
+      ["https://api.github.com/users", "public DNS host"],
+      ["http://[::ffff:8.8.8.8]/", "IPv4-mapped public"],
+      ["https://[2606:4700:4700::1111]/", "public IPv6"],
+    ])("allows %s (%s)", (url) => {
+      expect(isPrivateHost(new URL(url).hostname)).toBe(false);
+    });
+    /* eslint-enable sonarjs/no-clear-text-protocols */
+  });
+});

--- a/packages/connector-rest/src/private-host.ts
+++ b/packages/connector-rest/src/private-host.ts
@@ -1,0 +1,143 @@
+/**
+ * SSRF host guard — rejects endpoint hosts that resolve to a private, loopback,
+ * link-local, or otherwise non-public address.
+ *
+ * WHY (guard the sink, not the provenance): a REST endpoint URL is the SSRF
+ * vector itself. Whether the URL was authored by a human via the config form or
+ * by the assistant, an endpoint pointing at an internal host (cloud metadata at
+ * 169.254.169.254, a loopback admin port, an RFC-1918 LAN service) is the same
+ * attack surface. The check lives at the connector's fetch sink (and form
+ * validation) so every authoring path inherits it — no caller is trusted to have
+ * pre-sanitized the host.
+ *
+ * IMPLEMENTATION: IP classification is delegated to `ipaddr.js`, whose named
+ * ranges (`private`, `loopback`, `linkLocal`, `uniqueLocal`, `carrierGradeNat`,
+ * `unspecified`, `reserved`, `ipv4Mapped`) are battle-tested and auditable — a
+ * hand-rolled IPv6 classifier missed the IPv4-mapped hex form (`::ffff:a9fe:a9fe`
+ * = 169.254.169.254) that `URL.hostname` normalizes to. For an IPv4-mapped IPv6
+ * address we re-classify the embedded IPv4 (so `::ffff:10.0.0.1` is treated as
+ * the private 10.0.0.1 it is).
+ *
+ * SCOPE / LIMITS: this is a SYNCHRONOUS literal-host check. It blocks IP-literal
+ * hosts in the non-public ranges and the obvious loopback hostnames. It does NOT
+ * resolve DNS — a hostname that resolves to a private IP at fetch time (DNS
+ * rebinding) is out of scope here and belongs to a fetch-time / resolved-address
+ * guard, not this literal-host validator. Blocking the literal ranges is the
+ * cheap, high-value floor; DNS-time defense is a separate concern.
+ */
+
+import ipaddr from "ipaddr.js";
+
+/**
+ * Strip an optional `[...]` bracket wrapper (IPv6 literal hosts in URLs are
+ * bracketed, e.g. `http://[::1]/`). `URL.hostname` already removes the brackets,
+ * but callers passing a raw host string may include them.
+ */
+function unbracket(host: string): string {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
+
+/** Loopback / unspecified hostnames that never address a public host. */
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+]);
+
+/**
+ * `ipaddr.js` range names that designate a non-public destination. `unicast` is
+ * the only public range; everything else here is private, reserved, or a
+ * loopback/link-local/CGNAT address a server-side fetch must not reach.
+ */
+const BLOCKED_IPV4_RANGES = new Set([
+  "unspecified", // 0.0.0.0/8 — "this host"; a common loopback bypass
+  "private", // 10/8, 172.16/12, 192.168/16
+  "loopback", // 127/8
+  "linkLocal", // 169.254/16 (cloud metadata)
+  "carrierGradeNat", // 100.64/10
+  "reserved", // 192.0.0/24, 240/4, etc.
+  "broadcast", // 255.255.255.255/32
+]);
+
+const BLOCKED_IPV6_RANGES = new Set([
+  "unspecified", // ::/128
+  "loopback", // ::1/128
+  "linkLocal", // fe80::/10
+  "uniqueLocal", // fc00::/7
+  "reserved", // various reserved blocks
+]);
+
+/** True if an `ipaddr.js`-parsed IPv4 address is in a blocked (non-public) range. */
+function isBlockedIpv4(addr: ReturnType<typeof ipaddr.parse>): boolean {
+  return BLOCKED_IPV4_RANGES.has(addr.range());
+}
+
+/**
+ * Classify a parsed IP address as private/internal.
+ *
+ * For an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`, however `URL` compresses it)
+ * we re-classify the embedded IPv4 — `ipaddr.js` reports the wrapper as the
+ * generic `ipv4Mapped` range, which would otherwise let a mapped private address
+ * through. We also block the deprecated IPv4-compatible form (`::/96`,
+ * e.g. `::a00:1`), which `ipaddr.js` reports as `unicast` but still embeds an
+ * IPv4 destination.
+ */
+function isBlockedIp(addr: ReturnType<typeof ipaddr.parse>): boolean {
+  if (addr.kind() === "ipv4") {
+    return isBlockedIpv4(addr);
+  }
+  // IPv6.
+  const v6 = addr as ipaddr.IPv6;
+  if (v6.isIPv4MappedAddress()) {
+    // Re-classify on the embedded IPv4 (::ffff:10.0.0.1 → private 10.0.0.1).
+    return isBlockedIpv4(v6.toIPv4Address());
+  }
+  const range = v6.range();
+  if (BLOCKED_IPV6_RANGES.has(range)) return true;
+  // Deprecated IPv4-compatible (::/96, e.g. ::a00:1 = ::10.0.0.1) embeds an IPv4
+  // destination but is reported as unicast — block when the embedded IPv4 is
+  // private. The first six hextets are all zero for this form.
+  const parts = v6.parts;
+  const isV4Compatible =
+    parts[0] === 0 &&
+    parts[1] === 0 &&
+    parts[2] === 0 &&
+    parts[3] === 0 &&
+    parts[4] === 0 &&
+    parts[5] === 0 &&
+    // Exclude ::/128 (unspecified) and ::1 (loopback), already handled above.
+    !(parts[6] === 0 && (parts[7] === 0 || parts[7] === 1));
+  if (isV4Compatible) {
+    const embedded = ipaddr.fromByteArray([
+      parts[6]! >> 8,
+      parts[6]! & 0xff,
+      parts[7]! >> 8,
+      parts[7]! & 0xff,
+    ]);
+    return isBlockedIpv4(embedded);
+  }
+  return false;
+}
+
+/**
+ * True if `host` (a URL hostname — IP literal or hostname) addresses a private,
+ * loopback, link-local, or reserved destination that must not be reachable from
+ * a server-side fetch. Used as the SSRF sink-guard in connector URL validation
+ * and at the connector's fetch sink.
+ *
+ * @param host - A bare hostname or IP literal (e.g. from `new URL(url).hostname`).
+ *               IPv6 brackets are tolerated but `URL.hostname` already strips them.
+ */
+export function isPrivateHost(host: string): boolean {
+  const normalized = unbracket(host.trim().toLowerCase());
+  if (normalized.length === 0) return true; // empty host is never a valid public target
+  if (BLOCKED_HOSTNAMES.has(normalized)) return true;
+
+  // An IP literal classifies by range; a DNS hostname does not parse as an IP and
+  // is treated as public (DNS-rebinding to a private IP is out of scope — see
+  // module doc).
+  if (ipaddr.isValid(normalized)) {
+    return isBlockedIp(ipaddr.parse(normalized));
+  }
+  return false;
+}

--- a/packages/connector-rest/src/private-host.ts
+++ b/packages/connector-rest/src/private-host.ts
@@ -37,6 +37,17 @@ function unbracket(host: string): string {
   return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
 }
 
+/**
+ * Strip all trailing dots from a hostname (non-regex, to avoid a backtracking
+ * ReDoS lint flag on `\.+$`). `localhost.`, `localhost..` etc. are the same
+ * rooted FQDN as `localhost`.
+ */
+function stripTrailingDots(host: string): string {
+  let end = host.length;
+  while (end > 0 && host.charCodeAt(end - 1) === 46 /* '.' */) end--;
+  return host.slice(0, end);
+}
+
 /** Loopback / unspecified hostnames that never address a public host. */
 const BLOCKED_HOSTNAMES = new Set([
   "localhost",
@@ -129,7 +140,13 @@ function isBlockedIp(addr: ReturnType<typeof ipaddr.parse>): boolean {
  *               IPv6 brackets are tolerated but `URL.hostname` already strips them.
  */
 export function isPrivateHost(host: string): boolean {
-  const normalized = unbracket(host.trim().toLowerCase());
+  // Strip ALL trailing dots: `localhost.` (and the multi-dot `localhost..`,
+  // which `new URL()` also accepts) is the same host as `localhost` — a rooted
+  // FQDN. Stripping only one dot would let `http://localhost../` slip past the
+  // exact-match blocked-hostname set; many resolvers collapse trailing dots and
+  // still resolve it to loopback. Also lets a dotted-quad with trailing dots
+  // (`127.0.0.1..`) parse as the IP it is.
+  const normalized = stripTrailingDots(unbracket(host.trim().toLowerCase()));
   if (normalized.length === 0) return true; // empty host is never a valid public target
   if (BLOCKED_HOSTNAMES.has(normalized)) return true;
 


### PR DESCRIPTION
## What

Ships **3 of the 4** items from YW-298 (agent-authored REST source). The 4th (the agent-authoring E2E + allow-listing `CreateDataSource`/`SetDataSourceConfig`) is **held for an owner security decision** — see "Held" below.

### 1. SSRF private-host guard (the security-load-bearing item)
`RestConnector` now refuses an endpoint whose host is private / loopback / link-local / reserved.

- **New `private-host.ts`** — `isPrivateHost(host)` classifies via `ipaddr.js` named ranges: RFC-1918 (10/8, 172.16/12, 192.168/16), 127/8, 169.254/16 (cloud metadata), `::1`, `fc00::/7`, `fe80::/10`, `0.0.0.0`, CGNAT 100.64/10, IPv4-mapped, and the deprecated IPv4-compatible `::/96`.
- **Guard the SINK, not the provenance** — `assertPublicUrl()` fires inside `fetchPage()`, the single fetch choke point every pagination strategy and `connect()` route through. An internal endpoint is refused **before the request leaves the process**, regardless of how the config was authored (UI form, assistant, direct wire). `validate()` also rejects form-side for early UX, but the fetch sink is the authoritative guard.
- A human-authored internal URL is the same SSRF vector as an assistant-authored one — the gate is on the URL, not the author.

> Note: a hand-rolled first draft of the classifier had a real bypass — `URL.hostname` normalizes IPv4-mapped IPv6 (`::ffff:169.254.169.254`) to the hex form `::ffff:a9fe:a9fe`, which a dotted-form-only regex missed, reaching cloud metadata. Local review (3 lenses) caught it; the `ipaddr.js` rewrite closes it. The end-to-end test now drives fixtures through `new URL().hostname` — the actual production path.

### 2. `SetDataSourceConfig` accepts the REST config shape
Confirmed (+ test) that `extra: { endpoint, method, authRef, pagination, rowPath, fieldMap }` round-trips into `DataSource.config` — the sink guard rejects only `apiKey`/`connectionString`, so the REST shape lands unstripped. `authRef` is a SecretRef (opaque id), not a credential.

### 3. Command guide `connector` group
Re-tagged the data-source commands into a `connector` group and documented the REST config contract. **These commands are HUMAN-ONLY today** — they are intentionally NOT in the `applyCommand` draft-safe allow-list. The guide documents the contract; it does not authorize agent emission. Freshness test stays green (name set unchanged).

## Held for owner decision (item 4)

The ticket's AC #1 has the assistant emit `CreateDataSource`+`SetDataSourceConfig` via `applyCommand`. But `apply-command-tool.ts` (YW-279, merged) **deliberately excludes** these from `DRAFT_SAFE_COMMANDS` for two reasons: (1) `vault.store` is a non-transactional keychain side-effect that escapes draft rollback, and (2) data-source creation is a human-owned trust step. **YW-298's grooming did not account for this conflict** (its verified-against-tree table omits `apply-command-tool.ts`).

Allow-listing these is a security-boundary change (the allow-list is blanket-by-type, so adding the names also permits credential-bearing variants — needs a credential-key guard at the tool seam). **This PR does NOT touch `DRAFT_SAFE_COMMANDS`.** The E2E proving the agent path + the allow-list change are deferred to a follow-up once the owner rules on whether the assistant may author data sources. This PR is valuable regardless of that ruling.

## Out of scope / known limits (documented in code)
- **DNS-rebinding** (a public hostname resolving to a private IP at fetch time) — a fetch-time / resolved-address concern, not a literal-host check.
- **IPv6 translation prefixes** (NAT64 `64:ff9b::`, 6to4 `2002::`) embedding a private IPv4 — not exploitable in DashFrame's Electron/`serve` runtime (no translation gateway); blocking them outright would false-positive on public-IPv4-carrying forms. Recorded as a defense-in-depth gap, not a regression (strictly safer than the prior code).

## Tests & verification
- `turbo typecheck` graph-wide: 48/48 ✓
- connector-rest 97, assistant 77, server 287 — all green ✓
- lint clean (SSRF test fixtures carry justified, scoped eslint-disables for `no-hardcoded-ip` / `no-clear-text-protocols`)
- Local `code-review` (correctness + security + simplify/testing/docs lenses) run + findings resolved; a focused security re-review of the fix returned SHIP.

Security gate (SSRF) — expects an independent pass at merge.

Tracked internally as YW-298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an SSRF private-host guard to `RestConnector`, implemented via `ipaddr.js` range classification at the fetch sink (`fetchPage`/`assertPublicUrl`), plus manual redirect following with per-hop SSRF validation and cross-host credential stripping. Also confirms `SetDataSourceConfig` correctly accepts the full REST config shape through `extra`, and renames the command guide group from `"dataSource"` to `"connector"` with expanded human-only documentation.

- **SSRF guard (`private-host.ts`)**: `isPrivateHost` delegates IP classification to `ipaddr.js` and explicitly re-classifies the embedded IPv4 for both IPv4-mapped (the known bypass vector) and the deprecated IPv4-compatible (`::/96`) forms; loopback hostnames and trailing-dot variants are also blocked.
- **Redirect hardening (`connector.ts`)**: `fetchPage` switches to `redirect: "manual"`, caps at 20 follows, re-runs `assertPublicUrl` on every `Location` before following it, and strips `Authorization`/`Cookie` on cross-host or scheme-downgrade redirects.
- **`SetDataSourceConfig` + command guide**: a new test confirms the REST config shape lands in `DataSource.config` unstripped; the three data-source commands are marked "human-only (not draft-safe)" in the guide with the SSRF note embedded.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The SSRF guard is placed at the single fetch choke point so every authoring path inherits it; the redirect chain is validated hop-by-hop; credentials are correctly stripped on cross-host and scheme-downgrade redirects.

All changed paths are guarded and tested. The ipaddr.js classifier correctly handles the IPv4-mapped bypass that the prior hand-rolled regex missed, redirect-to-private is refused before the second network call, and the credential-stripping logic is exercised by dedicated test cases with a real vault. No regressions in the command guide, and no privacy-floor violations.

No files require special attention. The acknowledged DNS-rebinding and NAT64-prefix gaps are documented in code and are out of scope for this PR.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/connector-rest/src/private-host.ts | New SSRF host-guard module. Correctly handles RFC-1918, loopback/127/8, link-local/169.254/16, IPv6 private ranges, IPv4-mapped (the key bypass vector), deprecated IPv4-compatible (::/96), CGNAT, trailing-dot hostnames, and empty hosts. |
| packages/connector-rest/src/connector.ts | Adds assertPublicUrl at the fetch sink and rewrites fetchPage to follow redirects manually with per-hop SSRF validation, credential stripping on cross-host/scheme-downgrade, and a 20-follow cap. |
| packages/connector-rest/src/private-host.test.ts | New test file; exhaustively covers each blocked IP range, hex-normalized IPv4-mapped forms, loopback hostnames with trailing-dot variants, and the full production path through new URL().hostname. |
| packages/connector-rest/src/connector.test.ts | Extends connector tests with SSRF-sink and redirect scenarios: private-endpoint blocking, redirect-to-private blocking, public redirect following, cross-host credential stripping, and scheme-downgrade credential stripping. |
| packages/assistant/src/read/command-guide.ts | Renames the command group from dataSource to connector and expands notes documenting REST config shape and human-only status. The group field is display-only. |
| apps/server/src/functions/commands.test.ts | Adds a round-trip test confirming the REST config shape lands in DataSource.config unstripped via SetDataSourceConfig extra. |
| packages/connector-rest/package.json | Adds ipaddr.js@2.4.0 as a runtime dependency. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(connector-rest): close redirect SSRF..."](https://github.com/youhaowei/dashframe/commit/af664e87f845a4ac9bc83d05c7147166606def8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39912314)</sub>

<!-- /greptile_comment -->