### PR TITLE
[YW-307] fix(engine-server): flaky atomic-ingest pending-query race

### DIFF
--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -378,6 +378,10 @@ describe("DuckDB cleanup-path mechanism — appender-error does not poison fresh
     // Reproduce appender error → closeSync → fresh conn.run() — the sequence
     // that the catch block uses. The key assertion: resolves (no throw), not
     // that the TEMP table was actually removed (it wasn't — TEMP is conn-local).
+    //
+    // Engine-level usability after a failed registerArrowTable (the "primary conn
+    // taint" concern) is covered by the "atomic ingest" test above: engine.query()
+    // is called on the same NativeDuckDBEngine instance after rejects.toThrow().
     const instance = await DuckDBInstance.create(":memory:");
     const conn = await instance.connect();
 
@@ -388,17 +392,15 @@ describe("DuckDB cleanup-path mechanism — appender-error does not poison fresh
 
       // Force the appender into error state: flush an incomplete row
       // (1 value appended, 2 columns required → "incomplete append to row").
+      // Assert that flushSync() actually throws — the catch block only exercises
+      // the failure path when this precondition holds.
       const appender = await conn.createAppender("__staging_test_1");
       appender.appendInteger(42); // only 1 of 2 required columns
-      try {
-        appender.flushSync();
-      } catch {
-        /* expected: incomplete row */
-      }
+      expect(() => appender.flushSync()).toThrow(); // precondition: must throw
       try {
         appender.closeSync();
       } catch {
-        /* expected: appender in error state */
+        /* close may also throw in error state — ignored, propagate nothing */
       }
 
       // A fresh connection from the same instance must not throw — even though

--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -1,3 +1,4 @@
+import { DuckDBInstance } from "@duckdb/node-api";
 import {
   Bool,
   DateDay,
@@ -351,5 +352,69 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
       );
       expect(Number(staging.rows[0]?.cnt)).toBe(0);
     });
+  });
+});
+
+// ─── Cleanup-path mechanism: fresh connection after appender error ────────────
+//
+// On Linux, duckdb_appender_close() on a failed appender marks the connection
+// with a pending-result error. The next duckdb_query() on the same connection
+// then fails with "Attempting to execute an unsuccessful or closed pending
+// query result" — emitted as an unhandled NAPI-layer rejection that bypasses
+// the surrounding JS try/catch. The fix routes the catch-block cleanup through
+// a fresh DuckDBConnection (not tainted by the appender error), eliminating
+// the unhandled rejection.
+//
+// TEMP table scope caveat: staging tables are connection-local. A fresh
+// connection cannot see them, so the DROP in the catch block is effectively a
+// no-op (IF EXISTS guards it from throwing). The staging table drops on
+// `conn` disconnect (dispose()). The fix's value is crash-prevention, not
+// early cleanup.
+//
+// These tests pin the mechanism at the DuckDBInstance layer, independent of
+// the registerArrowTable contract tests above.
+describe("DuckDB cleanup-path mechanism — appender-error does not poison fresh connection", () => {
+  it("a fresh connection can issue DROP after appender close in error state without throwing", async () => {
+    // Reproduce appender error → closeSync → fresh conn.run() — the sequence
+    // that the catch block uses. The key assertion: resolves (no throw), not
+    // that the TEMP table was actually removed (it wasn't — TEMP is conn-local).
+    const instance = await DuckDBInstance.create(":memory:");
+    const conn = await instance.connect();
+
+    try {
+      await conn.run(
+        "CREATE TEMP TABLE __staging_test_1 (x INTEGER, y INTEGER)",
+      );
+
+      // Force the appender into error state: flush an incomplete row
+      // (1 value appended, 2 columns required → "incomplete append to row").
+      const appender = await conn.createAppender("__staging_test_1");
+      appender.appendInteger(42); // only 1 of 2 required columns
+      try {
+        appender.flushSync();
+      } catch {
+        /* expected: incomplete row */
+      }
+      try {
+        appender.closeSync();
+      } catch {
+        /* expected: appender in error state */
+      }
+
+      // A fresh connection from the same instance must not throw — even though
+      // the TEMP table is connection-local and the DROP is a no-op, the fresh
+      // connection is untainted and the call resolves cleanly.
+      const cleanupConn = await instance.connect();
+      try {
+        await expect(
+          cleanupConn.run("DROP TABLE IF EXISTS __staging_test_1"),
+        ).resolves.toBeDefined();
+      } finally {
+        cleanupConn.disconnectSync();
+      }
+    } finally {
+      conn.disconnectSync();
+      instance.closeSync();
+    }
   });
 });

--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -355,68 +355,146 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
   });
 });
 
-// ─── Cleanup-path mechanism: fresh connection after appender error ────────────
+// ─── Connection-reset mechanism: disconnect + reconnect after appender error ──
 //
 // On Linux, duckdb_appender_close() on a failed appender marks the connection
 // with a pending-result error. The next duckdb_query() on the same connection
 // then fails with "Attempting to execute an unsuccessful or closed pending
 // query result" — emitted as an unhandled NAPI-layer rejection that bypasses
-// the surrounding JS try/catch. The fix routes the catch-block cleanup through
-// a fresh DuckDBConnection (not tainted by the appender error), eliminating
-// the unhandled rejection.
+// the surrounding JS try/catch.
 //
-// TEMP table scope caveat: staging tables are connection-local. A fresh
-// connection cannot see them, so the DROP in the catch block is effectively a
-// no-op (IF EXISTS guards it from throwing). The staging table drops on
-// `conn` disconnect (dispose()). The fix's value is crash-prevention, not
-// early cleanup.
+// this.connection is the PERSISTENT connection reused for the whole session
+// (query, queryArrow, every registerArrowTable call). A simple "issue cleanup
+// on a fresh connection" approach leaves this.connection tainted, relocating
+// the flake to the NEXT operation. The fix disconnects this.connection and
+// reconnects from the same DuckDBInstance — preserving all non-TEMP tables
+// (instance-scoped) while discarding the tainted connection state. The partial
+// staging TEMP table (connection-local) is dropped automatically by DuckDB
+// when the old connection closes.
 //
 // These tests pin the mechanism at the DuckDBInstance layer, independent of
-// the registerArrowTable contract tests above.
-describe("DuckDB cleanup-path mechanism — appender-error does not poison fresh connection", () => {
-  it("a fresh connection can issue DROP after appender close in error state without throwing", async () => {
-    // Reproduce appender error → closeSync → fresh conn.run() — the sequence
-    // that the catch block uses. The key assertion: resolves (no throw), not
-    // that the TEMP table was actually removed (it wasn't — TEMP is conn-local).
-    //
-    // Engine-level usability after a failed registerArrowTable (the "primary conn
-    // taint" concern) is covered by the "atomic ingest" test above: engine.query()
-    // is called on the same NativeDuckDBEngine instance after rejects.toThrow().
+// the registerArrowTable contract tests above. The Linux-specific taint cannot
+// be reproduced on macOS (conn.run() succeeds after appender error there), so
+// these tests act as a smoke screen locally; Linux CI is the discriminating run.
+describe("DuckDB connection-reset mechanism — appender-error recovery", () => {
+  it("a fresh connection from the same instance works after a tainted appender closeSync", async () => {
+    // Reproduce: force appender into error state → closeSync → disconnect the
+    // tainted conn → reconnect from same instance → new conn is clean.
+    // The TEMP staging table (connection-local) must be gone after disconnect.
     const instance = await DuckDBInstance.create(":memory:");
     const conn = await instance.connect();
 
+    let freshConn;
     try {
       await conn.run(
-        "CREATE TEMP TABLE __staging_test_1 (x INTEGER, y INTEGER)",
+        "CREATE TEMP TABLE __staging_reset_test (x INTEGER, y INTEGER)",
       );
 
       // Force the appender into error state: flush an incomplete row
       // (1 value appended, 2 columns required → "incomplete append to row").
-      // Assert that flushSync() actually throws — the catch block only exercises
-      // the failure path when this precondition holds.
-      const appender = await conn.createAppender("__staging_test_1");
+      // Precondition: flushSync must throw — this is what triggers the taint.
+      const appender = await conn.createAppender("__staging_reset_test");
       appender.appendInteger(42); // only 1 of 2 required columns
       expect(() => appender.flushSync()).toThrow(); // precondition: must throw
       try {
         appender.closeSync();
       } catch {
-        /* close may also throw in error state — ignored, propagate nothing */
+        /* close may also throw in error state — ignored */
       }
 
-      // A fresh connection from the same instance must not throw — even though
-      // the TEMP table is connection-local and the DROP is a no-op, the fresh
-      // connection is untainted and the call resolves cleanly.
-      const cleanupConn = await instance.connect();
-      try {
-        await expect(
-          cleanupConn.run("DROP TABLE IF EXISTS __staging_test_1"),
-        ).resolves.toBeDefined();
-      } finally {
-        cleanupConn.disconnectSync();
-      }
-    } finally {
+      // Disconnect the tainted connection (mirrors the fix in registerArrowTable).
       conn.disconnectSync();
+
+      // A fresh connection from the same instance must be clean and functional.
+      freshConn = await instance.connect();
+
+      // The staging TEMP table was connection-local to `conn` — it is gone now.
+      // Query duckdb_tables() to confirm: zero rows matching the staging name.
+      const reader = await freshConn.runAndReadAll(
+        "SELECT count(*) AS cnt FROM duckdb_tables() WHERE table_name = '__staging_reset_test'",
+      );
+      const rows = reader.getRowObjectsJson() as Array<{ cnt: unknown }>;
+      expect(Number(rows[0]?.cnt)).toBe(0);
+
+      // The fresh connection can execute arbitrary queries without error.
+      const reader2 = await freshConn.runAndReadAll("SELECT 1 AS alive");
+      const rows2 = reader2.getRowObjectsJson() as Array<{ alive: unknown }>;
+      expect(Number(rows2[0]?.alive)).toBe(1);
+    } finally {
+      freshConn?.disconnectSync();
       instance.closeSync();
     }
+  });
+});
+
+// ─── Engine reuse regression: query succeeds after registerArrowTable fails ───
+//
+// The taint is Linux-only; macOS conn.run() succeeds even after appender error.
+// This test verifies the ENGINE-LEVEL contract: registerArrowTable failure must
+// not leave the engine in a state where subsequent operations throw. On macOS
+// this passes regardless of fix (no taint), so the local run is a smoke test;
+// Linux CI is the discriminating run. The test documents the CONTRACT even if
+// it cannot reproduce the exact failure mode here.
+describe("NativeDuckDBEngine — reuse after registerArrowTable failure", () => {
+  let engine: NativeDuckDBEngine | null = null;
+
+  afterEach(async () => {
+    await engine?.dispose();
+    engine = null;
+  });
+
+  it("engine remains usable for query() and registerArrowTable() after a failed ingest", async () => {
+    // Scenario: registerArrowTable fails INSIDE the append loop (valid Arrow
+    // buffer, but the value causes appendTimestamp to throw before flushSync).
+    // A very-large TimestampMillisecond value overflows DuckDB's range and
+    // throws synchronously in appendArrowValue — inside the try block, after
+    // the appender is created and the connection is potentially tainted.
+    engine = new NativeDuckDBEngine();
+    await engine.initialize();
+
+    // Register a good table first so we can verify it survives the failure.
+    const goodInitBuf = tableToIPC(
+      new Table({ n: vectorFromArray([1.0, 2.0, 3.0], new Float64()) }),
+    );
+    await engine.registerArrowTable("df_before", goodInitBuf);
+    const before = await engine.query(
+      'SELECT COUNT(*) AS cnt FROM "df_before"',
+    );
+    expect(Number(before.rows[0]?.cnt)).toBe(3); // precondition
+
+    // Now trigger a failure inside the append loop.
+    const overflowBuf = tableToIPC(
+      new Table({
+        ts: vectorFromArray(
+          // 2.5e18 ms is ~year 79270000 — far outside DuckDB TIMESTAMP range.
+          // The value is valid in Arrow (TimestampMillisecond accepts any bigint),
+          // but appendTimestamp throws before flushSync is reached.
+          [2.5e18, 1000],
+          new TimestampMillisecond(),
+        ),
+      }),
+    );
+    await expect(
+      engine.registerArrowTable("df_overflow", overflowBuf),
+    ).rejects.toThrow(); // precondition: must fail inside the try block
+
+    // The engine must still be operational after the failure.
+    // query() must not throw the "pending-result" NAPI error.
+    const after = await engine.query('SELECT COUNT(*) AS cnt FROM "df_before"');
+    expect(Number(after.rows[0]?.cnt)).toBe(3); // pre-existing table intact
+
+    // registerArrowTable with valid data must succeed on the SAME engine instance.
+    const ts = Date.UTC(2026, 0, 15, 12, 30, 0);
+    const goodBuf = tableToIPC(
+      new Table({ ts: vectorFromArray([ts], new TimestampMillisecond()) }),
+    );
+    await expect(
+      engine.registerArrowTable("df_after_failure", goodBuf),
+    ).resolves.toBeUndefined();
+
+    const afterReg = await engine.query(
+      'SELECT COUNT(*) AS cnt FROM "df_after_failure"',
+    );
+    expect(Number(afterReg.rows[0]?.cnt)).toBe(1);
   });
 });

--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -9,6 +9,7 @@ import {
   tableFromIPC,
   tableToIPC,
   TimestampMillisecond,
+  Uint64,
   Utf8,
   vectorFromArray,
 } from "apache-arrow";
@@ -445,10 +446,24 @@ describe("NativeDuckDBEngine — reuse after registerArrowTable failure", () => 
 
   it("engine remains usable for query() and registerArrowTable() after a failed ingest", async () => {
     // Scenario: registerArrowTable fails INSIDE the append loop (valid Arrow
-    // buffer, but the value causes appendTimestamp to throw before flushSync).
-    // A very-large TimestampMillisecond value overflows DuckDB's range and
-    // throws synchronously in appendArrowValue — inside the try block, after
-    // the appender is created and the connection is potentially tainted.
+    // buffer decodes without error, but appending a Uint64 value that exceeds
+    // DuckDB's signed BIGINT range throws "bigint out of int64 range" synchronously
+    // inside appendArrowValue — after the appender is created and the connection
+    // is potentially tainted on Linux).
+    //
+    // Arrow `Uint64` maps to typeId `ArrowType.Int` (isSigned=false, bitWidth=64).
+    // `arrowFieldToDuckDBType` maps it to `BIGINT` (signed int64), and
+    // `appendArrowValue` calls `appendBigInt(value)` since `.get()` returns a
+    // BigInt. A value of 2^63 (= 9223372036854775808n) exceeds int64 max and
+    // throws at the native DuckDB layer — inside the try block, after the
+    // appender is open.
+    //
+    // On macOS this path does NOT taint the connection (macOS-specific DuckDB
+    // behavior), so the test passes regardless of the fix there. On Linux the
+    // connection IS tainted by the failed appendBigInt; without the fix the
+    // subsequent query() would hit the "pending-result" unhandled rejection.
+    // Linux CI is the discriminating run; this test documents the contract and
+    // verifies the catch-block failure path is actually reached.
     engine = new NativeDuckDBEngine();
     await engine.initialize();
 
@@ -462,31 +477,28 @@ describe("NativeDuckDBEngine — reuse after registerArrowTable failure", () => 
     );
     expect(Number(before.rows[0]?.cnt)).toBe(3); // precondition
 
-    // Now trigger a failure inside the append loop.
+    // Trigger a failure INSIDE the append loop (inside the try block, after the
+    // appender is created). 2^63 is a valid Uint64 value in Arrow but exceeds
+    // DuckDB BIGINT max (2^63 - 1), so appendBigInt throws.
+    const OVER_INT64 = 9223372036854775808n; // 2^63 = INT64_MAX + 1
     const overflowBuf = tableToIPC(
       new Table({
-        ts: vectorFromArray(
-          // 2.5e18 ms is ~year 79270000 — far outside DuckDB TIMESTAMP range.
-          // The value is valid in Arrow (TimestampMillisecond accepts any bigint),
-          // but appendTimestamp throws before flushSync is reached.
-          [2.5e18, 1000],
-          new TimestampMillisecond(),
-        ),
+        n: vectorFromArray([1n, OVER_INT64, 3n], new Uint64()),
       }),
     );
     await expect(
       engine.registerArrowTable("df_overflow", overflowBuf),
-    ).rejects.toThrow(); // precondition: must fail inside the try block
+    ).rejects.toThrow("bigint out of int64 range"); // precondition: catch block exercised
 
     // The engine must still be operational after the failure.
-    // query() must not throw the "pending-result" NAPI error.
+    // On Linux without the fix this would throw "executing an unsuccessful or
+    // closed pending query result" as an unhandled NAPI rejection.
     const after = await engine.query('SELECT COUNT(*) AS cnt FROM "df_before"');
     expect(Number(after.rows[0]?.cnt)).toBe(3); // pre-existing table intact
 
     // registerArrowTable with valid data must succeed on the SAME engine instance.
-    const ts = Date.UTC(2026, 0, 15, 12, 30, 0);
     const goodBuf = tableToIPC(
-      new Table({ ts: vectorFromArray([ts], new TimestampMillisecond()) }),
+      new Table({ n: vectorFromArray([1.0], new Float64()) }),
     );
     await expect(
       engine.registerArrowTable("df_after_failure", goodBuf),

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -200,9 +200,11 @@ export class NativeDuckDBEngine implements QueryEngine {
 
     // Create a session-scoped TEMP table for staging — if the append fails
     // partway through, the live table is untouched (atomic all-or-nothing).
-    // The TEMP table is session-scoped: DuckDB drops it automatically when the
-    // connection closes, and the explicit DROP after the swap ensures we don't
-    // accumulate stale staging tables across repeated registerArrowTable calls.
+    // The TEMP table is session-scoped (connection-local): DuckDB drops it
+    // automatically when `conn` closes. On the success path, the explicit DROP
+    // after the swap keeps stale staging tables from accumulating across
+    // repeated registerArrowTable calls. On the failure path, the staging table
+    // is left until dispose() — see the catch-block comment below.
     //
     // The staging name carries a per-call unique suffix. Two concurrent
     // registrations of the SAME live table would otherwise share one
@@ -242,10 +244,31 @@ export class NativeDuckDBEngine implements QueryEngine {
       } catch {
         // ignore close error — propagate original
       }
+      // Issue the cleanup on a FRESH connection, never on `conn`.
+      //
+      // On Linux, duckdb_appender_close() on a failed appender marks `conn`
+      // with a pending-result error. The next duckdb_query() on the same
+      // connection then fails with "Attempting to execute an unsuccessful or
+      // closed pending query result" — emitted as an unhandled NAPI-layer
+      // rejection that bypasses the surrounding try/catch. A fresh connection
+      // from the same instance is not affected by the appender's error state.
+      //
+      // Note: staging tables are TEMP and connection-local — a fresh connection
+      // cannot see them, so the DROP is a no-op (passes only via IF EXISTS).
+      // The table drops automatically when `conn` is eventually disconnected
+      // (dispose()). Early cleanup is therefore not achieved here; the goal is
+      // solely to avoid the unhandled NAPI rejection.
       try {
-        await conn.run(`DROP TABLE IF EXISTS ${quoteIdent(stagingName)}`);
+        const cleanupConn = await this.instance!.connect();
+        try {
+          await cleanupConn.run(
+            `DROP TABLE IF EXISTS ${quoteIdent(stagingName)}`,
+          );
+        } finally {
+          cleanupConn.disconnectSync();
+        }
       } catch {
-        // best-effort cleanup
+        // best-effort — swallow any connect-or-disconnect failure
       }
       throw err;
     }

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -200,11 +200,11 @@ export class NativeDuckDBEngine implements QueryEngine {
 
     // Create a session-scoped TEMP table for staging — if the append fails
     // partway through, the live table is untouched (atomic all-or-nothing).
-    // The TEMP table is session-scoped (connection-local): DuckDB drops it
-    // automatically when `conn` closes. On the success path, the explicit DROP
-    // after the swap keeps stale staging tables from accumulating across
-    // repeated registerArrowTable calls. On the failure path, the staging table
-    // is left until dispose() — see the catch-block comment below.
+    // TEMP tables are connection-local: DuckDB drops them automatically when
+    // the owning connection closes. On the success path, the explicit DROP after
+    // the swap keeps stale staging tables from accumulating across repeated
+    // registerArrowTable calls. On the failure path, the catch block disconnects
+    // and replaces this.connection, so the staging table is dropped then too.
     //
     // The staging name carries a per-call unique suffix. Two concurrent
     // registrations of the SAME live table would otherwise share one
@@ -237,38 +237,36 @@ export class NativeDuckDBEngine implements QueryEngine {
       }
       appender.flushSync();
     } catch (err) {
-      // Append failed — staging table may be partially written; clean it up
-      // before surfacing the error so the live table is never replaced.
+      // Append failed — staging table may be partially written.
       try {
         appender.closeSync();
       } catch {
         // ignore close error — propagate original
       }
-      // Issue the cleanup on a FRESH connection, never on `conn`.
-      //
-      // On Linux, duckdb_appender_close() on a failed appender marks `conn`
-      // with a pending-result error. The next duckdb_query() on the same
-      // connection then fails with "Attempting to execute an unsuccessful or
+      // On Linux, duckdb_appender_close() on a failed appender marks the
+      // connection with a pending-result error. The next duckdb_query() on the
+      // same connection fails with "Attempting to execute an unsuccessful or
       // closed pending query result" — emitted as an unhandled NAPI-layer
-      // rejection that bypasses the surrounding try/catch. A fresh connection
-      // from the same instance is not affected by the appender's error state.
+      // rejection that bypasses the surrounding try/catch.
       //
-      // Note: staging tables are TEMP and connection-local — a fresh connection
-      // cannot see them, so the DROP is a no-op (passes only via IF EXISTS).
-      // The table drops automatically when `conn` is eventually disconnected
-      // (dispose()). Early cleanup is therefore not achieved here; the goal is
-      // solely to avoid the unhandled NAPI rejection.
+      // `conn` is `this.connection` — the PERSISTENT connection reused for the
+      // whole session (query, queryArrow, registerArrowTable). Leaving it tainted
+      // relocates the flake to the NEXT operation instead of killing it.
+      //
+      // Fix: disconnect the tainted connection and replace it with a fresh one
+      // from the same instance. When the old connection closes, DuckDB drops all
+      // its TEMP tables — including the partial staging table — so the cleanup
+      // also happens for free.
       try {
-        const cleanupConn = await this.instance!.connect();
-        try {
-          await cleanupConn.run(
-            `DROP TABLE IF EXISTS ${quoteIdent(stagingName)}`,
-          );
-        } finally {
-          cleanupConn.disconnectSync();
-        }
+        this.connection!.disconnectSync();
       } catch {
-        // best-effort — swallow any connect-or-disconnect failure
+        // best-effort — continue to reconnect even if disconnect throws
+      }
+      this.connection = null;
+      try {
+        this.connection = await this.instance!.connect();
+      } catch {
+        // Reconnect failed — engine is unusable; surface on next call via conn()
       }
       throw err;
     }


### PR DESCRIPTION
## Summary

Fixes the intermittent `"Attempting to execute an unsuccessful or closed pending query result"` flake in `native-engine.test.ts` — the "atomic ingest" test that blocked unrelated PRs on every CI re-run.

## Root cause

In `registerArrowTable`'s catch block, after `appender.closeSync()` on a failed appender, the cleanup `DROP TABLE` was issued on the **same connection (`conn`)**. On Linux, `duckdb_appender_close()` on a failed appender marks the connection with a pending-result error. The next `duckdb_query()` on that connection then fails with the reported error — **emitted as an unhandled NAPI-layer rejection that bypasses the surrounding JS `try/catch`**, so the error surfaced and killed the test.

## Fix

Route the catch-block cleanup `DROP TABLE` through a **fresh `DuckDBConnection`** from the same `DuckDBInstance`. The fresh connection is not affected by the appender's error state.

**Important caveat (verified empirically):** DuckDB TEMP tables are connection-local — the fresh connection cannot see the staging table, so the DROP is a no-op (passes only via `IF EXISTS`). The staging table persists until `dispose()` clears the main connection. The fix's value is **crash prevention** (avoiding the unhandled NAPI rejection), not early cleanup. Comments updated throughout to reflect this accurately.

## 50× loop result

```
=== 50× RESULT: 50/50 passed, 0/50 failed ===
```

Run under `npx vitest run` (77 tests × 50 iterations), same runner as CI. Note: the Linux-specific NAPI taint cannot be reproduced on macOS/arm64; the 50× confirms no regression on the success path and cross-platform API correctness of the fresh-connection pattern.

## Changes

- **`native-engine.ts`**: Catch block now uses `this.instance!.connect()` for the cleanup, disconnects in `finally`, swallows connect/disconnect failures. Block comment updated to accurately describe success-vs-failure-path cleanup semantics and TEMP scope.
- **`native-engine.test.ts`**: New `describe` block at the `DuckDBInstance` layer proves a fresh connection can issue `DROP` after appender error without throwing. Separately from the existing "atomic ingest" contract test (which continues to verify the observable: prior table row count is intact after a failed registration).

## Screenshots

No UI change — `engine-server` internals only.

Tracked internally as YW-307.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes the intermittent \"pending-result\" crash in `registerArrowTable` by disconnecting the Linux-tainted connection in the catch block and replacing it with a fresh one from the same `DuckDBInstance`, rather than issuing a `DROP TABLE` on the already-broken connection.

- **`native-engine.ts`**: The catch block now calls `disconnectSync()` on `this.connection`, nulls it, and reconnects — letting DuckDB implicitly drop the partial staging TEMP table when the old connection closes. The success path is unchanged and still uses the original `conn` reference, which is safe because the reconnect only happens on the throw path.
- **`native-engine.test.ts`**: Two new `describe` blocks pin the fix: one at the raw `DuckDBInstance` layer (disconnect + fresh-connect survives appender error) and one at the engine contract level (subsequent `query()` and `registerArrowTable()` succeed after a failed ingest).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the disconnect-and-reconnect approach is mechanically correct and the 50x loop confirms no regressions.

The catch block always throws so the stale conn local is never reached on the error path; non-TEMP tables survive the connection swap because they are instance-scoped; _registeredTables remains accurate throughout.

The reconnect-failure branch in native-engine.ts (lines 260-270) could benefit from clearing initPromise to keep initialize() usable as a recovery path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/engine-server/src/native-engine.ts | Catch block now disconnects and replaces the tainted connection instead of issuing a DROP on the same tainted connection; a reconnect-failure edge case leaves initPromise stale and initialize() unable to recover. |
| packages/engine-server/src/native-engine.test.ts | Two new describe blocks added: a DuckDBInstance-layer mechanism test and an engine-level contract test for reuse after failure; both are well-structured with clear preconditions and accurate comments about platform-specific behavior. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant Engine as NativeDuckDBEngine
    participant Conn as this.connection
    participant Instance as DuckDBInstance

    Caller->>Engine: registerArrowTable(df, buf)
    Engine->>Conn: run(CREATE TEMP TABLE __staging_...)
    Engine->>Conn: createAppender(__staging_...)
    Engine->>Conn: appendArrowValue x N rows
    Note over Conn: append throws
    Engine->>Conn: appender.closeSync() swallow
    Engine->>Conn: disconnectSync() TEMP table auto-dropped
    Engine->>Engine: "this.connection = null"
    Engine->>Instance: connect() fresh connection
    Engine->>Engine: "this.connection = freshConn"
    Engine-->>Caller: rejects with original error
    Caller->>Engine: query(SELECT ...)
    Engine->>Instance: runAndReadAll via freshConn
    Instance-->>Caller: QueryResult success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant Engine as NativeDuckDBEngine
    participant Conn as this.connection
    participant Instance as DuckDBInstance

    Caller->>Engine: registerArrowTable(df, buf)
    Engine->>Conn: run(CREATE TEMP TABLE __staging_...)
    Engine->>Conn: createAppender(__staging_...)
    Engine->>Conn: appendArrowValue x N rows
    Note over Conn: append throws
    Engine->>Conn: appender.closeSync() swallow
    Engine->>Conn: disconnectSync() TEMP table auto-dropped
    Engine->>Engine: "this.connection = null"
    Engine->>Instance: connect() fresh connection
    Engine->>Engine: "this.connection = freshConn"
    Engine-->>Caller: rejects with original error
    Caller->>Engine: query(SELECT ...)
    Engine->>Instance: runAndReadAll via freshConn
    Instance-->>Caller: QueryResult success
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["test(engine-server): use Uint64 overflow..."](https://github.com/youhaowei/dashframe/commit/632c256c8a3193c84217a43a6bbdcdb751eb8076) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40261388)</sub>

<!-- /greptile_comment -->