### PR TITLE
[YW-310] fix(connector-postgres): NUMERIC/BIGINT coercion + empty-result schema loss

### DIFF
--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -19,12 +19,13 @@ import {
 } from "@wystack/secret-vault";
 import { tableFromIPC } from "apache-arrow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PgClientLike, PgQueryConfig } from "./connector.js";
+import type { PgClientLike, PgFieldDef, PgQueryConfig } from "./connector.js";
 import {
   PostgresConnector,
   assertReadOnlyQuery,
   listTablesInSchema,
   makePostgresConnector,
+  pgOidToColumnType,
 } from "./connector.js";
 import type { PostgresConnectorConfig } from "./types.js";
 
@@ -69,20 +70,23 @@ function callText(arg: string | PgQueryConfig): string {
   return typeof arg === "string" ? arg : arg.text;
 }
 
-function makeSpyClient(dataRows: Record<string, unknown>[] = []): SpyClient {
+function makeSpyClient(
+  dataRows: Record<string, unknown>[] = [],
+  dataFields: PgFieldDef[] = [],
+): SpyClient {
   const spy = vi.fn();
 
   // The spy handles three call shapes:
   //   1. SET SESSION CHARACTERISTICS... (returns empty rows)
   //   2. SET search_path TO ... (returns empty rows — for listTablesInSchema)
-  //   3. Any other query (returns dataRows)
+  //   3. Any other query (returns dataRows + dataFields)
   // The first arg may be a string OR a PgQueryConfig object (when queryMode is set).
   spy.mockImplementation((arg: string | PgQueryConfig) => {
     const upper = callText(arg).toUpperCase().trim();
     if (upper.startsWith("SET")) {
-      return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [], fields: [] });
     }
-    return Promise.resolve({ rows: dataRows });
+    return Promise.resolve({ rows: dataRows, fields: dataFields });
   });
 
   return {
@@ -481,8 +485,10 @@ describe("AC5 — Arrow output shape matches registry contract", () => {
     expect(table.numRows).toBe(2);
   });
 
-  it("returns rowCount = 0 for an empty result set", async () => {
-    const spyClient = makeSpyClient([]);
+  it("returns rowCount = 0 for an empty result set (no pg column metadata)", async () => {
+    // When the spy provides no fields metadata (legacy / no OID info),
+    // the result is an empty schema — this is the pre-fix baseline.
+    const spyClient = makeSpyClient([], []);
     const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
 
     const result = await connector.query(
@@ -496,6 +502,32 @@ describe("AC5 — Arrow output shape matches registry contract", () => {
     // arrowBuffer should still be a valid base64 string (empty Arrow table).
     expect(typeof result.arrowBuffer).toBe("string");
     expect(result.arrowBuffer.length).toBeGreaterThan(0);
+  });
+
+  it("preserves schema from pg column metadata on a zero-row result (empty-result schema fix)", async () => {
+    // Simulate pg returning column descriptors even when rows is empty.
+    const pgFields: PgFieldDef[] = [
+      { name: "id", dataTypeID: 23 }, // int4
+      { name: "amount", dataTypeID: 1700 }, // NUMERIC
+    ];
+    const spyClient = makeSpyClient([], pgFields);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT id, amount FROM ledger WHERE 1=0",
+      crypto.randomUUID(),
+    );
+
+    expect(result.rowCount).toBe(0);
+    // Schema must be inferred from pg column metadata, not from rows.
+    expect(result.fields).toHaveLength(2);
+    expect(result.fieldIds).toHaveLength(2);
+    const fieldNames = result.fields.map((f) => f.name);
+    expect(fieldNames).toContain("id");
+    expect(fieldNames).toContain("amount");
+    // NUMERIC (OID 1700) must map to "string" — lossless coercion.
+    const amountField = result.fields.find((f) => f.name === "amount");
+    expect(amountField?.type).toBe("string");
   });
 
   it("returns correct rowCount for connect() listing tables", async () => {
@@ -729,5 +761,106 @@ describe("read-only guard: allowlisted queries pass through to pg", () => {
         crypto.randomUUID(),
       ),
     ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pgOidToColumnType — OID → ColumnType mapping
+// ---------------------------------------------------------------------------
+
+describe("pgOidToColumnType", () => {
+  it("maps BIGINT (OID 20) to 'string' — preserves precision for values > 2^53", () => {
+    expect(pgOidToColumnType(20)).toBe("string");
+  });
+
+  it("maps NUMERIC (OID 1700) to 'string' — preserves decimal precision", () => {
+    expect(pgOidToColumnType(1700)).toBe("string");
+  });
+
+  it("returns undefined for unrecognized OIDs (fall through to value inference)", () => {
+    expect(pgOidToColumnType(23)).toBeUndefined(); // int4
+    expect(pgOidToColumnType(25)).toBeUndefined(); // text
+    expect(pgOidToColumnType(16)).toBeUndefined(); // bool
+    expect(pgOidToColumnType(700)).toBeUndefined(); // float4
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NUMERIC / BIGINT Arrow coercion — field-type matches value-type (string)
+// ---------------------------------------------------------------------------
+
+describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", () => {
+  it("BIGINT column: field type is 'string' and Arrow value is a string (no precision loss)", async () => {
+    // node-postgres returns BIGINT (OID 20) as a string.
+    const bigValue = "9007199254740993"; // > Number.MAX_SAFE_INTEGER
+    const pgFields: PgFieldDef[] = [
+      { name: "big_id", dataTypeID: 20 }, // BIGINT
+    ];
+    const spyClient = makeSpyClient([{ big_id: bigValue }], pgFields);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT big_id FROM things",
+      crypto.randomUUID(),
+    );
+
+    // Field type must be "string" (matches the string value pg returns).
+    const field = result.fields.find((f) => f.name === "big_id");
+    expect(field?.type).toBe("string");
+
+    // Arrow round-trip: the value must survive byte-for-byte as a string.
+    const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+    const table = tableFromIPC(bytes);
+    const arrowValue = table.getChildAt(0)?.get(0);
+    // Arrow stores it as a string column — the exact value must be preserved.
+    expect(String(arrowValue)).toBe(bigValue);
+  });
+
+  it("NUMERIC column: field type is 'string' and Arrow value is a string (no precision loss)", async () => {
+    // node-postgres returns NUMERIC (OID 1700) as a string.
+    const numericValue = "123456789.987654321";
+    const pgFields: PgFieldDef[] = [
+      { name: "amount", dataTypeID: 1700 }, // NUMERIC
+    ];
+    const spyClient = makeSpyClient([{ amount: numericValue }], pgFields);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT amount FROM ledger",
+      crypto.randomUUID(),
+    );
+
+    // Field type must be "string".
+    const field = result.fields.find((f) => f.name === "amount");
+    expect(field?.type).toBe("string");
+
+    // Arrow round-trip: exact decimal string must be preserved.
+    const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+    const table = tableFromIPC(bytes);
+    const arrowValue = table.getChildAt(0)?.get(0);
+    expect(String(arrowValue)).toBe(numericValue);
+  });
+
+  it("mixed row: only BIGINT/NUMERIC columns are typed as 'string'; others use value inference", async () => {
+    const pgFields: PgFieldDef[] = [
+      { name: "id", dataTypeID: 23 }, // int4 → value inference → "number"
+      { name: "balance", dataTypeID: 1700 }, // NUMERIC → "string"
+      { name: "score", dataTypeID: 20 }, // BIGINT → "string"
+    ];
+    const spyClient = makeSpyClient(
+      [{ id: 1, balance: "9999.99", score: "42" }],
+      pgFields,
+    );
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT * FROM scores",
+      crypto.randomUUID(),
+    );
+
+    const byName = Object.fromEntries(result.fields.map((f) => [f.name, f]));
+    expect(byName["id"]?.type).toBe("number"); // int4 — value inference
+    expect(byName["balance"]?.type).toBe("string"); // NUMERIC OID override
+    expect(byName["score"]?.type).toBe("string"); // BIGINT OID override
   });
 });

--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -863,4 +863,33 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     expect(byName["balance"]?.type).toBe("string"); // NUMERIC OID override
     expect(byName["score"]?.type).toBe("string"); // BIGINT OID override
   });
+
+  it("deduplicates duplicate column names from pgFields (e.g. JOIN with shared column names)", async () => {
+    // A JOIN query can produce pgFields with the same column name twice.
+    // The connector must not emit more Fields than Arrow has columns — that
+    // would break the fieldIds↔arrowBuffer alignment contract.
+    const pgFields: PgFieldDef[] = [
+      { name: "id", dataTypeID: 23 }, // int4 — first occurrence
+      { name: "name", dataTypeID: 25 }, // text
+      { name: "id", dataTypeID: 23 }, // int4 — duplicate (JOIN ambiguity)
+    ];
+    const spyClient = makeSpyClient([{ id: 1, name: "Alice" }], pgFields);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT a.id, a.name, b.id FROM a JOIN b ON a.id = b.id",
+      crypto.randomUUID(),
+    );
+
+    // Only 2 unique fields despite 3 pgFields entries.
+    expect(result.fields).toHaveLength(2);
+    expect(result.fieldIds).toHaveLength(2);
+    const fieldNames = result.fields.map((f) => f.name);
+    expect(fieldNames).toEqual(["id", "name"]);
+
+    // Arrow table must also have 2 columns — no fieldIds↔arrowBuffer mismatch.
+    const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+    const table = tableFromIPC(bytes);
+    expect(table.schema.fields).toHaveLength(2);
+  });
 });

--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -887,12 +887,15 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     const field = result.fields.find((f) => f.name === "big_id");
     expect(field?.type).toBe("string");
 
-    // Arrow round-trip: the value must survive byte-for-byte as a string.
+    // Arrow round-trip: the value must survive byte-for-byte as a string —
+    // not just be stringifiable (Number/BigInt can also pass String()). Arrow
+    // encodes a string-typed column as Utf8; the recovered value is a JS string.
     const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
     const table = tableFromIPC(bytes);
     const arrowValue = table.getChildAt(0)?.get(0);
-    // Arrow stores it as a string column — the exact value must be preserved.
-    expect(String(arrowValue)).toBe(bigValue);
+    // The Arrow column must be a true string type (Utf8), not numeric.
+    expect(typeof arrowValue).toBe("string");
+    expect(arrowValue).toBe(bigValue);
   });
 
   it("NUMERIC column: field type is 'string' and Arrow value is a string (no precision loss)", async () => {
@@ -913,11 +916,14 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     const field = result.fields.find((f) => f.name === "amount");
     expect(field?.type).toBe("string");
 
-    // Arrow round-trip: exact decimal string must be preserved.
+    // Arrow round-trip: exact decimal string must be preserved as a true string
+    // (not numeric — String("123456789.987654321") works for number too, so we
+    // check typeof to enforce the Utf8 column type contract).
     const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
     const table = tableFromIPC(bytes);
     const arrowValue = table.getChildAt(0)?.get(0);
-    expect(String(arrowValue)).toBe(numericValue);
+    expect(typeof arrowValue).toBe("string");
+    expect(arrowValue).toBe(numericValue);
   });
 
   it("mixed row: OID path takes priority; BIGINT/NUMERIC → 'string', int4 → 'number'", async () => {
@@ -947,12 +953,20 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     // A JOIN query can produce pgFields with the same column name twice.
     // The connector must not emit more Fields than Arrow has columns — that
     // would break the fieldIds↔arrowBuffer alignment contract.
+    // Use DIFFERENT OIDs for the duplicate name to test that last-occurrence OID
+    // is selected — aligning with node-postgres row object behavior (last value wins).
     const pgFields: PgFieldDef[] = [
-      { name: "id", dataTypeID: 23 }, // int4 — first occurrence
+      { name: "id", dataTypeID: 23 }, // int4 — first occurrence (row value comes from last)
       { name: "name", dataTypeID: 25 }, // text
-      { name: "id", dataTypeID: 23 }, // int4 — duplicate (JOIN ambiguity)
+      { name: "id", dataTypeID: 20 }, // BIGINT — last occurrence (pg row: id = string value)
     ];
-    const spyClient = makeSpyClient([{ id: 1, name: "Alice" }], pgFields);
+    // Simulate pg row: node-postgres overwrites id with the last column's value.
+    // BIGINT (OID 20) is returned as a string by pg.
+    const bigIntId = "9007199254740993";
+    const spyClient = makeSpyClient(
+      [{ id: bigIntId, name: "Alice" }],
+      pgFields,
+    );
     const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
 
     const result = await connector.query(
@@ -966,9 +980,17 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     const fieldNames = result.fields.map((f) => f.name);
     expect(fieldNames).toEqual(["id", "name"]);
 
-    // Arrow table must also have 2 columns — no fieldIds↔arrowBuffer mismatch.
+    // Last-occurrence OID (20 / BIGINT → "string") must win for the id field
+    // so field.type agrees with the actual Arrow value (a string from bigint).
+    const idField = result.fields.find((f) => f.name === "id");
+    expect(idField?.type).toBe("string"); // OID 20 (last) → "string", not OID 23 (first) → "number"
+
+    // Arrow table must have 2 columns and the id value must round-trip as a string.
     const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
     const table = tableFromIPC(bytes);
     expect(table.schema.fields).toHaveLength(2);
+    const arrowId = table.getChildAt(0)?.get(0);
+    expect(typeof arrowId).toBe("string");
+    expect(arrowId).toBe(bigIntId);
   });
 });

--- a/packages/connector-postgres/src/connector.test.ts
+++ b/packages/connector-postgres/src/connector.test.ts
@@ -525,9 +525,65 @@ describe("AC5 — Arrow output shape matches registry contract", () => {
     const fieldNames = result.fields.map((f) => f.name);
     expect(fieldNames).toContain("id");
     expect(fieldNames).toContain("amount");
+    // int4 (OID 23) must map to "number".
+    const idField = result.fields.find((f) => f.name === "id");
+    expect(idField?.type).toBe("number");
     // NUMERIC (OID 1700) must map to "string" — lossless coercion.
     const amountField = result.fields.find((f) => f.name === "amount");
     expect(amountField?.type).toBe("string");
+  });
+
+  it("recovers common OID types (bool, text, float8) on a zero-row result", async () => {
+    // Verifies the extended OID map covers standard column types for empty-result
+    // schema recovery. A zero-row result has no sample values — OID is the only
+    // type signal, so every listed type must map to a non-"unknown" ColumnType.
+    const pgFields: PgFieldDef[] = [
+      { name: "active", dataTypeID: 16 }, // bool   → "boolean"
+      { name: "label", dataTypeID: 25 }, //  text   → "string"
+      { name: "score", dataTypeID: 701 }, // float8 → "number"
+    ];
+    const spyClient = makeSpyClient([], pgFields);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT active, label, score FROM metrics WHERE 1=0",
+      crypto.randomUUID(),
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.fields).toHaveLength(3);
+    const byName = Object.fromEntries(
+      result.fields.map((f) => [f.name, f.type]),
+    );
+    expect(byName["active"]).toBe("boolean");
+    expect(byName["label"]).toBe("string");
+    expect(byName["score"]).toBe("number");
+  });
+
+  it("unmapped OID on zero-row result falls back to 'unknown' without throwing", async () => {
+    // When pgFields lists a column with an OID that pgOidToColumnType doesn't map
+    // (e.g. jsonb OID 3802, uuid OID 2950), and there are no rows to run value
+    // inference, inferColumnType must return "unknown" cleanly without throwing.
+    // The Arrow buffer must still be valid (empty column, schema preserved).
+    const pgFields: PgFieldDef[] = [
+      { name: "payload", dataTypeID: 3802 }, // jsonb — not in OID map
+    ];
+    const spyClient = makeSpyClient([], pgFields);
+    const connector = makeTestConnector(noopDsnResolver, baseConfig, spyClient);
+
+    const result = await connector.query(
+      "SELECT payload FROM events WHERE 1=0",
+      crypto.randomUUID(),
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.fields).toHaveLength(1);
+    const field = result.fields.find((f) => f.name === "payload");
+    expect(field?.type).toBe("unknown");
+    // Arrow buffer must still be valid with 1 column (schema preserved)
+    const bytes = Uint8Array.from(Buffer.from(result.arrowBuffer, "base64"));
+    const table = tableFromIPC(bytes);
+    expect(table.schema.fields).toHaveLength(1);
   });
 
   it("returns correct rowCount for connect() listing tables", async () => {
@@ -777,11 +833,34 @@ describe("pgOidToColumnType", () => {
     expect(pgOidToColumnType(1700)).toBe("string");
   });
 
+  it("maps common integer/float OIDs to 'number'", () => {
+    expect(pgOidToColumnType(21)).toBe("number"); // int2
+    expect(pgOidToColumnType(23)).toBe("number"); // int4
+    expect(pgOidToColumnType(700)).toBe("number"); // float4
+    expect(pgOidToColumnType(701)).toBe("number"); // float8
+  });
+
+  it("maps bool (OID 16) to 'boolean'", () => {
+    expect(pgOidToColumnType(16)).toBe("boolean");
+  });
+
+  it("maps text/varchar/char OIDs to 'string'", () => {
+    expect(pgOidToColumnType(18)).toBe("string"); // internal "char" (1-byte)
+    expect(pgOidToColumnType(25)).toBe("string"); // text
+    expect(pgOidToColumnType(1042)).toBe("string"); // bpchar / CHAR(n)
+    expect(pgOidToColumnType(1043)).toBe("string"); // varchar
+  });
+
+  it("maps date/timestamp OIDs to 'date'", () => {
+    expect(pgOidToColumnType(1082)).toBe("date"); // date
+    expect(pgOidToColumnType(1114)).toBe("date"); // timestamp
+    expect(pgOidToColumnType(1184)).toBe("date"); // timestamptz
+  });
+
   it("returns undefined for unrecognized OIDs (fall through to value inference)", () => {
-    expect(pgOidToColumnType(23)).toBeUndefined(); // int4
-    expect(pgOidToColumnType(25)).toBeUndefined(); // text
-    expect(pgOidToColumnType(16)).toBeUndefined(); // bool
-    expect(pgOidToColumnType(700)).toBeUndefined(); // float4
+    expect(pgOidToColumnType(0)).toBeUndefined();
+    expect(pgOidToColumnType(3802)).toBeUndefined(); // jsonb
+    expect(pgOidToColumnType(2950)).toBeUndefined(); // uuid
   });
 });
 
@@ -841,11 +920,11 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     expect(String(arrowValue)).toBe(numericValue);
   });
 
-  it("mixed row: only BIGINT/NUMERIC columns are typed as 'string'; others use value inference", async () => {
+  it("mixed row: OID path takes priority; BIGINT/NUMERIC → 'string', int4 → 'number'", async () => {
     const pgFields: PgFieldDef[] = [
-      { name: "id", dataTypeID: 23 }, // int4 → value inference → "number"
-      { name: "balance", dataTypeID: 1700 }, // NUMERIC → "string"
-      { name: "score", dataTypeID: 20 }, // BIGINT → "string"
+      { name: "id", dataTypeID: 23 }, // int4 → OID 23 → "number"
+      { name: "balance", dataTypeID: 1700 }, // NUMERIC → OID 1700 → "string"
+      { name: "score", dataTypeID: 20 }, // BIGINT → OID 20 → "string"
     ];
     const spyClient = makeSpyClient(
       [{ id: 1, balance: "9999.99", score: "42" }],
@@ -859,9 +938,9 @@ describe("NUMERIC/BIGINT coercion: field-type and Arrow value-type must agree", 
     );
 
     const byName = Object.fromEntries(result.fields.map((f) => [f.name, f]));
-    expect(byName["id"]?.type).toBe("number"); // int4 — value inference
-    expect(byName["balance"]?.type).toBe("string"); // NUMERIC OID override
-    expect(byName["score"]?.type).toBe("string"); // BIGINT OID override
+    expect(byName["id"]?.type).toBe("number"); // int4 — OID path
+    expect(byName["balance"]?.type).toBe("string"); // NUMERIC — OID path
+    expect(byName["score"]?.type).toBe("string"); // BIGINT — OID path
   });
 
   it("deduplicates duplicate column names from pgFields (e.g. JOIN with shared column names)", async () => {

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -257,12 +257,22 @@ function inferFieldsFromRows(
 
   if (pgFields && pgFields.length > 0) {
     // Use pg's column metadata as the canonical list (handles empty results).
-    columnNames = pgFields
-      .map((f) => f.name)
-      .filter((n) => !DANGEROUS_COLUMN_NAMES.has(n));
+    // Deduplicate column names: a JOIN with overlapping column names produces
+    // duplicate entries in pg's result.fields. Keeping duplicates would let
+    // createFieldsFromColumns emit more Fields than Arrow has columns (the
+    // columnArrays object dedupes by key), violating the fieldIds↔arrowBuffer
+    // alignment contract. First-occurrence wins — consistent with the old
+    // key-union fallback path. The oidByName map is populated only from the
+    // surviving deduplicated set so dangerous-key filtering and OID lookup are
+    // always in sync.
+    const seenNames = new Set<string>();
     for (const f of pgFields) {
+      if (DANGEROUS_COLUMN_NAMES.has(f.name)) continue;
+      if (seenNames.has(f.name)) continue; // first-occurrence wins
+      seenNames.add(f.name);
       oidByName.set(f.name, f.dataTypeID);
     }
+    columnNames = [...seenNames];
   } else {
     // Fallback: derive column names from the row key-union.
     const seen = new Set<string>();

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -206,29 +206,151 @@ const DANGEROUS_COLUMN_NAMES = new Set([
 /**
  * Postgres OID → ColumnType.
  *
- * node-postgres returns NUMERIC (OID 1700) and BIGINT/int8 (OID 20) as
- * **strings** even though their pg type is numeric. Coercing them to JS
- * `number` would silently corrupt values outside IEEE-754 double precision
- * (BIGINT > 2^53, high-precision NUMERIC). We therefore keep them as
- * `"string"` — field-type and Arrow value-type agree (both string/lossless),
- * and DuckDB casts VARCHAR→BIGINT/NUMERIC during ingest.
+ * Maps common Postgres OIDs to the ColumnType that agrees with both the JS
+ * value node-postgres returns AND how `inferStringColumnType` would classify a
+ * sample value from that column. The mapping is critical for two scenarios:
  *
- * All other OIDs are left as `undefined` — the caller falls back to
+ * 1. **Empty-result schema recovery** — zero-row results have no sample values
+ *    to run through value inference, so OID metadata is the only type signal.
+ * 2. **Precision-safe coercion** — BIGINT (OID 20) and NUMERIC (OID 1700) are
+ *    returned as strings by node-postgres to preserve precision beyond IEEE-754
+ *    double. Mapping them to "string" keeps field-type and Arrow value-type in
+ *    agreement, and DuckDB casts VARCHAR→BIGINT/NUMERIC during ingest.
+ *
+ * OIDs not listed here return `undefined` — the caller falls back to
  * value-based inference via `inferStringColumnType`.
+ *
+ * Agreement table (populated-row path must agree with OID path):
+ *   OID 16  bool        → JS boolean   → String("true") → "boolean"  ✓
+ *   OID 20  int8/BIGINT → JS string    → already string              ✓ (precision)
+ *   OID 21  int2        → JS number    → String(1) → Number ok       "number" ✓
+ *   OID 23  int4        → JS number    → String(1) → Number ok       "number" ✓
+ *   OID 700 float4      → JS number    → String(1.5) → Number ok     "number" ✓
+ *   OID 701 float8      → JS number    → String(1.5) → Number ok     "number" ✓
+ *   OID 18  char        → JS string    → OID "string" is stable      ✓
+ *   OID 25  text        → JS string    → OID "string" is stable      ✓
+ *   OID 1043 varchar    → JS string    → OID "string" is stable      ✓
+ *   OID 1082 date       → JS Date      → String(date) parseable      "date"  ✓
+ *   OID 1114 timestamp  → JS Date      → String(date) parseable      "date"  ✓
+ *   OID 1184 timestamptz→ JS Date      → String(date) parseable      "date"  ✓
+ *   OID 1700 NUMERIC    → JS string    → already string              ✓ (precision)
  */
 export function pgOidToColumnType(
   dataTypeID: number,
 ): ReturnType<typeof inferStringColumnType> | undefined {
   switch (dataTypeID) {
+    // Boolean
+    case 16:
+      return "boolean";
     // BIGINT / int8 — returned as string by node-postgres to preserve precision.
     case 20:
       return "string";
+    // int2 / smallint
+    case 21:
+      return "number";
+    // int4 / integer
+    case 23:
+      return "number";
+    // float4
+    case 700:
+      return "number";
+    // float8 / double precision
+    case 701:
+      return "number";
+    // "char" — 1-byte internal Postgres type (system catalogs, rarely in user tables)
+    case 18:
+      return "string";
+    // text
+    case 25:
+      return "string";
+    // bpchar / CHAR(n)
+    case 1042:
+      return "string";
+    // varchar
+    case 1043:
+      return "string";
+    // date
+    case 1082:
+      return "date";
+    // timestamp without time zone
+    case 1114:
+      return "date";
+    // timestamp with time zone
+    case 1184:
+      return "date";
     // NUMERIC / decimal — also returned as string by node-postgres.
     case 1700:
       return "string";
     default:
       return undefined;
   }
+}
+
+/**
+ * Build a deduplicated column list and OID map from pg column metadata.
+ *
+ * Deduplication is required: a JOIN with overlapping column names produces
+ * duplicate entries in pg's result.fields. Duplicates would let
+ * createFieldsFromColumns emit more Fields than Arrow has columns (the
+ * columnArrays object deduplicates by key), violating the fieldIds↔arrowBuffer
+ * alignment contract. First-occurrence wins — consistent with the row key-union
+ * fallback path. Dangerous column names are excluded from both outputs.
+ */
+function columnListFromPgFields(pgFields: PgFieldDef[]): {
+  columnNames: string[];
+  oidByName: Map<string, number>;
+} {
+  const seenNames = new Set<string>();
+  const oidByName = new Map<string, number>();
+  for (const f of pgFields) {
+    if (DANGEROUS_COLUMN_NAMES.has(f.name)) continue;
+    if (seenNames.has(f.name)) continue; // first-occurrence wins
+    seenNames.add(f.name);
+    oidByName.set(f.name, f.dataTypeID);
+  }
+  return { columnNames: [...seenNames], oidByName };
+}
+
+/**
+ * Derive the column name list from the key-union of the given rows.
+ * Dangerous column names are excluded.
+ */
+function columnNamesFromRows(rows: Record<string, unknown>[]): string[] {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!DANGEROUS_COLUMN_NAMES.has(key)) seen.add(key);
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * Infer the ColumnType for a single column.
+ *
+ * Priority:
+ *   1. OID-based type via `pgOidToColumnType` (highest priority — handles
+ *      empty-result and precision-sensitive types like BIGINT/NUMERIC).
+ *   2. Value-based inference via `inferStringColumnType` on the first non-null
+ *      row value (legacy fallback when OID is absent or unmapped).
+ */
+function inferColumnType(
+  name: string,
+  oidByName: Map<string, number>,
+  rows: Record<string, unknown>[],
+): ReturnType<typeof inferStringColumnType> {
+  const oid = oidByName.get(name);
+  if (oid !== undefined) {
+    const oidType = pgOidToColumnType(oid);
+    if (oidType !== undefined) return oidType;
+  }
+  for (const row of rows) {
+    const v = row[name];
+    if (v !== null && v !== undefined) {
+      return inferStringColumnType(String(v));
+    }
+  }
+  return "unknown";
 }
 
 /**
@@ -241,72 +363,25 @@ export function pgOidToColumnType(
  *   2. Key-union of `rows` — fallback when no metadata is supplied (legacy
  *      call-sites and spy clients that predate this change).
  *
- * Type source priority per column:
- *   1. OID mapping via `pgOidToColumnType` — fixes NUMERIC/BIGINT coercion.
- *   2. Value-based inference via `inferStringColumnType` — legacy path.
+ * Type source priority per column: see `inferColumnType`.
  */
 function inferFieldsFromRows(
   rows: Record<string, unknown>[],
   tableId: UUID,
   pgFields?: PgFieldDef[],
 ): Field[] {
-  // --- Column list ---
-  let columnNames: string[];
-  /** OID lookup by column name, populated when pgFields is present. */
-  const oidByName = new Map<string, number>();
+  const hasPgFields = pgFields && pgFields.length > 0;
+  const { columnNames, oidByName } = hasPgFields
+    ? columnListFromPgFields(pgFields)
+    : {
+        columnNames: columnNamesFromRows(rows),
+        oidByName: new Map<string, number>(),
+      };
 
-  if (pgFields && pgFields.length > 0) {
-    // Use pg's column metadata as the canonical list (handles empty results).
-    // Deduplicate column names: a JOIN with overlapping column names produces
-    // duplicate entries in pg's result.fields. Keeping duplicates would let
-    // createFieldsFromColumns emit more Fields than Arrow has columns (the
-    // columnArrays object dedupes by key), violating the fieldIds↔arrowBuffer
-    // alignment contract. First-occurrence wins — consistent with the old
-    // key-union fallback path. The oidByName map is populated only from the
-    // surviving deduplicated set so dangerous-key filtering and OID lookup are
-    // always in sync.
-    const seenNames = new Set<string>();
-    for (const f of pgFields) {
-      if (DANGEROUS_COLUMN_NAMES.has(f.name)) continue;
-      if (seenNames.has(f.name)) continue; // first-occurrence wins
-      seenNames.add(f.name);
-      oidByName.set(f.name, f.dataTypeID);
-    }
-    columnNames = [...seenNames];
-  } else {
-    // Fallback: derive column names from the row key-union.
-    const seen = new Set<string>();
-    for (const row of rows) {
-      for (const key of Object.keys(row)) {
-        if (DANGEROUS_COLUMN_NAMES.has(key)) continue;
-        seen.add(key);
-      }
-    }
-    columnNames = [...seen];
-  }
-
-  // --- Type per column ---
-  const columns = columnNames.map((name) => {
-    // 1. OID-based type (highest priority — covers empty-result + precision).
-    const oid = oidByName.get(name);
-    if (oid !== undefined) {
-      const oidType = pgOidToColumnType(oid);
-      if (oidType !== undefined) {
-        return { name, type: oidType };
-      }
-    }
-
-    // 2. Value-based inference fallback.
-    let type: ReturnType<typeof inferStringColumnType> = "unknown";
-    for (const row of rows) {
-      const v = row[name];
-      if (v !== null && v !== undefined) {
-        type = inferStringColumnType(String(v));
-        break;
-      }
-    }
-    return { name, type };
-  });
+  const columns = columnNames.map((name) => ({
+    name,
+    type: inferColumnType(name, oidByName, rows),
+  }));
 
   return createFieldsFromColumns(columns, tableId);
 }

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -129,13 +129,23 @@ export interface PgQueryConfig {
   values?: unknown[];
 }
 
+/** Minimal column descriptor returned by pg in result.fields. */
+export interface PgFieldDef {
+  name: string;
+  dataTypeID: number;
+}
+
+/** Result shape returned by query helpers — rows plus column metadata. */
+export interface PgQueryResult {
+  rows: Record<string, unknown>[];
+  /** Column metadata from pg. Present on every successful query, even zero-row results. */
+  fields: PgFieldDef[];
+}
+
 export interface PgClientLike {
-  query(text: string): Promise<{ rows: Record<string, unknown>[] }>;
-  query(
-    text: string,
-    values: unknown[],
-  ): Promise<{ rows: Record<string, unknown>[] }>;
-  query(config: PgQueryConfig): Promise<{ rows: Record<string, unknown>[] }>;
+  query(text: string): Promise<PgQueryResult>;
+  query(text: string, values: unknown[]): Promise<PgQueryResult>;
+  query(config: PgQueryConfig): Promise<PgQueryResult>;
   end(): Promise<void>;
 }
 
@@ -173,7 +183,7 @@ export async function listTablesInSchema(
 }
 
 // ---------------------------------------------------------------------------
-// Field inference from rows
+// Field inference from rows + pg column metadata
 // ---------------------------------------------------------------------------
 
 /**
@@ -193,19 +203,90 @@ const DANGEROUS_COLUMN_NAMES = new Set([
   "prototype",
 ]);
 
+/**
+ * Postgres OID → ColumnType.
+ *
+ * node-postgres returns NUMERIC (OID 1700) and BIGINT/int8 (OID 20) as
+ * **strings** even though their pg type is numeric. Coercing them to JS
+ * `number` would silently corrupt values outside IEEE-754 double precision
+ * (BIGINT > 2^53, high-precision NUMERIC). We therefore keep them as
+ * `"string"` — field-type and Arrow value-type agree (both string/lossless),
+ * and DuckDB casts VARCHAR→BIGINT/NUMERIC during ingest.
+ *
+ * All other OIDs are left as `undefined` — the caller falls back to
+ * value-based inference via `inferStringColumnType`.
+ */
+export function pgOidToColumnType(
+  dataTypeID: number,
+): ReturnType<typeof inferStringColumnType> | undefined {
+  switch (dataTypeID) {
+    // BIGINT / int8 — returned as string by node-postgres to preserve precision.
+    case 20:
+      return "string";
+    // NUMERIC / decimal — also returned as string by node-postgres.
+    case 1700:
+      return "string";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Infer Field[] from pg query result.
+ *
+ * Column list source priority:
+ *   1. `pgFields` (pg column metadata) — always present, even on zero-row
+ *      results. Used as the authoritative column list when available (fixes
+ *      empty-result schema loss).
+ *   2. Key-union of `rows` — fallback when no metadata is supplied (legacy
+ *      call-sites and spy clients that predate this change).
+ *
+ * Type source priority per column:
+ *   1. OID mapping via `pgOidToColumnType` — fixes NUMERIC/BIGINT coercion.
+ *   2. Value-based inference via `inferStringColumnType` — legacy path.
+ */
 function inferFieldsFromRows(
   rows: Record<string, unknown>[],
   tableId: UUID,
+  pgFields?: PgFieldDef[],
 ): Field[] {
-  const columnNames = new Set<string>();
-  for (const row of rows) {
-    for (const key of Object.keys(row)) {
-      if (DANGEROUS_COLUMN_NAMES.has(key)) continue; // never a real column
-      columnNames.add(key);
+  // --- Column list ---
+  let columnNames: string[];
+  /** OID lookup by column name, populated when pgFields is present. */
+  const oidByName = new Map<string, number>();
+
+  if (pgFields && pgFields.length > 0) {
+    // Use pg's column metadata as the canonical list (handles empty results).
+    columnNames = pgFields
+      .map((f) => f.name)
+      .filter((n) => !DANGEROUS_COLUMN_NAMES.has(n));
+    for (const f of pgFields) {
+      oidByName.set(f.name, f.dataTypeID);
     }
+  } else {
+    // Fallback: derive column names from the row key-union.
+    const seen = new Set<string>();
+    for (const row of rows) {
+      for (const key of Object.keys(row)) {
+        if (DANGEROUS_COLUMN_NAMES.has(key)) continue;
+        seen.add(key);
+      }
+    }
+    columnNames = [...seen];
   }
 
-  const columns = [...columnNames].map((name) => {
+  // --- Type per column ---
+  const columns = columnNames.map((name) => {
+    // 1. OID-based type (highest priority — covers empty-result + precision).
+    const oid = oidByName.get(name);
+    if (oid !== undefined) {
+      const oidType = pgOidToColumnType(oid);
+      if (oidType !== undefined) {
+        return { name, type: oidType };
+      }
+    }
+
+    // 2. Value-based inference fallback.
     let type: ReturnType<typeof inferStringColumnType> = "unknown";
     for (const row of rows) {
       const v = row[name];
@@ -406,6 +487,7 @@ export class PostgresConnector extends RemoteApiConnector {
 
     return this.#withClient(async (client) => {
       let rows: Record<string, unknown>[];
+      let pgFields: PgFieldDef[] | undefined;
 
       if (isTableRef) {
         // Table reference — split on the pre-computed dot index.
@@ -413,7 +495,15 @@ export class PostgresConnector extends RemoteApiConnector {
         const refTable = trimmed.slice(dotIdx + 1);
         // Sink 2: both parts quoted via quoteIdentifier(). Pagination is pushed
         // down into the SQL (LIMIT/OFFSET) so we never materialize a full table.
-        rows = await fetchTable(client, refSchema, refTable, limit, offset);
+        const result = await fetchTable(
+          client,
+          refSchema,
+          refTable,
+          limit,
+          offset,
+        );
+        rows = result.rows;
+        pgFields = result.fields;
       } else {
         // User-supplied SQL — allowlist already passed above; send with zero
         // interpolation. We deliberately do NOT wrap user SQL to inject
@@ -422,7 +512,9 @@ export class PostgresConnector extends RemoteApiConnector {
         // contract, and (2) break legal allowlisted forms like `EXPLAIN …`,
         // `TABLE …`, and trailing-`;` queries. The user authored this query and
         // can bound it; statement_timeout + the post-fetch slice are backstops.
-        rows = await runUserQuery(client, databaseId);
+        const result = await runUserQuery(client, databaseId);
+        rows = result.rows;
+        pgFields = result.fields;
       }
 
       // Slice only when the window was NOT already pushed into SQL.
@@ -431,8 +523,10 @@ export class PostgresConnector extends RemoteApiConnector {
           ? rows.slice(offset, offset + limit)
           : rows;
 
-      // Infer fields from rows.
-      const fields = inferFieldsFromRows(slicedRows, tableId);
+      // Infer fields from rows + pg column metadata.
+      // pgFields is the authoritative column list (handles empty results and
+      // OID-based type overrides for NUMERIC/BIGINT precision).
+      const fields = inferFieldsFromRows(slicedRows, tableId, pgFields);
 
       // Build Arrow column arrays from the inferred field set.
       const columnArrays: Record<string, unknown[]> = Object.create(
@@ -462,7 +556,7 @@ export class PostgresConnector extends RemoteApiConnector {
 // ---------------------------------------------------------------------------
 
 /**
- * Run a user-supplied SELECT and return its rows.
+ * Run a user-supplied SELECT and return rows plus pg column metadata.
  *
  * Sink 3 compliance: the query text is sent as-is, with NO string
  * interpolation of any user value. The text has already passed the allowlist
@@ -481,9 +575,8 @@ export class PostgresConnector extends RemoteApiConnector {
 async function runUserQuery(
   client: PgClientLike,
   sql: string,
-): Promise<Record<string, unknown>[]> {
-  const result = await client.query({ text: sql, queryMode: "extended" });
-  return result.rows;
+): Promise<PgQueryResult> {
+  return client.query({ text: sql, queryMode: "extended" });
 }
 
 /**
@@ -497,6 +590,9 @@ async function runUserQuery(
  * preview with `limit: 50` must NOT pull an unbounded table into Node memory
  * and slice afterward. When `limit` is undefined, the plain SELECT is emitted
  * unchanged (full-table behavior preserved for callers that want every row).
+ *
+ * Returns rows plus pg column metadata (result.fields) for OID-based type
+ * inference and zero-row schema recovery.
  */
 async function fetchTable(
   client: PgClientLike,
@@ -504,18 +600,13 @@ async function fetchTable(
   table: string,
   limit?: number,
   offset = 0,
-): Promise<Record<string, unknown>[]> {
+): Promise<PgQueryResult> {
   const base = `SELECT * FROM ${quoteIdentifier(schema)}.${quoteIdentifier(table)}`;
   if (limit === undefined) {
-    const result = await client.query(base);
-    return result.rows;
+    return client.query(base);
   }
   // Bound window: limit/offset as $1/$2 value parameters → extended protocol.
-  const result = await client.query(`${base} LIMIT $1 OFFSET $2`, [
-    limit,
-    offset,
-  ]);
-  return result.rows;
+  return client.query(`${base} LIMIT $1 OFFSET $2`, [limit, offset]);
 }
 
 /**

--- a/packages/connector-postgres/src/connector.ts
+++ b/packages/connector-postgres/src/connector.ts
@@ -293,8 +293,17 @@ export function pgOidToColumnType(
  * duplicate entries in pg's result.fields. Duplicates would let
  * createFieldsFromColumns emit more Fields than Arrow has columns (the
  * columnArrays object deduplicates by key), violating the fieldIds↔arrowBuffer
- * alignment contract. First-occurrence wins — consistent with the row key-union
- * fallback path. Dangerous column names are excluded from both outputs.
+ * alignment contract. Dangerous column names are excluded from both outputs.
+ *
+ * Column order: first-occurrence determines position (so column order is stable
+ * and consistent with what the query author expects).
+ *
+ * OID: last-occurrence wins. node-postgres overwrites earlier same-name columns
+ * in the row object with the later column's value, so the row value for a
+ * duplicate-name column comes from the last occurrence. Using that occurrence's
+ * OID ensures field.type and the actual Arrow value are in agreement, even when
+ * the two same-name columns have different Postgres types (e.g. int4 + int8 in
+ * a cross-type JOIN).
  */
 function columnListFromPgFields(pgFields: PgFieldDef[]): {
   columnNames: string[];
@@ -304,8 +313,10 @@ function columnListFromPgFields(pgFields: PgFieldDef[]): {
   const oidByName = new Map<string, number>();
   for (const f of pgFields) {
     if (DANGEROUS_COLUMN_NAMES.has(f.name)) continue;
-    if (seenNames.has(f.name)) continue; // first-occurrence wins
+    // Track first-occurrence for column-list ordering.
     seenNames.add(f.name);
+    // Always overwrite OID — last-occurrence aligns with how pg's row object
+    // resolves duplicate names (last value wins).
     oidByName.set(f.name, f.dataTypeID);
   }
   return { columnNames: [...seenNames], oidByName };


### PR DESCRIPTION
## Summary

Tracked internally as YW-310.

Two correctness follow-ups from YW-299 / PR #165 (Postgres connector), both flagged by Codex review and deliberately deferred. Both fixes are in `packages/connector-postgres/src/connector.ts`.

### Fix 1: NUMERIC/BIGINT Arrow coercion

node-postgres returns `NUMERIC` (OID 1700) and `BIGINT` (OID 20) as **strings** — e.g. `"9007199254740993"`. The prior code passed these through `inferStringColumnType`, which sniffs `"123"` → `"number"`, so `Field.type` was `"number"` while the actual Arrow value was a string. Schema and data type disagreed.

**Approach:** `pgOidToColumnType(oid)` maps OID 20/1700 → `"string"` (lossless). Field-type and Arrow value-type now agree.

**Why not int64/decimal Arrow types (divergence from brief):** the engine's `ColumnType` has no `int64` or `decimal` variant, and Arrow Int64 (BigInt) vectors carry IPC→renderer→DuckDB pipeline risk that would need a verified end-to-end round-trip test before committing. String is the safe default — DuckDB casts VARCHAR→BIGINT/NUMERIC during ingest. This can be revisited as a follow-up if int64 Arrow encoding is desired.

### Fix 2: Empty-result schema loss

`inferFieldsFromRows` only derived column names from row keys. A zero-row result (empty table or `WHERE 1=0` SELECT) produced `fields: []` / `fieldIds: []`, even though pg returns column metadata in `result.fields` on every successful query.

**Approach:** `runUserQuery` and `fetchTable` now return `PgQueryResult` (rows + fields) instead of just rows. `inferFieldsFromRows` accepts optional `PgFieldDef[]` and uses pg's column metadata as the authoritative column list when present, falling back to key-union for callers that supply no metadata.

## Changes

- `PgClientLike.query` return type widened to `PgQueryResult` (adds `fields: PgFieldDef[]`)
- `runUserQuery` / `fetchTable` now return `PgQueryResult`
- `inferFieldsFromRows` accepts optional `pgFields?: PgFieldDef[]`
- New exported `pgOidToColumnType(oid)` helper
- `makeSpyClient` updated to return `fields` alongside `rows`
- Existing empty-result test split: no-metadata baseline stays, new test verifies schema recovery from pg column metadata
- New test suites: `pgOidToColumnType` unit tests, NUMERIC/BIGINT Arrow round-trip tests

## Test plan

- [ ] `turbo test --filter=@dashframe/connector-postgres` — 48 tests pass
- [ ] `turbo typecheck --filter=@dashframe/connector-postgres` — clean
- [ ] New tests verify: BIGINT > 2^53 survives byte-for-byte as string; NUMERIC exact decimal survives; zero-row SELECT returns correct schema from pg column metadata; OID 20/1700 map to "string", other OIDs fall through to value inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two correctness issues in the Postgres connector's field inference pipeline: BIGINT/NUMERIC values being mistyped (OID 20/1700 are returned as strings by node-postgres but were previously classified as `"number"` by value inference), and zero-row query results losing all schema information (no sample values to infer column names or types from).

- Adds `pgOidToColumnType(oid)` which maps well-known Postgres OIDs to `ColumnType`; OID 20 and OID 1700 explicitly map to `"string"` to keep field type aligned with the actual JS value node-postgres delivers.
- `PgClientLike.query` return type is widened to `PgQueryResult` (rows + fields), `runUserQuery` and `fetchTable` propagate this metadata to `inferFieldsFromRows`, which now accepts an optional `PgFieldDef[]` and uses pg's column descriptors as the authoritative column list on empty results while still falling back to key-union-of-rows for callers that supply no metadata.
- New unit tests cover OID → type mapping, BIGINT/NUMERIC Arrow round-trips (byte-for-byte string preservation), empty-result schema recovery, and duplicate-column deduplication (JOIN case).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both fixes are narrowly scoped to field inference, the dangerous-column guard is applied consistently in every new code path, and the added tests are precise about Arrow value types and schema round-trips.

The two changed code paths (OID-based type coercion and empty-result schema recovery) are well-isolated from the rest of the connector. The BIGINT/NUMERIC → string mapping is correct given node-postgres's documented behavior, the deduplication logic for JOIN column collisions is sound, and the fallback to row-based inference when pgFields is absent or empty preserves backward compatibility. No dangerous-column filtering gaps, no type misalignments, and no regressions to the read-only security contracts were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/connector-postgres/src/connector.ts | Adds PgFieldDef/PgQueryResult types, pgOidToColumnType helper, columnListFromPgFields deduplication, and threads pg column metadata through fetchTable/runUserQuery into inferFieldsFromRows. Logic is correct; dangerous-column guard is applied consistently in the new code path; OID priority over value inference is sound. |
| packages/connector-postgres/src/connector.test.ts | makeSpyClient updated to carry PgFieldDef[], new test suites cover OID mapping, BIGINT/NUMERIC Arrow round-trips, empty-result schema recovery (including unmapped OIDs), and duplicate-column JOIN deduplication. Coverage is thorough and the test assertions are precise. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["connector.query"] --> B{isTableRef?}
    B -- yes --> C["fetchTable → PgQueryResult"]
    B -- no --> D["runUserQuery → PgQueryResult"]
    C --> E["rows + pgFields"]
    D --> E
    E --> F["inferFieldsFromRows(slicedRows, tableId, pgFields)"]
    F --> G{pgFields present and non-empty?}
    G -- yes --> H["columnListFromPgFields\ndedup + oidByName Map"]
    G -- no --> I["columnNamesFromRows\nkey-union fallback"]
    H --> J["inferColumnType per column"]
    I --> J
    J --> K{OID in map?}
    K -- yes --> L["pgOidToColumnType\ne.g. OID 20 → string, OID 23 → number"]
    K -- no --> M["inferStringColumnType on first non-null value\nor unknown if all null"]
    L --> N["createFieldsFromColumns → Field[]"]
    M --> N
    N --> O["tableFromArrays → Arrow IPC base64\nConnectorQueryResult"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["connector.query"] --> B{isTableRef?}
    B -- yes --> C["fetchTable → PgQueryResult"]
    B -- no --> D["runUserQuery → PgQueryResult"]
    C --> E["rows + pgFields"]
    D --> E
    E --> F["inferFieldsFromRows(slicedRows, tableId, pgFields)"]
    F --> G{pgFields present and non-empty?}
    G -- yes --> H["columnListFromPgFields\ndedup + oidByName Map"]
    G -- no --> I["columnNamesFromRows\nkey-union fallback"]
    H --> J["inferColumnType per column"]
    I --> J
    J --> K{OID in map?}
    K -- yes --> L["pgOidToColumnType\ne.g. OID 20 → string, OID 23 → number"]
    K -- no --> M["inferStringColumnType on first non-null value\nor unknown if all null"]
    L --> N["createFieldsFromColumns → Field[]"]
    M --> N
    N --> O["tableFromArrays → Arrow IPC base64\nConnectorQueryResult"]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(connector-postgres): last-occurrence..."](https://github.com/youhaowei/dashframe/commit/1e6213ce3d89b7dfff2ae53b46bd16276028d12f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39978239)</sub>

<!-- /greptile_comment -->