### PR TITLE
[YW-155] refactor: migrate DashFrame to DrizzleTracker + bump wystack pin

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -602,7 +602,7 @@ describe("buildDashframeApp — vault injection seam", () => {
     // This test confirms the injected vault is available to handlers on the
     // app.call path — a credential-bearing write that requires vault.store().
     // The runHandler wrapper uses the identical merge; direct runHandler coverage
-    // would require a caller-supplied TrackedDb (low-level escape hatch).
+    // would require a caller-supplied DrizzleTracker (low-level escape hatch).
     const { vault: injectedVault } = makeTestVault();
     const app = await buildDashframeApp({
       db: project.db,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -41,7 +41,7 @@ import {
 import { schema } from "@dashframe/server-core";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
-import type { DraftTrackedDb, TrackedDb } from "@wystack/db";
+import type { DraftDrizzleTracker, DrizzleTracker } from "@wystack/db";
 import {
   isSecretRef,
   type SecretRef,
@@ -266,15 +266,15 @@ const DRAFTABLE_TABLE_NAMES: ReadonlySet<string> = new Set([
  * in DashFrame (which owns the closed shadow set), not in the generic
  * @wystack/db `withDraft` primitive.
  *
- * Shape note: returned as `DraftTrackedDb` because that is the type the seam
+ * Shape note: returned as `DraftDrizzleTracker` because that is the type the seam
  * yields; both base and draft handles share the `from/into/transaction` surface
- * handlers use, and `runHandler` already casts to `TrackedDb` (the builder
+ * handlers use, and `runHandler` already casts to `DrizzleTracker` (the builder
  * return-type difference is never observed by a handler).
  */
 export function createFallThroughDraftDb(
-  base: TrackedDb,
+  base: DrizzleTracker,
   draftId: string,
-): DraftTrackedDb {
+): DraftDrizzleTracker {
   const draft = base.withDraft(draftId);
   const isDraftable = (table: Table): boolean =>
     DRAFTABLE_TABLE_NAMES.has(getTableName(table));
@@ -288,12 +288,12 @@ export function createFallThroughDraftDb(
     from(table) {
       return (
         isDraftable(table) ? draft.from(table) : base.from(table)
-      ) as ReturnType<DraftTrackedDb["from"]>;
+      ) as ReturnType<DraftDrizzleTracker["from"]>;
     },
     into(table) {
       return (
         isDraftable(table) ? draft.into(table) : base.into(table)
-      ) as ReturnType<DraftTrackedDb["into"]>;
+      ) as ReturnType<DraftDrizzleTracker["into"]>;
     },
     transaction: draft.transaction.bind(draft),
   };
@@ -332,13 +332,13 @@ export function createFallThroughDraftDb(
  *     authorize it against the caller (single-user desktop is exempt).
  */
 export function withDraftSeam(
-  tracked: TrackedDb | DraftTrackedDb,
+  tracked: DrizzleTracker | DraftDrizzleTracker,
   context: Record<string, unknown> | undefined,
-): TrackedDb | DraftTrackedDb {
+): DrizzleTracker | DraftDrizzleTracker {
   const draftId = draftIdFromContext(context);
   if (draftId === undefined) return tracked;
-  // A draft handle has no nested `withDraft`; only a base TrackedDb is scoped.
-  // `call` always passes a fresh base TrackedDb, so this is the live path. The
+  // A draft handle has no nested `withDraft`; only a base DrizzleTracker is scoped.
+  // `call` always passes a fresh base DrizzleTracker, so this is the live path. The
   // fall-through wrapper routes non-draftable tables to canonical.
   return "withDraft" in tracked
     ? createFallThroughDraftDb(tracked, draftId)
@@ -390,7 +390,7 @@ export function withDraftSeam(
  * route MUST fire `onWrite()` when `result.tablesWritten.size > 0` — the
  * controller does not fire it (mirroring `applyCommands`' posture). Adding
  * `onWrite` to this `runHandler` wrapper cannot safely cover that path because:
- * (a) preview also uses canonical `TrackedDb` handles that look identical at this
+ * (a) preview also uses canonical `DrizzleTracker` handles that look identical at this
  * level, and (b) `runHandler` is called per-command while `tablesWritten`
  * accumulates across the batch — the per-command check would fire multiple times
  * or miss the first-write-only case. The clean seam is the `publishDraft` return
@@ -411,7 +411,7 @@ export async function buildDashframeApp(opts: {
   const hasStaticContext = Object.keys(staticContext).length > 0;
 
   // The draft seam wraps `call` itself (not just runHandler): `rawApp.call`
-  // mints its own fresh TrackedDb internally, so a draftId-bearing `call` would
+  // mints its own fresh DrizzleTracker internally, so a draftId-bearing `call` would
   // otherwise hit canonical. We mirror rawApp.call's composition (fresh tracked
   // → runHandler → result shape) but pass the draft-scoped handle when a draftId
   // is present, leaving the no-draft path identical to rawApp.call.

--- a/apps/server/src/assistant-read-host.ts
+++ b/apps/server/src/assistant-read-host.ts
@@ -78,7 +78,7 @@ export function createAssistantReadHost(
   const { app, draftId, readSourceFile } = opts;
 
   // Every read carries the draftId in context so the withDraftSeam routes the
-  // read against the draft overlay. A fresh TrackedDb per call (read-only; the
+  // read against the draft overlay. A fresh DrizzleTracker per call (read-only; the
   // tracking sets are discarded — we never publish from a read).
   const context: Record<string, unknown> =
     draftId !== undefined ? { draftId } : {};

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -572,7 +572,7 @@ describe("DraftController (persisted draft overlay)", () => {
     // Regression: appendToDraft must NOT pre-build a raw `withDraft(draftId)`
     // handle (which `withDraftSeam` returns unchanged — no fall-through), or a
     // command handler reading a non-draftable table mid-append would throw on the
-    // missing `<table>__draft` relation. It must pass a BASE TrackedDb + draftId
+    // missing `<table>__draft` relation. It must pass a BASE DrizzleTracker + draftId
     // in context so `withDraftSeam` builds the per-table fall-through wrapper —
     // the identical seam the `call` path funnels through.
     //

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -306,7 +306,7 @@ export function createDraftController(
     },
 
     async appendToDraft(draftId, batch, context = {}) {
-      // Route writes through the draft overlay by passing a BASE TrackedDb plus a
+      // Route writes through the draft overlay by passing a BASE DrizzleTracker plus a
       // `draftId` in context, so `app.runHandler`'s `withDraftSeam` builds the
       // per-table FALL-THROUGH draft handle (draftable tables → `<table>__draft`,
       // non-draftable like project_meta → canonical). Building the raw
@@ -373,7 +373,7 @@ export function createDraftController(
       // intact for a clean retry. This mirrors wystack's own consumer
       // (draft-lifecycle.ts `publish()`), the reference adoption of the same seam.
       //
-      // `TrackedDb.transaction` is generic over its callback's return type, so we
+      // `DrizzleTracker.transaction` is generic over its callback's return type, so we
       // capture the CommitResult directly. `tx.raw` is the native Drizzle handle
       // bound to this transaction — passing it to `deleteLog`/`sweepShadows`
       // routes their DELETEs through the same commit boundary as the replay.

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -383,7 +383,7 @@ function rowToVisualization(row: VisualizationRow): Visualization {
 }
 
 async function loadDataTable(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   id: string,
 ): Promise<DataTable> {
   const row = (await ctx.db.from(dataTables).where(eq("id", id)).first()) as
@@ -394,7 +394,7 @@ async function loadDataTable(
 }
 
 async function loadInsight(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   id: string,
 ): Promise<Insight> {
   const row = (await ctx.db.from(insights).where(eq("id", id)).first()) as
@@ -1088,7 +1088,7 @@ const removeVisualization = mutation({
 const clearAllData = mutation({
   args: {},
   handler: async (ctx): Promise<{ ok: true }> => {
-    // One unconditional DELETE FROM per table (TrackedDb.delete() with no
+    // One unconditional DELETE FROM per table (DrizzleTracker.delete() with no
     // .where() clears the whole table). Idempotent and a single statement
     // each — no per-row round-trips, no partial-clear retry hazard. FK-child
     // tables first so cascade order is satisfied even without DB-level FKs.

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -218,7 +218,7 @@ export const storedInsightDefinitionSchema = z.object({
  * produces a clear validation error instead of throwing on property access.
  */
 async function requireInsightDefinition(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   insightId: string,
 ): Promise<{ row: InsightRow; definition: StoredInsightDefinition }> {
   const row = (await ctx.db
@@ -246,7 +246,7 @@ async function requireInsightDefinition(
  * CreateInsight and SetInsightSource route source writes through here.
  */
 async function requireSourceExists(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   source: InsightSource,
 ): Promise<void> {
   const table = source.sourceType === "insight" ? insights : dataTables;
@@ -271,7 +271,7 @@ async function requireSourceExists(
  * handle or propagate that error.
  */
 async function wouldCreateCycle(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   startId: string,
   targetId: string,
 ): Promise<boolean> {
@@ -514,7 +514,7 @@ const createDataTable = mutation({
  * enforces (`setDataSourceConfig`, `renameNode`, `patchDataTableCollection`).
  */
 async function requireDataTable(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   id: string,
 ): Promise<void> {
   const row = await ctx.db.from(dataTables).where(eq("id", id)).first();
@@ -915,7 +915,7 @@ type CollectionOp =
  * the command shape (`{ nodeId, ... }`) never needs to know the kind up front.
  */
 async function resolveNode(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   nodeId: string,
 ): Promise<ResolvedNode> {
   const table = (await ctx.db
@@ -965,7 +965,7 @@ function requireInsightMetricShape(value: unknown): InsightMetric {
  *     against the read path. Fail loudly instead.
  */
 async function patchInsightSelectedFields(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   nodeId: string,
   _row: InsightRow,
   op: CollectionOp,
@@ -1019,7 +1019,7 @@ async function patchInsightSelectedFields(
  * backend needs SELECT FOR UPDATE or jsonb-native append.
  */
 async function patchDataTableCollection(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   nodeId: string,
   kind: "fields" | "metrics",
   op: CollectionOp,
@@ -1238,7 +1238,7 @@ const createVisualization = mutation({
 });
 
 async function requireVisualization(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   id: string,
 ): Promise<void> {
   const row = await ctx.db.from(visualizations).where(eq("id", id)).first();
@@ -1325,7 +1325,7 @@ interface DashboardItemOverrides {
 
 /** Load a dashboard's layout array, throwing if the dashboard does not exist. */
 async function requireDashboardItems(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   dashboardId: string,
 ): Promise<DashboardItem[]> {
   const row = (await ctx.db
@@ -1821,7 +1821,7 @@ function definitionRefers(
 }
 
 async function findOrphanedInsights(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   sourceId: string,
 ): Promise<{ id: string }[]> {
   const allInsights = (await ctx.db.from(insights).all()) as InsightRow[];
@@ -1845,7 +1845,7 @@ async function findOrphanedInsights(
  * `deleteArrowData(storage.key)` (see `packages/app-data/src/data-frames.ts`).
  */
 async function deleteInsightDataFrames(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   insightId: string,
 ): Promise<void> {
   // Delete all DataFrame rows whose insightId matches — there should be at
@@ -1867,7 +1867,7 @@ async function deleteInsightDataFrames(
  * tables do not produce N round-trips.
  */
 async function deleteDataSourceDependents(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   ownedTables: (typeof dataTables.$inferSelect)[],
 ): Promise<OrphanedNode[]> {
   // Fetch all insights once — avoids O(N) full-table scans inside the loop.

--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -202,7 +202,7 @@ const removeDashboard = mutation({
 
 /** Load a dashboard's items for read-modify-write, or throw if missing. */
 async function loadItems(
-  ctx: { db: import("@wystack/db").TrackedDb },
+  ctx: { db: import("@wystack/db").DrizzleTracker },
   id: string,
 ): Promise<DashboardItem[]> {
   const row = (await ctx.db.from(dashboards).where(eq("id", id)).first()) as

--- a/packages/server-core/src/write-gate.ts
+++ b/packages/server-core/src/write-gate.ts
@@ -49,9 +49,9 @@
  * - `.update(dataFrames).set(...)`                 → set payload stripped
  * - `db.transaction(async (tx) => ...)`            → `tx` is itself gated, so
  *   transactional and nested-transaction (savepoint) writes are stripped too.
- *   This composes with WyStack's TrackedDb, which calls `db.transaction(...)`
+ *   This composes with WyStack's DrizzleTracker, which calls `db.transaction(...)`
  *   on the underlying Drizzle instance and hands the resulting `tx` to its own
- *   wrapper — TrackedDb receives a gated `tx`, not a raw one.
+ *   wrapper — DrizzleTracker receives a gated `tx`, not a raw one.
  * - A `sql\`…\`` expression supplied as the `analysis` value (e.g.
  *   `.set({ analysis: sql\`…\` })`) cannot be statically stripped, so the gate
  *   THROWS rather than letting it through silently.  See


### PR DESCRIPTION
## Summary

- Bumps the `libs/wystack` submodule pointer from `46da483` to `521ddbca` (wystack PR #52, which renamed `TrackedDb → DrizzleTracker` / `DraftTrackedDb → DraftDrizzleTracker` / `createTrackedDb → createDrizzleTracker`)
- Renames all 9 DashFrame source files that consumed the old type names so they use the new names
- The submodule bump and the consumer rename land in a **single atomic commit** — no intermediate state where DashFrame points at a wystack exporting different names than it imports

**Files changed:** `apps/server/src/app.ts`, `apps/server/src/app.test.ts`, `apps/server/src/draft-controller.ts`, `apps/server/src/draft-controller.test.ts`, `apps/server/src/assistant-read-host.ts`, `apps/server/src/functions/commands.ts`, `apps/server/src/functions/dashboards.ts`, `apps/server/src/functions/app-artifacts.ts`, `packages/server-core/src/write-gate.ts` (comments), plus `libs/wystack` submodule pointer.

**Tracked internally as YW-155**

## Verification

- `grep -rn "TrackedDb|DraftTrackedDb" packages apps` (excl. libs/wystack, dist) = **0 hits**
- `turbo typecheck` — **48/48 tasks successful**
- `turbo test` — **42/42 tasks successful, 303 tests passed**

## Screenshots

No UI change — this is a pure type rename + submodule pointer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `libs/wystack` submodule from `46da483` to `521ddbc` and mechanically renames every consumer of the old `TrackedDb`/`DraftTrackedDb` type names to `DrizzleTracker`/`DraftDrizzleTracker` across the DashFrame codebase.

- Submodule pointer is bumped atomically with the consumer renames, so no intermediate broken state exists.
- All 10 changed files are pure identifier substitutions in type positions and code comments — no logic or runtime behaviour is altered.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — every change is a mechanical identifier rename with no behavioural difference.

All 10 files contain only type-position substitutions (TrackedDb → DrizzleTracker, DraftTrackedDb → DraftDrizzleTracker) and corresponding comment updates. No logic, runtime paths, or data flow are altered. The submodule bump and consumer renames land atomically, the old names are confirmed absent from apps and packages, and typecheck + tests are reported green.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Core app module — updates import and all type usages from TrackedDb/DraftTrackedDb to DrizzleTracker/DraftDrizzleTracker; pure rename, no logic change. |
| apps/server/src/app.test.ts | Single comment line updated to reference DrizzleTracker; no test logic changed. |
| apps/server/src/draft-controller.ts | Two inline comments updated to use DrizzleTracker; no logic change. |
| apps/server/src/draft-controller.test.ts | Single regression-test comment updated to use DrizzleTracker; no test logic changed. |
| apps/server/src/assistant-read-host.ts | Single inline comment updated from TrackedDb to DrizzleTracker; no logic change. |
| apps/server/src/functions/commands.ts | Ten helper function ctx-type annotations updated from TrackedDb to DrizzleTracker; purely mechanical, no logic change. |
| apps/server/src/functions/dashboards.ts | One helper function ctx-type annotation updated to DrizzleTracker; no logic change. |
| apps/server/src/functions/app-artifacts.ts | Two function ctx-type annotations and one inline comment updated to DrizzleTracker; no logic change. |
| libs/wystack | Submodule pointer bumped from 46da483 to 521ddbc (wystack PR #52 — TrackedDb → DrizzleTracker rename). |
| packages/server-core/src/write-gate.ts | Two comment references updated from TrackedDb to DrizzleTracker; no logic change. |

</details>

<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class DrizzleTracker {
        +from(table) QueryBuilder
        +into(table) MutationBuilder
        +transaction(cb) T
        +withDraft(draftId) DraftDrizzleTracker
    }
    class DraftDrizzleTracker {
        +from(table) QueryBuilder
        +into(table) MutationBuilder
        +transaction(cb) T
    }
    DrizzleTracker --> DraftDrizzleTracker : withDraft()

    note for DrizzleTracker "Renamed from TrackedDb (wystack PR #52)"
    note for DraftDrizzleTracker "Renamed from DraftTrackedDb (wystack PR #52)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class DrizzleTracker {
        +from(table) QueryBuilder
        +into(table) MutationBuilder
        +transaction(cb) T
        +withDraft(draftId) DraftDrizzleTracker
    }
    class DraftDrizzleTracker {
        +from(table) QueryBuilder
        +into(table) MutationBuilder
        +transaction(cb) T
    }
    DrizzleTracker --> DraftDrizzleTracker : withDraft()

    note for DrizzleTracker "Renamed from TrackedDb (wystack PR #52)"
    note for DraftDrizzleTracker "Renamed from DraftTrackedDb (wystack PR #52)"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["\[YW-155\] refactor: migrate DashFrame to ..."](https://github.com/youhaowei/dashframe/commit/914c7527c0a30dc925b9d2b76d8fc438caaf420f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40258105)</sub>

<!-- /greptile_comment -->