### PR TITLE
[YW-325] fix: repeat-join _j1 collapse in suggest-charts and analysisByFieldId

### DIFF
--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
@@ -309,10 +309,16 @@ describe("DataSourcePageContent — loading state contract", () => {
 // entries. j1 must never overwrite j0.
 
 describe("buildAnalysisByFieldId — repeat-join identity", () => {
-  // Stable UUID used across fixtures
+  // Repeat-join fixtures:
+  //   COL_J0 → bare alias (first instance, NO _j0 suffix, per engine convention)
+  //   COL_J1 → _j1-suffixed alias (second instance)
   const UUID = "dd05ef4b-1234-5678-abcd-ef1234567890";
-  const COL_J0 = `field_${UUID.replace(/-/g, "_")}`;
-  const COL_J1 = `${COL_J0}_j1`;
+  const COL_J0 = `field_${UUID.replace(/-/g, "_")}`; // bare = first instance
+  const COL_J1 = `${COL_J0}_j1`; // _j1 suffix = second instance
+
+  // Single-join fixture: uses a DISTINCT UUID so it's unambiguous vs repeat-join.
+  const SINGLE_UUID = "ccbbaa99-1234-5678-abcd-ef1234567890";
+  const COL_SINGLE = `field_${SINGLE_UUID.replace(/-/g, "_")}`;
 
   // Inline parser matching the real extractColumnAliasComponents behaviour.
   const realParser = (alias: string) => {
@@ -354,13 +360,15 @@ describe("buildAnalysisByFieldId — repeat-join identity", () => {
   });
 
   it("single-join (no _j suffix) — not regressed, uses bare UUID key", () => {
-    const col = makeCol(COL_J0, 10);
+    // COL_SINGLE comes from a table joined exactly once (bare alias).
+    // Uses a distinct UUID so this test is unambiguous vs the repeat-join tests above.
+    const col = makeCol(COL_SINGLE, 10);
     const map = buildAnalysisByFieldId([col]);
 
-    expect(map.has(UUID)).toBe(true);
+    expect(map.has(SINGLE_UUID)).toBe(true);
     expect(map.size).toBe(1);
     // Must NOT create a _j0 key
-    expect(map.has(`${UUID}_j0`)).toBe(false);
+    expect(map.has(`${SINGLE_UUID}_j0`)).toBe(false);
   });
 
   it("prefers explicit fieldId over parsed columnName when fieldId is set", () => {

--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
@@ -1,16 +1,18 @@
 /**
- * Route-level loading-state contract for DataSourcePageContent.
+ * DataSourcePageContent tests.
  *
- * Contract: when useDataSources is loading, the component shows a loading
- * indicator and NEVER shows "Data source not found" for a source that exists
- * in the resolved data. Once data arrives the content renders.
+ * Section 1 — loading-state contract:
+ *   When useDataSources is loading, the component shows a loading indicator and
+ *   NEVER shows "Data source not found" for a source that exists in the resolved
+ *   data. Once data arrives the content renders.
+ *   (Regression for the hardcoded `const isLoading = false` bug.)
  *
- * This tests the fix for the hardcoded `const isLoading = false` bug: on
- * initial render allDataSources is empty until the store hydrates, so without
- * the real flag the component flashed "not found" before data arrived.
+ * Section 2 — buildAnalysisByFieldId repeat-join identity:
+ *   Columns from a repeat-join have _j0 / _j1 suffixes on their aliases. The
+ *   analysis map must store them under distinct keys so j1 cannot overwrite j0.
  */
 import { act, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock helpers ──────────────────────────────────────────────────────────────
 
@@ -46,7 +48,7 @@ vi.mock("@/lib/perf", () => ({
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 vi.mock("@dashframe/engine", () => ({
-  extractUUIDFromColumnAlias: () => null,
+  extractColumnAliasComponents: vi.fn(() => null),
 }));
 
 vi.mock("@dashframe/types", () => ({
@@ -181,8 +183,11 @@ vi.mock("@/components/data-sources/SensitivityBadge", () => ({
 
 // ── Component under test ──────────────────────────────────────────────────────
 
+import { extractColumnAliasComponents } from "@dashframe/engine";
 import React from "react";
-import DataSourcePageContent from "./DataSourcePageContent";
+import DataSourcePageContent, {
+  buildAnalysisByFieldId,
+} from "./DataSourcePageContent";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -296,3 +301,90 @@ describe("DataSourcePageContent — loading state contract", () => {
     screen.getByDisplayValue("My Database");
   });
 });
+
+// ── buildAnalysisByFieldId — repeat-join identity ────────────────────────────
+//
+// Contract: two analysis columns for the same base field but different join
+// instances (field_<uuid>_j0 and field_<uuid>_j1) must occupy DISTINCT map
+// entries. j1 must never overwrite j0.
+
+describe("buildAnalysisByFieldId — repeat-join identity", () => {
+  // Stable UUID used across fixtures
+  const UUID = "dd05ef4b-1234-5678-abcd-ef1234567890";
+  const COL_J0 = `field_${UUID.replace(/-/g, "_")}`;
+  const COL_J1 = `${COL_J0}_j1`;
+
+  // Inline parser matching the real extractColumnAliasComponents behaviour.
+  const realParser = (alias: string) => {
+    const m = alias.match(/^(?:field|metric)_(.+)$/);
+    if (!m) return null;
+    const raw = m[1] ?? "";
+    const inst = raw.match(/^(.+)_j(\d+)$/);
+    const uuidRaw = inst ? (inst[1] ?? "") : raw;
+    const instanceIndex = inst ? parseInt(inst[2] ?? "0", 10) : 0;
+    const parts = uuidRaw.split("_");
+    const uuid =
+      parts.length === 5 ? parts.join("-") : uuidRaw.replace(/_/g, "-");
+    return { uuid, instanceIndex };
+  };
+
+  beforeEach(() => {
+    vi.mocked(extractColumnAliasComponents).mockImplementation(realParser);
+  });
+
+  afterEach(() => {
+    vi.mocked(extractColumnAliasComponents).mockReturnValue(null);
+  });
+
+  it("maps j0 column to the bare UUID key", () => {
+    const col = makeCol(COL_J0, 5);
+    const map = buildAnalysisByFieldId([col]);
+    expect(map.has(UUID)).toBe(true);
+    expect(map.get(UUID)).toBe(col);
+  });
+
+  it("maps j1 column to <uuid>_j1 key — does NOT overwrite j0", () => {
+    const j0 = makeCol(COL_J0, 5);
+    const j1 = makeCol(COL_J1, 15);
+    const map = buildAnalysisByFieldId([j0, j1]);
+
+    expect(map.size).toBe(2);
+    expect(map.get(UUID)).toBe(j0);
+    expect(map.get(`${UUID}_j1`)).toBe(j1);
+  });
+
+  it("single-join (no _j suffix) — not regressed, uses bare UUID key", () => {
+    const col = makeCol(COL_J0, 10);
+    const map = buildAnalysisByFieldId([col]);
+
+    expect(map.has(UUID)).toBe(true);
+    expect(map.size).toBe(1);
+    // Must NOT create a _j0 key
+    expect(map.has(`${UUID}_j0`)).toBe(false);
+  });
+
+  it("prefers explicit fieldId over parsed columnName when fieldId is set", () => {
+    const explicitId = "explicit-field-id";
+    const col = { ...makeCol(COL_J0, 3), fieldId: explicitId };
+    const map = buildAnalysisByFieldId([col]);
+
+    expect(map.get(explicitId)).toBe(col);
+    expect(map.has(UUID)).toBe(false); // not re-parsed
+  });
+});
+
+// Minimal categorical ColumnAnalysis fixture.
+function makeCol(
+  columnName: string,
+  cardinality: number,
+): import("@dashframe/types").ColumnAnalysis {
+  return {
+    columnName,
+    dataType: "string",
+    semantic: "categorical",
+    cardinality,
+    uniqueness: 0.5,
+    nullCount: 0,
+    sampleValues: [],
+  };
+}

--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx
@@ -15,7 +15,7 @@ import {
   useDataTableMutations,
   useDataTables,
 } from "@dashframe/core";
-import { extractUUIDFromColumnAlias } from "@dashframe/engine";
+import { extractColumnAliasComponents } from "@dashframe/engine";
 import type { ColumnAnalysis, FieldSensitivity, UUID } from "@dashframe/types";
 import {
   buildSensitivityUpdate,
@@ -64,6 +64,48 @@ const SENSITIVITY_TOASTS: Record<FieldSensitivity, string> = {
   cleared: "Field marked as not sensitive",
   unclassified: "Field reset to unclassified",
 };
+
+/**
+ * Build a lookup map from field ID → column analysis.
+ *
+ * Keys use the same synthetic-ID convention as `buildInsightAvailableFields`:
+ * - Base / first-join instance (j0): canonical UUID  → `"<uuid>"`
+ * - Repeat-join j1, j2, …:          instance-qualified → `"<uuid>_j1"`, `"<uuid>_j2"`
+ *
+ * This prevents a repeat-join's j1 analysis from overwriting j0's in the map,
+ * and ensures that `analysisByFieldId.get(field.id)` returns the correct instance
+ * for every field shown in the UI.
+ *
+ * Exported for unit testing.
+ */
+export function buildAnalysisByFieldId(
+  columns: ColumnAnalysis[],
+): Map<string, ColumnAnalysis> {
+  const map = new Map<string, ColumnAnalysis>();
+  for (const column of columns) {
+    if (column.fieldId) {
+      // Fast-path: analysis already carries an explicit fieldId.
+      // IMPORTANT: if fieldId is ever populated via extractUUIDFromColumnAlias
+      // (which strips the _jN suffix), this path will silently re-introduce the
+      // j1-overwrites-j0 collapse. The only safe source for fieldId here is a
+      // value already instance-qualified (e.g. "<uuid>_j1") — matching the keys
+      // produced by buildInsightAvailableFields.
+      // As of today, analyze.ts does NOT persist fieldId onto ColumnAnalysis, so
+      // this branch is dead. Keep it as-is to not break any future caller that
+      // correctly provides instance-qualified fieldIds.
+      map.set(column.fieldId, column);
+      continue;
+    }
+    const components = extractColumnAliasComponents(column.columnName);
+    if (!components) continue;
+    const fieldId =
+      components.instanceIndex === 0
+        ? components.uuid
+        : `${components.uuid}_j${components.instanceIndex}`;
+    map.set(fieldId, column);
+  }
+  return map;
+}
 
 // Get icon for a data source type, driven by the connector registry.
 // Renders the connector's own icon; falls back to a generic database glyph.
@@ -196,15 +238,10 @@ export default function DataSourcePageContent({
 
   // Cached column analysis keyed by field ID, for data-driven sensitivity
   // signals (email-shaped values, free text) beyond name heuristics.
-  const analysisByFieldId = useMemo(() => {
-    const map = new Map<string, ColumnAnalysis>();
-    for (const column of dataFrameEntry?.analysis?.columns ?? []) {
-      const fieldId =
-        column.fieldId ?? extractUUIDFromColumnAlias(column.columnName);
-      if (fieldId) map.set(fieldId, column);
-    }
-    return map;
-  }, [dataFrameEntry]);
+  const analysisByFieldId = useMemo(
+    () => buildAnalysisByFieldId(dataFrameEntry?.analysis?.columns ?? []),
+    [dataFrameEntry],
+  );
 
   // One-click sensitivity marking. Confirming a classifier suggestion keeps
   // its reasons; deliberate marking/clearing is recorded as a user decision.

--- a/packages/app/src/lib/visualizations/suggest-charts.test.ts
+++ b/packages/app/src/lib/visualizations/suggest-charts.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Repeat-join identity tests for suggest-charts.
+ *
+ * When the same table is joined twice (repeat-join), the SQL layer produces
+ * column aliases with _j0 and _j1 instance suffixes (e.g.
+ * `field_dd05ef4b_..._j0` and `field_dd05ef4b_..._j1`). These two columns
+ * carry different data and must be treated as distinct by the suggestion engine.
+ *
+ * Invariant: _j1 never collapses to _j0 in suggestion IDs or suggestion output.
+ * Single-join (no suffix) must not regress.
+ *
+ * Design pin: `enrichColumnAnalysis` keeps `fieldId` as the canonical UUID
+ * (bare UUID, NOT instance-qualified) so that `fields[fieldId]` resolves for
+ * BOTH j0 and j1. The `fields` map (from InsightView.tsx's `fieldMap`) is keyed
+ * only by bare UUIDs — instance-qualifying `fieldId` would make j1's metadata
+ * lookup return `undefined` (no display name, no isBlocked check). Instance
+ * identity is tracked via `instanceIndex` / `instanceIdSuffix` instead.
+ */
+import type { ColumnAnalysis, UUID } from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import type { Insight } from "../stores/types";
+import { suggestByChartType, suggestCharts } from "./suggest-charts";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const STUB_INSIGHT: Insight = {
+  id: "insight-1" as UUID,
+  name: "Test",
+  baseTable: { tableId: "table-1" as UUID, selectedFields: [] },
+  metrics: [],
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+// Stable base UUID for all fixtures
+const BASE_UUID = "dd05ef4b-1234-5678-abcd-ef1234567890";
+// Column-alias format used by the engine (hyphens → underscores, prefixed)
+const COL_J0 = `field_${BASE_UUID.replace(/-/g, "_")}`;
+const COL_J1 = `${COL_J0}_j1`;
+
+// Numerical column that is distinct from the categorical ones above
+const NUM_UUID = "aabbccdd-1234-5678-abcd-ef1234567890";
+const COL_NUM = `field_${NUM_UUID.replace(/-/g, "_")}`;
+
+function makeCategorical(columnName: string, cardinality = 10): ColumnAnalysis {
+  return {
+    columnName,
+    dataType: "string",
+    semantic: "categorical",
+    cardinality,
+    uniqueness: 0.5,
+    nullCount: 0,
+    sampleValues: ["a", "b"],
+  };
+}
+
+function makeNumerical(columnName: string): ColumnAnalysis {
+  return {
+    columnName,
+    dataType: "number",
+    semantic: "numerical",
+    cardinality: 100,
+    uniqueness: 1,
+    nullCount: 0,
+    sampleValues: [1, 2, 3],
+    min: 1,
+    max: 1000,
+  };
+}
+
+// ── suggestByChartType — repeat-join fallback ─────────────────────────────────
+
+describe("suggestByChartType — repeat-join instance identity", () => {
+  it("returns j1 suggestion when j0 encoding is excluded (barY)", () => {
+    // Arrange: both j0 and j1 are valid categorical X-axis candidates
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM),
+    ];
+    // Simulate that a barY chart using j0 already exists
+    const j0Sig = `${COL_J0}|sum(${COL_NUM})|`;
+    const excludeEncodings = new Set([j0Sig]);
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      {},
+      "barY",
+      { excludeEncodings },
+    );
+
+    // After fix: j1 must be used when j0 is excluded
+    expect(suggestion).not.toBeNull();
+    expect(suggestion!.encoding.x).toBe(COL_J1);
+  });
+
+  it("returns a suggestion when neither instance is excluded (barY) — one of j0 or j1", () => {
+    // Note: shuffleWithSeed may reorder columns; the contract is that ONE valid
+    // suggestion is returned and its encoding preserves the actual column alias.
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM),
+    ];
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      {},
+      "barY",
+    );
+
+    expect(suggestion).not.toBeNull();
+    // The encoding must use the ACTUAL column alias (j0 or j1, not a bare UUID)
+    expect([COL_J0, COL_J1]).toContain(suggestion!.encoding.x);
+  });
+
+  it("returns null only when both j0 and j1 are excluded (barY)", () => {
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM),
+    ];
+    const j0Sig = `${COL_J0}|sum(${COL_NUM})|`;
+    const j1Sig = `${COL_J1}|sum(${COL_NUM})|`;
+    const excludeEncodings = new Set([j0Sig, j1Sig]);
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      {},
+      "barY",
+      { excludeEncodings },
+    );
+
+    expect(suggestion).toBeNull();
+  });
+
+  it("j0 and j1 produce distinct suggestion IDs (barY)", () => {
+    const onlyJ0: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeNumerical(COL_NUM),
+    ];
+    const onlyJ1: ColumnAnalysis[] = [
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM),
+    ];
+
+    const s0 = suggestByChartType(STUB_INSIGHT, onlyJ0, 1000, {}, "barY");
+    const s1 = suggestByChartType(STUB_INSIGHT, onlyJ1, 1000, {}, "barY");
+
+    expect(s0).not.toBeNull();
+    expect(s1).not.toBeNull();
+    expect(s0!.id).not.toBe(s1!.id);
+  });
+
+  it("single-join (no _j suffix) — suggestion ID does not include _j suffix", () => {
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J0), // no _j1 suffix → single-join instance
+      makeNumerical(COL_NUM),
+    ];
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      {},
+      "barY",
+    );
+
+    expect(suggestion).not.toBeNull();
+    expect(suggestion!.id).not.toMatch(/_j\d+/);
+  });
+});
+
+// ── canonical-UUID resolution — fieldId metadata lookup ───────────────────────
+//
+// This describe block pins the design decision that `fieldId` must remain the
+// canonical UUID (not instance-qualified) so that `fields[fieldId]` resolves
+// correctly for BOTH j0 and j1 of the same base field.
+// A refactor that instance-qualifies fieldId would break this test.
+
+describe("suggestByChartType — canonical-UUID fieldId resolves j1 metadata", () => {
+  it("j1 suggestion title uses the field's display name, not the raw alias", () => {
+    // The base field has a human-readable name stored by UUID key
+    const fields: Record<string, import("@dashframe/types").Field> = {
+      [BASE_UUID]: {
+        id: BASE_UUID as import("@dashframe/types").UUID,
+        name: "City",
+        columnName: COL_J0,
+        isIdentifier: false,
+        isReference: false,
+        dataType: "string",
+      },
+    };
+
+    // Only the j1 instance is in the analysis
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM),
+    ];
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      fields, // populated map keyed by canonical UUID
+      "barY",
+    );
+
+    expect(suggestion).not.toBeNull();
+    // Title must use "City" (from fields map via canonical UUID), NOT the raw alias
+    expect(suggestion!.title).toContain("City");
+    // Encoding must still use the actual j1 column alias (not bare UUID)
+    expect(suggestion!.encoding.x).toBe(COL_J1);
+  });
+});
+
+// ── suggestCharts — distinct IDs for j0/j1 ───────────────────────────────────
+
+describe("suggestCharts — repeat-join instance identity", () => {
+  it("j0 and j1 categorical columns produce suggestions with distinct IDs", () => {
+    const analysisWithJ0: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeNumerical(COL_NUM),
+    ];
+    const analysisWithJ1: ColumnAnalysis[] = [
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM),
+    ];
+
+    const suggestionsJ0 = suggestCharts(STUB_INSIGHT, analysisWithJ0, 1000, {});
+    const suggestionsJ1 = suggestCharts(STUB_INSIGHT, analysisWithJ1, 1000, {});
+
+    const idsJ0 = suggestionsJ0.map((s) => s.id);
+    const idsJ1 = suggestionsJ1.map((s) => s.id);
+
+    // IDs must be completely disjoint between j0-based and j1-based suggestions
+    const overlap = idsJ0.filter((id) => idsJ1.includes(id));
+    expect(overlap).toHaveLength(0);
+  });
+});

--- a/packages/app/src/lib/visualizations/suggest-charts.test.ts
+++ b/packages/app/src/lib/visualizations/suggest-charts.test.ts
@@ -32,15 +32,29 @@ const STUB_INSIGHT: Insight = {
   updatedAt: 0,
 };
 
-// Stable base UUID for all fixtures
+// ── Repeat-join fixtures (COL_J0 / COL_J1) ───────────────────────────────────
+// When the same table is joined twice the engine produces:
+//   first instance  → bare alias (NO _j0 suffix): field_<uuid>
+//   second instance → _j1-suffixed alias:         field_<uuid>_j1
+// COL_J0 uses the bare alias because that is what the engine emits for
+// instanceIndex === 0 (see insight-sql.ts joinInstanceFieldId).
 const BASE_UUID = "dd05ef4b-1234-5678-abcd-ef1234567890";
-// Column-alias format used by the engine (hyphens → underscores, prefixed)
-const COL_J0 = `field_${BASE_UUID.replace(/-/g, "_")}`;
-const COL_J1 = `${COL_J0}_j1`;
+const COL_J0 = `field_${BASE_UUID.replace(/-/g, "_")}`; // bare = first instance
+const COL_J1 = `${COL_J0}_j1`; // _j1 suffix = second instance
+
+// ── Single-join fixture (COL_SINGLE) ─────────────────────────────────────────
+// A column that comes from a table joined exactly once — also a bare alias,
+// but uses a DISTINCT UUID so single-join regression tests are unambiguous.
+const SINGLE_UUID = "ccbbaa99-1234-5678-abcd-ef1234567890";
+const COL_SINGLE = `field_${SINGLE_UUID.replace(/-/g, "_")}`;
 
 // Numerical column that is distinct from the categorical ones above
 const NUM_UUID = "aabbccdd-1234-5678-abcd-ef1234567890";
 const COL_NUM = `field_${NUM_UUID.replace(/-/g, "_")}`;
+
+// Second numerical column (different UUID) for testing numerical fallback
+const NUM2_UUID = "11223344-1234-5678-abcd-ef1234567890";
+const COL_NUM2 = `field_${NUM2_UUID.replace(/-/g, "_")}`;
 
 function makeCategorical(columnName: string, cardinality = 10): ColumnAnalysis {
   return {
@@ -159,8 +173,10 @@ describe("suggestByChartType — repeat-join instance identity", () => {
   });
 
   it("single-join (no _j suffix) — suggestion ID does not include _j suffix", () => {
+    // COL_SINGLE is a column from a table joined exactly once (bare alias,
+    // no _j suffix). Its suggestion ID must not gain an instance suffix.
     const analysis: ColumnAnalysis[] = [
-      makeCategorical(COL_J0), // no _j1 suffix → single-join instance
+      makeCategorical(COL_SINGLE),
       makeNumerical(COL_NUM),
     ];
 
@@ -174,6 +190,64 @@ describe("suggestByChartType — repeat-join instance identity", () => {
 
     expect(suggestion).not.toBeNull();
     expect(suggestion!.id).not.toMatch(/_j\d+/);
+  });
+});
+
+// ── numerical-candidate iteration ─────────────────────────────────────────────
+//
+// barY and barX iterate over BOTH numerical and categorical candidates, so a
+// suggestion is returned even when all xJ0/yNum0 and xJ1/yNum0 combos are
+// excluded but xJ0/yNum1 (alternate numerical column) is not.
+
+describe("suggestByChartType — numerical candidate fallback (barY)", () => {
+  it("returns a suggestion using the alternate numerical column when num0 combos are all excluded", () => {
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeCategorical(COL_J1),
+      makeNumerical(COL_NUM), // num0 — all combos excluded below
+      makeNumerical(COL_NUM2), // num1 — should be tried as fallback
+    ];
+    // Exclude every combination of categorical × num0
+    const excludeEncodings = new Set([
+      `${COL_J0}|sum(${COL_NUM})|`,
+      `${COL_J1}|sum(${COL_NUM})|`,
+    ]);
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      {},
+      "barY",
+      { excludeEncodings },
+    );
+
+    // Must return a suggestion using num1 (not null)
+    expect(suggestion).not.toBeNull();
+    expect(suggestion!.encoding.y).toBe(`sum(${COL_NUM2})`);
+  });
+
+  it("returns null only when all numerical × categorical combinations are excluded (barY)", () => {
+    const analysis: ColumnAnalysis[] = [
+      makeCategorical(COL_J0),
+      makeNumerical(COL_NUM),
+      makeNumerical(COL_NUM2),
+    ];
+    const excludeEncodings = new Set([
+      `${COL_J0}|sum(${COL_NUM})|`,
+      `${COL_J0}|sum(${COL_NUM2})|`,
+    ]);
+
+    const suggestion = suggestByChartType(
+      STUB_INSIGHT,
+      analysis,
+      1000,
+      {},
+      "barY",
+      { excludeEncodings },
+    );
+
+    expect(suggestion).toBeNull();
   });
 });
 

--- a/packages/app/src/lib/visualizations/suggest-charts.ts
+++ b/packages/app/src/lib/visualizations/suggest-charts.ts
@@ -1069,28 +1069,31 @@ export function suggestByChartType(
         }
       } else {
         // Default: categorical X-axis for comparing values across categories.
-        // Iterate through candidates so a repeat-join's j1 instance is tried
-        // when j0's encoding is already in excludeEncodings.
+        // Outer loop over numerical (y-axis) candidates, inner loop over
+        // categorical (x-axis) candidates. This ensures a repeat-join's j1
+        // column is tried for EITHER axis when earlier combinations are already
+        // in excludeEncodings.
         if (categorical.length > 0 && numerical.length > 0) {
-          const yCol = numerical[0]!;
-          for (const xCol of categorical) {
-            const encoding: SuggestionEncoding = {
-              x: xCol.columnName,
-              y: `sum(${yCol.columnName})`,
-              xType: getAxisType(xCol),
-              yType: "quantitative",
-              xLabel: xCol.displayName,
-              yLabel: `sum of ${yCol.displayName}`,
-            };
-            if (!isExcludedEncoding(encoding)) {
-              suggestion = {
-                id: `barY-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
-                title: `${yCol.displayName} by ${xCol.displayName}`,
-                chartType: "barY",
-                encoding,
-                rationale: "Categorical dimension with numeric measure",
+          outerBarY: for (const yCol of numerical) {
+            for (const xCol of categorical) {
+              const encoding: SuggestionEncoding = {
+                x: xCol.columnName,
+                y: `sum(${yCol.columnName})`,
+                xType: getAxisType(xCol),
+                yType: "quantitative",
+                xLabel: xCol.displayName,
+                yLabel: `sum of ${yCol.displayName}`,
               };
-              break;
+              if (!isExcludedEncoding(encoding)) {
+                suggestion = {
+                  id: `barY-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
+                  title: `${yCol.displayName} by ${xCol.displayName}`,
+                  chartType: "barY",
+                  encoding,
+                  rationale: "Categorical dimension with numeric measure",
+                };
+                break outerBarY;
+              }
             }
           }
         }
@@ -1099,28 +1102,30 @@ export function suggestByChartType(
 
     case "barX":
       // Horizontal Bar: numerical X + categorical Y.
-      // Iterate through categorical candidates so a repeat-join's j1 column is
-      // tried when j0's encoding is already excluded.
+      // Outer loop over numerical (x-axis) candidates, inner loop over
+      // categorical (y-axis) candidates. Both axes are iterated so a
+      // repeat-join's j1 column is tried when earlier combinations are excluded.
       if (categorical.length > 0 && numerical.length > 0) {
-        const xCol = numerical[0]!;
-        for (const yCol of categorical) {
-          const encoding: SuggestionEncoding = {
-            x: `sum(${xCol.columnName})`,
-            y: yCol.columnName,
-            xType: "quantitative",
-            yType: getAxisType(yCol),
-            xLabel: `sum of ${xCol.displayName}`,
-            yLabel: yCol.displayName,
-          };
-          if (!isExcludedEncoding(encoding)) {
-            suggestion = {
-              id: `barX-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
-              title: `${xCol.displayName} by ${yCol.displayName}`,
-              chartType: "barX",
-              encoding,
-              rationale: "Horizontal categorical comparison",
+        outerBarX: for (const xCol of numerical) {
+          for (const yCol of categorical) {
+            const encoding: SuggestionEncoding = {
+              x: `sum(${xCol.columnName})`,
+              y: yCol.columnName,
+              xType: "quantitative",
+              yType: getAxisType(yCol),
+              xLabel: `sum of ${xCol.displayName}`,
+              yLabel: yCol.displayName,
             };
-            break;
+            if (!isExcludedEncoding(encoding)) {
+              suggestion = {
+                id: `barX-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
+                title: `${xCol.displayName} by ${yCol.displayName}`,
+                chartType: "barX",
+                encoding,
+                rationale: "Horizontal categorical comparison",
+              };
+              break outerBarX;
+            }
           }
         }
       }

--- a/packages/app/src/lib/visualizations/suggest-charts.ts
+++ b/packages/app/src/lib/visualizations/suggest-charts.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import {
   applyDateTransformToSql,
-  extractUUIDFromColumnAlias,
+  extractColumnAliasComponents,
   getAxisTypeForTransform,
   selectTemporalAggregation,
   temporalTransform,
@@ -38,29 +38,40 @@ export type SuggestionEncoding = ChartEncoding;
 type ExtendedColumnAnalysis = ColumnAnalysis & {
   /** User-visible display name from field metadata */
   displayName: string;
+  /**
+   * Join instance index (0 = first/base, 1 = _j1 repeat-join, 2 = _j2, …).
+   * Tracked separately from fieldId so fieldId always holds the canonical UUID
+   * for field-metadata lookups, while instanceIndex drives unique suggestion IDs
+   * across repeat-join instances of the same field.
+   */
+  instanceIndex: number;
 };
 
 /**
  * Enrich column analysis with display names from field metadata.
  *
  * With UUID-based column naming, column names in analysis are like `field_<uuid>`.
- * This function looks up the original field display name for use in suggestion titles.
+ * For repeat-join instances the alias is `field_<uuid>_j1`, `field_<uuid>_j2`, etc.
+ *
+ * `fieldId` is always set to the **canonical UUID** (shared by all join instances of
+ * the same field) so that field-metadata lookups work against the `fields` map, which
+ * is keyed by bare UUIDs only.  Instance identity is tracked via `instanceIndex`.
  *
  * @param analysis - Raw column analysis with UUID column names
- * @param fields - Field metadata keyed by field ID
- * @returns Enriched analysis with displayName and fieldId
+ * @param fields - Field metadata keyed by field ID (bare UUID)
+ * @returns Enriched analysis with displayName, fieldId, and instanceIndex
  */
 function enrichColumnAnalysis(
   analysis: ColumnAnalysis[],
   fields: Record<string, Field>,
 ): ExtendedColumnAnalysis[] {
   return analysis.map((col) => {
-    // Extract field ID from column alias (field_<uuid> → uuid)
-    const extractedFieldId = extractUUIDFromColumnAlias(col.columnName);
-    // Convert null to undefined to match ColumnAnalysisBase.fieldId type
-    const fieldId = extractedFieldId ?? undefined;
+    const components = extractColumnAliasComponents(col.columnName);
+    // Canonical UUID for field-metadata lookup (same for j0 and j1 of the same field).
+    const fieldId = components?.uuid ?? undefined;
+    const instanceIndex = components?.instanceIndex ?? 0;
 
-    // Look up field by ID for display name
+    // Look up field by canonical UUID for display name
     const field = fieldId ? fields[fieldId] : undefined;
     const displayName = field?.name ?? col.columnName;
 
@@ -68,8 +79,18 @@ function enrichColumnAnalysis(
       ...col,
       displayName,
       fieldId,
+      instanceIndex,
     };
   });
+}
+
+/**
+ * Returns the instance-index suffix string for a suggestion ID.
+ * Empty string for the first (j0) instance; "_j1", "_j2", etc. for repeats.
+ * Prevents suggestion-ID collisions across repeat-join instances.
+ */
+function instanceIdSuffix(col: ExtendedColumnAnalysis): string {
+  return col.instanceIndex > 0 ? `_j${col.instanceIndex}` : "";
 }
 
 /**
@@ -239,10 +260,13 @@ function shuffleWithSeed<T>(array: T[], random: () => number): T[] {
 }
 
 /**
- * Extended date analysis with display name.
+ * Extended date analysis with display name and instance index.
+ * Must include the same extra fields as ExtendedColumnAnalysis so the
+ * isDateAnalysis type-guard predicate is valid.
  */
 type ExtendedDateAnalysis = DateAnalysis & {
   displayName: string;
+  instanceIndex: number;
 };
 
 /**
@@ -483,7 +507,7 @@ export function suggestCharts(
         };
         if (
           addSuggestion({
-            id: `barY-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `barY-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title: `${yCol.displayName} by ${xCol.displayName}`,
             chartType: "barY",
             encoding,
@@ -519,7 +543,7 @@ export function suggestCharts(
           : `${yCol.displayName} over time`;
         if (
           addSuggestion({
-            id: `line-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `line-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title,
             chartType: "line",
             encoding,
@@ -551,7 +575,7 @@ export function suggestCharts(
           yLabel: yCol.displayName,
         };
         scatterAdded = addSuggestion({
-          id: `dot-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+          id: `dot-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
           title: `${yCol.displayName} vs ${xCol.displayName}`,
           chartType: "dot",
           encoding,
@@ -580,7 +604,7 @@ export function suggestCharts(
         };
         if (
           addSuggestion({
-            id: `areaY-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `areaY-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title: `${yCol.displayName} trend`,
             chartType: "areaY",
             encoding,
@@ -646,7 +670,7 @@ export function suggestCharts(
         colorLabel: colorCol.displayName,
       };
       addSuggestion({
-        id: `barY-grouped-${xCol.fieldId ?? xCol.columnName}-${colorCol.fieldId ?? colorCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+        id: `barY-grouped-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${colorCol.fieldId ?? colorCol.columnName}${instanceIdSuffix(colorCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
         title: `${yCol.displayName} by ${xCol.displayName} and ${colorCol.displayName}`,
         chartType: "barY",
         encoding,
@@ -1033,7 +1057,7 @@ export function suggestByChartType(
               ? `${yCol.displayName} ${aggregationLabel}`
               : `${yCol.displayName} over time`;
             suggestion = {
-              id: `barY-trend-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+              id: `barY-trend-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
               title,
               chartType: "barY",
               encoding,
@@ -1044,52 +1068,60 @@ export function suggestByChartType(
           }
         }
       } else {
-        // Default: categorical X-axis for comparing values across categories
+        // Default: categorical X-axis for comparing values across categories.
+        // Iterate through candidates so a repeat-join's j1 instance is tried
+        // when j0's encoding is already in excludeEncodings.
         if (categorical.length > 0 && numerical.length > 0) {
-          const xCol = categorical[0]!;
           const yCol = numerical[0]!;
-          const encoding: SuggestionEncoding = {
-            x: xCol.columnName,
-            y: `sum(${yCol.columnName})`,
-            xType: getAxisType(xCol),
-            yType: "quantitative",
-            xLabel: xCol.displayName,
-            yLabel: `sum of ${yCol.displayName}`,
-          };
-          if (!isExcludedEncoding(encoding)) {
-            suggestion = {
-              id: `barY-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
-              title: `${yCol.displayName} by ${xCol.displayName}`,
-              chartType: "barY",
-              encoding,
-              rationale: "Categorical dimension with numeric measure",
+          for (const xCol of categorical) {
+            const encoding: SuggestionEncoding = {
+              x: xCol.columnName,
+              y: `sum(${yCol.columnName})`,
+              xType: getAxisType(xCol),
+              yType: "quantitative",
+              xLabel: xCol.displayName,
+              yLabel: `sum of ${yCol.displayName}`,
             };
+            if (!isExcludedEncoding(encoding)) {
+              suggestion = {
+                id: `barY-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
+                title: `${yCol.displayName} by ${xCol.displayName}`,
+                chartType: "barY",
+                encoding,
+                rationale: "Categorical dimension with numeric measure",
+              };
+              break;
+            }
           }
         }
       }
       break;
 
     case "barX":
-      // Horizontal Bar: numerical X + categorical Y
+      // Horizontal Bar: numerical X + categorical Y.
+      // Iterate through categorical candidates so a repeat-join's j1 column is
+      // tried when j0's encoding is already excluded.
       if (categorical.length > 0 && numerical.length > 0) {
-        const yCol = categorical[0]!;
         const xCol = numerical[0]!;
-        const encoding: SuggestionEncoding = {
-          x: `sum(${xCol.columnName})`,
-          y: yCol.columnName,
-          xType: "quantitative",
-          yType: getAxisType(yCol),
-          xLabel: `sum of ${xCol.displayName}`,
-          yLabel: yCol.displayName,
-        };
-        if (!isExcludedEncoding(encoding)) {
-          suggestion = {
-            id: `barX-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
-            title: `${xCol.displayName} by ${yCol.displayName}`,
-            chartType: "barX",
-            encoding,
-            rationale: "Horizontal categorical comparison",
+        for (const yCol of categorical) {
+          const encoding: SuggestionEncoding = {
+            x: `sum(${xCol.columnName})`,
+            y: yCol.columnName,
+            xType: "quantitative",
+            yType: getAxisType(yCol),
+            xLabel: `sum of ${xCol.displayName}`,
+            yLabel: yCol.displayName,
           };
+          if (!isExcludedEncoding(encoding)) {
+            suggestion = {
+              id: `barX-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
+              title: `${xCol.displayName} by ${yCol.displayName}`,
+              chartType: "barX",
+              encoding,
+              rationale: "Horizontal categorical comparison",
+            };
+            break;
+          }
         }
       }
       break;
@@ -1116,7 +1148,7 @@ export function suggestByChartType(
             ? `${yCol.displayName} ${aggregationLabel}`
             : `${yCol.displayName} over time`;
           suggestion = {
-            id: `line-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `line-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title,
             chartType: "line",
             encoding,
@@ -1147,7 +1179,7 @@ export function suggestByChartType(
         };
         if (!isExcludedEncoding(encoding)) {
           suggestion = {
-            id: `areaY-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `areaY-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title: `${yCol.displayName} trend`,
             chartType: "areaY",
             encoding,
@@ -1176,7 +1208,7 @@ export function suggestByChartType(
         };
         if (!isExcludedEncoding(encoding)) {
           suggestion = {
-            id: `dot-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `dot-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title: `${yCol.displayName} vs ${xCol.displayName}`,
             chartType: "dot",
             encoding,
@@ -1204,7 +1236,7 @@ export function suggestByChartType(
         if (!isExcludedEncoding(encoding)) {
           const isLargeDataset = rowCount > SCATTER_MAX_POINTS;
           suggestion = {
-            id: `hexbin-${xCol.fieldId ?? xCol.columnName}-${yCol.fieldId ?? yCol.columnName}`,
+            id: `hexbin-${xCol.fieldId ?? xCol.columnName}${instanceIdSuffix(xCol)}-${yCol.fieldId ?? yCol.columnName}${instanceIdSuffix(yCol)}`,
             title: `${yCol.displayName} vs ${xCol.displayName}${isLargeDataset ? "" : " (density)"}`,
             chartType: "hexbin",
             encoding,

--- a/packages/app/src/lib/visualizations/suggest-charts.ts
+++ b/packages/app/src/lib/visualizations/suggest-charts.ts
@@ -1074,7 +1074,9 @@ export function suggestByChartType(
         // column is tried for EITHER axis when earlier combinations are already
         // in excludeEncodings.
         if (categorical.length > 0 && numerical.length > 0) {
-          outerBarY: for (const yCol of numerical) {
+          let foundBarY = false;
+          for (const yCol of numerical) {
+            if (foundBarY) break;
             for (const xCol of categorical) {
               const encoding: SuggestionEncoding = {
                 x: xCol.columnName,
@@ -1092,7 +1094,8 @@ export function suggestByChartType(
                   encoding,
                   rationale: "Categorical dimension with numeric measure",
                 };
-                break outerBarY;
+                foundBarY = true;
+                break;
               }
             }
           }
@@ -1106,7 +1109,9 @@ export function suggestByChartType(
       // categorical (y-axis) candidates. Both axes are iterated so a
       // repeat-join's j1 column is tried when earlier combinations are excluded.
       if (categorical.length > 0 && numerical.length > 0) {
-        outerBarX: for (const xCol of numerical) {
+        let foundBarX = false;
+        for (const xCol of numerical) {
+          if (foundBarX) break;
           for (const yCol of categorical) {
             const encoding: SuggestionEncoding = {
               x: `sum(${xCol.columnName})`,
@@ -1124,7 +1129,8 @@ export function suggestByChartType(
                 encoding,
                 rationale: "Horizontal categorical comparison",
               };
-              break outerBarX;
+              foundBarX = true;
+              break;
             }
           }
         }


### PR DESCRIPTION
## Summary

PR #176 fixed repeat-join in the data layer and `AxisSelectField`, but two consumer sinks still used `extractUUIDFromColumnAlias` — which strips the `_jN` suffix — causing j1 instances to collapse onto j0:

- **`suggest-charts.ts`** `enrichColumnAnalysis` gave j0 and j1 the same `fieldId`, so their suggestion IDs collided and `suggestByChartType` never tried j1 when j0 was already charted (ChartTypePicker grays out Bar even though j1 is a valid new suggestion).
- **`DataSourcePageContent.tsx`** `analysisByFieldId` keyed both j0 and j1 by the bare UUID; j1 silently overwrote j0's stats, causing wrong sensitivity suggestions for the first-instance field.

## Changes

### \`suggest-charts.ts\`
- Switch \`enrichColumnAnalysis\` from \`extractUUIDFromColumnAlias\` → \`extractColumnAliasComponents\`
- \`fieldId\` stays as **canonical UUID** (shared by both instances; needed because \`InsightView\`'s \`fieldMap\` is keyed by bare UUIDs only). Instance identity moves to a new \`instanceIndex\` field on the local \`ExtendedColumnAnalysis\` type.
- New \`instanceIdSuffix()\` helper appends \`_j1\`, \`_j2\` to suggestion IDs so they are distinct per instance.
- \`suggestByChartType\` \`barY\` (non-trend) and \`barX\` now **iterate** through categorical candidates, so j1 is tried when j0's encoding is already in \`excludeEncodings\`.
- All suggestion IDs in \`suggestCharts\` and \`suggestByChartType\` updated with instance suffix.

### \`DataSourcePageContent.tsx\`
- New exported \`buildAnalysisByFieldId()\` builds the map with **instance-qualified keys** (\`<uuid>\` for j0, \`<uuid>_j1\` for j1) matching the synthetic field IDs from \`buildInsightAvailableFields\`.
- \`analysisByFieldId\` useMemo delegates to it; j1 no longer overwrites j0.

## Tests

562 tests, all passing (38 test files).

**New (suggest-charts.test.ts — 7 tests):**
- j1 suggestion returned when j0 is excluded *(was the red test)*
- Both excluded → null returned
- j0 and j1 produce distinct suggestion IDs
- Single-join (no \`_j\` suffix) regression guard
- j1 metadata resolved via canonical UUID (design pin: instance-qualifying \`fieldId\` would break this)

**New (DataSourcePageContent.test.tsx — 4 tests):**
- j0 maps to bare UUID key
- j1 maps to \`<uuid>_j1\` key, does NOT overwrite j0
- Single-join regression guard
- Explicit \`fieldId\` fast-path

## Screenshots

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MqMDqmBK8SvATiQTJvKWk

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes repeat-join `_j1` column identity collapsing onto `_j0` in two consumer sinks that were still using `extractUUIDFromColumnAlias` (which strips the `_jN` suffix) instead of the newer `extractColumnAliasComponents`.

- **`suggest-charts.ts`**: Switches `enrichColumnAnalysis` to `extractColumnAliasComponents`, introduces `instanceIndex` on `ExtendedColumnAnalysis`, adds `instanceIdSuffix()` helper for suggestion IDs, and converts the `barY` (non-trend) and `barX` branches from picking only `[0]` to iterating across all candidate pairs so j1 is tried when j0's encoding is in `excludeEncodings`. All suggestion ID sites updated with the suffix.
- **`DataSourcePageContent.tsx`**: Extracts `buildAnalysisByFieldId()` (now exported for testing) that uses instance-qualified keys (`<uuid>` for j0, `<uuid>_j1` for j1) matching `buildInsightAvailableFields`, preventing j1 from silently overwriting j0 in the analysis map.
- New unit tests cover the primary barY repeat-join fallback, distinct suggestion IDs, single-join regression guard, canonical-UUID field-metadata resolution, and the `buildAnalysisByFieldId` key-qualification contract.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are tightly scoped to two consumer sinks, both well-tested, with no side-effects on the core data layer.

The fix is surgical: two call sites swap one utility function for a richer one, and the new loop structure in barY/barX correctly exits on the first non-excluded candidate pair. The design decision to keep fieldId as the canonical UUID is explicitly pinned in tests, preventing future regressions. No pre-existing functionality is removed or altered.

No files require special attention. The barX iteration path still lacks dedicated tests (noted in the prior review), but this is a pre-existing gap and does not introduce new risk.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/lib/visualizations/suggest-charts.ts | Switches to extractColumnAliasComponents, adds instanceIndex/instanceIdSuffix, converts barY and barX branches to iterate candidates; all suggestion ID sites correctly updated with instance suffix. |
| packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx | Extracts buildAnalysisByFieldId() with instance-qualified keys; useMemo delegates to it correctly; fast-path fieldId branch is guarded by a clear comment warning against future misuse. |
| packages/app/src/lib/visualizations/suggest-charts.test.ts | New test file covers barY repeat-join fallback, distinct IDs, single-join regression guard, canonical UUID resolution, and numerical-candidate fallback; barX iteration path remains untested (pre-existing gap noted in prior review). |
| packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx | Adds buildAnalysisByFieldId unit tests (j0/j1 key separation, non-overwrite, single-join, explicit fieldId fast-path); mock wiring for extractColumnAliasComponents is correct. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ColumnAnalysis array] --> B[enrichColumnAnalysis]
    B --> C[extractColumnAliasComponents]
    C -->|uuid + instanceIndex| D[ExtendedColumnAnalysis\nfieldId = canonical UUID\ninstanceIndex = 0 or N]

    D --> E{instanceIndex?}
    E -->|0 / j0| F[instanceIdSuffix = '']
    E -->|N / jN| G[instanceIdSuffix = '_jN']

    F --> H[suggestion ID: type-uuid-uuid]
    G --> I[suggestion ID: type-uuid_jN-uuid]

    D --> J{chart type}
    J -->|barY non-trend| K[iterate numerical x categorical\nstop on first non-excluded]
    J -->|barX| L[iterate numerical x categorical\nstop on first non-excluded]
    J -->|line/areaY| M[temporal-0 x numerical-0\nno iteration]
    J -->|dot/hexbin| N[numerical-0 x numerical-1\nno iteration]

    subgraph buildAnalysisByFieldId
    O[ColumnAnalysis] --> P{fieldId set?}
    P -->|yes| Q[map.set fieldId to col]
    P -->|no| R[extractColumnAliasComponents]
    R -->|instanceIndex === 0| S[key = uuid]
    R -->|instanceIndex > 0| T[key = uuid_jN]
    S --> U[Map: distinct j0 and j1 entries]
    T --> U
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ColumnAnalysis array] --> B[enrichColumnAnalysis]
    B --> C[extractColumnAliasComponents]
    C -->|uuid + instanceIndex| D[ExtendedColumnAnalysis\nfieldId = canonical UUID\ninstanceIndex = 0 or N]

    D --> E{instanceIndex?}
    E -->|0 / j0| F[instanceIdSuffix = '']
    E -->|N / jN| G[instanceIdSuffix = '_jN']

    F --> H[suggestion ID: type-uuid-uuid]
    G --> I[suggestion ID: type-uuid_jN-uuid]

    D --> J{chart type}
    J -->|barY non-trend| K[iterate numerical x categorical\nstop on first non-excluded]
    J -->|barX| L[iterate numerical x categorical\nstop on first non-excluded]
    J -->|line/areaY| M[temporal-0 x numerical-0\nno iteration]
    J -->|dot/hexbin| N[numerical-0 x numerical-1\nno iteration]

    subgraph buildAnalysisByFieldId
    O[ColumnAnalysis] --> P{fieldId set?}
    P -->|yes| Q[map.set fieldId to col]
    P -->|no| R[extractColumnAliasComponents]
    R -->|instanceIndex === 0| S[key = uuid]
    R -->|instanceIndex > 0| T[key = uuid_jN]
    S --> U[Map: distinct j0 and j1 entries]
    T --> U
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app/src/lib/visualizations/suggest-charts.test.ts`, line 303-410 ([link](https://github.com/youhaowei/dashframe/blob/17b9f2f1d27c2ab6d079730b92ff8a6f8e011c30/packages/app/src/lib/visualizations/suggest-charts.test.ts#L303-L410)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No iteration regression guard for `barX`**

   The PR converts the `barX` branch in `suggestByChartType` from `categorical[0]` to a `for…of` loop (mirroring the `barY` fix), but there are no tests exercising that iteration. The `barX` path and its `excludeEncodings` fallback are untested — any regression that removes the loop or breaks the encoding check would go unnoticed. Even a single test confirming "j1 returned when j0 is excluded for barX" would close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/lib/visualizations/suggest-charts.test.ts
   Line: 303-410

   Comment:
   **No iteration regression guard for `barX`**

   The PR converts the `barX` branch in `suggestByChartType` from `categorical[0]` to a `for…of` loop (mirroring the `barY` fix), but there are no tests exercising that iteration. The `barX` path and its `excludeEncodings` fallback are untested — any regression that removes the loop or breaks the encoding check would go unnoticed. Even a single test confirming "j1 returned when j0 is excluded for barX" would close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Flib%2Fvisualizations%2Fsuggest-charts.test.ts%0ALine%3A%20303-410%0A%0AComment%3A%0A**No%20iteration%20regression%20guard%20for%20%60barX%60**%0A%0AThe%20PR%20converts%20the%20%60barX%60%20branch%20in%20%60suggestByChartType%60%20from%20%60categorical%5B0%5D%60%20to%20a%20%60for%E2%80%A6of%60%20loop%20%28mirroring%20the%20%60barY%60%20fix%29%2C%20but%20there%20are%20no%20tests%20exercising%20that%20iteration.%20The%20%60barX%60%20path%20and%20its%20%60excludeEncodings%60%20fallback%20are%20untested%20%E2%80%94%20any%20regression%20that%20removes%20the%20loop%20or%20breaks%20the%20encoding%20check%20would%20go%20unnoticed.%20Even%20a%20single%20test%20confirming%20%22j1%20returned%20when%20j0%20is%20excluded%20for%20barX%22%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=183&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-325-repeat-join-j1-collapse%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-325-repeat-join-j1-collapse%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Flib%2Fvisualizations%2Fsuggest-charts.test.ts%0ALine%3A%20303-410%0A%0AComment%3A%0A**No%20iteration%20regression%20guard%20for%20%60barX%60**%0A%0AThe%20PR%20converts%20the%20%60barX%60%20branch%20in%20%60suggestByChartType%60%20from%20%60categorical%5B0%5D%60%20to%20a%20%60for%E2%80%A6of%60%20loop%20%28mirroring%20the%20%60barY%60%20fix%29%2C%20but%20there%20are%20no%20tests%20exercising%20that%20iteration.%20The%20%60barX%60%20path%20and%20its%20%60excludeEncodings%60%20fallback%20are%20untested%20%E2%80%94%20any%20regression%20that%20removes%20the%20loop%20or%20breaks%20the%20encoding%20check%20would%20go%20unnoticed.%20Even%20a%20single%20test%20confirming%20%22j1%20returned%20when%20j0%20is%20excluded%20for%20barX%22%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=183&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Flib%2Fvisualizations%2Fsuggest-charts.test.ts%0ALine%3A%20303-410%0A%0AComment%3A%0A**No%20iteration%20regression%20guard%20for%20%60barX%60**%0A%0AThe%20PR%20converts%20the%20%60barX%60%20branch%20in%20%60suggestByChartType%60%20from%20%60categorical%5B0%5D%60%20to%20a%20%60for%E2%80%A6of%60%20loop%20%28mirroring%20the%20%60barY%60%20fix%29%2C%20but%20there%20are%20no%20tests%20exercising%20that%20iteration.%20The%20%60barX%60%20path%20and%20its%20%60excludeEncodings%60%20fallback%20are%20untested%20%E2%80%94%20any%20regression%20that%20removes%20the%20loop%20or%20breaks%20the%20encoding%20check%20would%20go%20unnoticed.%20Even%20a%20single%20test%20confirming%20%22j1%20returned%20when%20j0%20is%20excluded%20for%20barX%22%20would%20close%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=183&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(lint): replace labeled break with bo..."](https://github.com/youhaowei/dashframe/commit/e5be469b0655e1d110d8bd153c303774e051db52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40339397)</sub>

<!-- /greptile_comment -->