### PR TITLE
[YW-323] fix(server): atomic publishDraft — close draft-publish crash window (#157)

### DIFF
--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -717,4 +717,101 @@ describe("DraftController (persisted draft overlay)", () => {
       (await db.select().from(insights)).find((r) => r.id === insightId)?.name,
     ).toBe("Original");
   });
+
+  it("rolls back the canonical replay when the log delete fails mid-publish — no double-replay, draft survives for retry (GH #157)", async () => {
+    // The crash-safety contract this slice exists to close. publishDraft replays
+    // the command log onto canonical, then deletes the log + sweeps the shadow.
+    // BEFORE the fix those were separate transactions: a process death between the
+    // canonical commit and the log delete left canonical written but the log
+    // intact, so a retried publish replayed a SECOND time — a duplicate-PK throw
+    // for create commands, with no clean recovery. The fix wraps replay + log
+    // delete + sweep in ONE outer transaction (the applyCommands `tx` seam), so a
+    // failure at the log delete rolls the canonical replay back with it.
+    //
+    // We exercise the exact #157 scenario by injecting a throw at the log delete
+    // INSIDE the publish transaction (the bookkeeping step that previously ran in
+    // its own autocommit). The interceptor wraps `app.createTracked().transaction`
+    // and patches the tx-bound raw handle's `delete` to throw for the
+    // draft_command_log table only — matched by table REFERENCE, not SQL text. If
+    // the replay and the log delete share a commit boundary, the failure unwinds
+    // both; if they don't, canonical stays committed and the retry double-replays.
+    const { tableId } = await seedTable(controller);
+    const insightId = id();
+
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Crash-window",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+
+    // Install the fault injector on the SAME app the controller publishes through
+    // (openStack returns this app; the controller calls app.createTracked() at
+    // publish time, so post-build patching takes effect).
+    // The fault injector reaches into the tracked-tx seam structurally (patching
+    // `tx.raw.delete` by table reference), so a few `any`s are unavoidable here —
+    // scoped to this block, not the suite.
+    /* eslint-disable @typescript-eslint/no-explicit-any -- structural fault injector over the tracked-tx seam */
+    let failLogDelete = false;
+    const realCreateTracked = app.createTracked.bind(app);
+    (app as any).createTracked = () => {
+      const t = realCreateTracked();
+      const realTx = t.transaction.bind(t);
+      t.transaction = ((fn: any, opts: any) =>
+        realTx(async (tx) => {
+          const realDelete = tx.raw.delete.bind(tx.raw);
+          tx.raw.delete = (table: any) => {
+            if (table === draftCommandLog && failLogDelete) {
+              throw new Error("injected log-delete failure");
+            }
+            return realDelete(table);
+          };
+          return fn(tx);
+        }, opts)) as any;
+      return t;
+    };
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    // First publish: the log delete throws inside the tx → the whole publish
+    // (canonical replay included) must roll back. The rejection must carry OUR
+    // injected message, so a spy that never fired cannot pass this test green.
+    failLogDelete = true;
+    await expect(controller.publishDraft(draftId)).rejects.toThrow(
+      "injected log-delete failure",
+    );
+
+    // The canonical replay rolled back with the failed log delete — the insight
+    // is NOT on canonical. (Before the fix it would be committed here.)
+    expect(
+      (await canonicalInsights()).find((r) => r.id === insightId),
+    ).toBeUndefined();
+    // The draft survived intact for a retry: its command log is still present.
+    const logRowsAfterFailure = (
+      await db.select().from(draftCommandLog)
+    ).filter((r) => r.draftId === draftId);
+    expect(logRowsAfterFailure).toHaveLength(1);
+
+    // Retry the publish with the fault cleared. This is the DISCRIMINATING proof:
+    // if the first attempt had committed canonical (the #157 bug), this retry
+    // would replay onto an already-populated canonical and throw a duplicate-PK.
+    // It succeeds because the first attempt rolled back fully.
+    failLogDelete = false;
+    await controller.publishDraft(draftId);
+
+    // Canonical holds the insight EXACTLY ONCE (no double-replay), and the draft
+    // is fully torn down (log + shadow swept).
+    const canonical = (await canonicalInsights()).filter(
+      (r) => r.id === insightId,
+    );
+    expect(canonical).toHaveLength(1);
+    expect(canonical[0]?.name).toBe("Crash-window");
+    expect(await draftInsightRows(draftId)).toHaveLength(0);
+    const logRowsAfterRetry = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRowsAfterRetry).toHaveLength(0);
+  });
 });

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -86,6 +86,16 @@ const DRAFT_SHADOW_TABLES = [
   dashboardsDraft,
 ] as const;
 
+/**
+ * The DB-handle surface the teardown helpers (`deleteLog`/`sweepShadows`) need:
+ * just `.delete()`. Narrowing to this (rather than the full `ArtifactDb`) keeps
+ * the publish path's `tx.raw` cast honest — a transaction-bound raw handle does
+ * NOT expose `.transaction()`, so widening to `ArtifactDb` would advertise a
+ * method that fails at runtime. With this type, any future helper that reaches for
+ * `.transaction()` is a compile error, not a latent footgun.
+ */
+type DeleteExecutor = Pick<ArtifactDb, "delete">;
+
 /** A persisted log row mapped back to the `DraftCommand` shape replay consumes. */
 function rowToDraftCommand(row: {
   path: string;
@@ -246,7 +256,7 @@ export function createDraftController(
    */
   async function deleteLog(
     draftId: string,
-    exec: ArtifactDb = db,
+    exec: DeleteExecutor = db,
   ): Promise<void> {
     await exec
       .delete(draftCommandLog)
@@ -269,7 +279,7 @@ export function createDraftController(
    */
   async function sweepShadows(
     draftId: string,
-    exec: ArtifactDb = db,
+    exec: DeleteExecutor = db,
   ): Promise<void> {
     for (const shadow of DRAFT_SHADOW_TABLES) {
       // `draftId` is a BOUND parameter (guard the sink); the table identifiers
@@ -388,7 +398,7 @@ export function createDraftController(
         // return (before these DELETEs) and the DELETEs run through `tx.raw`
         // (untracked), so the log/shadow tables never flush to invalidation —
         // matching the wystack consumer's posture.
-        const exec = tx.raw as ArtifactDb;
+        const exec = tx.raw as DeleteExecutor;
         await deleteLog(draftId, exec);
         await sweepShadows(draftId, exec);
         return committed;

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -67,7 +67,7 @@ import {
   type DraftCommand,
   type WyStackApp,
 } from "@wystack/server";
-import { eq, getTableName } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 /**
  * The closed set of `<table>__draft` shadows a draft can touch. Discard
@@ -141,10 +141,13 @@ export interface DraftController {
     context?: Record<string, unknown>,
   ): Promise<CommandResult[]>;
   /**
-   * Publish = replay the durable command log atomically onto canonical via
-   * `applyCommands(app, log, {commit})`, then sweep the (now-inert) shadow + log.
-   * Reads ONLY `draft_command_log` — never the shadow — so it works identically
-   * whether or not the opening process is still alive. Returns the CommitResult
+   * Publish = replay the durable command log onto canonical via
+   * `applyCommands(app, log, {commit, tx})`, with the log delete + shadow sweep
+   * running in the SAME outer transaction. Replay, log delete, and sweep share
+   * ONE commit boundary — a crash between them is impossible (both land together
+   * or both roll back), closing the double-replay crash window (GH #157). Reads
+   * ONLY `draft_command_log` — never the shadow — so it works identically whether
+   * or not the opening process is still alive. Returns the CommitResult
    * (`tablesWritten` is what the host flushes to invalidation).
    */
   publishDraft(
@@ -233,38 +236,45 @@ export function createDraftController(
    * `publishDraft` reads only `draft_command_log`, so once the log is gone a
    * retried publish reads an empty log and is a no-op rather than a second replay
    * onto canonical. A failure here MUST surface (the log still drives publish).
+   *
+   * `exec` is the Drizzle handle the DELETE runs against. The publish path passes
+   * the OUTER transaction's handle (`tx.raw`) so the log delete commits ATOMICALLY
+   * with the canonical replay — this is the load-bearing step that closes the
+   * crash window (a process death between replay-commit and log-delete is no
+   * longer possible; both land in one commit or both roll back). Other callers
+   * (discard) pass the autocommit `db` handle. Defaults to `db`.
    */
-  async function deleteLog(draftId: string): Promise<void> {
-    await db
+  async function deleteLog(
+    draftId: string,
+    exec: ArtifactDb = db,
+  ): Promise<void> {
+    await exec
       .delete(draftCommandLog)
       .where(eq(draftCommandLog.draftId, draftId));
   }
 
   /**
-   * Sweep a draft's `<table>__draft` shadow rows across the closed set. These
-   * rows are INERT once the log is gone (publish never reads the shadow; a read
-   * overlay for a draft with no log coalesces nothing), so a partial sweep leaves
-   * only orphaned, ignored rows. `throwOnError` lets the caller choose: discard
-   * wants a hard failure (the draft must be fully gone); post-publish cleanup
-   * wants best-effort (the canonical commit already succeeded — a sweep error
-   * must NOT turn a committed publish into a reported failure).
+   * Sweep a draft's `<table>__draft` shadow rows across the closed set. `exec` is
+   * the Drizzle handle the DELETEs run against — the publish path passes the outer
+   * transaction's `tx.raw` so the sweep commits ATOMICALLY with the canonical
+   * replay + log delete (defaults to the autocommit `db` for discard).
+   *
+   * A sweep failure HARD-FAILS (propagates). Both callers want this:
+   *   - discard — the whole draft must be fully gone; a partial sweep must surface.
+   *   - publish — the sweep runs inside the outer tx, so a failure must roll back
+   *     the whole publish (canonical replay + log delete included) and leave the
+   *     draft intact for a clean retry, never canonical-committed with a half-swept
+   *     shadow. (Earlier this path swept best-effort AFTER the commit; in-tx, there
+   *     is no committed state to preserve, so propagating is strictly correct.)
    */
   async function sweepShadows(
     draftId: string,
-    { throwOnError }: { throwOnError: boolean },
+    exec: ArtifactDb = db,
   ): Promise<void> {
     for (const shadow of DRAFT_SHADOW_TABLES) {
       // `draftId` is a BOUND parameter (guard the sink); the table identifiers
       // are static schema objects, not caller input.
-      try {
-        await db.delete(shadow).where(eq(shadow.draftId, draftId));
-      } catch (err) {
-        if (throwOnError) throw err;
-        console.error(
-          `[dashframe] draft ${draftId}: shadow sweep of ${getTableName(shadow)} failed (inert rows orphaned, log already cleared):`,
-          err,
-        );
-      }
+      await exec.delete(shadow).where(eq(shadow.draftId, draftId));
     }
   }
 
@@ -275,7 +285,7 @@ export function createDraftController(
    */
   async function dropDraft(draftId: string): Promise<void> {
     await deleteLog(draftId);
-    await sweepShadows(draftId, { throwOnError: true });
+    await sweepShadows(draftId);
   }
 
   return {
@@ -339,39 +349,54 @@ export function createDraftController(
       // draft-scoped write). `publishContext` carries the rest (e.g. vault).
       const publishContext = { ...context };
       delete publishContext.draftId;
-      const result = (await applyCommands(app, log, {
-        mode: "commit",
-        context: publishContext,
-      })) as CommitResult;
-      // Teardown AFTER the canonical commit landed durably. Two phases, in order:
+
+      // ATOMIC PUBLISH (closes GH #157): open ONE outer transaction so the
+      // canonical command-log replay, the log delete, and the shadow sweep share
+      // a single commit boundary. Previously the replay ran in `applyCommands`'s
+      // own transaction and the `deleteLog`/`sweepShadows` ran AFTER it returned
+      // (separate autocommit statements) — a process death in that gap left
+      // canonical committed but the log intact, so a retried publish replayed onto
+      // canonical a second time (a duplicate-PK throw for create commands, no
+      // clean recovery). Wiring all three into one tx via the `applyCommands`
+      // outer-tx seam (its optional `tx` param) eliminates the window: if either
+      // teardown step fails, the replay rolls back with it and the draft survives
+      // intact for a clean retry. This mirrors wystack's own consumer
+      // (draft-lifecycle.ts `publish()`), the reference adoption of the same seam.
       //
-      //  1. deleteLog — the idempotency gate. This MUST run and surface failures:
-      //     publish reads only the log, so deleting it is what makes a retried
-      //     publish a no-op instead of a second canonical replay.
-      //  2. sweepShadows — BEST-EFFORT. The shadow rows are inert once the log is
-      //     gone (publish never reads them). A sweep error must NOT turn an
-      //     already-committed publish into a reported failure (the caller would
-      //     surface a false error or retry into an empty log); we log and return
-      //     the CommitResult. Orphaned inert shadow rows are harmless and are
-      //     re-swept by the next discard/publish of the same draftId.
-      //
+      // `TrackedDb.transaction` is generic over its callback's return type, so we
+      // capture the CommitResult directly. `tx.raw` is the native Drizzle handle
+      // bound to this transaction — passing it to `deleteLog`/`sweepShadows`
+      // routes their DELETEs through the same commit boundary as the replay.
+      const result = await app.createTracked().transaction(async (tx) => {
+        const committed = (await applyCommands(app, log, {
+          mode: "commit",
+          context: publishContext,
+          tx,
+        })) as CommitResult;
+        // Teardown INSIDE the same tx, AFTER the replay writes are staged:
+        //
+        //  1. deleteLog — the idempotency gate. Deleting the log inside the tx is
+        //     what makes the fix atomic: once committed, a retried publish reads
+        //     an empty log and is a no-op rather than a second canonical replay.
+        //  2. sweepShadows — the (now-inert) shadow rows, swept in the same tx.
+        //     The sweep hard-fails here (unlike the old post-commit best-effort
+        //     posture): a sweep failure must roll back the whole publish so the
+        //     draft survives for a clean retry — there is no half-committed state
+        //     to preserve, because nothing has committed yet.
+        //
+        // The `tablesWritten` snapshot is taken by `applyCommands` at its own
+        // return (before these DELETEs) and the DELETEs run through `tx.raw`
+        // (untracked), so the log/shadow tables never flush to invalidation —
+        // matching the wystack consumer's posture.
+        const exec = tx.raw as ArtifactDb;
+        await deleteLog(draftId, exec);
+        await sweepShadows(draftId, exec);
+        return committed;
+      });
       // The host flushes result.tablesWritten to invalidation (the controller
-      // does not, mirroring applyCommands' posture).
-      //
-      // KNOWN DURABILITY WINDOW (tracked: see GitHub issue referenced below): the
-      // canonical commit and `deleteLog` are two separate transactions —
-      // `applyCommands` owns its own tx and does not accept an outer one. A
-      // process crash in the gap (canonical committed, log not yet deleted) leaves
-      // the log intact, so a retried publish replays onto canonical a second time
-      // — a duplicate-PK throw for create commands, with no clean recovery
-      // (canonical already holds the row; discard only sweeps the shadow). Closing
-      // this needs either an `applyCommands` that accepts an outer transaction
-      // (wystack-side) or a durable publish-state marker on a draft record (no
-      // draft record exists in this slice). Out of scope for the mechanism slice;
-      // must be closed before the seam is wired live — tracked as DashFrame
-      // GitHub issue #157.
-      await deleteLog(draftId);
-      await sweepShadows(draftId, { throwOnError: false });
+      // does not, mirroring applyCommands' posture). No post-commit teardown
+      // remains — the outer tx already swept the log + shadow atomically with the
+      // replay, so a crash here cannot leave a double-replay window.
       return result;
     },
 


### PR DESCRIPTION
## What

Wires DashFrame's `publishDraft` to run the canonical command-log replay, the draft-log delete, and the shadow sweep inside **one outer transaction** via the wystack `applyCommands` outer-tx seam (its optional `tx` param). This closes the draft-publish crash window.

## Why

`publishDraft` previously ran `applyCommands` in its own transaction, then ran `deleteLog` + `sweepShadows` **after** it returned as separate autocommit statements. A process death in that gap left canonical committed but the durable command log intact, so a retried publish replayed onto canonical a **second time** — a duplicate-PK throw for create commands, with no clean recovery. The code literally documented this as a KNOWN DURABILITY WINDOW that could only be closed once `applyCommands` accepted an outer transaction. That seam now exists (merged wystack-side and pulled in via the gitlink bump), so this is the DashFrame consumer adopting it.

## How

- `publishDraft` opens `app.createTracked().transaction(async (tx) => ...)`, runs `applyCommands(..., { tx })`, then `deleteLog` + `sweepShadows` against `tx.raw` **inside** the same callback. Replay, log delete, and sweep share one commit boundary — both land together or both roll back. Post-commit, only the CommitResult is returned (host flushes `tablesWritten` to invalidation, as before).
- `deleteLog` / `sweepShadows` take an optional tx-bound `exec` handle (defaults to the autocommit `db`): publish threads `tx.raw`; discard keeps `db`.
- The shadow sweep now **hard-fails** on the publish path — in-tx, a sweep failure must roll back the whole publish so the draft survives intact for a clean retry. This collapses the now-dead best-effort (`throwOnError: false`) branch; both callers want hard-fail.
- The `tablesWritten` snapshot is taken by `applyCommands` at its own return (before the deletes), and the deletes run through `tx.raw` (untracked), so the log/shadow tables never flush to invalidation — matching the wystack reference consumer's posture.
- Stale `applyCommands does not accept an outer one` durability-window comment removed.

Mirrors wystack's own consumer `libs/wystack/packages/server/src/draft-lifecycle.ts` `publish()`, the reference adoption of the same seam.

## Invariant / test

A crash between the canonical commit and the log-sweep must leave **no double-replay** on restart. The new crash-safety test forces a failure at the in-tx log delete and asserts the canonical replay rolls back with it: canonical is empty after the failure, the command log survives, and a **retry publishes the row exactly once** with no duplicate-PK. The retry-succeeds assertion is the discriminating exactly-once proof — a happy-path test does not exercise the window. Verified RED against a broken (non-atomic) implementation.

## Gate

- `turbo typecheck` (graph-wide, 48/48), `turbo lint` (21/21) green.
- `apps/server` full suite: 303/303 pass (16/16 in `draft-controller.test.ts`).
- Multi-lens review (correctness, security, testing, simplify, docs, api-contract + principal): no Critical/High in-diff findings outstanding; the two raised (private-tracker ID in a public-repo comment; dead best-effort branch) are fixed in this PR.

Tracked internally as YW-323.

Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeGZooqvrSHBxaTvTWkjJn

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the double-replay crash window in `publishDraft` (GH #157) by wrapping the canonical command-log replay, the log delete, and the shadow sweep inside a single outer transaction via the `applyCommands` `tx` seam. Previously those were separate autocommit statements, so a process death between the canonical commit and the log delete could leave the draft log intact and cause a duplicate-PK error on retry.

- `publishDraft` now opens `app.createTracked().transaction(...)`, passes the outer `tx` to `applyCommands`, then runs `deleteLog` + `sweepShadows` via `tx.raw as DeleteExecutor` — all three commit or roll back together.
- `sweepShadows` drops its `throwOnError` option (both callers now want hard-fail, since the publish path can no longer reach a half-committed state) and gains an optional `exec: DeleteExecutor` param; `deleteLog` gains the same param.
- A new crash-safety test exercises the exact GH #157 scenario by fault-injecting at the in-tx log delete and asserting that the canonical replay rolls back with it, then verifying a clean retry publishes the row exactly once.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the atomicity fix is straightforward and the crash-safety test provides discriminating proof that the double-replay window is closed.

The change is well-scoped: three previously separate autocommit statements are folded into one outer transaction via an existing seam, with no new external dependencies. The DeleteExecutor narrowing correctly addresses the prior type-widening concern. The crash-safety test is genuinely discriminating — it would have been RED against the old non-atomic implementation. No custom-rule violations found. Both callers of sweepShadows and deleteLog are updated consistently.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-controller.ts | Wraps replay + log delete + shadow sweep in one outer transaction; introduces `DeleteExecutor` narrow type; drops dead `throwOnError` branch — clean and correct. |
| apps/server/src/draft-controller.test.ts | Adds discriminating crash-safety test (GH #157): fault-injected log-delete failure inside the publish tx, rollback assertion, and exactly-once retry proof; test isolation is sound (fresh stack per `beforeEach`). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host
    participant publishDraft
    participant OuterTx as Outer Transaction
    participant applyCommands
    participant DB as Canonical DB

    Host->>publishDraft: publishDraft(draftId)
    publishDraft->>OuterTx: createTracked().transaction(tx)
    OuterTx->>applyCommands: "applyCommands(app, log, {mode:commit, tx})"
    applyCommands->>DB: write canonical rows via tx
    applyCommands-->>OuterTx: CommitResult (tablesWritten snapshot)
    OuterTx->>DB: DELETE draft_command_log WHERE draftId (tx.raw)
    OuterTx->>DB: DELETE shadow tables WHERE draftId (tx.raw)
    OuterTx-->>publishDraft: COMMIT — all three steps land together
    publishDraft-->>Host: CommitResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host
    participant publishDraft
    participant OuterTx as Outer Transaction
    participant applyCommands
    participant DB as Canonical DB

    Host->>publishDraft: publishDraft(draftId)
    publishDraft->>OuterTx: createTracked().transaction(tx)
    OuterTx->>applyCommands: "applyCommands(app, log, {mode:commit, tx})"
    applyCommands->>DB: write canonical rows via tx
    applyCommands-->>OuterTx: CommitResult (tablesWritten snapshot)
    OuterTx->>DB: DELETE draft_command_log WHERE draftId (tx.raw)
    OuterTx->>DB: DELETE shadow tables WHERE draftId (tx.raw)
    OuterTx-->>publishDraft: COMMIT — all three steps land together
    publishDraft-->>Host: CommitResult
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(server): narrow teardown exec t..."](https://github.com/youhaowei/dashframe/commit/d3457e18f39b53fdcdbce2c359efda0fc8044035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40027286)</sub>

<!-- /greptile_comment -->