### PR TITLE
[YW-302] fix(ui): off-token error color in select.tsx → palette-danger

### DIFF
--- a/packages/ui/src/fields/select.tsx
+++ b/packages/ui/src/fields/select.tsx
@@ -64,7 +64,10 @@ export function Select({
         onValueChange={(v) => onChange(typeof v === "string" ? v : "")}
       >
         <SelectTrigger
-          className={cn("w-full", error && "border-red-500 focus:ring-red-500")}
+          className={cn(
+            "w-full",
+            error && "border-palette-danger focus:ring-palette-danger",
+          )}
         >
           <SelectValue placeholder={placeholder}>
             {selectedOption?.label}
@@ -96,7 +99,7 @@ export function Select({
           ))}
         </SelectContent>
       </SelectPrimitive>
-      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+      {error && <p className="mt-1 text-xs text-palette-danger">{error}</p>}
     </Field>
   );
 }


### PR DESCRIPTION
## Summary

Replaces raw Tailwind `red-500` color literals in the `@dashframe/ui` field-level `Select` wrapper with the semantic `palette-danger` tokens established by YW-292. Enforces the DashFrame "no off-token color" rule (CLAUDE.md + DESIGN.md anti-pattern).

- error trigger: `border-red-500 focus:ring-red-500` → `border-palette-danger focus:ring-palette-danger`
- error message: `text-red-500` → `text-palette-danger`

No `-fg` foreground pair is used here. `palette-danger-fg` resolves to white (it's for text sitting *on* a danger-colored background — the `bg-X text-X-fg` chip pattern). These sites are danger-colored text/border on the normal field surface, so the danger color itself is correct; `text-palette-danger-fg` would be invisible white text.

## Premise correction

The ticket pointed at `libs/stdui/.../select.tsx`, but that file was **already on-token** — YW-292 (#164) confirmed it ("`select.tsx` was already on-token — no changes needed"). The actual off-token sites are in `packages/ui/src/fields/select.tsx`, the **DashFrame-local `@dashframe/ui` field wrapper** in the main repo — NOT the `libs/stdui` (`@wystack/ui`) submodule. Consequence: no submodule commit / gitlink bump is involved; this is a single-file main-repo change.

## Verification

- Typecheck: 48/48 turbo tasks clean
- Lint (`@dashframe/ui`): 0 errors; 1 pre-existing warning (`onClear` unused, unrelated to this change)
- Token resolution confirmed: `--color-palette-danger` is registered in `libs/stdui/packages/ui/src/styles/tokens.css` (line 19) for the `--color-*` namespace, so `border-`/`ring-`/`text-palette-danger` all generate correctly; light/dark covered by tokens.css lines 74/183.
- Local `wystack-agent-kit:code-review` (low effort): zero in-diff findings, SHIP.

Tracked internally as YW-302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces two raw Tailwind `red-500` color literals in the `@dashframe/ui` `Select` field wrapper with the semantic `palette-danger` token, bringing the component into compliance with the project's no-off-token-color invariant.

- `border-red-500 focus:ring-red-500` on the error-state `SelectTrigger` → `border-palette-danger focus:ring-palette-danger`
- `text-red-500` on the inline error message paragraph → `text-palette-danger`
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-file cosmetic token swap with no logic changes; safe to merge.

The change is a mechanical find-and-replace of two raw red-500 class literals with palette-danger tokens. No component behaviour, props interface, or conditional logic is altered. The token is confirmed registered in tokens.css and works across Tailwind's border-*, ring-*, and text-* utilities. Nothing else in the file was touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/fields/select.tsx | Two off-token red-500 class literals replaced with palette-danger semantic tokens; no logic changes, no new issues introduced. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Select Component] --> B{error prop set?}
    B -- No --> C[Normal border/ring styling]
    B -- Yes --> D[border-palette-danger\nfocus:ring-palette-danger]
    B -- Yes --> E[Error paragraph\ntext-palette-danger]
    D & E --> F[Token resolves via\n--color-palette-danger\nin tokens.css]
    F --> G[Correct light/dark\ntheme-aware color]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Select Component] --> B{error prop set?}
    B -- No --> C[Normal border/ring styling]
    B -- Yes --> D[border-palette-danger\nfocus:ring-palette-danger]
    B -- Yes --> E[Error paragraph\ntext-palette-danger]
    D & E --> F[Token resolves via\n--color-palette-danger\nin tokens.css]
    F --> G[Correct light/dark\ntheme-aware color]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["\[YW-302\] fix(ui): off-token error color ..."](https://github.com/youhaowei/dashframe/commit/d0916c98c1757d172f5f4861a47430f7c05f1f57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39977100)</sub>

**Context used:**

- Context used - NO OFF-TOKEN COLOR (invariant). No raw hex/rgb/okl... ([source](greptile.json))

<!-- /greptile_comment -->