### PR TITLE
[YW-295] fix(engine): end-to-end join-instance identity for repeat-joins

### DIFF
--- a/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
+++ b/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
@@ -26,6 +26,7 @@ import {
   useVisualizations,
 } from "@dashframe/core";
 import {
+  extractColumnAliasComponents,
   fieldIdToColumnAlias,
   getMetricDisplayLabel,
   isGeneratedColumnLabel,
@@ -479,9 +480,16 @@ export default function VisualizationPageContent({
     isAnalysisViewReady,
   ]);
 
-  // Get column options for Color/Size selects (derived from compiledInsight)
-  // Uses storage encoding format (field:<uuid>, metric:<uuid>) for values
-  // Includes icons to show column types
+  // Get column options for Color/Size selects (derived from compiledInsight +
+  // instance-aware fields for repeat-joins).
+  // Uses storage encoding format (field:<uuid>, metric:<uuid>) for values.
+  // Includes icons to show column types.
+  //
+  // `compiledInsight.dimensions` only contains bare-ID fields that were
+  // explicitly selected.  Repeat-join instances (field id `<uuid>_j1`) are
+  // available in `instanceAwareFields` but absent from `compiledInsight`.
+  // We append any such missing instances so Color/Size pickers expose the full
+  // set of chartable fields — matching the axis picker's behavior.
   const columnOptions = useMemo(() => {
     if (!compiledInsight) return [];
 
@@ -495,16 +503,43 @@ export default function VisualizationPageContent({
       icon: React.ComponentType<{ className?: string }>;
     }> = [];
 
-    // Add dimensions (resolved Field objects from compiledInsight)
-    // Use field:<uuid> encoding format for value
+    // Track which field encodings we have already added to avoid duplicates.
+    const addedEncodings = new Set<string>();
+
+    // Add dimensions (resolved Field objects from compiledInsight).
+    // Use disambiguated display names from axisColumnDisplayNames when available
+    // (they carry "(leftKey)" suffixes for repeat-join collisions).
     compiledInsight.dimensions.forEach((field) => {
       const sqlAlias = fieldIdToColumnAlias(field.id);
+      const enc = `field:${field.id}`;
+      const label = axisColumnDisplayNames[sqlAlias] ?? field.name;
       options.push({
-        label: field.name,
-        value: `field:${field.id}`,
+        label,
+        value: enc,
         icon: getColumnIcon(sqlAlias, columnAnalysis, metricAliases),
       });
+      addedEncodings.add(enc);
     });
+
+    // Append any repeat-join instance fields from instanceAwareFields that are
+    // not already covered by compiledInsight.dimensions.  A field is a repeat-
+    // join instance when extractColumnAliasComponents returns instanceIndex > 0.
+    for (const field of instanceAwareFields) {
+      const enc = `field:${field.id}`;
+      if (addedEncodings.has(enc)) continue;
+      const components = extractColumnAliasComponents(
+        fieldIdToColumnAlias(field.id),
+      );
+      if (!components || components.instanceIndex === 0) continue; // only j1+
+      const sqlAlias = fieldIdToColumnAlias(field.id);
+      const label = axisColumnDisplayNames[sqlAlias] ?? field.name;
+      options.push({
+        label,
+        value: enc,
+        icon: getColumnIcon(sqlAlias, columnAnalysis, metricAliases),
+      });
+      addedEncodings.add(enc);
+    }
 
     // Add metrics using metric:<uuid> encoding format
     compiledInsight.metrics.forEach((metric) => {
@@ -517,7 +552,13 @@ export default function VisualizationPageContent({
     });
 
     return options;
-  }, [compiledInsight, columnAnalysis, dataTable?.fields]);
+  }, [
+    compiledInsight,
+    columnAnalysis,
+    dataTable?.fields,
+    instanceAwareFields,
+    axisColumnDisplayNames,
+  ]);
 
   // Validate encoding configuration - returns errors for X/Y if invalid
   const encodingErrors = useMemo(() => {

--- a/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
+++ b/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
@@ -176,12 +176,15 @@ export default function VisualizationPageContent({
   // Get DuckDB view name for analysis (uses UUID-based column names)
   const { viewName: analysisViewName, isReady: isAnalysisViewReady } =
     useInsightView(insightForView);
-  const { columns: modelColumns, columnDisplayNames: modelColumnDisplayNames } =
-    useInsightPagination({
-      insight: insightForView ?? ({} as InsightType),
-      showModelPreview: true,
-      enabled: !!insightForView,
-    });
+  const {
+    columns: modelColumns,
+    columnDisplayNames: modelColumnDisplayNames,
+    resolvedFields: instanceAwareFields,
+  } = useInsightPagination({
+    insight: insightForView ?? ({} as InsightType),
+    showModelPreview: true,
+    enabled: !!insightForView,
+  });
   const { columnDisplayNames: renderedColumnDisplayNames } =
     useInsightPagination({
       insight: insightForView ?? ({} as InsightType),
@@ -932,7 +935,11 @@ export default function VisualizationPageContent({
                   chartType={visualization.visualizationType}
                   columnAnalysis={columnAnalysis}
                   compiledInsight={compiledInsight}
-                  availableFields={dataTable?.fields}
+                  availableFields={
+                    instanceAwareFields.length > 0
+                      ? instanceAwareFields
+                      : dataTable?.fields
+                  }
                   availableColumns={axisSourceColumns}
                   columnDisplayNames={axisColumnDisplayNames}
                   otherAxisColumn={visualization.encoding?.y}
@@ -965,7 +972,11 @@ export default function VisualizationPageContent({
                   chartType={visualization.visualizationType}
                   columnAnalysis={columnAnalysis}
                   compiledInsight={compiledInsight}
-                  availableFields={dataTable?.fields}
+                  availableFields={
+                    instanceAwareFields.length > 0
+                      ? instanceAwareFields
+                      : dataTable?.fields
+                  }
                   availableColumns={axisSourceColumns}
                   columnDisplayNames={axisColumnDisplayNames}
                   otherAxisColumn={visualization.encoding?.x}

--- a/packages/app/src/components/visualizations/AxisSelectField.render.test.tsx
+++ b/packages/app/src/components/visualizations/AxisSelectField.render.test.tsx
@@ -1,0 +1,421 @@
+/**
+ * AxisSelectField component-render acceptance test for repeat-join instance identity.
+ *
+ * Acceptance criterion: for an insight with a repeat-join (orders→users on
+ * created_by AND approved_by), the picker must expose BOTH join instances as
+ * DISTINCT selectable options with distinct encoding values AND distinct
+ * human-readable labels.  Selecting the second instance must emit the _j1
+ * encoding (field:<uuid>_j1), not the bare-UUID encoding.
+ *
+ * This test renders AxisSelectField directly (it has no context providers —
+ * only useCallback/useMemo React hooks) and intercepts the options passed to
+ * the inner SelectField via a stub.  The stub records what options the component
+ * computed, and records which value onChange was called with when the stub
+ * simulates a selection.
+ */
+
+import {
+  buildInsightAvailableFields,
+  fieldIdToColumnAlias,
+} from "@dashframe/engine";
+import type { ColumnAnalysis } from "@dashframe/engine-browser";
+import type {
+  CompiledInsight,
+  DataTable,
+  Field,
+  Insight,
+  UUID,
+} from "@dashframe/types";
+import { fieldEncoding } from "@dashframe/types";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AxisSelectField } from "./AxisSelectField";
+
+// ── Stubs ────────────────────────────────────────────────────────────────────
+
+// Capture the options list passed to SelectField from inside AxisSelectField.
+// We expose it via a module-level ref updated on each render call.
+let capturedOptions: Array<{ label: string; value: string }> = [];
+let capturedOnChange: (v: string) => void = () => {};
+
+vi.mock("@dashframe/ui", () => ({
+  SelectField: (props: {
+    label?: string;
+    value: string;
+    onChange: (v: string) => void;
+    options: Array<{ label: string; value: string }>;
+    placeholder?: string;
+    onClear?: () => void;
+    error?: string;
+    labelAddon?: unknown;
+  }) => {
+    // Record what was passed in so assertions can inspect it.
+    capturedOptions = props.options ?? [];
+    capturedOnChange = props.onChange;
+    return (
+      <select
+        data-testid="axis-select"
+        value={props.value}
+        onChange={(e) => props.onChange(e.target.value)}
+      >
+        {props.options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    );
+  },
+}));
+
+// Heavy deps with no relevant logic for these tests — stub out.
+vi.mock("@/lib/utils/field-icons", () => ({
+  getColumnIcon: () => null,
+}));
+
+vi.mock("@/lib/visualizations/axis-warnings", () => ({
+  getColumnWarning: () => null,
+  getRankedColumnOptions: (aliases: string[]) =>
+    aliases.map((a) => ({ value: a, label: a, warning: null })),
+}));
+
+vi.mock("@/lib/visualizations/encoding-enforcer", () => ({
+  getAxisSemanticLabel: () => undefined,
+  getValidColumnsForChannel: (
+    _axis: unknown,
+    _chartType: unknown,
+    cols: ColumnAnalysis[],
+  ) => cols.map((c) => c.columnName),
+  isColumnValidForChannel: () => ({ suitable: true }),
+}));
+
+vi.mock("@wystack/ui", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  TooltipPrimitive: ({ render: r }: { render: React.ReactNode }) => r,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  TooltipTrigger: ({ render: r }: { render: React.ReactNode }) => r,
+}));
+
+vi.mock("@wystack/ui-icons", () => ({
+  AlertCircleIcon: () => null,
+  ArrowUpDownIcon: () => null,
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ORDERS_TABLE_ID = "10101010-1010-1010-1010-101010101010" as UUID;
+const ORDERS_DF_ID = "20202020-2020-2020-2020-202020202020" as UUID;
+const USERS_TABLE_ID = "30303030-3030-3030-3030-303030303030" as UUID;
+const USERS_DF_ID = "40404040-4040-4040-4040-404040404040" as UUID;
+const DATA_SOURCE_ID = "33333333-3333-3333-3333-333333333333" as UUID;
+
+const O_ID_FIELD: Field = {
+  id: "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0" as UUID,
+  name: "Order ID",
+  tableId: ORDERS_TABLE_ID,
+  columnName: "id",
+  type: "string",
+};
+
+const U_NAME_FIELD: Field = {
+  id: "e0e0e0e0-e0e0-e0e0-e0e0-e0e0e0e0e0e0" as UUID,
+  name: "User Name",
+  tableId: USERS_TABLE_ID,
+  columnName: "name",
+  type: "string",
+};
+
+const U_EMAIL_FIELD: Field = {
+  id: "f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0" as UUID,
+  name: "User Email",
+  tableId: USERS_TABLE_ID,
+  columnName: "email",
+  type: "string",
+};
+
+const U_ID_FIELD: Field = {
+  id: "d0d0d0d0-d0d0-d0d0-d0d0-d0d0d0d0d0d0" as UUID,
+  name: "User ID",
+  tableId: USERS_TABLE_ID,
+  columnName: "id",
+  type: "string",
+};
+
+const ordersTable: DataTable = {
+  id: ORDERS_TABLE_ID,
+  name: "orders",
+  dataSourceId: DATA_SOURCE_ID,
+  table: "orders.csv",
+  fields: [
+    O_ID_FIELD,
+    {
+      id: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0" as UUID,
+      name: "Created By",
+      tableId: ORDERS_TABLE_ID,
+      columnName: "created_by",
+      type: "string",
+    },
+    {
+      id: "c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0" as UUID,
+      name: "Approved By",
+      tableId: ORDERS_TABLE_ID,
+      columnName: "approved_by",
+      type: "string",
+    },
+  ],
+  metrics: [],
+  dataFrameId: ORDERS_DF_ID,
+  createdAt: 0,
+};
+
+const usersTable: DataTable = {
+  id: USERS_TABLE_ID,
+  name: "users",
+  dataSourceId: DATA_SOURCE_ID,
+  table: "users.csv",
+  fields: [U_ID_FIELD, U_NAME_FIELD, U_EMAIL_FIELD],
+  metrics: [],
+  dataFrameId: USERS_DF_ID,
+  createdAt: 0,
+};
+
+const joinedTables = new Map([[USERS_TABLE_ID, usersTable]]);
+
+const doubleJoinInsight: Pick<Insight, "joins"> = {
+  joins: [
+    {
+      type: "inner",
+      rightTableId: USERS_TABLE_ID,
+      leftKey: "created_by",
+      rightKey: "id",
+    },
+    {
+      type: "inner",
+      rightTableId: USERS_TABLE_ID,
+      leftKey: "approved_by",
+      rightKey: "id",
+    },
+  ],
+};
+
+// Build instance-aware fields the same way the real app does
+// (buildInsightAvailableFields from @dashframe/engine).
+const instanceAwareFields =
+  buildInsightAvailableFields(ordersTable, joinedTables, doubleJoinInsight) ??
+  [];
+
+// j0 is the bare-UUID entry; j1 is the _j1 synthetic entry.
+const j1NameId = `${U_NAME_FIELD.id}_j1` as UUID;
+
+// Encoding values the picker must expose.
+const J0_ENC = fieldEncoding(U_NAME_FIELD.id as UUID); // field:<uuid>
+const J1_ENC = fieldEncoding(j1NameId); // field:<uuid>_j1
+
+// Verify the test fixtures are valid before running assertions.
+const j0Field = instanceAwareFields.find((f) => f.id === U_NAME_FIELD.id);
+const j1Field = instanceAwareFields.find((f) => f.id === j1NameId);
+if (!j0Field || !j1Field) {
+  throw new Error(
+    `Test fixture error: buildInsightAvailableFields did not return expected j0/j1 fields. ` +
+      `ids found: ${instanceAwareFields.map((f) => f.id).join(", ")}`,
+  );
+}
+
+// The compiledInsight only carries the base-table fields (as in the real app —
+// compiledInsight.dimensions comes from the selectedFields of the bare insight,
+// not the joined expansion).  AxisSelectField must merge in availableFields.
+const baseCompiledInsight: CompiledInsight = {
+  id: "ins-1" as UUID,
+  name: "Test Insight",
+  dimensions: [O_ID_FIELD],
+  metrics: [],
+};
+
+// ColumnAnalysis entries simulate what analyzeView/DuckDB returns for a
+// repeat-joined view.  The columnName carries the _j suffix DuckDB emits.
+const j0Alias = fieldIdToColumnAlias(U_NAME_FIELD.id);
+const j1Alias = `${fieldIdToColumnAlias(U_NAME_FIELD.id)}_j1`;
+
+const columnAnalysis: ColumnAnalysis[] = [
+  {
+    columnName: fieldIdToColumnAlias(O_ID_FIELD.id),
+    fieldId: O_ID_FIELD.id,
+    semantic: "string",
+    nullable: false,
+  },
+  // j0 instance — no fieldId (same as how analyzeView produces it for joined columns)
+  {
+    columnName: j0Alias,
+    fieldId: undefined,
+    semantic: "string",
+    nullable: false,
+  },
+  // j1 instance — _j1 suffix
+  {
+    columnName: j1Alias,
+    fieldId: undefined,
+    semantic: "string",
+    nullable: false,
+  },
+];
+
+// Disambiguated display names (mirrors useInsightPagination.columnDisplayNames).
+const columnDisplayNames: Record<string, string> = {
+  [j0Alias]: "User Name (created_by)",
+  [j1Alias]: "User Name (approved_by)",
+};
+
+// ── Shared render helper ──────────────────────────────────────────────────────
+
+function renderAxisSelect(value = "") {
+  return render(
+    <AxisSelectField
+      label="X Axis"
+      value={value}
+      onChange={vi.fn()}
+      axis="x"
+      chartType="barY"
+      columnAnalysis={columnAnalysis}
+      compiledInsight={baseCompiledInsight}
+      availableFields={instanceAwareFields}
+      columnDisplayNames={columnDisplayNames}
+    />,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AxisSelectField — repeat-join picker (component render)", () => {
+  beforeEach(() => {
+    capturedOptions = [];
+    capturedOnChange = () => {};
+    vi.clearAllMocks();
+  });
+
+  it("exposes BOTH repeat-join instances as distinct options", () => {
+    renderAxisSelect();
+
+    const values = capturedOptions.map((o) => o.value);
+    expect(values).toContain(J0_ENC);
+    expect(values).toContain(J1_ENC);
+    // They must be DISTINCT (not collapsed to the same encoding).
+    expect(J0_ENC).not.toBe(J1_ENC);
+  });
+
+  it("gives each repeat-join instance a distinct human-readable label", () => {
+    renderAxisSelect();
+
+    const j0Opt = capturedOptions.find((o) => o.value === J0_ENC);
+    const j1Opt = capturedOptions.find((o) => o.value === J1_ENC);
+
+    expect(j0Opt).toBeDefined();
+    expect(j1Opt).toBeDefined();
+
+    // Labels must be distinct — user can tell the two instances apart.
+    expect(j0Opt!.label).not.toBe(j1Opt!.label);
+
+    // The disambiguation suffix comes from columnDisplayNames.
+    expect(j0Opt!.label).toBe("User Name (created_by)");
+    expect(j1Opt!.label).toBe("User Name (approved_by)");
+  });
+
+  it("selecting the second join instance emits the _j1 encoding", () => {
+    const onChangeMock = vi.fn();
+    render(
+      <AxisSelectField
+        label="X Axis"
+        value=""
+        onChange={onChangeMock}
+        axis="x"
+        chartType="barY"
+        columnAnalysis={columnAnalysis}
+        compiledInsight={baseCompiledInsight}
+        availableFields={instanceAwareFields}
+        columnDisplayNames={columnDisplayNames}
+      />,
+    );
+
+    // Simulate the user selecting the j1 option via the stubbed select.
+    capturedOnChange(J1_ENC);
+
+    expect(onChangeMock).toHaveBeenCalledWith(J1_ENC);
+    // Must NOT collapse to the bare-UUID encoding.
+    expect(onChangeMock).not.toHaveBeenCalledWith(J0_ENC);
+  });
+
+  it("selecting the first join instance emits the bare-UUID encoding", () => {
+    const onChangeMock = vi.fn();
+    render(
+      <AxisSelectField
+        label="X Axis"
+        value=""
+        onChange={onChangeMock}
+        axis="x"
+        chartType="barY"
+        columnAnalysis={columnAnalysis}
+        compiledInsight={baseCompiledInsight}
+        availableFields={instanceAwareFields}
+        columnDisplayNames={columnDisplayNames}
+      />,
+    );
+
+    capturedOnChange(J0_ENC);
+
+    expect(onChangeMock).toHaveBeenCalledWith(J0_ENC);
+  });
+
+  it("single-join insight is unaffected — j0 option is present, no spurious j1", () => {
+    const singleJoinInsight: Pick<Insight, "joins"> = {
+      joins: [
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "created_by",
+          rightKey: "id",
+        },
+      ],
+    };
+    const singleAwareFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        singleJoinInsight,
+      ) ?? [];
+
+    render(
+      <AxisSelectField
+        label="X Axis"
+        value=""
+        onChange={vi.fn()}
+        axis="x"
+        chartType="barY"
+        columnAnalysis={[
+          {
+            columnName: fieldIdToColumnAlias(O_ID_FIELD.id),
+            fieldId: O_ID_FIELD.id,
+            semantic: "string",
+            nullable: false,
+          },
+          {
+            columnName: j0Alias,
+            fieldId: undefined,
+            semantic: "string",
+            nullable: false,
+          },
+        ]}
+        compiledInsight={baseCompiledInsight}
+        availableFields={singleAwareFields}
+      />,
+    );
+
+    const values = capturedOptions.map((o) => o.value);
+    // j0 (bare UUID) must be present.
+    expect(values).toContain(J0_ENC);
+    // No _j1 instance should appear for a single join.
+    expect(values).not.toContain(J1_ENC);
+  });
+});

--- a/packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts
+++ b/packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Acceptance: repeat-join instance identity in the axis picker.
+ *
+ * Contract: given an insight that joins the same right table twice (e.g.
+ * orders→users on created_by AND on approved_by), the axis picker must
+ * surface BOTH join instances as DISTINCT selectable options, and the
+ * encoding value for the second instance must resolve to the correct
+ * `_j1`-suffixed SQL alias so the chart queries the right column.
+ *
+ * This is the user-facing acceptance for the fix introduced in this PR.
+ * The test exercises the core matching logic that AxisSelectField.tsx
+ * now uses: extractColumnAliasComponents → synthetic field-ID → distinct
+ * encoding value per instance. It also validates the charting path via
+ * fieldIdToColumnAlias(syntheticId) producing the correct SQL alias.
+ */
+
+import {
+  buildInsightAvailableFields,
+  extractColumnAliasComponents,
+  fieldIdToColumnAlias,
+} from "@dashframe/engine";
+import type { DataTable, Field, Insight, UUID } from "@dashframe/types";
+import { fieldEncoding } from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+
+// ── Fixtures (matching engine test fixture format) ────────────────────────────
+
+const ORDERS_TABLE_ID = "10101010-1010-1010-1010-101010101010" as UUID;
+const ORDERS_DF_ID = "20202020-2020-2020-2020-202020202020" as UUID;
+const USERS_TABLE_ID = "30303030-3030-3030-3030-303030303030" as UUID;
+const USERS_DF_ID = "40404040-4040-4040-4040-404040404040" as UUID;
+const DATA_SOURCE_ID = "33333333-3333-3333-3333-333333333333" as UUID;
+
+const O_ID_FIELD: Field = {
+  id: "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0" as UUID,
+  name: "Order ID",
+  tableId: ORDERS_TABLE_ID,
+  columnName: "id",
+  type: "string",
+};
+const O_CREATED_BY_FIELD: Field = {
+  id: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0" as UUID,
+  name: "Created By",
+  tableId: ORDERS_TABLE_ID,
+  columnName: "created_by",
+  type: "string",
+};
+const O_APPROVED_BY_FIELD: Field = {
+  id: "c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0" as UUID,
+  name: "Approved By",
+  tableId: ORDERS_TABLE_ID,
+  columnName: "approved_by",
+  type: "string",
+};
+
+const U_ID_FIELD: Field = {
+  id: "d0d0d0d0-d0d0-d0d0-d0d0-d0d0d0d0d0d0" as UUID,
+  name: "User ID",
+  tableId: USERS_TABLE_ID,
+  columnName: "id",
+  type: "string",
+};
+const U_NAME_FIELD: Field = {
+  id: "e0e0e0e0-e0e0-e0e0-e0e0-e0e0e0e0e0e0" as UUID,
+  name: "User Name",
+  tableId: USERS_TABLE_ID,
+  columnName: "name",
+  type: "string",
+};
+const U_EMAIL_FIELD: Field = {
+  id: "f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0" as UUID,
+  name: "User Email",
+  tableId: USERS_TABLE_ID,
+  columnName: "email",
+  type: "string",
+};
+
+const ordersTable: DataTable = {
+  id: ORDERS_TABLE_ID,
+  name: "orders",
+  dataSourceId: DATA_SOURCE_ID,
+  table: "orders.csv",
+  fields: [O_ID_FIELD, O_CREATED_BY_FIELD, O_APPROVED_BY_FIELD],
+  metrics: [],
+  dataFrameId: ORDERS_DF_ID,
+  createdAt: 0,
+};
+
+const usersTable: DataTable = {
+  id: USERS_TABLE_ID,
+  name: "users",
+  dataSourceId: DATA_SOURCE_ID,
+  table: "users.csv",
+  fields: [U_ID_FIELD, U_NAME_FIELD, U_EMAIL_FIELD],
+  metrics: [],
+  dataFrameId: USERS_DF_ID,
+  createdAt: 0,
+};
+
+const doubleJoinInsight: Pick<Insight, "joins"> = {
+  joins: [
+    {
+      type: "inner",
+      rightTableId: USERS_TABLE_ID,
+      leftKey: "created_by",
+      rightKey: "id",
+    },
+    {
+      type: "inner",
+      rightTableId: USERS_TABLE_ID,
+      leftKey: "approved_by",
+      rightKey: "id",
+    },
+  ],
+};
+
+const singleJoinInsight: Pick<Insight, "joins"> = {
+  joins: [
+    {
+      type: "inner",
+      rightTableId: USERS_TABLE_ID,
+      leftKey: "created_by",
+      rightKey: "id",
+    },
+  ],
+};
+
+const joinedTables = new Map([[USERS_TABLE_ID, usersTable]]);
+
+// ── Helpers that mirror AxisSelectField's matching logic ─────────────────────
+
+/**
+ * Simulate the field-ID matching logic now used in AxisSelectField's
+ * allOptions and encodingToSqlAlias memos.
+ *
+ * For a given columnAlias from columnAnalysis, returns the encoding value
+ * that would be stored (field:<syntheticId>) or the raw alias as fallback.
+ */
+function resolveColumnToEncoding(
+  columnAlias: string,
+  selectableFields: Field[],
+): string {
+  const components = extractColumnAliasComponents(columnAlias);
+  if (!components) return columnAlias;
+
+  const syntheticId =
+    components.instanceIndex === 0
+      ? components.uuid
+      : `${components.uuid}_j${components.instanceIndex}`;
+
+  const byId = selectableFields.find((f) => f.id === syntheticId);
+  if (byId) return fieldEncoding(byId.id as UUID);
+
+  // Fallback: bare UUID match (single-join or base-table column)
+  const byBare = selectableFields.find((f) => f.id === components.uuid);
+  if (byBare) return fieldEncoding(byBare.id as UUID);
+
+  return columnAlias;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AxisSelectField — repeat-join instance identity (acceptance)", () => {
+  it("buildInsightAvailableFields produces distinct synthetic IDs for repeat-join instances", () => {
+    const fields = buildInsightAvailableFields(
+      ordersTable,
+      joinedTables,
+      doubleJoinInsight,
+    );
+    expect(fields).not.toBeNull();
+
+    // First join instance: bare UUID (no suffix)
+    const j0Name = fields!.find((f) => f.id === U_NAME_FIELD.id);
+    expect(j0Name).toBeDefined();
+
+    // Second join instance: synthetic id with _j1 suffix
+    const j1NameId = `${U_NAME_FIELD.id}_j1` as UUID;
+    const j1Name = fields!.find((f) => f.id === j1NameId);
+    expect(j1Name).toBeDefined();
+
+    // Their IDs are distinct — the core invariant
+    expect(j0Name!.id).not.toBe(j1Name!.id);
+
+    // Both carry the same human-readable name
+    expect(j0Name!.name).toBe(U_NAME_FIELD.name);
+    expect(j1Name!.name).toBe(U_NAME_FIELD.name);
+  });
+
+  it("extractColumnAliasComponents recovers uuid and instanceIndex from a _j1-suffixed alias", () => {
+    const j1NameId = `${U_NAME_FIELD.id}_j1` as UUID;
+    const alias = fieldIdToColumnAlias(j1NameId);
+    expect(alias).toContain("_j1");
+
+    const components = extractColumnAliasComponents(alias);
+    expect(components).not.toBeNull();
+    expect(components!.uuid).toBe(U_NAME_FIELD.id);
+    expect(components!.instanceIndex).toBe(1);
+  });
+
+  it("picker logic maps BOTH join-instance columns to DISTINCT encoding values", () => {
+    // ACCEPTANCE: this is the key invariant the bug violated.
+    // Before the fix: both columns got the same encoding → user saw one option.
+    // After the fix: each instance maps to a distinct encoding.
+    const selectableFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        doubleJoinInsight,
+      ) ?? [];
+
+    // DuckDB columnAnalysis would produce these two entries for the Name field:
+    const j0Alias = fieldIdToColumnAlias(U_NAME_FIELD.id); // instance 0
+    const j1Alias = fieldIdToColumnAlias(`${U_NAME_FIELD.id}_j1` as UUID); // instance 1
+
+    const enc0 = resolveColumnToEncoding(j0Alias, selectableFields);
+    const enc1 = resolveColumnToEncoding(j1Alias, selectableFields);
+
+    // Both must be valid field: encodings (not raw alias fallbacks)
+    expect(enc0).toMatch(/^field:/);
+    expect(enc1).toMatch(/^field:/);
+
+    // They must be DISTINCT (the acceptance invariant — picker shows both)
+    expect(enc0).not.toBe(enc1);
+
+    // enc0 maps to bare USER_NAME field, enc1 maps to <uuid>_j1
+    expect(enc0).toBe(`field:${U_NAME_FIELD.id}`);
+    expect(enc1).toBe(`field:${U_NAME_FIELD.id}_j1`);
+  });
+
+  it("instance-0 encoding resolves to bare SQL alias, instance-1 to _j1-suffixed alias", () => {
+    // CHARTING PATH: encoding → fieldIdToColumnAlias → SQL alias.
+    // The chart queries the model view by this alias — both must be distinct
+    // and correct for the chart to display the right data.
+    const j0Id = U_NAME_FIELD.id;
+    const j1Id = `${U_NAME_FIELD.id}_j1` as UUID;
+
+    const j0Alias = fieldIdToColumnAlias(j0Id);
+    const j1Alias = fieldIdToColumnAlias(j1Id);
+
+    // j1 alias has the _j1 suffix — matches what DuckDB emits
+    expect(j1Alias).toBe(`${j0Alias}_j1`);
+
+    // The two SQL aliases are distinct — each maps to a different DuckDB column
+    expect(j0Alias).not.toBe(j1Alias);
+  });
+
+  it("single-join insight is unaffected — field still resolves to bare encoding", () => {
+    // NON-REGRESSION: single joins must work identically to before the fix.
+    const selectableFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        singleJoinInsight,
+      ) ?? [];
+
+    const alias = fieldIdToColumnAlias(U_NAME_FIELD.id);
+    const enc = resolveColumnToEncoding(alias, selectableFields);
+
+    expect(enc).toBe(`field:${U_NAME_FIELD.id}`);
+  });
+
+  it("base-table columns are unaffected by the repeat-join fix", () => {
+    const selectableFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        doubleJoinInsight,
+      ) ?? [];
+
+    const orderId0Alias = fieldIdToColumnAlias(O_ID_FIELD.id);
+    const enc = resolveColumnToEncoding(orderId0Alias, selectableFields);
+
+    // Base-table field resolves to bare field encoding
+    expect(enc).toBe(`field:${O_ID_FIELD.id}`);
+  });
+});

--- a/packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts
+++ b/packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts
@@ -1,23 +1,25 @@
 /**
- * Acceptance: repeat-join instance identity in the axis picker.
+ * Repeat-join instance identity: picker helper composition + charting
+ * encoding resolution.
  *
- * Contract: given an insight that joins the same right table twice (e.g.
- * orders→users on created_by AND on approved_by), the axis picker must
- * surface BOTH join instances as DISTINCT selectable options, and the
- * encoding value for the second instance must resolve to the correct
- * `_j1`-suffixed SQL alias so the chart queries the right column.
+ * What this file proves:
+ * (A) PICKER LOGIC — the helper composition that AxisSelectField now uses
+ *     (extractColumnAliasComponents → synthetic field-ID → fieldEncoding)
+ *     maps both repeat-join instances to DISTINCT encoding values.
+ * (B) CHARTING PATH — resolveEncodingToSql with instance-aware fields
+ *     (from buildInsightAvailableFields) resolves field:<uuid>_j1 to the
+ *     correct _j1-suffixed SQL alias; and fails (undefined) when called
+ *     with bare dataTable.fields, catching the regression gap.
  *
- * This is the user-facing acceptance for the fix introduced in this PR.
- * The test exercises the core matching logic that AxisSelectField.tsx
- * now uses: extractColumnAliasComponents → synthetic field-ID → distinct
- * encoding value per instance. It also validates the charting path via
- * fieldIdToColumnAlias(syntheticId) producing the correct SQL alias.
+ * What this file does NOT prove: end-to-end React rendering of the picker
+ * or the chart component — those require DuckDB and full provider mounts.
  */
 
 import {
   buildInsightAvailableFields,
   extractColumnAliasComponents,
   fieldIdToColumnAlias,
+  resolveEncodingToSql,
 } from "@dashframe/engine";
 import type { DataTable, Field, Insight, UUID } from "@dashframe/types";
 import { fieldEncoding } from "@dashframe/types";
@@ -227,21 +229,51 @@ describe("AxisSelectField — repeat-join instance identity (acceptance)", () =>
     expect(enc1).toBe(`field:${U_NAME_FIELD.id}_j1`);
   });
 
-  it("instance-0 encoding resolves to bare SQL alias, instance-1 to _j1-suffixed alias", () => {
-    // CHARTING PATH: encoding → fieldIdToColumnAlias → SQL alias.
-    // The chart queries the model view by this alias — both must be distinct
-    // and correct for the chart to display the right data.
-    const j0Id = U_NAME_FIELD.id;
-    const j1Id = `${U_NAME_FIELD.id}_j1` as UUID;
+  it("resolveEncodingToSql with instance-aware fields resolves _j1 encoding to the correct SQL alias", () => {
+    // CHARTING PATH (B): proves the full resolution pipeline used by
+    // VisualizationDisplay and VisualizationPreview after this fix.
+    // resolveEncodingToSql is the real function called by those components;
+    // testing against it catches surface regressions the helper-composition
+    // tests above cannot see.
+    const instanceAwareFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        doubleJoinInsight,
+      ) ?? [];
 
-    const j0Alias = fieldIdToColumnAlias(j0Id);
-    const j1Alias = fieldIdToColumnAlias(j1Id);
+    const j0Enc = `field:${U_NAME_FIELD.id}`;
+    const j1Enc = `field:${U_NAME_FIELD.id}_j1`;
 
-    // j1 alias has the _j1 suffix — matches what DuckDB emits
-    expect(j1Alias).toBe(`${j0Alias}_j1`);
+    const context = {
+      fields: instanceAwareFields,
+      metrics: [],
+    };
 
-    // The two SQL aliases are distinct — each maps to a different DuckDB column
-    expect(j0Alias).not.toBe(j1Alias);
+    // Instance 0: resolves to bare alias
+    const j0Sql = resolveEncodingToSql({ x: j0Enc }, context);
+    expect(j0Sql.x).toBe(fieldIdToColumnAlias(U_NAME_FIELD.id));
+
+    // Instance 1: resolves to the _j1-suffixed alias — the SQL alias DuckDB emits
+    const j1Sql = resolveEncodingToSql({ x: j1Enc }, context);
+    expect(j1Sql.x).toBe(`${fieldIdToColumnAlias(U_NAME_FIELD.id)}_j1`);
+
+    // Verify they differ (regression guard)
+    expect(j0Sql.x).not.toBe(j1Sql.x);
+  });
+
+  it("resolveEncodingToSql with bare dataTable.fields cannot resolve a _j1 encoding", () => {
+    // Proves the gap that existed BEFORE this fix on Preview/Display surfaces.
+    // If bare fields are used (old behavior), instance-1 resolves to undefined.
+    // This test is the detector that would have caught VisualizationPreview's bug.
+    const j1Enc = `field:${U_NAME_FIELD.id}_j1`;
+    const bareContext = {
+      fields: usersTable.fields ?? [],
+      metrics: [],
+    };
+
+    const result = resolveEncodingToSql({ x: j1Enc }, bareContext);
+    expect(result.x).toBeUndefined();
   });
 
   it("single-join insight is unaffected — field still resolves to bare encoding", () => {

--- a/packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts
+++ b/packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts
@@ -1,6 +1,6 @@
 /**
  * Repeat-join instance identity: picker helper composition + charting
- * encoding resolution.
+ * encoding resolution + label disambiguation.
  *
  * What this file proves:
  * (A) PICKER LOGIC — the helper composition that AxisSelectField now uses
@@ -10,6 +10,10 @@
  *     (from buildInsightAvailableFields) resolves field:<uuid>_j1 to the
  *     correct _j1-suffixed SQL alias; and fails (undefined) when called
  *     with bare dataTable.fields, catching the regression gap.
+ * (C) LABEL DISAMBIGUATION — the display-name logic used by
+ *     useInsightPagination.columnDisplayNames produces distinct, human-readable
+ *     labels for colliding repeat-join instances (e.g. "User Name (created_by)"
+ *     vs "User Name (approved_by)"), while leaving Field.name canonical.
  *
  * What this file does NOT prove: end-to-end React rendering of the picker
  * or the chart component — those require DuckDB and full provider mounts.
@@ -304,5 +308,130 @@ describe("AxisSelectField — repeat-join instance identity (acceptance)", () =>
 
     // Base-table field resolves to bare field encoding
     expect(enc).toBe(`field:${O_ID_FIELD.id}`);
+  });
+
+  it("(C) display-name disambiguation: both repeat-join instances get distinct labels including leftKey", () => {
+    // This test verifies the label logic used by useInsightPagination.columnDisplayNames.
+    // Both colliding instances must be labeled so neither appears as an unlabeled
+    // default.  Field.name stays canonical ("User Name") — only the picker/display
+    // label gets the "(leftKey)" suffix.
+    const resolvedFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        doubleJoinInsight,
+      ) ?? [];
+
+    // Mirror the hook's disambiguation logic:
+    // 1. Walk joins to build (rightTableId, instanceIndex) → leftKey map.
+    const joinKeyByInstance = new Map<string, string>();
+    const instanceCount = new Map<string, number>();
+    for (const join of doubleJoinInsight.joins!) {
+      const idx = instanceCount.get(join.rightTableId) ?? 0;
+      joinKeyByInstance.set(`${join.rightTableId}:${idx}`, join.leftKey);
+      instanceCount.set(join.rightTableId, idx + 1);
+    }
+
+    // 2. Find base UUIDs that have ≥2 instances.
+    const baseUuidsWithRepeat = new Set<string>();
+    for (const field of resolvedFields) {
+      const components = extractColumnAliasComponents(
+        fieldIdToColumnAlias(field.id),
+      );
+      if (components && components.instanceIndex > 0) {
+        baseUuidsWithRepeat.add(components.uuid);
+      }
+    }
+
+    // 3. Build display name map with disambiguation.
+    const displayNames: Record<string, string> = {};
+    for (const field of resolvedFields) {
+      const alias = fieldIdToColumnAlias(field.id);
+      const components = extractColumnAliasComponents(alias);
+      if (components && baseUuidsWithRepeat.has(components.uuid)) {
+        const leftKey = joinKeyByInstance.get(
+          `${field.tableId}:${components.instanceIndex}`,
+        );
+        displayNames[alias] = leftKey
+          ? `${field.name} (${leftKey})`
+          : field.name;
+      } else {
+        displayNames[alias] = field.name;
+      }
+    }
+
+    const j0Alias = fieldIdToColumnAlias(U_NAME_FIELD.id);
+    const j1NameId = `${U_NAME_FIELD.id}_j1` as UUID;
+    const j1Alias = fieldIdToColumnAlias(j1NameId);
+
+    // J0 → "User Name (created_by)", J1 → "User Name (approved_by)"
+    expect(displayNames[j0Alias]).toBe("User Name (created_by)");
+    expect(displayNames[j1Alias]).toBe("User Name (approved_by)");
+
+    // Labels are distinct — the picker shows two distinguishable options.
+    expect(displayNames[j0Alias]).not.toBe(displayNames[j1Alias]);
+
+    // Field.name is NOT mutated — it stays canonical.
+    const j0Field = resolvedFields.find((f) => f.id === U_NAME_FIELD.id);
+    const j1Field = resolvedFields.find((f) => f.id === j1NameId);
+    expect(j0Field!.name).toBe(U_NAME_FIELD.name);
+    expect(j1Field!.name).toBe(U_NAME_FIELD.name);
+
+    // Non-colliding fields (e.g. User Email) are unaffected — no "(leftKey)" suffix.
+    const j0EmailAlias = fieldIdToColumnAlias(U_EMAIL_FIELD.id);
+    const j1EmailId = `${U_EMAIL_FIELD.id}_j1` as UUID;
+    const j1EmailAlias = fieldIdToColumnAlias(j1EmailId);
+    expect(displayNames[j0EmailAlias]).toBe("User Email (created_by)");
+    expect(displayNames[j1EmailAlias]).toBe("User Email (approved_by)");
+  });
+
+  it("(C) single-join: display names are unambiguous bare field names (no leftKey suffix)", () => {
+    // Non-regression: when there's only one join to a table, no disambiguation
+    // suffix should appear.  "User Name" stays "User Name".
+    const resolvedFields =
+      buildInsightAvailableFields(
+        ordersTable,
+        joinedTables,
+        singleJoinInsight,
+      ) ?? [];
+
+    // Walk the single join
+    const joinKeyByInstance = new Map<string, string>();
+    const instanceCount = new Map<string, number>();
+    for (const join of singleJoinInsight.joins!) {
+      const idx = instanceCount.get(join.rightTableId) ?? 0;
+      joinKeyByInstance.set(`${join.rightTableId}:${idx}`, join.leftKey);
+      instanceCount.set(join.rightTableId, idx + 1);
+    }
+
+    const baseUuidsWithRepeat = new Set<string>();
+    for (const field of resolvedFields) {
+      const components = extractColumnAliasComponents(
+        fieldIdToColumnAlias(field.id),
+      );
+      if (components && components.instanceIndex > 0) {
+        baseUuidsWithRepeat.add(components.uuid);
+      }
+    }
+
+    const displayNames: Record<string, string> = {};
+    for (const field of resolvedFields) {
+      const alias = fieldIdToColumnAlias(field.id);
+      const components = extractColumnAliasComponents(alias);
+      if (components && baseUuidsWithRepeat.has(components.uuid)) {
+        const leftKey = joinKeyByInstance.get(
+          `${field.tableId}:${components.instanceIndex}`,
+        );
+        displayNames[alias] = leftKey
+          ? `${field.name} (${leftKey})`
+          : field.name;
+      } else {
+        displayNames[alias] = field.name;
+      }
+    }
+
+    const j0Alias = fieldIdToColumnAlias(U_NAME_FIELD.id);
+    // Single join — no repeat — so no disambiguation suffix.
+    expect(displayNames[j0Alias]).toBe("User Name");
   });
 });

--- a/packages/app/src/components/visualizations/AxisSelectField.tsx
+++ b/packages/app/src/components/visualizations/AxisSelectField.tsx
@@ -35,6 +35,35 @@ import {
 import { AlertCircleIcon, ArrowUpDownIcon } from "@wystack/ui-icons";
 import { useCallback, useMemo } from "react";
 
+/**
+ * Match a column analysis entry to a selectable Field using instance-qualified
+ * synthetic IDs. For repeat-join instances, `columnAlias` carries a `_j{n}`
+ * suffix (e.g. `field_<uuid>_j1`); extractColumnAliasComponents recovers the
+ * bare UUID and instance index so we can reconstruct the synthetic field ID
+ * (`<uuid>_j1`) and match it against `selectableFields`.
+ *
+ * Returns `undefined` when no match is found (raw column with no Field).
+ */
+function matchColumnToField(
+  fieldId: string | undefined,
+  columnAlias: string,
+  selectableFields: Field[],
+): Field | undefined {
+  if (fieldId) {
+    return selectableFields.find((f) => f.id === fieldId);
+  }
+  const components = extractColumnAliasComponents(columnAlias);
+  if (!components) return undefined;
+  const syntheticId =
+    components.instanceIndex === 0
+      ? components.uuid
+      : `${components.uuid}_j${components.instanceIndex}`;
+  return (
+    selectableFields.find((f) => f.id === syntheticId) ??
+    selectableFields.find((f) => f.id === components.uuid)
+  );
+}
+
 interface AxisSelectFieldProps {
   /** Field label displayed above the select */
   label: string;
@@ -171,25 +200,11 @@ export function AxisSelectField({
     // selectableFields — which now carries instance-qualified fields when
     // availableFields comes from buildInsightAvailableFields.
     columnAnalysis.forEach((column) => {
-      let matchedField: Field | undefined;
-      if (column.fieldId) {
-        matchedField = selectableFields.find((f) => f.id === column.fieldId);
-      } else {
-        const components = extractColumnAliasComponents(column.columnName);
-        if (components) {
-          const syntheticId =
-            components.instanceIndex === 0
-              ? components.uuid
-              : `${components.uuid}_j${components.instanceIndex}`;
-          matchedField = selectableFields.find((f) => f.id === syntheticId);
-          // Fallback: bare UUID match (for single-join or base-table columns)
-          if (!matchedField) {
-            matchedField = selectableFields.find(
-              (f) => f.id === components.uuid,
-            );
-          }
-        }
-      }
+      const matchedField = matchColumnToField(
+        column.fieldId,
+        column.columnName,
+        selectableFields,
+      );
       const mappedLabel = columnDisplayNames?.[column.columnName];
       const value = matchedField
         ? fieldEncoding(matchedField.id as UUID)
@@ -236,24 +251,11 @@ export function AxisSelectField({
       map.set(enc, alias);
     });
     for (const column of columnAnalysis) {
-      let matchedField: Field | undefined;
-      if (column.fieldId) {
-        matchedField = selectableFields.find((f) => f.id === column.fieldId);
-      } else {
-        const components = extractColumnAliasComponents(column.columnName);
-        if (components) {
-          const syntheticId =
-            components.instanceIndex === 0
-              ? components.uuid
-              : `${components.uuid}_j${components.instanceIndex}`;
-          matchedField = selectableFields.find((f) => f.id === syntheticId);
-          if (!matchedField) {
-            matchedField = selectableFields.find(
-              (f) => f.id === components.uuid,
-            );
-          }
-        }
-      }
+      const matchedField = matchColumnToField(
+        column.fieldId,
+        column.columnName,
+        selectableFields,
+      );
       if (matchedField) {
         map.set(fieldEncoding(matchedField.id as UUID), column.columnName);
       } else {
@@ -270,19 +272,11 @@ export function AxisSelectField({
           field.columnName === column.name || field.name === column.name,
       );
       const analyzedColumn = matchedField
-        ? columnAnalysis.find((c) => {
-            if (c.fieldId) return c.fieldId === matchedField.id;
-            const components = extractColumnAliasComponents(c.columnName);
-            if (!components) return false;
-            const syntheticId =
-              components.instanceIndex === 0
-                ? components.uuid
-                : `${components.uuid}_j${components.instanceIndex}`;
-            return (
-              syntheticId === matchedField.id ||
-              components.uuid === matchedField.id
-            );
-          })?.columnName
+        ? columnAnalysis.find(
+            (c) =>
+              matchColumnToField(c.fieldId, c.columnName, selectableFields)
+                ?.id === matchedField.id,
+          )?.columnName
         : undefined;
       map.set(column.name, analyzedColumn ?? column.name);
     });

--- a/packages/app/src/components/visualizations/AxisSelectField.tsx
+++ b/packages/app/src/components/visualizations/AxisSelectField.tsx
@@ -58,10 +58,14 @@ function matchColumnToField(
     components.instanceIndex === 0
       ? components.uuid
       : `${components.uuid}_j${components.instanceIndex}`;
-  return (
-    selectableFields.find((f) => f.id === syntheticId) ??
-    selectableFields.find((f) => f.id === components.uuid)
-  );
+  // For repeat-join instances (instanceIndex > 0), only match the exact
+  // synthetic ID — do NOT fall back to the bare UUID.  Falling back would
+  // collapse the j1 column onto the j0 field, corrupting encodingToSqlAlias
+  // and making both instances appear identical in the picker.
+  const exactMatch = selectableFields.find((f) => f.id === syntheticId);
+  if (exactMatch || components.instanceIndex > 0) return exactMatch;
+  // instanceIndex === 0: bare-UUID fallback is safe (no disambiguation needed).
+  return selectableFields.find((f) => f.id === components.uuid);
 }
 
 interface AxisSelectFieldProps {

--- a/packages/app/src/components/visualizations/AxisSelectField.tsx
+++ b/packages/app/src/components/visualizations/AxisSelectField.tsx
@@ -10,7 +10,7 @@ import {
   isColumnValidForChannel,
 } from "@/lib/visualizations/encoding-enforcer";
 import {
-  extractUUIDFromColumnAlias,
+  extractColumnAliasComponents,
   fieldIdToColumnAlias,
   getMetricDisplayLabel,
   isGeneratedColumnLabel,
@@ -163,12 +163,33 @@ export function AxisSelectField({
     // NOT guaranteed to share an order — joins and hidden columns can shift
     // the alignment. Match by fieldId; if that fails, surface the generated
     // alias rather than guessing positionally.
+    //
+    // For repeat-joins, column.columnName carries the join-instance suffix
+    // (e.g. `field_<uuid>_j1`). extractColumnAliasComponents recovers the
+    // bare UUID AND the instanceIndex so we can reconstruct the synthetic
+    // field ID (`<uuid>_j1` for instanceIndex≥1) and match it against
+    // selectableFields — which now carries instance-qualified fields when
+    // availableFields comes from buildInsightAvailableFields.
     columnAnalysis.forEach((column) => {
-      const fieldId =
-        column.fieldId ?? extractUUIDFromColumnAlias(column.columnName);
-      const matchedField = fieldId
-        ? selectableFields.find((field) => field.id === fieldId)
-        : undefined;
+      let matchedField: Field | undefined;
+      if (column.fieldId) {
+        matchedField = selectableFields.find((f) => f.id === column.fieldId);
+      } else {
+        const components = extractColumnAliasComponents(column.columnName);
+        if (components) {
+          const syntheticId =
+            components.instanceIndex === 0
+              ? components.uuid
+              : `${components.uuid}_j${components.instanceIndex}`;
+          matchedField = selectableFields.find((f) => f.id === syntheticId);
+          // Fallback: bare UUID match (for single-join or base-table columns)
+          if (!matchedField) {
+            matchedField = selectableFields.find(
+              (f) => f.id === components.uuid,
+            );
+          }
+        }
+      }
       const mappedLabel = columnDisplayNames?.[column.columnName];
       const value = matchedField
         ? fieldEncoding(matchedField.id as UUID)
@@ -215,11 +236,24 @@ export function AxisSelectField({
       map.set(enc, alias);
     });
     for (const column of columnAnalysis) {
-      const fieldId =
-        column.fieldId ?? extractUUIDFromColumnAlias(column.columnName);
-      const matchedField = fieldId
-        ? selectableFields.find((field) => field.id === fieldId)
-        : undefined;
+      let matchedField: Field | undefined;
+      if (column.fieldId) {
+        matchedField = selectableFields.find((f) => f.id === column.fieldId);
+      } else {
+        const components = extractColumnAliasComponents(column.columnName);
+        if (components) {
+          const syntheticId =
+            components.instanceIndex === 0
+              ? components.uuid
+              : `${components.uuid}_j${components.instanceIndex}`;
+          matchedField = selectableFields.find((f) => f.id === syntheticId);
+          if (!matchedField) {
+            matchedField = selectableFields.find(
+              (f) => f.id === components.uuid,
+            );
+          }
+        }
+      }
       if (matchedField) {
         map.set(fieldEncoding(matchedField.id as UUID), column.columnName);
       } else {
@@ -237,8 +271,17 @@ export function AxisSelectField({
       );
       const analyzedColumn = matchedField
         ? columnAnalysis.find((c) => {
-            const fid = c.fieldId ?? extractUUIDFromColumnAlias(c.columnName);
-            return fid === matchedField.id;
+            if (c.fieldId) return c.fieldId === matchedField.id;
+            const components = extractColumnAliasComponents(c.columnName);
+            if (!components) return false;
+            const syntheticId =
+              components.instanceIndex === 0
+                ? components.uuid
+                : `${components.uuid}_j${components.instanceIndex}`;
+            return (
+              syntheticId === matchedField.id ||
+              components.uuid === matchedField.id
+            );
           })?.columnName
         : undefined;
       map.set(column.name, analyzedColumn ?? column.name);

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -328,9 +328,14 @@ export function VisualizationDisplay({
 
       const parsed = parseEncoding(encodingValue);
       if (parsed?.type === "field") {
-        // Prefer instanceAwareFields so repeat-join instances (synthetic IDs like
-        // `<uuid>_j1`) resolve to their human-readable name. Fall back to the
-        // raw data-table fields for the common single-join / no-join case.
+        // Prefer the disambiguated label from columnDisplayNames (keyed on the
+        // SQL alias, e.g. `field_<uuid>_j1`) so repeat-join instances show
+        // "User Name (approved_by)" instead of the bare "User Name" that a
+        // direct field.name lookup would return.  Fall back to field.name for
+        // the common case where no disambiguation entry exists (single join or
+        // base-table field), then to the raw resolvedValue as a last resort.
+        const disambiguated = columnDisplayNames[resolvedValue];
+        if (disambiguated) return disambiguated;
         const effectiveFields =
           instanceAwareFields.length > 0
             ? instanceAwareFields

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -209,6 +209,7 @@ export function VisualizationDisplay({
     columns,
     isReady: isPaginationReady,
     columnDisplayNames,
+    resolvedFields: instanceAwareFields,
   } = useInsightPagination({
     insight: insightForView ?? ({} as Insight),
     showModelPreview: false, // Apply full insight transformations
@@ -287,9 +288,16 @@ export function VisualizationDisplay({
       return {};
     }
 
-    // Build resolution context with fields and metrics
+    // Build resolution context with fields and metrics.
+    // For repeat-joins, instanceAwareFields carries synthetic fields with
+    // instance-suffixed IDs (e.g. `<uuid>_j1`) that match the SQL aliases
+    // DuckDB produces. Fall back to bare dataTable fields when the hook
+    // hasn't resolved yet (first render or no joins).
     const context = {
-      fields: dataTable.fields ?? [],
+      fields:
+        instanceAwareFields.length > 0
+          ? instanceAwareFields
+          : (dataTable.fields ?? []),
       metrics: insight.metrics ?? [],
     };
 
@@ -320,7 +328,14 @@ export function VisualizationDisplay({
 
       const parsed = parseEncoding(encodingValue);
       if (parsed?.type === "field") {
-        const field = dataTable.fields?.find((f) => f.id === parsed.id);
+        // Prefer instanceAwareFields so repeat-join instances (synthetic IDs like
+        // `<uuid>_j1`) resolve to their human-readable name. Fall back to the
+        // raw data-table fields for the common single-join / no-join case.
+        const effectiveFields =
+          instanceAwareFields.length > 0
+            ? instanceAwareFields
+            : (dataTable.fields ?? []);
+        const field = effectiveFields.find((f) => f.id === parsed.id);
         return (
           field?.name ?? columnDisplayNames[resolvedValue] ?? resolvedValue
         );
@@ -353,7 +368,14 @@ export function VisualizationDisplay({
       colorLabel: getEncodingDisplayLabel(activeViz.encoding.color, color),
       sizeLabel: getEncodingDisplayLabel(activeViz.encoding.size, size),
     };
-  }, [activeViz, dataTable, insight, columns, columnDisplayNames]);
+  }, [
+    activeViz,
+    dataTable,
+    insight,
+    columns,
+    columnDisplayNames,
+    instanceAwareFields,
+  ]);
 
   // Build column configs for VirtualTable to show human-readable headers
   const columnConfigs = useMemo((): VirtualTableColumnConfig[] => {
@@ -368,7 +390,11 @@ export function VisualizationDisplay({
     const colorEncoding = activeViz?.encoding?.color;
     const parsed = parseEncoding(colorEncoding);
     if (parsed?.type === "field") {
-      const field = dataTable?.fields?.find((f) => f.id === parsed.id);
+      const effectiveFields =
+        instanceAwareFields.length > 0
+          ? instanceAwareFields
+          : (dataTable?.fields ?? []);
+      const field = effectiveFields.find((f) => f.id === parsed.id);
       return field?.name ?? columnDisplayNames[resolvedEncoding.color ?? ""];
     }
     if (parsed?.type === "metric") {
@@ -385,6 +411,7 @@ export function VisualizationDisplay({
     insight?.metrics,
     resolvedEncoding.color,
     columnDisplayNames,
+    instanceAwareFields,
   ]);
 
   // Check if there's enough space to show both views

--- a/packages/app/src/components/visualizations/VisualizationPreview.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.tsx
@@ -1,7 +1,8 @@
+import { useInsightPagination } from "@/hooks/useInsightPagination";
 import { useInsightView } from "@/hooks/useInsightView";
 import { useDataTables, useInsight } from "@dashframe/core";
 import { resolveEncodingToSql } from "@dashframe/engine";
-import type { ChartEncoding, Visualization } from "@dashframe/types";
+import type { ChartEncoding, Insight, Visualization } from "@dashframe/types";
 import { Chart } from "@dashframe/visualization";
 import { Spinner } from "@wystack/ui";
 import { useMemo } from "react";
@@ -53,9 +54,29 @@ export function VisualizationPreview({
     ? undefined
     : dataTables.find((t) => t.id === insight.baseTableId);
 
+  // Build a minimal insight shape for hook consumption (joins only; no
+  // selectedFields/metrics/filters — preview renders raw model data).
+  const insightForView = useMemo((): Insight | null => {
+    if (!insight) return null;
+    return {
+      id: insight.id,
+      name: insight.name,
+      baseTableId: insight.baseTableId,
+      joins: insight.joins,
+    } as Insight;
+  }, [insight]);
+
   // Create/get the DuckDB view using the same hook as insight pages
   // This ensures views are created on-demand and properly cached
   const { viewName, isReady, error } = useInsightView(insight);
+
+  // Resolve instance-qualified fields for repeat-join insights so that
+  // field:<uuid>_j1 encodings resolve to their SQL alias correctly.
+  const { resolvedFields: instanceAwareFields } = useInsightPagination({
+    insight: insightForView ?? ({} as Insight),
+    showModelPreview: false,
+    enabled: !!insightForView,
+  });
 
   // Resolve encoding from storage format (field:<uuid>, metric:<uuid>) to SQL expressions
   // - field:<uuid> → column name (e.g., "Product")
@@ -65,9 +86,16 @@ export function VisualizationPreview({
       return {};
     }
 
-    // Build resolution context with fields and metrics
+    // Build resolution context with fields and metrics.
+    // For repeat-joins, instanceAwareFields carries synthetic fields with
+    // instance-suffixed IDs (e.g. `<uuid>_j1`) that match the SQL aliases
+    // the model view emits. Fall back to bare table fields before the hook
+    // resolves (initial render) or when there are no joins.
     const context = {
-      fields: dataTable.fields ?? [],
+      fields:
+        instanceAwareFields.length > 0
+          ? instanceAwareFields
+          : (dataTable.fields ?? []),
       metrics: insight.metrics ?? [],
     };
 
@@ -82,7 +110,7 @@ export function VisualizationPreview({
       xTransform: visualization.encoding.xTransform,
       yTransform: visualization.encoding.yTransform,
     };
-  }, [visualization.encoding, dataTable, insight]);
+  }, [visualization.encoding, dataTable, insight, instanceAwareFields]);
 
   // Error state — checked BEFORE the loading guard so that view-creation errors
   // that leave `isReady=false` reach a terminal UI instead of spinning forever.

--- a/packages/app/src/hooks/useInsightPagination.test.tsx
+++ b/packages/app/src/hooks/useInsightPagination.test.tsx
@@ -58,6 +58,11 @@ vi.mock("@dashframe/engine-browser", () => ({
 // engine exports used by the hook at import time
 vi.mock("@dashframe/engine", () => ({
   buildInsightSQL: (...args: unknown[]) => mockBuildInsightSQL(...args),
+  buildInsightAvailableFields: (
+    baseTable: DataTable,
+    _joinedTables: unknown,
+    _insight: unknown,
+  ) => baseTable.fields ?? [],
   fieldIdToColumnAlias: (id: string) => `field_${id.replace(/-/g, "_")}`,
   metricIdToColumnAlias: (id: string) => `metric_${id.replace(/-/g, "_")}`,
 }));

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -1,8 +1,8 @@
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
-import { computeCombinedFields } from "@/lib/insights/compute-combined-fields";
 import { getDataFrame, getDataTable } from "@dashframe/core";
 import type { EffectiveParams } from "@dashframe/engine";
 import {
+  buildInsightAvailableFields,
   buildInsightSQL,
   fieldIdToColumnAlias,
   metricIdToColumnAlias,
@@ -132,33 +132,31 @@ export function useInsightPagination({
     // The caller (init) writes the cache after its generation check passes.
 
     // Collect fields visible in the SQL result set.
-    // Raw concatenation of base + joined table fields includes right join-key
-    // fields that processSingleJoin drops from the emitted subquery.
-    // columnDisplayNames / columnTypeMap built from those stale entries would
-    // let VirtualTable resolve wrong display names or types for UUID aliases
-    // that don't exist in the result.
     //
-    // We drop ONLY the right join-key fields (step 1 of computeFilterableFields)
-    // — those are the columns processSingleJoin excludes from SELECT.  We do NOT
-    // apply step 2 (ambiguous-bare-name exclusion): that step exists for filter-
-    // picker safety, but both sides of a bare-name collision still appear in the
-    // SQL result under distinct UUID aliases, so they MUST keep display-name and
-    // type-map entries (else VirtualTable shows raw field_<uuid> and loses type).
-    const allDataTables = [baseTable, ...joinedTables.values()];
-    const { fields: combinedFields } = computeCombinedFields(
-      baseTable,
-      insight.joins,
-      allDataTables,
-    );
-    const rightKeySet = new Set(
-      (insight.joins ?? []).map(
-        (j) => `${j.rightTableId}:${j.rightKey.toLowerCase()}`,
-      ),
-    );
-    const allFields: Field[] = combinedFields.filter((f) => {
-      const colKey = `${f.sourceTableId}:${(f.columnName ?? f.name).toLowerCase()}`;
-      return !rightKeySet.has(colKey);
-    });
+    // `buildInsightAvailableFields` mirrors `buildJoinedSQL`'s field accumulation
+    // exactly — it drops right join-keys and returns synthetic Field objects with
+    // instance-suffixed IDs (field.id = `<uuid>_j{n}`) for repeat-joins (two
+    // joins to the same rightTableId).  Because `columnDisplayNames` and
+    // `columnTypeMap` are keyed on `fieldIdToColumnAlias(field.id)`, they will
+    // map `field_<uuid>_j{n}` → the right display name / type — matching the
+    // actual SQL column aliases DuckDB produces from the join builder.
+    //
+    // Deriving this list independently (e.g. via computeCombinedFields + manual
+    // key-drop) risks a desync: if the builder skips a join instance (missing
+    // keys), the counter stays at n while an independent re-derive would advance
+    // to n+1, putting the hook's map one alias ahead of what DuckDB emitted.
+    // Single-sourcing through `buildInsightAvailableFields` eliminates that gap.
+    //
+    // We pass a minimal Insight-shaped object containing only `joins` — the only
+    // field buildInsightAvailableFields reads from the insight. `insight.joins` is
+    // already in the dep array below, so the closure captures it through `joins`
+    // without adding the full mutable `insight` reference as a dependency.
+    const joins = insight.joins;
+    const allFields: Field[] =
+      buildInsightAvailableFields(baseTable, joinedTables, {
+        joins,
+      } as Insight) ??
+      (baseTable.fields ?? []).filter((f) => !f.name.startsWith("_"));
 
     return { baseTable, joinedTables, allFields };
   }, [insight.baseTableId, insight.joins]);

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -23,19 +23,48 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Build a map of `"${rightTableId}:${instanceIndex}" → leftKey` by walking
- * insight.joins with the same counter logic as buildInsightAvailableFields.
- * Used by buildRepeatJoinDisplayNames to recover which join leftKey produced
- * each field alias, without needing to re-derive from the field alone.
+ * insight.joins, mirroring buildInsightAvailableFields' skip behaviour.
+ *
+ * A join that was SKIPPED by buildInsightAvailableFields (invalid type, missing
+ * table, missing key fields) must NOT advance the per-rightTableId counter —
+ * otherwise subsequent valid joins get a wrong index, and
+ * buildRepeatJoinDisplayNames would look up the wrong leftKey for each synthetic
+ * field's (tableId, instanceIndex) pair.
+ *
+ * We detect skipped joins by checking whether resolvedFields contains any field
+ * from that (rightTableId, instanceIndex) slot.  Because resolvedFields is the
+ * OUTPUT of buildInsightAvailableFields, any index it consumed is guaranteed
+ * valid; indices not represented in resolvedFields were skipped.  This avoids
+ * re-implementing the engine's whitelist + key-validation logic in the hook.
  */
 function buildJoinKeyByInstance(
   joins: NonNullable<Insight["joins"]>,
+  resolvedFields: Field[],
 ): Map<string, string> {
+  // Build a quick-lookup set of (tableId, instanceIndex) pairs that exist in
+  // resolvedFields.  If a slot is absent, the join at that logical position was
+  // skipped by buildInsightAvailableFields.
+  const resolvedSlots = new Set<string>();
+  for (const field of resolvedFields) {
+    const components = extractColumnAliasComponents(
+      fieldIdToColumnAlias(field.id),
+    );
+    if (components) {
+      resolvedSlots.add(`${field.tableId}:${components.instanceIndex}`);
+    }
+  }
+
   const result = new Map<string, string>();
   const instanceCount = new Map<string, number>();
   for (const join of joins) {
     const idx = instanceCount.get(join.rightTableId) ?? 0;
-    result.set(`${join.rightTableId}:${idx}`, join.leftKey);
-    instanceCount.set(join.rightTableId, idx + 1);
+    const slot = `${join.rightTableId}:${idx}`;
+    if (resolvedSlots.has(slot)) {
+      // This join was NOT skipped by buildInsightAvailableFields — record it.
+      result.set(slot, join.leftKey);
+      instanceCount.set(join.rightTableId, idx + 1);
+    }
+    // Skipped join: do NOT advance the counter.
   }
   return result;
 }
@@ -44,11 +73,12 @@ function buildJoinKeyByInstance(
  * Build a display-name record for the given resolved fields, disambiguating
  * repeat-join collisions by appending the join's leftKey in parentheses.
  *
- * When the same right-table is joined twice (e.g. orders→users on `created_by`
- * AND `approved_by`), both instances produce fields with the same `field.name`
- * (e.g. "User Name").  This function detects collisions and produces distinct
- * labels for BOTH: "User Name (created_by)" and "User Name (approved_by)".
- * Fields not involved in a collision keep their bare `field.name`.
+ * When the same right-table is joined more than once (N≥2, e.g. orders→users on
+ * `created_by` AND `approved_by`), all instances produce fields with the same
+ * `field.name` (e.g. "User Name").  This function detects collisions and
+ * produces distinct labels for ALL instances: "User Name (created_by)" and
+ * "User Name (approved_by)".  Fields not involved in a collision keep their
+ * bare `field.name`.
  *
  * `field.name` is NOT mutated — it remains the canonical human name.
  */
@@ -234,7 +264,7 @@ export function useInsightPagination({
   // vs "User Name (approved_by)".  field.name is NOT mutated.
   const columnDisplayNames = useMemo(() => {
     const joinKeyByInstance = insight.joins?.length
-      ? buildJoinKeyByInstance(insight.joins)
+      ? buildJoinKeyByInstance(insight.joins, resolvedFields)
       : new Map<string, string>();
 
     const displayNames = buildRepeatJoinDisplayNames(

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -4,6 +4,7 @@ import type { EffectiveParams } from "@dashframe/engine";
 import {
   buildInsightAvailableFields,
   buildInsightSQL,
+  extractColumnAliasComponents,
   fieldIdToColumnAlias,
   metricIdToColumnAlias,
 } from "@dashframe/engine";
@@ -17,6 +18,71 @@ import type {
 } from "@dashframe/types";
 import type { FetchDataParams, FetchDataResult } from "@dashframe/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// ── Module-level pure helpers ─────────────────────────────────────────────────
+
+/**
+ * Build a map of `"${rightTableId}:${instanceIndex}" → leftKey` by walking
+ * insight.joins with the same counter logic as buildInsightAvailableFields.
+ * Used by buildRepeatJoinDisplayNames to recover which join leftKey produced
+ * each field alias, without needing to re-derive from the field alone.
+ */
+function buildJoinKeyByInstance(
+  joins: NonNullable<Insight["joins"]>,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  const instanceCount = new Map<string, number>();
+  for (const join of joins) {
+    const idx = instanceCount.get(join.rightTableId) ?? 0;
+    result.set(`${join.rightTableId}:${idx}`, join.leftKey);
+    instanceCount.set(join.rightTableId, idx + 1);
+  }
+  return result;
+}
+
+/**
+ * Build a display-name record for the given resolved fields, disambiguating
+ * repeat-join collisions by appending the join's leftKey in parentheses.
+ *
+ * When the same right-table is joined twice (e.g. orders→users on `created_by`
+ * AND `approved_by`), both instances produce fields with the same `field.name`
+ * (e.g. "User Name").  This function detects collisions and produces distinct
+ * labels for BOTH: "User Name (created_by)" and "User Name (approved_by)".
+ * Fields not involved in a collision keep their bare `field.name`.
+ *
+ * `field.name` is NOT mutated — it remains the canonical human name.
+ */
+function buildRepeatJoinDisplayNames(
+  resolvedFields: Field[],
+  joinKeyByInstance: Map<string, string>,
+): Record<string, string> {
+  // First pass: find which base UUIDs have ≥2 instances (any _j1+ sibling).
+  const baseUuidsWithRepeat = new Set<string>();
+  for (const field of resolvedFields) {
+    const components = extractColumnAliasComponents(
+      fieldIdToColumnAlias(field.id),
+    );
+    if (components && components.instanceIndex > 0) {
+      baseUuidsWithRepeat.add(components.uuid);
+    }
+  }
+
+  // Second pass: build display names, applying disambiguation for collisions.
+  const displayNames: Record<string, string> = {};
+  for (const field of resolvedFields) {
+    const alias = fieldIdToColumnAlias(field.id);
+    const components = extractColumnAliasComponents(alias);
+    if (components && baseUuidsWithRepeat.has(components.uuid)) {
+      const leftKey = joinKeyByInstance.get(
+        `${field.tableId}:${components.instanceIndex}`,
+      );
+      displayNames[alias] = leftKey ? `${field.name} (${leftKey})` : field.name;
+    } else {
+      displayNames[alias] = field.name;
+    }
+  }
+  return displayNames;
+}
 
 /**
  * Options for useInsightPagination hook.
@@ -158,16 +224,23 @@ export function useInsightPagination({
     return { baseTable, joinedTables, allFields };
   }, [insight.baseTableId, insight.joins]);
 
-  // Build mapping from UUID column aliases to display names
-  // This allows VirtualTable to show human-readable column headers
+  // Build mapping from UUID column aliases to display names.
+  // This allows VirtualTable to show human-readable column headers.
+  //
+  // For repeat-join insights (same rightTableId joined twice), both join
+  // instances produce fields with identical `field.name` values.
+  // buildRepeatJoinDisplayNames detects these collisions and appends the
+  // join's leftKey so pickers and headers show e.g. "User Name (created_by)"
+  // vs "User Name (approved_by)".  field.name is NOT mutated.
   const columnDisplayNames = useMemo(() => {
-    const displayNames: Record<string, string> = {};
+    const joinKeyByInstance = insight.joins?.length
+      ? buildJoinKeyByInstance(insight.joins)
+      : new Map<string, string>();
 
-    // Map field IDs to display names
-    for (const field of resolvedFields) {
-      const alias = fieldIdToColumnAlias(field.id);
-      displayNames[alias] = field.name;
-    }
+    const displayNames = buildRepeatJoinDisplayNames(
+      resolvedFields,
+      joinKeyByInstance,
+    );
 
     // Map metric IDs to display names
     for (const metric of insight.metrics ?? []) {
@@ -176,7 +249,7 @@ export function useInsightPagination({
     }
 
     return displayNames;
-  }, [resolvedFields, insight.metrics]);
+  }, [resolvedFields, insight.metrics, insight.joins]);
 
   // Build mapping from UUID column aliases to ColumnType.
   // Metrics are always numeric (aggregations); fields carry their declared type.

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -147,15 +147,12 @@ export function useInsightPagination({
     // to n+1, putting the hook's map one alias ahead of what DuckDB emitted.
     // Single-sourcing through `buildInsightAvailableFields` eliminates that gap.
     //
-    // We pass a minimal Insight-shaped object containing only `joins` — the only
-    // field buildInsightAvailableFields reads from the insight. `insight.joins` is
-    // already in the dep array below, so the closure captures it through `joins`
-    // without adding the full mutable `insight` reference as a dependency.
+    // `buildInsightAvailableFields` accepts `Pick<Insight, "joins">`, so we extract
+    // `joins` and pass a minimal object. This also keeps `insight.joins` in the dep
+    // array below without introducing the full mutable `insight` reference.
     const joins = insight.joins;
     const allFields: Field[] =
-      buildInsightAvailableFields(baseTable, joinedTables, {
-        joins,
-      } as Insight) ??
+      buildInsightAvailableFields(baseTable, joinedTables, { joins }) ??
       (baseTable.fields ?? []).filter((f) => !f.name.startsWith("_"));
 
     return { baseTable, joinedTables, allFields };

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -486,5 +486,13 @@ export function useInsightPagination({
      * Values: "string" | "number" | "boolean" | "date" | "unknown"
      */
     columnTypeMap,
+    /**
+     * Instance-qualified Field list produced by buildInsightAvailableFields.
+     * For repeat-joins (same rightTableId twice), fields from the Nth instance
+     * carry synthetic IDs with `_j{N}` suffix (e.g. `<uuid>_j1`).
+     * Use this as `availableFields` in pickers that must expose both instances
+     * as distinct selectable options.
+     */
+    resolvedFields,
   };
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -97,7 +97,9 @@ export type {
 // ============================================================================
 
 export {
+  buildInsightAvailableFields,
   buildInsightSQL,
+  extractColumnAliasComponents,
   extractUUIDFromColumnAlias,
   // UUID column naming utilities
   fieldIdToColumnAlias,

--- a/packages/engine/src/sql/index.ts
+++ b/packages/engine/src/sql/index.ts
@@ -5,7 +5,9 @@
  */
 
 export {
+  buildInsightAvailableFields,
   buildInsightSQL,
+  extractColumnAliasComponents,
   extractUUIDFromColumnAlias,
   // UUID column naming utilities
   fieldIdToColumnAlias,

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -9,7 +9,10 @@ import type {
 import { describe, expect, it } from "bun:test";
 
 import {
+  buildInsightAvailableFields,
   buildInsightSQL,
+  extractColumnAliasComponents,
+  extractUUIDFromColumnAlias,
   fieldIdToColumnAlias,
   metricIdToColumnAlias,
   metricToSqlExpression,
@@ -1057,5 +1060,338 @@ describe("metricToSqlExpression — DSL format contract", () => {
       baseMetric({ aggregation: "sum", columnName: undefined }),
     );
     expect(expr).toBe("sum(*)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUUIDFromColumnAlias + extractColumnAliasComponents — round-trip with
+// join-instance suffixes (_j1, _j2 …).
+//
+// Contract:
+//  - extractUUIDFromColumnAlias strips the suffix and returns the bare UUID
+//    (all consumers that only need the field ID continue to work).
+//  - extractColumnAliasComponents returns { uuid, instanceIndex } so consumers
+//    that must distinguish join instances can do so.
+// ---------------------------------------------------------------------------
+
+describe("extractUUIDFromColumnAlias — join-instance suffix stripping", () => {
+  const FIELD_UUID = "dd05ef4b-1234-5678-abcd-ef1234567890" as UUID;
+  const canonicalAlias = fieldIdToColumnAlias(FIELD_UUID);
+
+  it("round-trip: canonical alias (no suffix) → original UUID", () => {
+    expect(extractUUIDFromColumnAlias(canonicalAlias)).toBe(FIELD_UUID);
+  });
+
+  it("round-trip: _j1-suffixed alias → same original UUID (suffix stripped)", () => {
+    const suffixed = `${canonicalAlias}_j1`;
+    expect(extractUUIDFromColumnAlias(suffixed)).toBe(FIELD_UUID);
+  });
+
+  it("round-trip: _j9-suffixed alias → same original UUID", () => {
+    const suffixed = `${canonicalAlias}_j9`;
+    expect(extractUUIDFromColumnAlias(suffixed)).toBe(FIELD_UUID);
+  });
+
+  it("returns null for non-field/metric aliases (no regression)", () => {
+    expect(extractUUIDFromColumnAlias("some_random_column")).toBeNull();
+  });
+});
+
+describe("extractColumnAliasComponents — instance-index disambiguation", () => {
+  const FIELD_UUID = "dd05ef4b-1234-5678-abcd-ef1234567890" as UUID;
+  const canonicalAlias = fieldIdToColumnAlias(FIELD_UUID);
+
+  it("canonical alias → { uuid, instanceIndex: 0 }", () => {
+    const result = extractColumnAliasComponents(canonicalAlias);
+    expect(result).not.toBeNull();
+    expect(result!.uuid).toBe(FIELD_UUID);
+    expect(result!.instanceIndex).toBe(0);
+  });
+
+  it("_j1-suffixed alias → { uuid, instanceIndex: 1 }", () => {
+    const result = extractColumnAliasComponents(`${canonicalAlias}_j1`);
+    expect(result).not.toBeNull();
+    expect(result!.uuid).toBe(FIELD_UUID);
+    expect(result!.instanceIndex).toBe(1);
+  });
+
+  it("_j2-suffixed alias → { uuid, instanceIndex: 2 }", () => {
+    const result = extractColumnAliasComponents(`${canonicalAlias}_j2`);
+    expect(result).not.toBeNull();
+    expect(result!.uuid).toBe(FIELD_UUID);
+    expect(result!.instanceIndex).toBe(2);
+  });
+
+  it("returns null for unrecognised alias", () => {
+    expect(extractColumnAliasComponents("totally_random")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Two joins to the same table — alias emission + buildInsightAvailableFields.
+//
+// Scenario: orders→users on created_by (instance 0) AND approved_by (instance 1).
+// The two joins share the same rightTableId and therefore the same Field UUIDs.
+// The fix ensures:
+//  (a) the second join's non-key columns get `_j1`-suffixed SQL aliases;
+//  (b) buildInsightAvailableFields returns synthetic Fields whose IDs encode the
+//      instance index, so display-name/type maps keyed on fieldIdToColumnAlias
+//      match what DuckDB actually emitted.
+// ---------------------------------------------------------------------------
+
+describe("join-instance identity — two joins to the same table", () => {
+  // Table IDs
+  const ORDERS_TABLE_ID = "10101010-1010-1010-1010-101010101010" as UUID;
+  const ORDERS_DF_ID = "20202020-2020-2020-2020-202020202020" as UUID;
+  const USERS_TABLE_ID = "30303030-3030-3030-3030-303030303030" as UUID;
+  const USERS_DF_ID = "40404040-4040-4040-4040-404040404040" as UUID;
+
+  // Orders fields
+  const O_ID_FIELD: Field = {
+    id: "a0a0a0a0-a0a0-a0a0-a0a0-a0a0a0a0a0a0" as UUID,
+    name: "Order ID",
+    tableId: ORDERS_TABLE_ID,
+    columnName: "id",
+    type: "string",
+  };
+  const O_CREATED_BY_FIELD: Field = {
+    id: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0" as UUID,
+    name: "Created By",
+    tableId: ORDERS_TABLE_ID,
+    columnName: "created_by",
+    type: "string",
+  };
+  const O_APPROVED_BY_FIELD: Field = {
+    id: "c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0" as UUID,
+    name: "Approved By",
+    tableId: ORDERS_TABLE_ID,
+    columnName: "approved_by",
+    type: "string",
+  };
+
+  // Users fields (same DataTable joined twice)
+  const U_ID_FIELD: Field = {
+    id: "d0d0d0d0-d0d0-d0d0-d0d0-d0d0d0d0d0d0" as UUID,
+    name: "User ID",
+    tableId: USERS_TABLE_ID,
+    columnName: "id",
+    type: "string",
+  };
+  const U_NAME_FIELD: Field = {
+    id: "e0e0e0e0-e0e0-e0e0-e0e0-e0e0e0e0e0e0" as UUID,
+    name: "User Name",
+    tableId: USERS_TABLE_ID,
+    columnName: "name",
+    type: "string",
+  };
+  const U_EMAIL_FIELD: Field = {
+    id: "f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0" as UUID,
+    name: "User Email",
+    tableId: USERS_TABLE_ID,
+    columnName: "email",
+    type: "string",
+  };
+
+  const ordersTable: DataTable = {
+    id: ORDERS_TABLE_ID,
+    name: "orders",
+    dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+    table: "orders.csv",
+    fields: [O_ID_FIELD, O_CREATED_BY_FIELD, O_APPROVED_BY_FIELD],
+    metrics: [],
+    dataFrameId: ORDERS_DF_ID,
+    createdAt: 0,
+  };
+
+  const usersTable: DataTable = {
+    id: USERS_TABLE_ID,
+    name: "users",
+    dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+    table: "users.csv",
+    fields: [U_ID_FIELD, U_NAME_FIELD, U_EMAIL_FIELD],
+    metrics: [],
+    dataFrameId: USERS_DF_ID,
+    createdAt: 0,
+  };
+
+  // Insight: orders joined to users on created_by→id AND approved_by→id.
+  const doubleJoinInsight: Insight = {
+    id: "50505050-5050-5050-5050-505050505050" as UUID,
+    name: "Orders with creator and approver",
+    baseTableId: ORDERS_TABLE_ID,
+    selectedFields: [],
+    metrics: [],
+    joins: [
+      {
+        type: "inner",
+        rightTableId: USERS_TABLE_ID,
+        leftKey: "created_by",
+        rightKey: "id",
+      },
+      {
+        type: "inner",
+        rightTableId: USERS_TABLE_ID,
+        leftKey: "approved_by",
+        rightKey: "id",
+      },
+    ],
+    createdAt: 0,
+  };
+
+  // Canonical (first instance) aliases
+  const nameAliasJ0 = fieldIdToColumnAlias(U_NAME_FIELD.id);
+  const emailAliasJ0 = fieldIdToColumnAlias(U_EMAIL_FIELD.id);
+  // Suffixed (second instance) aliases
+  const nameAliasJ1 = `${nameAliasJ0}_j1`;
+  const emailAliasJ1 = `${emailAliasJ0}_j1`;
+
+  it("emits NO duplicate AS clause when the same table is joined twice", () => {
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+
+    const countDefs = (alias: string) =>
+      (sql!.match(new RegExp(`AS "${alias}"`, "g")) ?? []).length;
+
+    // Both first-instance aliases defined exactly once
+    expect(countDefs(nameAliasJ0)).toBe(1);
+    expect(countDefs(emailAliasJ0)).toBe(1);
+    // Both second-instance aliases also defined exactly once (distinct from first)
+    expect(countDefs(nameAliasJ1)).toBe(1);
+    expect(countDefs(emailAliasJ1)).toBe(1);
+  });
+
+  it("includes both instances' non-key columns in the SELECT", () => {
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ0}"`);
+    expect(sql!).toContain(`AS "${nameAliasJ1}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ1}"`);
+  });
+
+  it("single join still emits canonical (unsuffixed) alias — no regression", () => {
+    const singleJoinInsight: Insight = {
+      ...doubleJoinInsight,
+      joins: [doubleJoinInsight.joins![0]!],
+    };
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      singleJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).not.toContain(`_j1`);
+  });
+
+  it("counter does NOT advance when first join instance is skipped (missing left key)", () => {
+    // A join whose leftKey doesn't exist in the base table is skipped.  The
+    // valid second join must still get instance index 0 (not 1), so its alias
+    // is the canonical `field_<uuid>` — not `field_<uuid>_j1`.
+    const insightWithBadFirstJoin: Insight = {
+      ...doubleJoinInsight,
+      joins: [
+        // invalid: "no_such_field" not in ordersTable → skip
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "no_such_field",
+          rightKey: "id",
+        },
+        // valid: approved_by → id (must become instance 0, not 1)
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "id",
+        },
+      ],
+    };
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insightWithBadFirstJoin,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    // Second (valid) join must use canonical aliases — index 0, no suffix
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ0}"`);
+    // No suffix should appear — the failed first join did not consume an index slot
+    expect(sql!).not.toContain(`_j1`);
+  });
+
+  it("buildInsightAvailableFields returns synthetic suffixed Fields for repeat-join instances", () => {
+    const fields = buildInsightAvailableFields(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+    );
+    expect(fields).not.toBeNull();
+
+    // First-instance fields: canonical IDs (no suffix)
+    const j0Name = fields!.find((f) => f.id === U_NAME_FIELD.id);
+    const j0Email = fields!.find((f) => f.id === U_EMAIL_FIELD.id);
+    expect(j0Name).toBeDefined();
+    expect(j0Email).toBeDefined();
+
+    // Second-instance fields: synthetic IDs with _j1 suffix
+    const j1NameId = `${U_NAME_FIELD.id}_j1` as UUID;
+    const j1EmailId = `${U_EMAIL_FIELD.id}_j1` as UUID;
+    const j1Name = fields!.find((f) => f.id === j1NameId);
+    const j1Email = fields!.find((f) => f.id === j1EmailId);
+    expect(j1Name).toBeDefined();
+    expect(j1Email).toBeDefined();
+
+    // Synthetic fields carry the canonical field name (for display-name lookup)
+    expect(j1Name!.name).toBe(U_NAME_FIELD.name);
+    expect(j1Email!.name).toBe(U_EMAIL_FIELD.name);
+
+    // fieldIdToColumnAlias(syntheticId) must equal the alias the SQL builder emitted
+    expect(fieldIdToColumnAlias(j1NameId)).toBe(nameAliasJ1);
+    expect(fieldIdToColumnAlias(j1EmailId)).toBe(emailAliasJ1);
+  });
+
+  it("buildInsightAvailableFields: counter stays at 0 when first join is skipped", () => {
+    // Mirror the counter-fix test above but for the field-list computation.
+    const insightWithBadFirstJoin: Insight = {
+      ...doubleJoinInsight,
+      joins: [
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "no_such_field",
+          rightKey: "id",
+        },
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "id",
+        },
+      ],
+    };
+    const fields = buildInsightAvailableFields(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insightWithBadFirstJoin,
+    );
+    expect(fields).not.toBeNull();
+    // Valid join must appear at instance 0 — canonical IDs, no suffix
+    expect(fields!.find((f) => f.id === U_NAME_FIELD.id)).toBeDefined();
+    expect(fields!.find((f) => f.id === U_EMAIL_FIELD.id)).toBeDefined();
+    // No _j1-suffixed entry should exist
+    expect(fields!.find((f) => f.id.endsWith("_j1"))).toBeUndefined();
   });
 });

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -1394,4 +1394,240 @@ describe("join-instance identity — two joins to the same table", () => {
     // No _j1-suffixed entry should exist
     expect(fields!.find((f) => f.id.endsWith("_j1"))).toBeUndefined();
   });
+
+  it("counter does NOT advance when join is skipped due to missing right key", () => {
+    // Symmetric counterpart to the missing-leftKey test: the right table exists
+    // but its join key is not present as a column → join is skipped.
+    // The second valid join must still get instance index 0 (canonical alias).
+    const insightWithBadRightKey: Insight = {
+      ...doubleJoinInsight,
+      joins: [
+        // invalid: rightKey "no_such_col" not in usersTable → skip
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "created_by",
+          rightKey: "no_such_col",
+        },
+        // valid: approved_by → id (must become instance 0, not 1)
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "id",
+        },
+      ],
+    };
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insightWithBadRightKey,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ0}"`);
+    expect(sql!).not.toContain(`_j1`);
+
+    // Mirror for buildInsightAvailableFields
+    const fields = buildInsightAvailableFields(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insightWithBadRightKey,
+    );
+    expect(fields).not.toBeNull();
+    expect(fields!.find((f) => f.id === U_NAME_FIELD.id)).toBeDefined();
+    expect(fields!.find((f) => f.id.endsWith("_j1"))).toBeUndefined();
+  });
+
+  it("counter is not disrupted by a skip between two successful joins — [valid, invalid, valid]", () => {
+    // Pattern: first join succeeds (instance 0, canonical), second join is
+    // skipped (bad leftKey), third join must get instance 1 (NOT 2).
+    // A regression here would produce `_j2` for the third join.
+    const insightMiddleSkip: Insight = {
+      ...doubleJoinInsight,
+      joins: [
+        // valid: created_by → id → instance 0
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "created_by",
+          rightKey: "id",
+        },
+        // invalid: bad left key → skipped, counter stays at 1
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "no_such_field",
+          rightKey: "id",
+        },
+        // valid: approved_by → id → must be instance 1 (alias _j1)
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "id",
+        },
+      ],
+    };
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insightMiddleSkip,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    // Instance 0: canonical aliases present
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ0}"`);
+    // Instance 1: _j1 aliases present (NOT _j2)
+    expect(sql!).toContain(`AS "${nameAliasJ1}"`);
+    expect(sql!).toContain(`AS "${emailAliasJ1}"`);
+    expect(sql!).not.toContain(`_j2`);
+
+    // Mirror for buildInsightAvailableFields
+    const fields = buildInsightAvailableFields(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insightMiddleSkip,
+    );
+    expect(fields).not.toBeNull();
+    const j1NameId = `${U_NAME_FIELD.id}_j1` as UUID;
+    expect(fields!.find((f) => f.id === U_NAME_FIELD.id)).toBeDefined();
+    expect(fields!.find((f) => f.id === j1NameId)).toBeDefined();
+    expect(fields!.find((f) => f.id.endsWith("_j2"))).toBeUndefined();
+  });
+
+  it("buildInsightAvailableFields field IDs match buildInsightSQL column aliases — round-trip", () => {
+    // The single-source contract: every alias that buildInsightAvailableFields
+    // implies (via fieldIdToColumnAlias) must appear in the SQL that buildInsightSQL emits.
+    const sql = buildInsightSQL(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+      { mode: "model" },
+    );
+    const fields = buildInsightAvailableFields(
+      ordersTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      doubleJoinInsight,
+    );
+    expect(sql).not.toBeNull();
+    expect(fields).not.toBeNull();
+
+    // Every non-base-table field's implied alias must appear in the SQL
+    const ordersFieldIds = new Set(ordersTable.fields?.map((f) => f.id) ?? []);
+    const joinedFields = fields!.filter(
+      (f) => !ordersFieldIds.has(f.id as UUID),
+    );
+    for (const f of joinedFields) {
+      const alias = fieldIdToColumnAlias(f.id);
+      expect(sql!).toContain(`AS "${alias}"`);
+    }
+  });
+
+  it("counters are independent per table — mixed tables (orders→users×2 AND orders→products×1)", () => {
+    // Introduce a separate "products" table joined once.
+    // The products join must get instance index 0 regardless of the users joins.
+    const PRODUCTS_TABLE_ID = "60606060-6060-6060-6060-606060606060" as UUID;
+    const PRODUCTS_DF_ID = "70707070-7070-7070-7070-707070707070" as UUID;
+    const P_ID_FIELD: Field = {
+      id: "11111111-2222-3333-4444-555555555555" as UUID,
+      name: "Product ID",
+      tableId: PRODUCTS_TABLE_ID,
+      columnName: "id",
+      type: "string",
+    };
+    const P_NAME_FIELD: Field = {
+      id: "aaaabbbb-cccc-dddd-eeee-ffffffffffff" as UUID,
+      name: "Product Name",
+      tableId: PRODUCTS_TABLE_ID,
+      columnName: "name",
+      type: "string",
+    };
+    const productsTable: DataTable = {
+      id: PRODUCTS_TABLE_ID,
+      name: "products",
+      dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+      table: "products.csv",
+      fields: [P_ID_FIELD, P_NAME_FIELD],
+      metrics: [],
+      dataFrameId: PRODUCTS_DF_ID,
+      createdAt: 0,
+    };
+    const ordersFieldsExtended = [
+      ...ordersTable.fields!,
+      {
+        id: "99998888-7777-6666-5555-444433332222" as UUID,
+        name: "Product ID Ref",
+        tableId: ORDERS_TABLE_ID,
+        columnName: "product_id",
+        type: "string" as const,
+      },
+    ];
+    const ordersTableExtended: DataTable = {
+      ...ordersTable,
+      fields: ordersFieldsExtended,
+    };
+    const mixedJoinInsight: Insight = {
+      ...doubleJoinInsight,
+      joins: [
+        // users join 0 (instance 0)
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "created_by",
+          rightKey: "id",
+        },
+        // products join (independent counter, instance 0)
+        {
+          type: "inner",
+          rightTableId: PRODUCTS_TABLE_ID,
+          leftKey: "product_id",
+          rightKey: "id",
+        },
+        // users join 1 (instance 1 for users counter)
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "id",
+        },
+      ],
+    };
+    const productNameAlias = fieldIdToColumnAlias(P_NAME_FIELD.id);
+
+    const sql = buildInsightSQL(
+      ordersTableExtended,
+      new Map([
+        [USERS_TABLE_ID, usersTable],
+        [PRODUCTS_TABLE_ID, productsTable],
+      ]),
+      mixedJoinInsight,
+      { mode: "model" },
+    );
+    expect(sql).not.toBeNull();
+    // Users instance 0 (canonical)
+    expect(sql!).toContain(`AS "${nameAliasJ0}"`);
+    // Products canonical (no suffix — independent counter)
+    expect(sql!).toContain(`AS "${productNameAlias}"`);
+    expect(sql!).not.toContain(`${productNameAlias}_j`);
+    // Users instance 1
+    expect(sql!).toContain(`AS "${nameAliasJ1}"`);
+
+    // Mirror for buildInsightAvailableFields
+    const fields = buildInsightAvailableFields(
+      ordersTableExtended,
+      new Map([
+        [USERS_TABLE_ID, usersTable],
+        [PRODUCTS_TABLE_ID, productsTable],
+      ]),
+      mixedJoinInsight,
+    );
+    expect(fields).not.toBeNull();
+    expect(fields!.find((f) => f.id === P_NAME_FIELD.id)).toBeDefined();
+    expect(
+      fields!.find((f) => f.id === (`${P_NAME_FIELD.id}_j1` as UUID)),
+    ).toBeUndefined();
+  });
 });

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -9,11 +9,13 @@
  * All columns use UUID-based aliases for consistency:
  * - Fields: `field_<uuid>` (e.g., `field_dd05ef4b_1234_5678_abcd_ef1234567890`)
  * - Metrics: `metric_<uuid>` (e.g., `metric_cc33dd44_1234_5678_abcd_ef1234567890`)
+ * - Repeat-join fields: `field_<uuid>_j{n}` (index≥1; e.g., `field_<uuid>_j1`)
  *
  * This ensures:
  * - No collision handling needed (UUIDs are globally unique)
  * - Encoding value = SQL column name = axis selection key (zero transformation)
  * - Display names looked up from field/metric definitions when rendering UI
+ * - Two joins to the same table each get distinct aliases (via `_j{n}` suffix)
  */
 
 import type {
@@ -37,12 +39,35 @@ import { quoteIdentifier } from "./quoting";
  * Convert a field ID to a SQL-safe column alias.
  * Format: field_<uuid_with_underscores>
  *
+ * For repeat-join columns the caller passes an INSTANCE-QUALIFIED field ID
+ * (produced by `joinInstanceFieldId`) so the resulting alias is
+ * `field_<uuid>_j{n}` — distinct from the first instance's `field_<uuid>`.
+ *
  * @example
  * fieldIdToColumnAlias("dd05ef4b-1234-5678-abcd-ef1234567890")
  * // Returns: "field_dd05ef4b_1234_5678_abcd_ef1234567890"
  */
 export function fieldIdToColumnAlias(fieldId: string): string {
   return `field_${fieldId.replace(/-/g, "_")}`;
+}
+
+/**
+ * Encode a join instance index into a field ID so two joins to the same table
+ * produce distinct column aliases.
+ *
+ * - index 0 (first join): returns `fieldId` unchanged → alias stays `field_<uuid>`
+ * - index ≥ 1 (repeat join): returns `fieldId_j{n}` → alias becomes `field_<uuid>_j{n}`
+ *
+ * This is an internal SQL-builder helper only — the returned value is NEVER
+ * stored in the Insight model or compared against real field IDs. It is only
+ * fed into `fieldIdToColumnAlias` to produce unique SQL aliases.
+ */
+function joinInstanceFieldId(
+  fieldId: string,
+  joinInstanceIndex: number,
+): string {
+  if (joinInstanceIndex === 0) return fieldId;
+  return `${fieldId}_j${joinInstanceIndex}`;
 }
 
 /**
@@ -59,27 +84,77 @@ export function metricIdToColumnAlias(metricId: string): string {
 
 /**
  * Extract the original UUID from a column alias.
- * Handles both field_* and metric_* formats.
+ * Handles both field_* and metric_* formats, including repeat-join suffixed
+ * aliases produced by `joinInstanceFieldId` (e.g. `field_<uuid>_j1`).
+ *
+ * The join-instance suffix is stripped before UUID reconstruction so all callers
+ * that need only the canonical field ID work correctly. Consumers that must
+ * distinguish join instances should call `extractColumnAliasComponents` instead.
  *
  * @example
  * extractUUIDFromColumnAlias("field_dd05ef4b_1234_5678_abcd_ef1234567890")
+ * // Returns: "dd05ef4b-1234-5678-abcd-ef1234567890"
+ *
+ * extractUUIDFromColumnAlias("field_dd05ef4b_1234_5678_abcd_ef1234567890_j1")
  * // Returns: "dd05ef4b-1234-5678-abcd-ef1234567890"
  */
 export function extractUUIDFromColumnAlias(columnAlias: string): string | null {
   const match = columnAlias.match(/^(?:field|metric)_(.+)$/);
   if (!match) return null;
 
-  // Convert underscores back to hyphens in UUID format
-  const uuidPart = match[1];
-  if (!uuidPart) return null;
+  // Strip the join-instance suffix appended by joinInstanceFieldId (e.g. `_j1`,
+  // `_j2`) before reconstructing the UUID.
+  const rawPart = (match[1] ?? "").replace(/_j\d+$/, "");
+  if (!rawPart) return null;
   // UUID format: 8-4-4-4-12 characters
   // With underscores: 8_4_4_4_12
-  const parts = uuidPart.split("_");
+  const parts = rawPart.split("_");
   if (parts.length === 5) {
     return parts.join("-");
   }
   // Fallback: just replace all underscores (may not be exact UUID format)
-  return uuidPart.replace(/_/g, "-");
+  return rawPart.replace(/_/g, "-");
+}
+
+/**
+ * Extract both the canonical UUID and the join-instance index from a column alias.
+ *
+ * Use this when downstream code needs to DISTINGUISH two join instances of the
+ * same field (e.g. orders→users via created_by vs approved_by).
+ * `extractUUIDFromColumnAlias` returns only the UUID (stripping the suffix);
+ * this function returns the full breakdown.
+ *
+ * @example
+ * extractColumnAliasComponents("field_dd05ef4b_1234_5678_abcd_ef1234567890")
+ * // Returns: { uuid: "dd05ef4b-1234-5678-abcd-ef1234567890", instanceIndex: 0 }
+ *
+ * extractColumnAliasComponents("field_dd05ef4b_1234_5678_abcd_ef1234567890_j1")
+ * // Returns: { uuid: "dd05ef4b-1234-5678-abcd-ef1234567890", instanceIndex: 1 }
+ */
+export function extractColumnAliasComponents(
+  columnAlias: string,
+): { uuid: string; instanceIndex: number } | null {
+  const match = columnAlias.match(/^(?:field|metric)_(.+)$/);
+  if (!match) return null;
+
+  const rawPart = match[1] ?? "";
+  // Check for join-instance suffix
+  const instanceMatch = rawPart.match(/^(.+)_j(\d+)$/);
+  let uuidRaw: string;
+  let instanceIndex: number;
+  if (instanceMatch) {
+    uuidRaw = instanceMatch[1] ?? "";
+    instanceIndex = parseInt(instanceMatch[2] ?? "0", 10);
+  } else {
+    uuidRaw = rawPart;
+    instanceIndex = 0;
+  }
+  if (!uuidRaw) return null;
+
+  const parts = uuidRaw.split("_");
+  const uuid =
+    parts.length === 5 ? parts.join("-") : uuidRaw.replace(/_/g, "-");
+  return { uuid, instanceIndex };
 }
 
 // ============================================================================
@@ -510,6 +585,13 @@ function buildFieldSelects(tableName: string, fields: Field[]): string[] {
  *
  * The first step wraps the base table with UUID aliases, then subsequent joins
  * can reference columns by their UUID alias names.
+ *
+ * When the same `rightTableId` appears in multiple joins (a legitimate
+ * double-join, e.g. orders→users on `created_by` AND `approved_by`), the
+ * second and later instances get `_j{n}`-suffixed aliases so DuckDB never sees
+ * duplicate column names in the SELECT.  `availableFields` contains synthetic
+ * Field objects with the instance-qualified IDs so that display-name/type maps
+ * keyed on `fieldIdToColumnAlias(field.id)` match the emitted aliases exactly.
  */
 function buildJoinedSQL(
   baseDFTable: string,
@@ -523,28 +605,116 @@ function buildJoinedSQL(
   let currentSQL = `(SELECT ${baseSelects.join(", ")} FROM ${baseDFTable} AS ${quoteIdentifier(baseDisplayName)})`;
   let currentFields = baseFields;
 
+  // Track how many times each rightTableId has been successfully joined so
+  // processSingleJoin can suffix aliases for repeat-join instances.
+  // IMPORTANT: the counter is only incremented on SUCCESSFUL joins — a skipped
+  // join (missing table, missing keys, invalid type) does NOT advance the index.
+  // This keeps the emitted suffix and the hooks' display-name maps in sync.
+  const joinInstanceCount = new Map<UUID, number>();
+
   for (const join of insight.joins ?? []) {
+    const instanceIndex = joinInstanceCount.get(join.rightTableId) ?? 0;
+
     const joinResult = processSingleJoin(
       join,
       joinedTables,
       currentSQL,
       baseDisplayName,
       currentFields,
+      instanceIndex,
     );
 
     if (joinResult) {
+      // Advance the counter ONLY on success — a skipped join must not consume
+      // an index slot, otherwise the next valid join gets a wrong suffix.
+      joinInstanceCount.set(join.rightTableId, instanceIndex + 1);
       currentSQL = joinResult.sql;
       // Accumulate fields from all joined tables for subsequent joins.
-      // `joinResult.allFields` excludes dropped right join-keys, so it is the
-      // accurate set of columns actually present in `currentSQL`.
+      // `joinResult.allFields` excludes dropped right join-keys and contains
+      // synthetic Fields with instance-suffixed IDs for repeat-joins, so it is
+      // the accurate column set actually present in `currentSQL`.
       currentFields = joinResult.allFields;
     }
   }
 
   // `currentFields` is the exact column set in the emitted subquery — dropped
-  // join keys are already excluded. Returning it lets callers build a field map
-  // that matches the FROM clause, so filters can't reference a missing column.
+  // join keys and instance suffixes already applied. Returning it lets callers
+  // build display-name/type maps that match the FROM clause precisely.
   return { sql: currentSQL, availableFields: currentFields };
+}
+
+/**
+ * Compute the field set that `buildInsightSQL` will emit for a given insight.
+ *
+ * Returns the same synthetic Field list that `buildJoinedSQL` accumulates
+ * internally: base fields + joined fields with dropped right join-keys and
+ * instance-suffixed IDs for repeat-joins (`field_<uuid>_j{n}` for index≥1).
+ *
+ * Use this in hooks/UI code to build display-name and type maps that are
+ * keyed on `fieldIdToColumnAlias(field.id)` and therefore match the SQL
+ * column names DuckDB actually produces — without re-deriving the instance
+ * index logic in multiple places (the desync risk #162 left open).
+ *
+ * Returns `null` when `baseTable.dataFrameId` is absent (same guard as
+ * `buildInsightSQL`).
+ */
+export function buildInsightAvailableFields(
+  baseTable: DataTable,
+  joinedTables: Map<UUID, DataTable>,
+  insight: Insight,
+): Field[] | null {
+  if (!baseTable.dataFrameId) return null;
+
+  const baseFields = (baseTable.fields ?? []).filter(
+    (f) => !f.name.startsWith("_"),
+  );
+
+  if (!insight.joins?.length) {
+    return baseFields;
+  }
+
+  // Mirror buildJoinedSQL's field accumulation without emitting any SQL.
+  const joinInstanceCount = new Map<UUID, number>();
+  let currentFields: Field[] = baseFields;
+
+  for (const join of insight.joins) {
+    const instanceIndex = joinInstanceCount.get(join.rightTableId) ?? 0;
+    const joinTable = joinedTables.get(join.rightTableId);
+    if (!joinTable || !joinTable.dataFrameId) continue;
+
+    const joinFields = (joinTable.fields ?? []).filter(
+      (f) => !f.name.startsWith("_"),
+    );
+
+    // Validate join keys exactly as processSingleJoin does; skip if invalid.
+    const currentKeyField = currentFields.find(
+      (f) => (f.columnName ?? f.name) === join.leftKey,
+    );
+    const joinKeyField = joinFields.find(
+      (f) => (f.columnName ?? f.name) === join.rightKey,
+    );
+    if (!currentKeyField || !joinKeyField) continue;
+
+    const rightColName = joinKeyField.columnName ?? joinKeyField.name;
+    const rawJoinType = join.type ?? "inner";
+    if (!JOIN_TYPE_WHITELIST_CONST.has(rawJoinType)) continue;
+
+    const nonKeyJoinFields = joinFields.filter(
+      (f) => (f.columnName ?? f.name) !== rightColName,
+    );
+
+    // Mirror processSingleJoin: instance 0 → canonical IDs; index≥1 → suffixed.
+    const instanceFields: Field[] = nonKeyJoinFields.map((f) => ({
+      ...f,
+      id: joinInstanceFieldId(f.id, instanceIndex) as UUID,
+    }));
+
+    // Counter advances only on a valid join (mirrors buildJoinedSQL).
+    joinInstanceCount.set(join.rightTableId, instanceIndex + 1);
+    currentFields = [...currentFields, ...instanceFields];
+  }
+
+  return currentFields;
 }
 
 /** Result from processing a single join */
@@ -557,6 +727,13 @@ interface JoinResult {
 /**
  * Process a single join and return the updated SQL with UUID-based column aliases.
  * Returns null if join is invalid.
+ *
+ * @param joinInstanceIndex - How many times this `rightTableId` has been
+ *   successfully joined BEFORE this call (0 = first time, 1 = second, …).
+ *   When > 0, the right-side non-key columns get `_j{n}`-suffixed aliases so
+ *   two joins to the same table emit distinct SQL output column names.
+ *   Without this, DuckDB silently keeps only the first occurrence → the second
+ *   join's columns are unreachable (silent wrong results).
  */
 function processSingleJoin(
   join: NonNullable<Insight["joins"]>[number],
@@ -564,6 +741,7 @@ function processSingleJoin(
   currentSQL: string,
   currentDisplayName: string,
   currentFields: Field[],
+  joinInstanceIndex: number,
 ): JoinResult | null {
   // Validate join table
   const joinTable = joinedTables.get(join.rightTableId);
@@ -623,20 +801,23 @@ function processSingleJoin(
     return `"${alias}"`;
   });
 
-  // For the right side, select with UUID aliases (excluding join key to avoid duplication)
-  const joinSelects = joinFields
-    .filter((f) => {
-      const colName = f.columnName ?? f.name;
-      return colName !== rightColName;
-    })
-    .map((field) => {
-      const columnName = field.columnName ?? field.name;
-      return buildColumnSelectWithFieldId(
-        joinDisplayName,
-        columnName,
-        field.id,
-      );
-    });
+  // Right side: exclude the join key; suffix aliases for repeat-join instances.
+  // For instance 0 (first join to this table) the suffix is absent → alias is
+  // the canonical `field_<uuid>` (no regression vs. the pre-fix behaviour).
+  // For instance ≥ 1 the alias becomes `field_<uuid>_j{n}` so DuckDB sees two
+  // distinct output columns and cannot silently discard the second (the bug).
+  const nonKeyJoinFields = joinFields.filter(
+    (f) => (f.columnName ?? f.name) !== rightColName,
+  );
+  const joinSelects = nonKeyJoinFields.map((field) => {
+    const columnName = field.columnName ?? field.name;
+    const instanceId = joinInstanceFieldId(field.id, joinInstanceIndex);
+    return buildColumnSelectWithFieldId(
+      joinDisplayName,
+      columnName,
+      instanceId,
+    );
+  });
 
   const selectParts = [...baseSelects, ...joinSelects];
 
@@ -648,14 +829,18 @@ function processSingleJoin(
     ON "${leftKeyAlias}" = ${quoteIdentifier(joinDisplayName)}.${quoteIdentifier(rightColName)}
   )`;
 
-  // Combine all fields for subsequent joins (excluding duplicate join key)
-  const allFields = [
-    ...currentFields,
-    ...joinFields.filter((f) => {
-      const colName = f.columnName ?? f.name;
-      return colName !== rightColName;
-    }),
-  ];
+  // Combine fields for subsequent joins (excluding dropped right join-key).
+  // For repeat-join instances, create synthetic Fields with instance-suffixed IDs
+  // so that subsequent join iterations see the correct suffixed aliases when
+  // building their passthrough SELECTs — not the original IDs from a prior instance.
+  // Note: selectedFields / metrics / filters in the Insight model still reference
+  // canonical (un-suffixed) field IDs — they map to the first join instance.
+  const instanceFields = nonKeyJoinFields.map((f) => ({
+    ...f,
+    id: joinInstanceFieldId(f.id, joinInstanceIndex) as UUID,
+  }));
+
+  const allFields = [...currentFields, ...instanceFields];
 
   return { sql, allFields, displayName: joinDisplayName };
 }

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -58,9 +58,15 @@ export function fieldIdToColumnAlias(fieldId: string): string {
  * - index 0 (first join): returns `fieldId` unchanged → alias stays `field_<uuid>`
  * - index ≥ 1 (repeat join): returns `fieldId_j{n}` → alias becomes `field_<uuid>_j{n}`
  *
- * This is an internal SQL-builder helper only — the returned value is NEVER
- * stored in the Insight model or compared against real field IDs. It is only
- * fed into `fieldIdToColumnAlias` to produce unique SQL aliases.
+ * This helper is used in two ways:
+ * - SQL emission: fed into `fieldIdToColumnAlias` to produce unique SQL column aliases.
+ * - Field accumulation: used as `Field.id` on SYNTHETIC Field objects returned by
+ *   `buildInsightAvailableFields` and `processSingleJoin` so display-name / type maps
+ *   keyed on `fieldIdToColumnAlias(field.id)` match the emitted aliases exactly.
+ *
+ * The instance-qualified ID is NEVER stored in the persisted Insight model; it
+ * exists only in transient in-memory synthetic Field objects produced during a
+ * single SQL-build or field-accumulation pass.
  */
 function joinInstanceFieldId(
   fieldId: string,

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -661,7 +661,7 @@ function buildJoinedSQL(
 export function buildInsightAvailableFields(
   baseTable: DataTable,
   joinedTables: Map<UUID, DataTable>,
-  insight: Insight,
+  insight: Pick<Insight, "joins">,
 ): Field[] | null {
   if (!baseTable.dataFrameId) return null;
 
@@ -697,6 +697,12 @@ export function buildInsightAvailableFields(
 
     const rightColName = joinKeyField.columnName ?? joinKeyField.name;
     const rawJoinType = join.type ?? "inner";
+    // Intentional divergence from processSingleJoin: that function throws on an
+    // invalid join type (fail-closed SQL path), while here we skip the join
+    // instead.  `buildInsightAvailableFields` must never throw — it runs in
+    // render-path hooks that have no error boundary around this call.  The
+    // counters stay in sync because the throw in buildJoinedSQL prevents
+    // `joinInstanceCount.set` from ever being reached for the invalid join.
     if (!JOIN_TYPE_WHITELIST_CONST.has(rawJoinType)) continue;
 
     const nonKeyJoinFields = joinFields.filter(


### PR DESCRIPTION
## Summary

Fixes the silent-wrong-results bug (YW-237 class-3) where two `InsightJoinConfig` entries with the same `rightTableId` (e.g. orders→users on `created_by` AND `approved_by`) emitted duplicate `field_<uuid>` SQL aliases → DuckDB kept only the first → second join's columns unreachable.

Tracked internally as YW-295.

## Changes

### Data layer (earlier commits — kept)
- `joinInstanceFieldId` + per-`rightTableId` counter in `buildJoinedSQL`/`processSingleJoin`: repeat-join instances get `_j{n}`-suffixed aliases; counter only advances on successful joins
- `extractColumnAliasComponents` (new export): returns `{uuid, instanceIndex}` for consumers that must distinguish instances
- `buildInsightAvailableFields` (new export): mirrors `buildJoinedSQL`'s field accumulation without SQL; returns synthetic Fields with instance-suffixed IDs
- `useInsightPagination`: single-sourced through `buildInsightAvailableFields`; now exports `resolvedFields`

### Picker + chart layer (new commits — the user-facing fix)
- `useInsightPagination`: export `resolvedFields` (instance-qualified Field[]); `buildJoinKeyByInstance` now mirrors `buildInsightAvailableFields` skip logic (resolvedFields-based gate instead of unconditional counter)
- `VisualizationPageContent`: use `instanceAwareFields` (from `resolvedFields`) as `availableFields` for `AxisSelectField` instead of bare `dataTable?.fields`; also threads into Color/Size `columnOptions`
- `AxisSelectField`: `matchColumnToField` helper — for `instanceIndex > 0`, returns `undefined` rather than collapsing to the j0 field (no bare-UUID fallback for repeat-join instances)
- `VisualizationDisplay`: prefer `columnDisplayNames[resolvedValue]` over bare `field.name` so chart axis/legend labels show the disambiguated "User Name (approved_by)" form
- `VisualizationDisplay` + `VisualizationPreview`: use `instanceAwareFields` in `resolveEncodingToSql` context so `field:<uuid>_j1` encodings resolve to the correct SQL alias for chart rendering

## Screenshots

This is a SQL-layer + hook fix — the visual change is that the X/Y/Color/Size axis pickers in the Visualization editor now show BOTH join instances as distinct selectable options (e.g. "User Name (created_by)" and "User Name (approved_by)") instead of only showing one.

Before the fix: only the first join instance's fields were selectable; the second instance's columns were silently unreachable.
After the fix: both instances appear as distinct picker options with disambiguated labels; selecting either one charts the correct underlying data.

Visual evidence (running app screenshots) requires a DuckDB connection with a repeat-join insight configured — not available in the CI environment. The acceptance proof is provided by the component render tests (AxisSelectField.render.test.tsx) which verify the picker options in isolation.

## Acceptance evidence

`AxisSelectField.render.test.tsx` (5 tests, component render at the picker seam):
- Both repeat-join instances appear as distinct options in the rendered picker
- Labels are distinct: "User Name (created_by)" vs "User Name (approved_by)"
- Selecting j1 emits `field:<uuid>_j1`, not the bare-UUID encoding
- Single-join non-regression: j0 present, no spurious j1

`AxisSelectField.repeatjoin.test.ts` (9 tests, helper composition + charting):
- Both repeat-join instances produce distinct encoding values (`field:<uuid>` and `field:<uuid>_j1`)
- `resolveEncodingToSql` with instance-aware fields resolves `_j1` encoding to the correct `_j1`-suffixed SQL alias
- `resolveEncodingToSql` with bare `dataTable.fields` returns `undefined` for `_j1` encoding (regression guard)
- Single-join and base-table columns unaffected (non-regression)
- Label disambiguation: both instances get distinct leftKey-suffixed labels

## Test plan

- [x] `bun test packages/engine/src/sql/` — all pass
- [x] `bun test packages/app/src/components/visualizations/` — 14 tests pass (all 3 test files)
- [x] `npx turbo test --filter=@dashframe/app` — 551/551 tests pass
- [x] `npx turbo typecheck` — 48/48 packages pass
- [x] Single-join and no-join insights: options unchanged (non-regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a silent wrong-results bug where two `InsightJoinConfig` entries with the same `rightTableId` (e.g. orders→users on `created_by` AND `approved_by`) produced duplicate SQL `field_<uuid>` aliases, causing DuckDB to silently discard the second join's columns and making them unreachable in the picker and chart.

- **Engine (`insight-sql.ts`)**: adds `joinInstanceFieldId`, `extractColumnAliasComponents`, and `buildInsightAvailableFields`; modifies `buildJoinedSQL`/`processSingleJoin` to track per-`rightTableId` instance counters and emit `field_<uuid>_j{n}` aliases for repeat joins; counter only advances on successful joins so skipped joins don't consume index slots.
- **Hook (`useInsightPagination`)**: replaces the `computeCombinedFields`+manual-key-drop approach with `buildInsightAvailableFields` (single-source of truth), adds `buildRepeatJoinDisplayNames` to show `"User Name (created_by)"` vs `"User Name (approved_by)"` disambiguation labels, and exports `resolvedFields` as `instanceAwareFields`.
- **UI layer**: `VisualizationPageContent`, `VisualizationDisplay`, and `VisualizationPreview` all switch from bare `dataTable.fields` to `instanceAwareFields` as the `availableFields`/encoding-resolution context; `AxisSelectField` replaces `extractUUIDFromColumnAlias` with `extractColumnAliasComponents` via a new `matchColumnToField` helper to map `_j1`-suffixed columns to distinct synthetic fields.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the bug fix is self-contained and thoroughly tested, and no regressions were introduced for single-join or no-join insights.

The instance-counter logic in both buildJoinedSQL and buildInsightAvailableFields correctly advances only on successful joins, keeping the SQL alias and the field-list in lockstep. The _j{n} suffix regex is unambiguous because 'j' is not a hex character, so no real UUID alias can collide with it. The disambiguation label logic, the encoding resolution change, and the picker matching all have direct acceptance tests. The one minor issue found (dead-code fallback in matchColumnToField) does not affect runtime behavior.

No files require special attention; all changed paths have corresponding test coverage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/engine/src/sql/insight-sql.ts | Core fix: adds joinInstanceFieldId, extractColumnAliasComponents, and buildInsightAvailableFields; join-instance counter logic is correct (only advances on success); regex for _j{n} suffix is safe since 'j' is non-hex and cannot appear in a real UUID alias. |
| packages/app/src/hooks/useInsightPagination.ts | Single-sources field list through buildInsightAvailableFields; buildJoinKeyByInstance correctly detects skipped joins by comparing against resolvedSlots from actual output fields; buildRepeatJoinDisplayNames produces correct disambiguated labels for all colliding instances. |
| packages/app/src/components/visualizations/AxisSelectField.tsx | Introduces matchColumnToField helper using extractColumnAliasComponents for instance-aware field matching; correctly blocks bare-UUID fallback for instanceIndex > 0 to prevent j1 from collapsing onto j0; minor dead-code path in the instanceIndex === 0 fallback. |
| packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx | Uses instanceAwareFields from useInsightPagination.resolvedFields as availableFields for AxisSelectField and the Color/Size picker columnOptions; correctly appends only instanceIndex > 0 fields to avoid duplicating the compiledInsight.dimensions already present. |
| packages/app/src/components/visualizations/VisualizationDisplay.tsx | Switches resolveEncodingToSql context to instanceAwareFields; label resolution correctly prefers columnDisplayNames[resolvedValue] first (for disambiguated labels) then falls back to field.name; all new deps added to both affected useMemo arrays. |
| packages/app/src/components/visualizations/VisualizationPreview.tsx | Adds useInsightPagination call to get resolvedFields; insightForView memo correctly gates the hook via enabled=!!insightForView; uses instanceAwareFields.length > 0 fallback pattern consistently with VisualizationDisplay. |
| packages/app/src/components/visualizations/AxisSelectField.repeatjoin.test.ts | Comprehensive acceptance tests: distinct encoding values for both instances, resolveEncodingToSql with instanceAwareFields vs bare fields, single-join and base-table non-regression, and display-name disambiguation — all 7 tests cover the key invariants of the fix. |
| packages/engine/src/sql/insight-sql.test.ts | New test suite covers: no duplicate AS clause, both instance aliases in SELECT, single-join non-regression, skipped-first-join counter invariant, skipped-right-key, valid-invalid-valid middle-skip pattern, round-trip alias contract, and multi-table independent counter isolation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["insight.joins"] --> B["buildInsightAvailableFields\nper-rightTableId counter"]
    B --> C["resolvedFields with synthetic IDs\nfirst instance: uuid\nsecond instance: uuid_j1"]
    C --> D["useInsightPagination\nexports resolvedFields"]

    D --> E["buildRepeatJoinDisplayNames\nalias map: uuid -> Name created_by\nalias_j1 -> Name approved_by"]

    D --> G["AxisSelectField\navailableFields = instanceAwareFields"]
    G --> H["matchColumnToField\nextractColumnAliasComponents"]
    H --> I["field:uuid and field:uuid_j1\ndistinct encodings per instance"]

    D --> K["resolveEncodingToSql\nVisualizationDisplay + Preview"]
    K --> L["field_uuid_j1 SQL alias\nmatches DuckDB output"]

    B -. "mirrors counter logic" .-> M["buildJoinedSQL\nprocessSingleJoin\ncounter only on success"]
    M --> N["SELECT col AS field_uuid\nSELECT col AS field_uuid_j1"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["insight.joins"] --> B["buildInsightAvailableFields\nper-rightTableId counter"]
    B --> C["resolvedFields with synthetic IDs\nfirst instance: uuid\nsecond instance: uuid_j1"]
    C --> D["useInsightPagination\nexports resolvedFields"]

    D --> E["buildRepeatJoinDisplayNames\nalias map: uuid -> Name created_by\nalias_j1 -> Name approved_by"]

    D --> G["AxisSelectField\navailableFields = instanceAwareFields"]
    G --> H["matchColumnToField\nextractColumnAliasComponents"]
    H --> I["field:uuid and field:uuid_j1\ndistinct encodings per instance"]

    D --> K["resolveEncodingToSql\nVisualizationDisplay + Preview"]
    K --> L["field_uuid_j1 SQL alias\nmatches DuckDB output"]

    B -. "mirrors counter logic" .-> M["buildJoinedSQL\nprocessSingleJoin\ncounter only on success"]
    M --> N["SELECT col AS field_uuid\nSELECT col AS field_uuid_j1"]
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["test(app): AxisSelectField component ren..."](https://github.com/youhaowei/dashframe/commit/c8a280e8c043cf3829aee2dcbaa2648dc5d2c4e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39987666)</sub>

<!-- /greptile_comment -->