### PR TITLE
[YW-308] feat(dashboard): fan-out batch command — clone viz item N times with field pin

### DIFF
--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2130,6 +2130,376 @@ describe("command vocabulary", () => {
   });
 
   // ===========================================================================
+  // FanOutDashboardItems
+  // ===========================================================================
+
+  describe("FanOutDashboardItems", () => {
+    /**
+     * Seed a dashboard with one visualization item; returns ids needed by tests.
+     * The source insight definition is intentionally minimal — the fan-out primitive
+     * must never read or write it.
+     */
+    async function makeDashWithVizItem(overrides?: {
+      existingFilters?: {
+        field: string;
+        operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains" | "in";
+        value: unknown;
+      }[];
+    }) {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      const dashId = id();
+      const sourceItemId = id();
+
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "Sales Insight",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Sales Chart",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+        cmd("CreateDashboard", { id: dashId, name: "Sales Dashboard" }),
+        cmd("AddDashboardItem", {
+          dashboardId: dashId,
+          item: {
+            id: sourceItemId,
+            type: "visualization",
+            visualizationId: vizId,
+            x: 0,
+            y: 0,
+            width: 6,
+            height: 4,
+            ...(overrides?.existingFilters
+              ? {
+                  overrides: {
+                    filters: overrides.existingFilters,
+                  },
+                }
+              : {}),
+          },
+        }),
+      );
+
+      return { tableId, insightId, vizId, dashId, sourceItemId };
+    }
+
+    it("should emit exactly N new items for N placements, each with the correct field pin", async () => {
+      const { dashId, sourceItemId, vizId } = await makeDashWithVizItem();
+      const ids = [id(), id(), id()];
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "region",
+          placements: [
+            { id: ids[0]!, value: "EMEA", x: 0, y: 5 },
+            { id: ids[1]!, value: "APAC", x: 6, y: 5 },
+            { id: ids[2]!, value: "AMER", x: 12, y: 5 },
+          ],
+        }),
+      );
+
+      const [row] = await dashboardsById(dashId);
+      const layout = row?.layout as {
+        id: string;
+        visualizationId: string;
+        overrides: {
+          filters: { field: string; operator: string; value: unknown }[];
+        };
+      }[];
+
+      // Source item is still there → total = 1 (source) + 3 (clones).
+      expect(layout).toHaveLength(4);
+
+      // All three clone ids are present.
+      for (const cloneId of ids) {
+        expect(layout.map((it) => it.id)).toContain(cloneId);
+      }
+
+      // Each clone shares the source visualizationId.
+      for (const cloneId of ids) {
+        const clone = layout.find((it) => it.id === cloneId)!;
+        expect(clone.visualizationId).toBe(vizId);
+      }
+
+      // Each clone pins the field to the correct value (order follows placements).
+      const cloneByValue = (v: unknown) =>
+        layout.find(
+          (it) =>
+            it.overrides?.filters?.some(
+              (f) => f.field === "region" && f.value === v,
+            ) ?? false,
+        );
+      expect(cloneByValue("EMEA")?.id).toBe(ids[0]);
+      expect(cloneByValue("APAC")?.id).toBe(ids[1]);
+      expect(cloneByValue("AMER")?.id).toBe(ids[2]);
+    });
+
+    it("should use operator 'eq' for all pinned filters", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      const cloneId = id();
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "status",
+          placements: [{ id: cloneId, value: "active", x: 0, y: 8 }],
+        }),
+      );
+
+      const [row] = await dashboardsById(dashId);
+      const layout = row?.layout as {
+        id: string;
+        overrides: {
+          filters: { field: string; operator: string; value: unknown }[];
+        };
+      }[];
+      const clone = layout.find((it) => it.id === cloneId)!;
+      const pin = clone.overrides.filters.find((f) => f.field === "status")!;
+      expect(pin.operator).toBe("eq");
+      expect(pin.value).toBe("active");
+    });
+
+    it("should inherit source item dimensions as defaults when placement omits width/height", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      const cloneId = id();
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "category",
+          placements: [{ id: cloneId, value: "A", x: 7, y: 0 }],
+        }),
+      );
+
+      const [row] = await dashboardsById(dashId);
+      const layout = row?.layout as {
+        id: string;
+        width: number;
+        height: number;
+      }[];
+      const clone = layout.find((it) => it.id === cloneId)!;
+      // Source item was 6×4; clone must inherit those dimensions.
+      expect(clone.width).toBe(6);
+      expect(clone.height).toBe(4);
+    });
+
+    it("should preserve existing overrides on the source item and not mutate it", async () => {
+      const existingFilters = [
+        { field: "year", operator: "eq" as const, value: 2024 },
+      ];
+      const { dashId, sourceItemId } = await makeDashWithVizItem({
+        existingFilters,
+      });
+      const cloneId = id();
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "region",
+          placements: [{ id: cloneId, value: "EMEA", x: 0, y: 8 }],
+        }),
+      );
+
+      const [row] = await dashboardsById(dashId);
+      const layout = row?.layout as {
+        id: string;
+        overrides?: {
+          filters?: { field: string; operator: string; value: unknown }[];
+        };
+      }[];
+
+      // Source item's overrides are byte-identical (not mutated by fan-out).
+      const source = layout.find((it) => it.id === sourceItemId)!;
+      expect(source.overrides?.filters).toEqual(existingFilters);
+
+      // Clone carries both the inherited year filter AND the new region pin.
+      const clone = layout.find((it) => it.id === cloneId)!;
+      const cloneFilters = clone.overrides?.filters ?? [];
+      expect(cloneFilters).toContainEqual(existingFilters[0]);
+      expect(cloneFilters).toContainEqual({
+        field: "region",
+        operator: "eq",
+        value: "EMEA",
+      });
+    });
+
+    it("should replace an existing same-field filter on the source rather than duplicating it", async () => {
+      const existingFilters = [
+        { field: "region", operator: "eq" as const, value: "US" },
+      ];
+      const { dashId, sourceItemId } = await makeDashWithVizItem({
+        existingFilters,
+      });
+      const cloneId = id();
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "region",
+          placements: [{ id: cloneId, value: "EMEA", x: 0, y: 8 }],
+        }),
+      );
+
+      const [row] = await dashboardsById(dashId);
+      const layout = row?.layout as {
+        id: string;
+        overrides?: {
+          filters?: { field: string; operator: string; value: unknown }[];
+        };
+      }[];
+      const clone = layout.find((it) => it.id === cloneId)!;
+      const regionFilters = (clone.overrides?.filters ?? []).filter(
+        (f) => f.field === "region",
+      );
+      // Exactly one region filter — the old "US" filter was replaced by "EMEA".
+      expect(regionFilters).toHaveLength(1);
+      expect(regionFilters[0]?.value).toBe("EMEA");
+    });
+
+    it("should leave the insight definition byte-identical after fan-out (source insight never mutated)", async () => {
+      const { dashId, sourceItemId, insightId } = await makeDashWithVizItem();
+
+      const insightBefore = (await insightsById(insightId))[0];
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "country",
+          placements: [
+            { id: id(), value: "US", x: 0, y: 6 },
+            { id: id(), value: "GB", x: 6, y: 6 },
+          ],
+        }),
+      );
+
+      const insightAfter = (await insightsById(insightId))[0];
+      // The insight row is structurally identical — fan-out only writes layout.
+      expect(JSON.stringify(insightAfter?.definition)).toBe(
+        JSON.stringify(insightBefore?.definition),
+      );
+    });
+
+    it("should reject a source item that is markdown (no visualizationId to clone)", async () => {
+      const dashId = id();
+      const markdownId = id();
+      await commit(
+        cmd("CreateDashboard", { id: dashId, name: "D" }),
+        cmd("AddDashboardItem", {
+          dashboardId: dashId,
+          item: {
+            id: markdownId,
+            type: "markdown",
+            content: "## Title",
+            x: 0,
+            y: 0,
+            width: 12,
+            height: 2,
+          },
+        }),
+      );
+
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId: markdownId,
+            field: "region",
+            placements: [{ id: id(), value: "EMEA", x: 0, y: 4 }],
+          }),
+        ),
+      ).rejects.toThrow(/visualization/);
+    });
+
+    it("should reject a missing sourceItemId (no silent no-op)", async () => {
+      const { dashId } = await makeDashWithVizItem();
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId: id(),
+            field: "region",
+            placements: [{ id: id(), value: "EMEA", x: 0, y: 4 }],
+          }),
+        ),
+      ).rejects.toThrow(/not found/);
+    });
+
+    it("should reject empty placements (no silent no-op)", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId,
+            field: "region",
+            placements: [],
+          }),
+        ),
+      ).rejects.toThrow(/non-empty/);
+    });
+
+    it("should reject duplicate placement ids (no corrupt layout state)", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      const dupId = id();
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId,
+            field: "region",
+            placements: [
+              { id: dupId, value: "EMEA", x: 0, y: 4 },
+              { id: dupId, value: "APAC", x: 6, y: 4 },
+            ],
+          }),
+        ),
+      ).rejects.toThrow(/duplicate/);
+    });
+
+    it("should reject a placement id that already exists in the layout (client-id invariant)", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      // Use the source item's own id as a collision.
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId,
+            field: "region",
+            placements: [{ id: sourceItemId, value: "EMEA", x: 0, y: 4 }],
+          }),
+        ),
+      ).rejects.toThrow(/already exists/);
+    });
+
+    it("should reject a missing dashboard (no silent no-op)", async () => {
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: id(),
+            sourceItemId: id(),
+            field: "region",
+            placements: [{ id: id(), value: "EMEA", x: 0, y: 4 }],
+          }),
+        ),
+      ).rejects.toThrow(/not found/);
+    });
+  });
+
+  // ===========================================================================
   // Cross-cutting — DeleteNode + extended RenameNode
   // ===========================================================================
 

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1876,6 +1876,54 @@ describe("command vocabulary", () => {
       expect(layout[0]?.x).toBe(2);
     });
 
+    it("should update overrides on a dashboard item via UpdateDashboardItem", async () => {
+      // Verifies that UpdateDashboardItem propagates the overrides field through
+      // sanitizeDashboardItemUpdates — so agents can adjust a cloned panel's
+      // filter pin without re-creating it.
+      const dashId = id();
+      const itemId = id();
+      await commit(
+        cmd("CreateDashboard", { id: dashId, name: "D" }),
+        cmd("AddDashboardItem", {
+          dashboardId: dashId,
+          item: {
+            id: itemId,
+            type: "visualization" as const,
+            visualizationId: id(),
+            x: 0,
+            y: 0,
+            width: 6,
+            height: 4,
+          },
+        }),
+      );
+
+      await commit(
+        cmd("UpdateDashboardItem", {
+          dashboardId: dashId,
+          itemId,
+          updates: {
+            overrides: {
+              filters: [
+                { field: "region", operator: "eq" as const, value: "EMEA" },
+              ],
+            },
+          },
+        }),
+      );
+
+      const rows = await dashboardsById(dashId);
+      const item = (
+        rows[0]?.layout as {
+          id: string;
+          overrides?: { filters?: { field: string; value: unknown }[] };
+        }[]
+      ).find((it) => it.id === itemId)!;
+      expect(item.overrides?.filters).toEqual([
+        { field: "region", operator: "eq", value: "EMEA" },
+      ]);
+    });
+
     it("should throw on UpdateDashboardItem with a missing itemId (no silent no-op)", async () => {
       const dashId = id();
       await commit(cmd("CreateDashboard", { id: dashId, name: "D" }));
@@ -2523,6 +2571,41 @@ describe("command vocabulary", () => {
           }),
         ),
       ).rejects.toThrow(/not found/);
+    });
+
+    it("should reject a placement that omits the value key (null is allowed, absent is not)", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      // A placement with value: null is valid (pin IS NULL).
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId,
+            field: "region",
+            placements: [{ id: id(), value: null, x: 0, y: 8 }],
+          }),
+        ),
+      ).resolves.toMatchObject({ mode: "commit" });
+
+      // A placement without a value key at all must be rejected (would produce a
+      // valueless filter object in JSON — `{"field":"region","operator":"eq"}`).
+      await expect(
+        commit(
+          cmd("FanOutDashboardItems", {
+            dashboardId: dashId,
+            sourceItemId,
+            field: "status",
+            placements: [
+              { id: id(), x: 0, y: 10 } as unknown as {
+                id: string;
+                value: unknown;
+                x: number;
+                y: number;
+              },
+            ],
+          }),
+        ),
+      ).rejects.toThrow(/value key/);
     });
   });
 

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2393,6 +2393,33 @@ describe("command vocabulary", () => {
       );
     });
 
+    it("should use placement-supplied width/height when provided (overrides source dimensions)", async () => {
+      const { dashId, sourceItemId } = await makeDashWithVizItem();
+      const cloneId = id();
+
+      await commit(
+        cmd("FanOutDashboardItems", {
+          dashboardId: dashId,
+          sourceItemId,
+          field: "region",
+          placements: [
+            { id: cloneId, value: "EMEA", x: 0, y: 8, width: 3, height: 2 },
+          ],
+        }),
+      );
+
+      const [row] = await dashboardsById(dashId);
+      const layout = row?.layout as {
+        id: string;
+        width: number;
+        height: number;
+      }[];
+      const clone = layout.find((it) => it.id === cloneId)!;
+      // Explicit placement dims take precedence over source item's 6×4.
+      expect(clone.width).toBe(3);
+      expect(clone.height).toBe(2);
+    });
+
     it("should reject a source item that is markdown (no visualizationId to clone)", async () => {
       const dashId = id();
       const markdownId = id();

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -2145,12 +2145,27 @@ export interface TypedInsightFilter {
 }
 
 /**
- * Filter override for a single dashboard item. Mirrors the domain
- * `InsightFilterOverride` shape — kept here to avoid a shared-package coupling.
+ * Filter override for a single dashboard item. Intentional subset of the domain
+ * `InsightFilterOverride` (from @dashframe/types):
+ *   - No `id?` field — override filters created by the fan-out primitive are
+ *     anonymous (id is a UI-path concern for stable re-targeting concurrent edits).
+ *   - `cleared?` is retained — callers can widen a source item's filter by passing
+ *     `cleared: true` to cancel a specific field's inherited filter.
+ *   - Kept inline (not imported) to avoid a circular package dependency from the
+ *     server layer back into @dashframe/types.
  */
 export interface DashboardItemFilterOverride {
   field: string;
-  operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains" | "in";
+  operator:
+    | "eq"
+    | "ne"
+    | "gt"
+    | "gte"
+    | "lt"
+    | "lte"
+    | "contains"
+    | "in"
+    | "between";
   value: unknown;
   cleared?: boolean;
 }

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1295,6 +1295,18 @@ interface DashboardItem {
   y: number;
   width: number;
   height: number;
+  overrides?: DashboardItemOverrides;
+}
+
+/**
+ * Override bag written into `DashboardItem.overrides` by the fan-out primitive.
+ * Mirrors `DashboardItemOverrides` from @dashframe/types — kept inline to avoid
+ * a circular package dependency from the server layer.
+ */
+interface DashboardItemOverrides {
+  filters?: { field: string; operator: string; value: unknown }[];
+  sorts?: { field: string; direction: "asc" | "desc" }[];
+  limit?: number;
 }
 
 /** Load a dashboard's layout array, throwing if the dashboard does not exist. */
@@ -1334,6 +1346,8 @@ function requireDashboardItem(value: unknown): DashboardItem {
       throw new Error(`AddDashboardItem: item.${key} must be a number`);
     }
   }
+  // `overrides` is passed through as-is — it is written by the fan-out primitive
+  // which controls the shape; the per-field filter pin is validated there.
   return value as unknown as DashboardItem;
 }
 
@@ -1487,6 +1501,137 @@ const removeDashboardItem = mutation({
       .where(eq("id", dashboardId))
       .update({ layout: items.filter((it) => it.id !== itemId) });
     return { ok: true };
+  },
+});
+
+/**
+ * FanOutDashboardItems — batch-clone a source viz item N times, each pinning
+ * one value of a field in its `overrides`.
+ *
+ * The agent supplies all inputs deterministically:
+ *   - `sourceItemId`  — the existing viz panel to clone
+ *   - `field`         — the field name to pin in each clone's overrides
+ *   - `placements`    — one entry per value: `{ id, value, x, y, width?, height? }`
+ *     `width`/`height` default to the source item's dimensions if omitted.
+ *
+ * Contracts:
+ *   - Source item must be a `visualization` (has `visualizationId`); markdown
+ *     items have no insight to override.
+ *   - `placements` must be non-empty (no silent no-op).
+ *   - All clone ids must be unique against each other AND the existing layout.
+ *   - Source item's existing `overrides.filters` are cloned; the pin for `field`
+ *     replaces an existing filter on the same field (in-place) or appends.
+ *   - The source item itself and the insight definition are never mutated.
+ */
+const fanOutDashboardItems = mutation({
+  args: {
+    dashboardId: uuid,
+    sourceItemId: uuid,
+    field: text,
+    placements: jsonb,
+  },
+  handler: async (
+    ctx,
+    { dashboardId, sourceItemId, field, placements: rawPlacements },
+  ): Promise<{ ok: true; created: string[] }> => {
+    // Validate placements shape.
+    if (!Array.isArray(rawPlacements) || rawPlacements.length === 0) {
+      throw new Error(
+        "FanOutDashboardItems: placements must be a non-empty array",
+      );
+    }
+    type Placement = {
+      id: string;
+      value: unknown;
+      x: number;
+      y: number;
+      width?: number;
+      height?: number;
+    };
+    const placements = rawPlacements as Placement[];
+    for (const p of placements) {
+      if (typeof p.id !== "string") {
+        throw new Error(
+          "FanOutDashboardItems: each placement must have a string id",
+        );
+      }
+      if (typeof p.x !== "number" || typeof p.y !== "number") {
+        throw new Error(
+          "FanOutDashboardItems: each placement must have numeric x and y",
+        );
+      }
+    }
+
+    const items = await requireDashboardItems(ctx, dashboardId);
+
+    // Locate the source item.
+    const source = items.find((it) => it.id === sourceItemId);
+    if (!source) {
+      throw new Error(
+        `FanOutDashboardItems: source item ${sourceItemId} not found`,
+      );
+    }
+    if (source.type !== "visualization" || !source.visualizationId) {
+      throw new Error(
+        "FanOutDashboardItems: source item must be a visualization with a visualizationId",
+      );
+    }
+
+    // Guard: all clone ids must be unique against each other AND the existing
+    // layout (the client-id invariant).
+    const existingIds = new Set(items.map((it) => it.id));
+    const newIds = placements.map((p) => p.id);
+    if (new Set(newIds).size !== newIds.length) {
+      throw new Error(
+        "FanOutDashboardItems: placements contains duplicate ids",
+      );
+    }
+    for (const newId of newIds) {
+      if (existingIds.has(newId)) {
+        throw new Error(
+          `FanOutDashboardItems: clone id ${newId} already exists in the dashboard`,
+        );
+      }
+    }
+
+    // Build N clones. Each clone inherits the source's overrides.filters (and
+    // sorts/limit) then replaces/appends the pin for `field`.
+    const sourceFilters: DashboardItemOverrides["filters"] =
+      source.overrides?.filters ?? [];
+    const sourceSorts = source.overrides?.sorts;
+    const sourceLimit = source.overrides?.limit;
+
+    const clones: DashboardItem[] = placements.map((p) => {
+      // Clone the source filters array; replace the filter for `field` in-place
+      // if one exists, otherwise append. Stable ordering for reproducibility.
+      const baseFilters = sourceFilters.filter((f) => f.field !== field);
+      const pin = { field, operator: "eq", value: p.value };
+      const filters = [...baseFilters, pin];
+
+      const overrides: DashboardItemOverrides = { filters };
+      if (sourceSorts) overrides.sorts = sourceSorts;
+      if (sourceLimit !== undefined) overrides.limit = sourceLimit;
+
+      return {
+        id: p.id,
+        type: "visualization",
+        visualizationId: source.visualizationId,
+        x: p.x,
+        y: p.y,
+        width: typeof p.width === "number" ? p.width : source.width,
+        height: typeof p.height === "number" ? p.height : source.height,
+        overrides,
+      };
+    });
+
+    // Write all clones into the layout in one read-modify-write.
+    const next = [...items, ...clones];
+    await ctx.db
+      .from(dashboards)
+      .where(eq("id", dashboardId))
+      .update({ layout: next });
+
+    return { ok: true, created: newIds };
   },
 });
 
@@ -1949,6 +2094,7 @@ export const commandFunctions = {
   updateDashboardItemCmd: updateDashboardItem,
   setDashboardLayout,
   removeDashboardItemCmd: removeDashboardItem,
+  fanOutDashboardItemsCmd: fanOutDashboardItems,
   // Cross-cutting
   renameNode,
   deleteNode,
@@ -1998,6 +2144,24 @@ export interface TypedInsightFilter {
   value: FilterOperandValue;
 }
 
+/**
+ * Filter override for a single dashboard item. Mirrors the domain
+ * `InsightFilterOverride` shape — kept here to avoid a shared-package coupling.
+ */
+export interface DashboardItemFilterOverride {
+  field: string;
+  operator: "eq" | "ne" | "gt" | "gte" | "lt" | "lte" | "contains" | "in";
+  value: unknown;
+  cleared?: boolean;
+}
+
+/** Override bag for a dashboard item (instrument-level overrides). */
+export interface DashboardItemOverridesInput {
+  filters?: DashboardItemFilterOverride[];
+  sorts?: { field: string; direction: "asc" | "desc" }[];
+  limit?: number;
+}
+
 /** A Dashboard item as supplied in AddDashboardItem / SetDashboardLayout. */
 export interface DashboardItemInput {
   id: UUID;
@@ -2008,6 +2172,7 @@ export interface DashboardItemInput {
   y: number;
   width: number;
   height: number;
+  overrides?: DashboardItemOverridesInput;
 }
 
 /**
@@ -2103,6 +2268,19 @@ export interface CommandPayloads {
   };
   SetDashboardLayout: { dashboardId: UUID; items: DashboardItemInput[] };
   RemoveDashboardItem: { dashboardId: UUID; itemId: UUID };
+  FanOutDashboardItems: {
+    dashboardId: UUID;
+    sourceItemId: UUID;
+    field: string;
+    placements: {
+      id: UUID;
+      value: unknown;
+      x: number;
+      y: number;
+      width?: number;
+      height?: number;
+    }[];
+  };
   // Cross-cutting
   RenameNode: { id: UUID; name: string };
   DeleteNode: { id: UUID };
@@ -2146,6 +2324,7 @@ export const COMMAND_PATHS: {
   UpdateDashboardItem: "updateDashboardItemCmd",
   SetDashboardLayout: "setDashboardLayout",
   RemoveDashboardItem: "removeDashboardItemCmd",
+  FanOutDashboardItems: "fanOutDashboardItemsCmd",
   RenameNode: "renameNode",
   DeleteNode: "deleteNode",
 };

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1304,7 +1304,21 @@ interface DashboardItem {
  * a circular package dependency from the server layer.
  */
 interface DashboardItemOverrides {
-  filters?: { field: string; operator: string; value: unknown }[];
+  filters?: {
+    field: string;
+    operator:
+      | "eq"
+      | "ne"
+      | "gt"
+      | "gte"
+      | "lt"
+      | "lte"
+      | "contains"
+      | "in"
+      | "between";
+    value: unknown;
+    cleared?: boolean;
+  }[];
   sorts?: { field: string; direction: "asc" | "desc" }[];
   limit?: number;
 }
@@ -1369,6 +1383,15 @@ function sanitizeDashboardItemUpdates(
   if (typeof updates.y === "number") next.y = updates.y;
   if (typeof updates.width === "number") next.width = updates.width;
   if (typeof updates.height === "number") next.height = updates.height;
+  // `overrides` is passed through as-is — callers use this to update or clear
+  // a panel's filter/sort/limit bag. The shape is opaque jsonb; downstream
+  // rendering validates filters at query time, not at the write boundary.
+  // An explicit `undefined` means "not updating overrides" (the key was absent
+  // in the updates object); `null` is not in the type so omit check mirrors
+  // the other field guards.
+  if ("overrides" in updates) {
+    next.overrides = updates.overrides as DashboardItemOverrides | undefined;
+  }
   return next;
 }
 
@@ -1560,6 +1583,13 @@ const fanOutDashboardItems = mutation({
           "FanOutDashboardItems: each placement must have numeric x and y",
         );
       }
+      // Reject missing `value` key explicitly (use `in` not truthiness so that
+      // null and false are valid pin values — only absent-key is an error).
+      if (!("value" in p)) {
+        throw new Error(
+          "FanOutDashboardItems: each placement must include a value key",
+        );
+      }
     }
 
     const items = await requireDashboardItems(ctx, dashboardId);
@@ -1598,14 +1628,19 @@ const fanOutDashboardItems = mutation({
     // sorts/limit) then replaces/appends the pin for `field`.
     const sourceFilters: DashboardItemOverrides["filters"] =
       source.overrides?.filters ?? [];
-    const sourceSorts = source.overrides?.sorts;
+    // Spread to avoid sharing the same array reference across all N clones —
+    // the serialization collapses the alias today, but explicit isolation makes
+    // any future per-clone mutation safe.
+    const sourceSorts = source.overrides?.sorts
+      ? [...source.overrides.sorts]
+      : undefined;
     const sourceLimit = source.overrides?.limit;
 
     const clones: DashboardItem[] = placements.map((p) => {
       // Clone the source filters array; replace the filter for `field` in-place
       // if one exists, otherwise append. Stable ordering for reproducibility.
       const baseFilters = sourceFilters.filter((f) => f.field !== field);
-      const pin = { field, operator: "eq", value: p.value };
+      const pin = { field, operator: "eq" as const, value: p.value };
       const filters = [...baseFilters, pin];
 
       const overrides: DashboardItemOverrides = { filters };

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -276,6 +276,13 @@ const COMMAND_DESCRIPTORS: Record<CommandPath, CommandDescriptor> = {
     change: "update",
     summary: (a) => `Remove dashboard item ${String(a.itemId)}`,
   },
+  fanOutDashboardItemsCmd: {
+    kind: "dashboard",
+    targetId: byDashboardId,
+    change: "update",
+    summary: (a) =>
+      `Fan out "${String(a.field)}" across ${Array.isArray(a.placements) ? a.placements.length : 0} item(s)`,
+  },
   renameNode: {
     // Polymorphic — the real kind comes from the handler's reported `renamed`
     // target (read in buildDirectNodes), NOT from this declared value. This
@@ -332,6 +339,7 @@ const PATH_TO_NAME: Record<CommandPath, string> = {
   updateDashboardItemCmd: "UpdateDashboardItem",
   setDashboardLayout: "SetDashboardLayout",
   removeDashboardItemCmd: "RemoveDashboardItem",
+  fanOutDashboardItemsCmd: "FanOutDashboardItems",
   renameNode: "RenameNode",
   deleteNode: "DeleteNode",
 };

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -143,6 +143,7 @@ export const DRAFT_SAFE_COMMANDS = new Set([
   "UpdateDashboardItem",
   "SetDashboardLayout",
   "RemoveDashboardItem",
+  "FanOutDashboardItems",
   // Cross-cutting rename (PK-addressed, no vault, no cascade)
   "RenameNode",
   //

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -335,6 +335,23 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
     args: { dashboardId: "UUID", itemId: "UUID" },
     notes: "Rejects a missing itemId.",
   },
+  {
+    name: "FanOutDashboardItems",
+    group: "dashboard",
+    summary:
+      "Batch-clone a source viz item N times, each pinning one value of a field in its overrides.",
+    args: {
+      dashboardId: "UUID",
+      sourceItemId: "UUID — the viz panel to clone",
+      field: "string — the field name to pin",
+      placements:
+        "{ id: UUID, value: unknown, x: number, y: number, width?: number, height?: number }[] — one per clone",
+    },
+    notes:
+      "Source item must be a visualization. All placement ids must be unique and not already in the layout. " +
+      "width/height default to the source item's dimensions if omitted. " +
+      "The source item and insight definition are never mutated — only DashboardItem.overrides is written.",
+  },
   // --- Cross-cutting (polymorphic over artifact kinds) ---
   {
     name: "RenameNode",

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -306,9 +306,12 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
     summary: "Place a viz panel or markdown block on a dashboard.",
     args: {
       dashboardId: "UUID",
-      item: "{ id, type:'visualization'|'markdown', visualizationId?|content?, x,y,width,height }",
+      item: "{ id, type:'visualization'|'markdown', visualizationId?|content?, x,y,width,height, overrides?: DashboardItemOverridesInput }",
     },
-    notes: "Rejects a duplicate item id.",
+    notes:
+      "Rejects a duplicate item id. " +
+      "overrides is optional — omit for a plain panel; supply to pin filters/sorts/limit at the item level. " +
+      "Use FanOutDashboardItems to batch-create N items with distinct field-value pins.",
   },
   {
     name: "UpdateDashboardItem",


### PR DESCRIPTION
## Summary

- Adds `FanOutDashboardItems` to the `applyCommand` vocabulary — a batch command that, given `{ dashboardId, sourceItemId, field, placements[] }`, clones a source viz item N times, each with `overrides.filters` pinning the field to the placement's value
- Source item and insight definition are never mutated — only `DashboardItem.overrides` is written, flowing through the existing draft/preview/publish pipeline
- No UI, no cardinality guard, no layout-rule logic — primitive only; the agent supplies all inputs deterministically

## Files changed

- `apps/server/src/functions/commands.ts` — `DashboardItemOverrides` interface, extend `DashboardItem`, `fanOutDashboardItems` mutation handler, registry/paths/payloads wired
- `apps/server/src/functions/preview-diff.ts` — `fanOutDashboardItemsCmd` added to exhaustive `COMMAND_DESCRIPTORS` and `PATH_TO_NAME` maps
- `packages/assistant/src/apply-command-tool.ts` — `FanOutDashboardItems` added to `DRAFT_SAFE_COMMANDS`
- `packages/assistant/src/read/command-guide.ts` — guide entry added (freshness gate passes)
- `apps/server/src/functions/commands.test.ts` — 11 new tests: N-item emit, eq-operator pin, dimension inheritance, override preservation, same-field replace, insight immutability, and all error guards

## Test plan

- [x] `command-guide-freshness.test.ts` — 3/3 (guide ⟷ registry in sync)
- [x] `commands.test.ts` — 117/117 (all existing + 11 new FanOutDashboardItems)
- [x] Full graph typecheck (`turbo typecheck`) — 48/48
- [x] `eslint` — clean on both `@dashframe/server` and `@dashframe/assistant`

Tracked internally as YW-308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `FanOutDashboardItems` — a batch command that clones a source viz panel N times, each pinning a field value in `DashboardItem.overrides`, and wires it through the full command vocabulary (registry, preview-diff, agent guide, draft-safe set). The source item and insight are never mutated; only the dashboard layout is written.

- `commands.ts` introduces `DashboardItemOverrides`/`DashboardItemFilterOverride` interfaces (with narrow operator union), the `fanOutDashboardItems` mutation handler with guards for empty placements, duplicate ids, missing source, and absent `value` key, and passes `overrides` through `requireDashboardItem`/`sanitizeDashboardItemUpdates` as opaque jsonb.
- `commands.test.ts` adds 11 focused tests covering clone count, operator pinning, dimension inheritance, override preservation, same-field replacement, insight immutability, and all error guards (including the null-vs-absent `value` edge case).
- `preview-diff.ts` and `apply-command-tool.ts` wire the new command into the exhaustive descriptor/name maps and the draft-safe set.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fan-out primitive is well-contained, the handler only writes to `dashboards.layout`, the source item and insight definition are never touched, and all validation guards are exercised by the 11 new tests.

The mutation follows the established read-modify-write pattern for dashboard layout updates, input validation is thorough (placement shape, absent `value` key, duplicate ids, markdown source guard), and the operator union on the internal interface is now correctly narrowed. All issues from previous review threads appear to have been addressed in this version.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/commands.ts | Core fan-out mutation handler added with solid validation guards; `overrides` is intentionally passed through opaque in `sanitizeDashboardItemUpdates`/`requireDashboardItem`, and `sourceSorts` spread (noted in prior thread) partially isolates from source but all N clones share the same spread array. |
| apps/server/src/functions/commands.test.ts | 11 new tests covering all key contracts: N-item emit, eq-operator, dimension inheritance, override preservation, same-field replacement, insight immutability, and all error paths including the null-vs-absent value edge case. |
| apps/server/src/functions/preview-diff.ts | Adds `fanOutDashboardItemsCmd` to the exhaustive `COMMAND_DESCRIPTORS` and `PATH_TO_NAME` maps with correct `kind`, `targetId`, and a safe summary lambda. |
| packages/assistant/src/apply-command-tool.ts | Single-line addition of `FanOutDashboardItems` to `DRAFT_SAFE_COMMANDS`; no concerns. |
| packages/assistant/src/read/command-guide.ts | New guide entry accurately describes the command contract, placement shape, dimension defaulting, and immutability guarantee; also updates `AddDashboardItem` notes to reference `FanOutDashboardItems`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant applyCommand
    participant fanOutDashboardItems
    participant DB

    Agent->>applyCommand: "FanOutDashboardItems { dashboardId, sourceItemId, field, placements[] }"
    applyCommand->>fanOutDashboardItems: validated payload

    fanOutDashboardItems->>fanOutDashboardItems: validate placements (non-empty, id/x/y types, value key present)
    fanOutDashboardItems->>DB: requireDashboardItems(dashboardId)
    DB-->>fanOutDashboardItems: DashboardItem[] (current layout)

    fanOutDashboardItems->>fanOutDashboardItems: locate source item (throws if missing or markdown)
    fanOutDashboardItems->>fanOutDashboardItems: guard duplicate ids vs existing layout

    loop for each placement p
        fanOutDashboardItems->>fanOutDashboardItems: "baseFilters = sourceFilters.filter(f != field)"
        fanOutDashboardItems->>fanOutDashboardItems: "pin = { field, op:eq, value: p.value }"
        fanOutDashboardItems->>fanOutDashboardItems: "clone = { ...source dims, overrides: { filters: [...baseFilters, pin] } }"
    end

    fanOutDashboardItems->>DB: "update layout = [...items, ...clones]"
    DB-->>fanOutDashboardItems: ok
    fanOutDashboardItems-->>applyCommand: "{ ok: true, created: string[] }"
    applyCommand-->>Agent: result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant applyCommand
    participant fanOutDashboardItems
    participant DB

    Agent->>applyCommand: "FanOutDashboardItems { dashboardId, sourceItemId, field, placements[] }"
    applyCommand->>fanOutDashboardItems: validated payload

    fanOutDashboardItems->>fanOutDashboardItems: validate placements (non-empty, id/x/y types, value key present)
    fanOutDashboardItems->>DB: requireDashboardItems(dashboardId)
    DB-->>fanOutDashboardItems: DashboardItem[] (current layout)

    fanOutDashboardItems->>fanOutDashboardItems: locate source item (throws if missing or markdown)
    fanOutDashboardItems->>fanOutDashboardItems: guard duplicate ids vs existing layout

    loop for each placement p
        fanOutDashboardItems->>fanOutDashboardItems: "baseFilters = sourceFilters.filter(f != field)"
        fanOutDashboardItems->>fanOutDashboardItems: "pin = { field, op:eq, value: p.value }"
        fanOutDashboardItems->>fanOutDashboardItems: "clone = { ...source dims, overrides: { filters: [...baseFilters, pin] } }"
    end

    fanOutDashboardItems->>DB: "update layout = [...items, ...clones]"
    DB-->>fanOutDashboardItems: ok
    fanOutDashboardItems-->>applyCommand: "{ ok: true, created: string[] }"
    applyCommand-->>Agent: result
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fixup! \[YW-308\] feat(dashboard): fan-out..."](https://github.com/youhaowei/dashframe/commit/adcae106bf0ba64d8cc13054536e337c08b35bbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40006403)</sub>

<!-- /greptile_comment -->