### PR TITLE
[YW-311] fix(hooks): reset columns/fieldCount on zero-row preview result

### DIFF
--- a/packages/app/src/hooks/useDataFramePagination.test.tsx
+++ b/packages/app/src/hooks/useDataFramePagination.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for useDataFramePagination hook — empty-result column reset
+ *
+ * Contract: when a resolved result has zero rows, columns must be reset to []
+ * rather than left at the prior DataFrame's column set.
+ *
+ * This guards against the YW-311 regression: if (rows.length > 0) skipping
+ * setColumns on the zero-row path, leaving stale schema visible for an empty
+ * table.
+ *
+ * The generation-guard invariant from YW-303 must NOT be regressed: the reset
+ * fires only inside the current generation's resolved continuation (after the
+ * gen check at the preview step), never from a superseded in-flight init.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDataFramePagination } from "./useDataFramePagination";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockUseDuckDB, mockGetDataFrame, mockUseDataFrames } = vi.hoisted(
+  () => ({
+    mockUseDuckDB: vi.fn(),
+    mockGetDataFrame: vi.fn(),
+    mockUseDataFrames: vi.fn(),
+  }),
+);
+
+vi.mock("@/components/providers/DuckDBProvider", () => ({
+  useDuckDB: () => mockUseDuckDB(),
+}));
+
+vi.mock("@dashframe/core", () => ({
+  getDataFrame: (...args: unknown[]) => mockGetDataFrame(...args),
+  useDataFrames: () => mockUseDataFrames(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a mock queryBuilder that produces the given preview rows. */
+function makeQueryBuilder(previewRows: Record<string, unknown>[]) {
+  const queryBuilder = {
+    sql: vi.fn().mockResolvedValue("SELECT 1"),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    sort: vi.fn().mockReturnThis(),
+  };
+
+  const dataFrame = {
+    id: "df-test",
+    load: vi.fn().mockResolvedValue(queryBuilder),
+  };
+
+  return { dataFrame };
+}
+
+const READY_DDB = {
+  isInitialized: true,
+  isLoading: false,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDataFramePagination — empty-result column reset (YW-311)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockUseDataFrames.mockReturnValue({ data: [] });
+  });
+
+  it("resets columns to [] when the current generation returns zero preview rows (was: stale prior columns stay visible)", async () => {
+    // Phase 1: render DataFrame A — preview returns 1 row with columns col_a, col_b.
+    // Phase 2: switch to DataFrame B — preview returns 0 rows.
+    // Expected: columns = [] after B settles.
+    // Pre-fix: columns = [{name:'col_a'}, {name:'col_b'}] — the YW-311 bug.
+
+    const { dataFrame: dfA } = makeQueryBuilder([{ col_a: "v1", col_b: "v2" }]);
+    const { dataFrame: dfB } = makeQueryBuilder([]);
+
+    // Single shared connection whose .query is swapped between phases.
+    const connection = {
+      query: vi
+        .fn()
+        // A — count
+        .mockResolvedValueOnce({ toArray: () => [{ count: BigInt(1) }] })
+        // A — preview (1 row with two columns)
+        .mockResolvedValueOnce({
+          toArray: () => [{ col_a: "v1", col_b: "v2" }],
+        }),
+    };
+
+    mockUseDuckDB.mockReturnValue({ ...READY_DDB, connection });
+    mockUseDataFrames.mockReturnValue({
+      data: [{ id: "df-a" }, { id: "df-b" }],
+    });
+    mockGetDataFrame.mockImplementation((id: string) => {
+      if (id === "df-a") return Promise.resolve(dfA);
+      if (id === "df-b") return Promise.resolve(dfB);
+      return Promise.resolve(null);
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dataFrameId }: { dataFrameId: string }) =>
+        useDataFramePagination(
+          dataFrameId as `${string}-${string}-${string}-${string}-${string}`,
+        ),
+      { initialProps: { dataFrameId: "df-a" } },
+    );
+
+    // Wait for A to settle — columns must be non-empty (non-triviality baseline).
+    await waitFor(() => {
+      expect(result.current.columns.length).toBeGreaterThan(0);
+    });
+    expect(result.current.columns.map((c) => c.name)).toEqual([
+      "col_a",
+      "col_b",
+    ]);
+
+    // Phase 2: swap query to return count=0, preview=[] for DataFrame B.
+    connection.query = vi
+      .fn()
+      // B — count
+      .mockResolvedValueOnce({ toArray: () => [{ count: BigInt(0) }] })
+      // B — preview (empty result)
+      .mockResolvedValueOnce({ toArray: () => [] });
+
+    // Rerender to B — triggers a new init in the hook.
+    rerender({ dataFrameId: "df-b" });
+
+    // Wait for B's totalCount to settle (observable without depending on isReady timing).
+    await waitFor(() => {
+      expect(result.current.totalCount).toBe(0);
+    });
+
+    // Critical assertion: columns must be [] for the zero-row result.
+    // waitFor polls until the rAF that calls setColumns([]) has landed.
+    await waitFor(() => {
+      expect(result.current.columns).toEqual([]);
+    });
+  });
+});

--- a/packages/app/src/hooks/useDataFramePagination.test.tsx
+++ b/packages/app/src/hooks/useDataFramePagination.test.tsx
@@ -4,13 +4,14 @@
  * Contract: when a resolved result has zero rows, columns must be reset to []
  * rather than left at the prior DataFrame's column set.
  *
- * This guards against the YW-311 regression: if (rows.length > 0) skipping
+ * This guards against the regression where `if (rows.length > 0)` skipped
  * setColumns on the zero-row path, leaving stale schema visible for an empty
  * table.
  *
- * The generation-guard invariant from YW-303 must NOT be regressed: the reset
- * fires only inside the current generation's resolved continuation (after the
- * gen check at the preview step), never from a superseded in-flight init.
+ * The generation-guard invariant (stale-async-state fix) must NOT be
+ * regressed: the reset fires only inside the current generation's resolved
+ * continuation (after the gen check at the preview step), never from a
+ * superseded in-flight init.
  */
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -67,7 +68,7 @@ const READY_DDB = {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("useDataFramePagination — empty-result column reset (YW-311)", () => {
+describe("useDataFramePagination — empty-result column reset", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -79,7 +80,7 @@ describe("useDataFramePagination — empty-result column reset (YW-311)", () => 
     // Phase 1: render DataFrame A — preview returns 1 row with columns col_a, col_b.
     // Phase 2: switch to DataFrame B — preview returns 0 rows.
     // Expected: columns = [] after B settles.
-    // Pre-fix: columns = [{name:'col_a'}, {name:'col_b'}] — the YW-311 bug.
+    // Pre-fix: columns = [{name:'col_a'}, {name:'col_b'}] — stale schema bug.
 
     const { dataFrame: dfA } = makeQueryBuilder([{ col_a: "v1", col_b: "v2" }]);
     const { dataFrame: dfB } = makeQueryBuilder([]);

--- a/packages/app/src/hooks/useDataFramePagination.test.tsx
+++ b/packages/app/src/hooks/useDataFramePagination.test.tsx
@@ -42,8 +42,8 @@ vi.mock("@dashframe/core", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a mock queryBuilder that produces the given preview rows. */
-function makeQueryBuilder(previewRows: Record<string, unknown>[]) {
+/** Build a mock queryBuilder (rows are controlled by the connection.query mock). */
+function makeQueryBuilder() {
   const queryBuilder = {
     sql: vi.fn().mockResolvedValue("SELECT 1"),
     limit: vi.fn().mockReturnThis(),
@@ -82,8 +82,8 @@ describe("useDataFramePagination — empty-result column reset", () => {
     // Expected: columns = [] after B settles.
     // Pre-fix: columns = [{name:'col_a'}, {name:'col_b'}] — stale schema bug.
 
-    const { dataFrame: dfA } = makeQueryBuilder([{ col_a: "v1", col_b: "v2" }]);
-    const { dataFrame: dfB } = makeQueryBuilder([]);
+    const { dataFrame: dfA } = makeQueryBuilder();
+    const { dataFrame: dfB } = makeQueryBuilder();
 
     // Single shared connection whose .query is swapped between phases.
     const connection = {

--- a/packages/app/src/hooks/useDataFramePagination.ts
+++ b/packages/app/src/hooks/useDataFramePagination.ts
@@ -86,15 +86,16 @@ export function useDataFramePagination(dataFrameId: UUID | undefined) {
         if (gen !== genRef.current) return; // superseded
         const rows = previewResult.toArray() as Record<string, unknown>[];
 
-        if (rows.length > 0) {
-          const cols = Object.keys(rows[0]!)
-            .filter((key) => !key.startsWith("_"))
-            .map((name) => ({ name }));
-          requestAnimationFrame(() => {
-            if (gen !== genRef.current) return; // superseded inside rAF
-            setColumns(cols);
-          });
-        }
+        const cols =
+          rows.length > 0
+            ? Object.keys(rows[0]!)
+                .filter((key) => !key.startsWith("_"))
+                .map((name) => ({ name }))
+            : [];
+        requestAnimationFrame(() => {
+          if (gen !== genRef.current) return; // superseded inside rAF
+          setColumns(cols);
+        });
 
         requestAnimationFrame(() => {
           if (gen !== genRef.current) return; // superseded inside rAF

--- a/packages/app/src/hooks/useInsightPagination.test.ts
+++ b/packages/app/src/hooks/useInsightPagination.test.ts
@@ -277,21 +277,21 @@ describe("useInsightPagination — allFields excludes dropped right join-keys", 
 });
 
 // ---------------------------------------------------------------------------
-// Empty-result column reset (YW-311)
+// Empty-result column reset
 // ---------------------------------------------------------------------------
 
 /**
  * Contract: when a resolved result returns zero preview rows, columns and
  * fieldCount must reset to [] / 0, not retain the prior insight's values.
  *
- * This guards the YW-311 bug: `if (rows.length > 0)` skipping setColumns on
+ * This guards the bug where `if (rows.length > 0)` skipping setColumns on
  * the zero-row path left stale schema visible.
  *
- * Generation-guard invariant (YW-303) must hold: the reset fires only inside
- * the current generation's continuation — after the gen check — so a
- * superseded in-flight init never resets the current state.
+ * The generation-guard invariant (stale-async-state fix) must hold: the
+ * reset fires only inside the current generation's continuation — after the
+ * gen check — so a superseded in-flight init never resets the current state.
  */
-describe("useInsightPagination — empty-result column reset (YW-311)", () => {
+describe("useInsightPagination — empty-result column reset", () => {
   // Minimal single-table insight; no joins needed to exercise the column path.
   const TABLE_ID = "cc000000-0000-0000-0000-000000000001" as UUID;
   const DF_ID = "cc000000-0000-0000-0000-000000000002" as UUID;
@@ -350,7 +350,7 @@ describe("useInsightPagination — empty-result column reset (YW-311)", () => {
     // Phase 1 — insight A: preview returns 1 row, populating columns + fieldCount.
     // Phase 2 — insight B: preview returns 0 rows → columns/fieldCount must clear.
     // Pre-fix: the `if (rows.length > 0)` guard skipped setColumns([]), leaving
-    // A's columns/fieldCount visible — the YW-311 bug.
+    // A's columns/fieldCount visible — stale schema bug.
 
     // Phase 1 mocks: getDataTable × 1, buildInsightSQL, count query, preview query (1 row).
     mockGetDataTable.mockResolvedValue(table);

--- a/packages/app/src/hooks/useInsightPagination.test.ts
+++ b/packages/app/src/hooks/useInsightPagination.test.ts
@@ -275,3 +275,125 @@ describe("useInsightPagination — allFields excludes dropped right join-keys", 
     expect(result.current.columnTypeMap[joinAuditAlias]).toBe("date");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Empty-result column reset (YW-311)
+// ---------------------------------------------------------------------------
+
+/**
+ * Contract: when a resolved result returns zero preview rows, columns and
+ * fieldCount must reset to [] / 0, not retain the prior insight's values.
+ *
+ * This guards the YW-311 bug: `if (rows.length > 0)` skipping setColumns on
+ * the zero-row path left stale schema visible.
+ *
+ * Generation-guard invariant (YW-303) must hold: the reset fires only inside
+ * the current generation's continuation — after the gen check — so a
+ * superseded in-flight init never resets the current state.
+ */
+describe("useInsightPagination — empty-result column reset (YW-311)", () => {
+  // Minimal single-table insight; no joins needed to exercise the column path.
+  const TABLE_ID = "cc000000-0000-0000-0000-000000000001" as UUID;
+  const DF_ID = "cc000000-0000-0000-0000-000000000002" as UUID;
+
+  const field: Field = {
+    id: "cc111111-aaaa-aaaa-aaaa-111111111111" as UUID,
+    name: "amount",
+    tableId: TABLE_ID,
+    columnName: "amount",
+    type: "number",
+  };
+
+  const table: DataTable = {
+    id: TABLE_ID,
+    name: "sales",
+    dataSourceId: "55555555-5555-5555-5555-555555555555" as UUID,
+    table: "sales.csv",
+    fields: [field],
+    metrics: [],
+    dataFrameId: DF_ID,
+    createdAt: 0,
+  };
+
+  const insightA: Insight = {
+    id: "insightA-0000-0000-0000-000000000001" as UUID,
+    name: "Sales insight A",
+    baseTableId: TABLE_ID,
+    selectedFields: [field.id],
+    metrics: [],
+    createdAt: 0,
+  };
+
+  const insightB: Insight = {
+    id: "insightB-0000-0000-0000-000000000002" as UUID,
+    name: "Sales insight B (empty result)",
+    baseTableId: TABLE_ID,
+    selectedFields: [field.id],
+    metrics: [],
+    createdAt: 0,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseDuckDB.mockReturnValue({
+      connection: mockConnection,
+      isInitialized: true,
+      isLoading: false,
+    });
+
+    mockGetDataFrame.mockResolvedValue({ id: DF_ID, storageType: "indexeddb" });
+    mockEnsureTableLoaded.mockResolvedValue(undefined);
+  });
+
+  it("resets columns and fieldCount to empty when the current generation returns zero preview rows", async () => {
+    // Phase 1 — insight A: preview returns 1 row, populating columns + fieldCount.
+    // Phase 2 — insight B: preview returns 0 rows → columns/fieldCount must clear.
+    // Pre-fix: the `if (rows.length > 0)` guard skipped setColumns([]), leaving
+    // A's columns/fieldCount visible — the YW-311 bug.
+
+    // Phase 1 mocks: getDataTable × 1, buildInsightSQL, count query, preview query (1 row).
+    mockGetDataTable.mockResolvedValue(table);
+    mockBuildInsightSQL.mockReturnValue("SELECT amount FROM sales");
+
+    mockQuery
+      // A — count
+      .mockResolvedValueOnce({ toArray: () => [{ count: 5 }] })
+      // A — preview (1 row with column `amount`)
+      .mockResolvedValueOnce({ toArray: () => [{ amount: 42 }] });
+
+    const { result, rerender } = renderHook(
+      ({ insight }: { insight: Insight }) =>
+        useInsightPagination({ insight, enabled: true }),
+      { initialProps: { insight: insightA } },
+    );
+
+    // Baseline: wait for A's columns to populate (non-triviality guard — ensures
+    // the test would be red on pre-fix code if it reached the assertion).
+    await waitFor(() => {
+      expect(result.current.columns.length).toBeGreaterThan(0);
+    });
+    expect(result.current.fieldCount).toBe(1);
+
+    // Phase 2 mocks: same table, but preview returns 0 rows.
+    mockQuery
+      // B — count
+      .mockResolvedValueOnce({ toArray: () => [{ count: 0 }] })
+      // B — preview (empty result)
+      .mockResolvedValueOnce({ toArray: () => [] });
+
+    // Switch to insight B.
+    rerender({ insight: insightB });
+
+    // Wait for B's totalCount to settle (observable without depending on isReady timing).
+    await waitFor(() => {
+      expect(result.current.totalCount).toBe(0);
+    });
+
+    // Critical assertions: stale schema from A must be gone.
+    await waitFor(() => {
+      expect(result.current.columns).toEqual([]);
+    });
+    expect(result.current.fieldCount).toBe(0);
+  });
+});

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -340,16 +340,17 @@ export function useInsightPagination({
           if (gen !== genRef.current) return; // superseded
           const rows = previewResult.toArray() as Record<string, unknown>[];
 
-          if (rows.length > 0) {
-            const cols = Object.keys(rows[0]!)
-              .filter((key) => !key.startsWith("_"))
-              .map((name) => ({ name }));
-            requestAnimationFrame(() => {
-              if (gen !== genRef.current) return; // superseded inside rAF
-              setColumns(cols);
-              setFieldCount(cols.length);
-            });
-          }
+          const cols =
+            rows.length > 0
+              ? Object.keys(rows[0]!)
+                  .filter((key) => !key.startsWith("_"))
+                  .map((name) => ({ name }))
+              : [];
+          requestAnimationFrame(() => {
+            if (gen !== genRef.current) return; // superseded inside rAF
+            setColumns(cols);
+            setFieldCount(cols.length);
+          });
         }
 
         requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary

- In `useDataFramePagination` and `useInsightPagination`, the `if (rows.length > 0)` guard around `setColumns` / `setFieldCount` had no else branch, so switching to a new insight/table whose preview returns zero rows left the prior schema visible.
- Fix: compute `cols` unconditionally as `rows.length > 0 ? [...keys...] : []` and call `setColumns(cols)` outside the conditional, inside the existing `requestAnimationFrame` with its gen guard intact.
- Generation-guard invariant (YW-303) is preserved: `cols` is computed *after* the `if (gen !== genRef.current) return` check, so superseded in-flight inits cannot reset the current state.

## Test plan

- [ ] `useInsightPagination.test.ts` — new `describe` block: render insight A (N>0 rows, columns populated) → rerender to insight B (0 rows, current generation) → assert `columns === []` and `fieldCount === 0`
- [ ] `useDataFramePagination.test.tsx` — new test file: same pattern for the DataFrame hook, asserts `columns === []` after zero-row init
- [ ] Both new tests confirmed red against pre-fix code (reverted one edit, ran suite, restored)
- [ ] `turbo typecheck` — 48/48 tasks pass
- [ ] Full hook suite — 537/537 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes the stale-schema bug in both pagination hooks where switching to an insight/table that returns zero preview rows left the prior columns and fieldCount visible. The `cols` computation is now unconditional (`rows.length > 0 ? [...keys] : []`) and `setColumns`/`setFieldCount` are always called inside the existing generation-guarded `requestAnimationFrame`, so superseded in-flight inits still cannot overwrite current state.

- **`useDataFramePagination.ts` / `useInsightPagination.ts`**: single-line restructure — moves the conditional inside the ternary rather than wrapping the entire `setColumns` call, keeping the rAF + gen-guard intact.
- **New tests** in both hook test files confirm the two-phase transition (non-empty → empty) produces `columns === []` and `fieldCount === 0`, and were verified red against pre-fix code.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a minimal, targeted restructure of two symmetric code paths with no new state, no new async logic, and matching test coverage that was verified red against pre-fix code.

Both production changes are one-hunk rewrites that preserve the existing generation-guard and rAF structure — only the conditional around setColumns is moved. New tests exercise the exact failure scenario described in the PR. No regressions to surrounding logic were introduced.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/hooks/useDataFramePagination.ts | Moves setColumns out of the rows.length > 0 guard — cols now computed unconditionally as [] on empty results; generation-guard and rAF structure preserved. |
| packages/app/src/hooks/useInsightPagination.ts | Same empty-result fix as the DataFrame hook; setColumns and setFieldCount are now always called inside the rAF when previewSQL is truthy. The outer if (previewSQL) guard is unchanged (pre-existing path). |
| packages/app/src/hooks/useDataFramePagination.test.tsx | New test file covering the zero-row column reset; two-phase render (A with rows → B with 0 rows), assertions correctly wrapped in waitFor; no ticket IDs present. |
| packages/app/src/hooks/useInsightPagination.test.ts | New describe block mirrors the DataFrame test; columns and fieldCount both asserted after zero-row phase, with fieldCount check immediately following the waitFor for columns (safe since both are set in the same rAF callback). |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Hook
    participant DuckDB
    participant RAF as requestAnimationFrame
    participant State

    Note over Hook: init() — gen N
    Hook->>DuckDB: query(countSQL)
    DuckDB-->>Hook: countResult
    Hook->>State: setTotalCount(count)
    Hook->>DuckDB: query(previewSQL, limit 1)
    DuckDB-->>Hook: previewResult (0 rows)
    Hook->>Hook: "check gen === genRef.current"
    Hook->>Hook: "cols = [] (rows.length === 0)"
    Hook->>RAF: schedule setColumns(cols)
    Hook->>RAF: schedule setIsReady(true)
    RAF->>Hook: "check gen === genRef.current"
    RAF->>State: setColumns([])
    RAF->>State: setFieldCount(0)
    Note over State: stale schema cleared ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Hook
    participant DuckDB
    participant RAF as requestAnimationFrame
    participant State

    Note over Hook: init() — gen N
    Hook->>DuckDB: query(countSQL)
    DuckDB-->>Hook: countResult
    Hook->>State: setTotalCount(count)
    Hook->>DuckDB: query(previewSQL, limit 1)
    DuckDB-->>Hook: previewResult (0 rows)
    Hook->>Hook: "check gen === genRef.current"
    Hook->>Hook: "cols = [] (rows.length === 0)"
    Hook->>RAF: schedule setColumns(cols)
    Hook->>RAF: schedule setIsReady(true)
    RAF->>Hook: "check gen === genRef.current"
    RAF->>State: setColumns([])
    RAF->>State: setFieldCount(0)
    Note over State: stale schema cleared ✓
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app/src/hooks/useInsightPagination.ts`, line 338-354 ([link](https://github.com/youhaowei/dashframe/blob/abf270ae197902cfd35dab220d08b7853ac3dd0c/packages/app/src/hooks/useInsightPagination.ts#L338-L354)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale columns/fieldCount when `previewSQL` is null**

   The fix correctly resets columns for zero-row results, but the `if (previewSQL)` guard still means `setColumns` and `setFieldCount` are never called when `buildInsightSQL` returns a falsy value. Switching to an insight whose SQL builder returns `null` after one that had rows would still leave the prior schema visible. Worth confirming this path is unreachable, or adding an `else` branch with `setColumns([])` / `setFieldCount(0)` to close the gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/hooks/useInsightPagination.ts
   Line: 338-354

   Comment:
   **Stale columns/fieldCount when `previewSQL` is null**

   The fix correctly resets columns for zero-row results, but the `if (previewSQL)` guard still means `setColumns` and `setFieldCount` are never called when `buildInsightSQL` returns a falsy value. Switching to an insight whose SQL builder returns `null` after one that had rows would still leave the prior schema visible. Worth confirming this path is unreachable, or adding an `else` branch with `setColumns([])` / `setFieldCount(0)` to close the gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%0ALine%3A%20338-354%0A%0AComment%3A%0A**Stale%20columns%2FfieldCount%20when%20%60previewSQL%60%20is%20null**%0A%0AThe%20fix%20correctly%20resets%20columns%20for%20zero-row%20results%2C%20but%20the%20%60if%20%28previewSQL%29%60%20guard%20still%20means%20%60setColumns%60%20and%20%60setFieldCount%60%20are%20never%20called%20when%20%60buildInsightSQL%60%20returns%20a%20falsy%20value.%20Switching%20to%20an%20insight%20whose%20SQL%20builder%20returns%20%60null%60%20after%20one%20that%20had%20rows%20would%20still%20leave%20the%20prior%20schema%20visible.%20Worth%20confirming%20this%20path%20is%20unreachable%2C%20or%20adding%20an%20%60else%60%20branch%20with%20%60setColumns%28%5B%5D%29%60%20%2F%20%60setFieldCount%280%29%60%20to%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-311-empty-result-column-reset%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-311-empty-result-column-reset%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%0ALine%3A%20338-354%0A%0AComment%3A%0A**Stale%20columns%2FfieldCount%20when%20%60previewSQL%60%20is%20null**%0A%0AThe%20fix%20correctly%20resets%20columns%20for%20zero-row%20results%2C%20but%20the%20%60if%20%28previewSQL%29%60%20guard%20still%20means%20%60setColumns%60%20and%20%60setFieldCount%60%20are%20never%20called%20when%20%60buildInsightSQL%60%20returns%20a%20falsy%20value.%20Switching%20to%20an%20insight%20whose%20SQL%20builder%20returns%20%60null%60%20after%20one%20that%20had%20rows%20would%20still%20leave%20the%20prior%20schema%20visible.%20Worth%20confirming%20this%20path%20is%20unreachable%2C%20or%20adding%20an%20%60else%60%20branch%20with%20%60setColumns%28%5B%5D%29%60%20%2F%20%60setFieldCount%280%29%60%20to%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fhooks%2FuseInsightPagination.ts%0ALine%3A%20338-354%0A%0AComment%3A%0A**Stale%20columns%2FfieldCount%20when%20%60previewSQL%60%20is%20null**%0A%0AThe%20fix%20correctly%20resets%20columns%20for%20zero-row%20results%2C%20but%20the%20%60if%20%28previewSQL%29%60%20guard%20still%20means%20%60setColumns%60%20and%20%60setFieldCount%60%20are%20never%20called%20when%20%60buildInsightSQL%60%20returns%20a%20falsy%20value.%20Switching%20to%20an%20insight%20whose%20SQL%20builder%20returns%20%60null%60%20after%20one%20that%20had%20rows%20would%20still%20leave%20the%20prior%20schema%20visible.%20Worth%20confirming%20this%20path%20is%20unreachable%2C%20or%20adding%20an%20%60else%60%20branch%20with%20%60setColumns%28%5B%5D%29%60%20%2F%20%60setFieldCount%280%29%60%20to%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(tests): remove dead previewRows para..."](https://github.com/youhaowei/dashframe/commit/eb5c1e769ddfd7fe06f2556ac3dddb0fafde7fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39918579)</sub>

<!-- /greptile_comment -->