### PR TITLE
[YW-312] feat(infra): worktree isolation guard — fail-closed commit block in main checkout

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,51 @@
-bunx lint-staged
+bunx lint-staged || exit 1
+
+# ── Worktree isolation guard ─────────────────────────────────────────────────
+# Refuse commits on a feature branch from the MAIN CHECKOUT.
+# Dispatched agents must work in an isolated worktree (scripts/ensure-worktree.sh).
+# Two concurrent agents committing in main corrupt each other's branch refs.
+#
+# Bypass (deliberate, documented):
+#   ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit ...
+#
+# Detection: if --git-dir == --git-common-dir we are in the main checkout.
+# In a linked worktree those differ (--git-dir points to the per-worktree
+# gitdir, --git-common-dir to the shared .git).  This comparison is
+# path-independent and safe inside submodules.
+
+git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
+git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+
+if [ -n "$git_dir" ] && [ "$git_dir" = "$git_common_dir" ]; then
+  # We are in the main checkout.
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|.*/||')
+  default_branch="${default_branch:-main}"
+
+  if [ "$current_branch" != "$default_branch" ] && [ "$current_branch" != "HEAD" ]; then
+    if [ "${ALLOW_MAIN_CHECKOUT_COMMIT:-0}" = "1" ]; then
+      echo "[worktree-guard] ALLOW_MAIN_CHECKOUT_COMMIT=1 — bypassing isolation check." >&2
+    else
+      echo "" >&2
+      echo "╔══════════════════════════════════════════════════════════════════╗" >&2
+      echo "║  WORKTREE ISOLATION GUARD — commit blocked                       ║" >&2
+      echo "╠══════════════════════════════════════════════════════════════════╣" >&2
+      echo "║  You are on '$current_branch'" >&2
+      echo "║  in the MAIN CHECKOUT (not an isolated worktree)." >&2
+      echo "║" >&2
+      echo "║  Feature-branch commits must happen in a dedicated worktree so" >&2
+      echo "║  concurrent agents cannot corrupt each other's work." >&2
+      echo "║" >&2
+      echo "║  Fix: provision an isolated worktree first:" >&2
+      echo "║    worktree=\$(scripts/ensure-worktree.sh $current_branch)" >&2
+      echo "║    cd \"\$worktree\"" >&2
+      echo "║  then commit from there." >&2
+      echo "║" >&2
+      echo "║  Deliberate bypass (you know what you're doing):" >&2
+      echo "║    ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit ..." >&2
+      echo "╚══════════════════════════════════════════════════════════════════╝" >&2
+      echo "" >&2
+      exit 1
+    fi
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-bunx lint-staged || exit 1
-
 # ── Worktree isolation guard ─────────────────────────────────────────────────
 # Refuse commits on a feature branch from the MAIN CHECKOUT.
 # Dispatched agents must work in an isolated worktree (scripts/ensure-worktree.sh).
@@ -49,3 +47,6 @@ if [ -n "$git_dir" ] && [ "$git_dir" = "$git_common_dir" ]; then
     fi
   fi
 fi
+# ── end guard ────────────────────────────────────────────────────────────────
+
+bunx lint-staged || exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,21 @@ Visual design system: see [DESIGN.md](DESIGN.md). Load it before any UI work.
 
 Key facts: product register; `@wystack/ui` tokens are the source of truth (vendored at `libs/stdui` — historical directory name); the shell is built on the **surface system** (`bg-surface-base` canvas, `--surface-radius`/`--surface-inset` geometry, shadow-lifted panels, no borders); web and Electron renderers are identical — no per-surface UI forks; no off-token color.
 
+## Worktree isolation (dispatched agents)
+
+Every dispatched agent that touches source files MUST work in an isolated git worktree — never in the shared main checkout (`/Users/youhaowei/Projects/DashFrame`). Two agents in the same checkout will revert each other's uncommitted work.
+
+**Bootstrap (first step in any feature-branch brief):**
+```sh
+worktree=$(scripts/ensure-worktree.sh <branch-name>)
+cd "$worktree"
+# all work happens here
+```
+
+`scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch>` if not already there and prints the path. If it fails, STOP — do not improvise another location.
+
+**Enforcement:** `.husky/pre-commit` blocks commits on a non-default branch in the main checkout. Bypass with `ALLOW_MAIN_CHECKOUT_COMMIT=1` only when you knowingly own that checkout.
+
 ## Pull requests
 
 Every PR description follows `.github/pull_request_template.md`. The **Screenshots** section is required on all PRs: any UI-touching change (components, layout, CSS, tokens — anything rendered) must include before/after images captured from the running app, with the relevant states (hover/focus, light + dark) when they changed. A diff cannot show hover, focus, spacing, or dark mode. Backend-only PRs satisfy the section by stating "No UI change". This is a hard expectation, not a nicety — a UI PR without visual evidence is not ready for review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ cd "$worktree"
 # all work happens here
 ```
 
-`scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch>` if not already there and prints the path. If it fails, STOP — do not improvise another location.
+`scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch-slug>` (forward-slashes and colons in the branch name become dashes, lowercase) if not already there and prints the path. If it fails, STOP — do not improvise another location.
 
 **Enforcement:** `.husky/pre-commit` blocks commits on a non-default branch in the main checkout. Bypass with `ALLOW_MAIN_CHECKOUT_COMMIT=1` only when you knowingly own that checkout.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Key facts: product register; `@wystack/ui` tokens are the source of truth (vendo
 Every dispatched agent that touches source files MUST work in an isolated git worktree — never in the shared main checkout (`/Users/youhaowei/Projects/DashFrame`). Two agents in the same checkout will revert each other's uncommitted work.
 
 **Bootstrap (first step in any feature-branch brief):**
+
 ```sh
 worktree=$(scripts/ensure-worktree.sh <branch-name>)
 cd "$worktree"

--- a/docs/audits/worktree-isolation-gap-2026-06-28.md
+++ b/docs/audits/worktree-isolation-gap-2026-06-28.md
@@ -5,12 +5,12 @@ Related: YW-312, PR #183
 
 ## What this PR ships (in-repo, fail-closed)
 
-| Artefact | What it does |
-|---|---|
-| `scripts/ensure-worktree.sh` | Proactive bootstrap: provisions `~/worktrees/dashframe/<branch>` and prints the path. Agents call this FIRST; hard-exits on any failure. |
-| `.husky/pre-commit` (addition) | Fail-closed git-layer guard: blocks commits on a non-default branch in the main checkout. Detection is symlink-safe (compares `--git-dir` vs `--git-common-dir`, not `.git`-is-a-file). Bypass: `ALLOW_MAIN_CHECKOUT_COMMIT=1`. |
-| `scripts/test-worktree-guard.sh` | Runnable proof: 7 scenarios against a scratch repo. All pass. |
-| `CLAUDE.md` note | Discoverability: agents reading the repo learn the bootstrap command. |
+| Artefact                         | What it does                                                                                                                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/ensure-worktree.sh`     | Proactive bootstrap: provisions `~/worktrees/dashframe/<branch>` and prints the path. Agents call this FIRST; hard-exits on any failure.                                                                                        |
+| `.husky/pre-commit` (addition)   | Fail-closed git-layer guard: blocks commits on a non-default branch in the main checkout. Detection is symlink-safe (compares `--git-dir` vs `--git-common-dir`, not `.git`-is-a-file). Bypass: `ALLOW_MAIN_CHECKOUT_COMMIT=1`. |
+| `scripts/test-worktree-guard.sh` | Runnable proof: 7 scenarios against a scratch repo. All pass.                                                                                                                                                                   |
+| `CLAUDE.md` note                 | Discoverability: agents reading the repo learn the bootstrap command.                                                                                                                                                           |
 
 ## What this PR does NOT fix (harness-side gap — needs owner decision)
 
@@ -18,11 +18,11 @@ Related: YW-312, PR #183
 The pre-commit hook fires at commit time. It catches one of the two collision modes from YW-312:
 
 ✅ Cross-stacking a foreign commit onto another agent's branch ref (commit blocked)  
-❌ Reverting another agent's *uncommitted* work (no pre-checkout hook; file-level races happen before any commit)
+❌ Reverting another agent's _uncommitted_ work (no pre-checkout hook; file-level races happen before any commit)
 
 The uncommitted-work race is only fully prevented by provisioning worktrees **before** agents start writing files — i.e., option (a) in the ticket's acceptance criteria:
 
-> *the dispatch harness provisions the worktree FOR the agent (not a brief instruction the agent executes)*
+> _the dispatch harness provisions the worktree FOR the agent (not a brief instruction the agent executes)_
 
 That lives in `~/.claude/skills/cockpit/references/dispatch-discipline.md` — outside the repo. The brief template's "Isolation" line currently reads:
 

--- a/docs/audits/worktree-isolation-gap-2026-06-28.md
+++ b/docs/audits/worktree-isolation-gap-2026-06-28.md
@@ -1,0 +1,37 @@
+# Worktree isolation — in-repo guard vs harness-side gap
+
+Date: 2026-06-28  
+Related: YW-312, PR #183
+
+## What this PR ships (in-repo, fail-closed)
+
+| Artefact | What it does |
+|---|---|
+| `scripts/ensure-worktree.sh` | Proactive bootstrap: provisions `~/worktrees/dashframe/<branch>` and prints the path. Agents call this FIRST; hard-exits on any failure. |
+| `.husky/pre-commit` (addition) | Fail-closed git-layer guard: blocks commits on a non-default branch in the main checkout. Detection is symlink-safe (compares `--git-dir` vs `--git-common-dir`, not `.git`-is-a-file). Bypass: `ALLOW_MAIN_CHECKOUT_COMMIT=1`. |
+| `scripts/test-worktree-guard.sh` | Runnable proof: 7 scenarios against a scratch repo. All pass. |
+| `CLAUDE.md` note | Discoverability: agents reading the repo learn the bootstrap command. |
+
+## What this PR does NOT fix (harness-side gap — needs owner decision)
+
+**Scope boundary of the commit-time guard:**  
+The pre-commit hook fires at commit time. It catches one of the two collision modes from YW-312:
+
+✅ Cross-stacking a foreign commit onto another agent's branch ref (commit blocked)  
+❌ Reverting another agent's *uncommitted* work (no pre-checkout hook; file-level races happen before any commit)
+
+The uncommitted-work race is only fully prevented by provisioning worktrees **before** agents start writing files — i.e., option (a) in the ticket's acceptance criteria:
+
+> *the dispatch harness provisions the worktree FOR the agent (not a brief instruction the agent executes)*
+
+That lives in `~/.claude/skills/cockpit/references/dispatch-discipline.md` — outside the repo. The brief template's "Isolation" line currently reads:
+
+> **Isolation** — worktree-isolated, PR-only, `run_in_background`.
+
+To close the gap fully, the harness brief template must be updated to:
+
+1. Tell the agent to call `scripts/ensure-worktree.sh <branch>` as step zero (making the `ensure-worktree.sh` helper the standardised interface).
+2. Make the bootstrap a HARD STOP: "if `ensure-worktree.sh` exits non-zero, STOP and report — do not improvise a path."
+3. (Longer term) The cockpit goal-tick could provision the worktree itself before spawning the agent, removing the dependency on the agent honouring the instruction.
+
+**Recommended action for the owner:** update `dispatch-discipline.md` § "Brief template" item 6 to mandate `ensure-worktree.sh` as the first command, replacing the prose "worktree-isolated" instruction.

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -94,14 +94,17 @@ mkdir -p "$worktree_base"
 
 # Run git worktree add; redirect BOTH stdout and stderr to a temp log so the
 # only thing this script writes to stdout is the final worktree path.
-# Check $? directly (not through a pipe) to preserve the exit status.
+# Use `|| _wt_rc=$?` (not `; _wt_rc=$?`) to capture the exit code under
+# set -e: with `set -e`, a bare semicolon sequence exits immediately on
+# failure before the assignment runs.
 _wt_log=$(mktemp)
+_wt_rc=0
 if git show-ref --verify --quiet "refs/heads/$branch"; then
-  git worktree add "$worktree_path" "$branch" >"$_wt_log" 2>&1; _wt_rc=$?
+  git worktree add "$worktree_path" "$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
 else
   # Try to track from origin; error out if the branch doesn't exist anywhere.
   if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-    git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1; _wt_rc=$?
+    git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
   else
     rm -f "$_wt_log"
     echo "ERROR [ensure-worktree]: branch '$branch' not found locally or on origin." >&2

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -45,11 +45,12 @@ git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/nu
 }
 
 if [ "$git_dir" != "$git_common_dir" ]; then
-  # Already in an isolated worktree — verify branch matches and we're clean.
+  # Already in an isolated worktree — verify branch matches.
   current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
   if [ "$current_branch" != "$branch" ] && [ "$current_branch" != "HEAD" ]; then
-    echo "WARNING [ensure-worktree]: worktree is on '$current_branch', expected '$branch'." >&2
-    # Soft warning only; the caller can still proceed — it's isolated regardless.
+    echo "ERROR [ensure-worktree]: already in a worktree on '$current_branch', expected '$branch'." >&2
+    echo "  Switch to the correct worktree for '$branch' or run from the default branch." >&2
+    exit 1
   fi
   # Print the worktree root for the caller to cd into (in case they're in a subdir).
   git rev-parse --show-toplevel
@@ -79,6 +80,14 @@ if [ -d "$worktree_path" ]; then
     echo "ERROR [ensure-worktree]: '$worktree_path' exists but is not a valid git checkout." >&2
     exit 1
   fi
+  # Verify the existing directory is a worktree of *this* repo (shares git-common-dir).
+  wt_common_dir=$(git -C "$worktree_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+  if [ "$wt_common_dir" != "$git_common_dir" ]; then
+    echo "ERROR [ensure-worktree]: '$worktree_path' belongs to a different repository." >&2
+    echo "  Expected: $git_common_dir" >&2
+    echo "  Found:    $wt_common_dir" >&2
+    exit 1
+  fi
   if [ "$existing_branch" != "$branch" ] && [ "$existing_branch" != "HEAD" ]; then
     echo "ERROR [ensure-worktree]: '$worktree_path' exists but is on '$existing_branch', not '$branch'." >&2
     echo "  Remove it manually ('git worktree remove $worktree_path') or choose a different base." >&2
@@ -104,6 +113,10 @@ if git show-ref --verify --quiet "refs/heads/$branch"; then
 else
   # Try to track from origin; error out if the branch doesn't exist anywhere.
   if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    # Fetch to ensure the local remote-tracking ref exists — ls-remote verifies the
+    # branch on the network but git worktree add resolves against the local
+    # refs/remotes/origin/<branch> ref, which only exists after a fetch.
+    git fetch origin "$branch" >/dev/null 2>&1 || true
     git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
   else
     rm -f "$_wt_log"

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env sh
+# ensure-worktree.sh — bootstrap isolation for dispatched agents
+#
+# USAGE:
+#   scripts/ensure-worktree.sh <branch-name>
+#
+# What it does:
+#   - Verifies the caller is already in an isolated worktree (not the main
+#     checkout).  If so, prints the worktree path and exits 0.
+#   - If the caller IS in the main checkout, creates a new worktree at
+#     ~/worktrees/<project>/<branch>, checks out <branch-name> there, and
+#     prints the new path.  The caller must cd into that path.
+#   - Hard-fails (exit 1) if anything goes wrong — this is fail-closed by
+#     design so that a briefed agent cannot silently proceed in main.
+#
+# ENV:
+#   WORKTREE_BASE  Override the base directory (default: ~/worktrees/<project>)
+#
+# NOTE: this script CANNOT cd for the caller — subprocess cd is not visible to
+# the parent shell.  The caller must:
+#   worktree=$(scripts/ensure-worktree.sh <branch>)
+#   cd "$worktree"
+# or, in a brief: "Run scripts/ensure-worktree.sh <branch>; cd into the path it prints."
+
+set -eu
+
+# ── 1. Require a branch argument ────────────────────────────────────────────
+branch="${1:-}"
+if [ -z "$branch" ]; then
+  echo "ERROR [ensure-worktree]: a branch name is required." >&2
+  echo "  Usage: scripts/ensure-worktree.sh <branch-name>" >&2
+  exit 1
+fi
+
+# ── 2. Detect whether we are in the main checkout or already in a worktree ──
+# git --git-dir  == git --git-common-dir  → main checkout
+# git --git-dir  != git --git-common-dir  → linked worktree
+git_dir=$(git rev-parse --path-format=absolute --git-dir 2>/dev/null) || {
+  echo "ERROR [ensure-worktree]: not inside a git repository." >&2
+  exit 1
+}
+git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+  echo "ERROR [ensure-worktree]: cannot determine git-common-dir." >&2
+  exit 1
+}
+
+if [ "$git_dir" != "$git_common_dir" ]; then
+  # Already in an isolated worktree — verify branch matches and we're clean.
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+  if [ "$current_branch" != "$branch" ] && [ "$current_branch" != "HEAD" ]; then
+    echo "WARNING [ensure-worktree]: worktree is on '$current_branch', expected '$branch'." >&2
+    # Soft warning only; the caller can still proceed — it's isolated regardless.
+  fi
+  # Print the worktree root for the caller to cd into (in case they're in a subdir).
+  git rev-parse --show-toplevel
+  exit 0
+fi
+
+# ── 3. We're in the main checkout — provision a new worktree ────────────────
+repo_root=$(git rev-parse --show-toplevel)
+# Lowercase the project name so the canonical worktree base is always
+# ~/worktrees/<lower-project>/<branch> regardless of how the repo dir is
+# capitalised on disk (e.g. DashFrame → dashframe).
+project_name=$(basename "$repo_root" | tr '[:upper:]' '[:lower:]')
+
+# Base dir: WORKTREE_BASE env override or ~/worktrees/<project>
+worktree_base="${WORKTREE_BASE:-$HOME/worktrees/$project_name}"
+
+# Sanitise branch name for use as a directory component.
+# Replace forward-slashes and colons with dashes; lowercase.
+dir_slug=$(printf '%s' "$branch" | tr '/:' '-' | tr '[:upper:]' '[:lower:]')
+worktree_path="$worktree_base/$dir_slug"
+
+if [ -d "$worktree_path" ]; then
+  # Worktree directory already exists.  Verify it belongs to this repo and is
+  # on the expected branch before re-using it.
+  existing_branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ -z "$existing_branch" ]; then
+    echo "ERROR [ensure-worktree]: '$worktree_path' exists but is not a valid git checkout." >&2
+    exit 1
+  fi
+  if [ "$existing_branch" != "$branch" ] && [ "$existing_branch" != "HEAD" ]; then
+    echo "ERROR [ensure-worktree]: '$worktree_path' exists but is on '$existing_branch', not '$branch'." >&2
+    echo "  Remove it manually ('git worktree remove $worktree_path') or choose a different base." >&2
+    exit 1
+  fi
+  echo "$worktree_path"
+  exit 0
+fi
+
+# Create the worktree.  If the branch already exists locally, use it; otherwise
+# track from origin.
+mkdir -p "$worktree_base"
+
+# Run git worktree add; redirect BOTH stdout and stderr to a temp log so the
+# only thing this script writes to stdout is the final worktree path.
+# Check $? directly (not through a pipe) to preserve the exit status.
+_wt_log=$(mktemp)
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  git worktree add "$worktree_path" "$branch" >"$_wt_log" 2>&1; _wt_rc=$?
+else
+  # Try to track from origin; error out if the branch doesn't exist anywhere.
+  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1; _wt_rc=$?
+  else
+    rm -f "$_wt_log"
+    echo "ERROR [ensure-worktree]: branch '$branch' not found locally or on origin." >&2
+    echo "  Create it first: git checkout -b $branch" >&2
+    exit 1
+  fi
+fi
+if [ "$_wt_rc" -ne 0 ]; then
+  sed 's/^/[ensure-worktree] /' "$_wt_log" >&2
+  rm -f "$_wt_log"
+  echo "ERROR [ensure-worktree]: git worktree add failed (exit $_wt_rc)." >&2
+  exit 1
+fi
+# On success, forward git's informational output to stderr (not stdout).
+sed 's/^/[ensure-worktree] /' "$_wt_log" >&2
+rm -f "$_wt_log"
+
+# Confirm the worktree was created and is in the right state.
+if [ ! -d "$worktree_path" ]; then
+  echo "ERROR [ensure-worktree]: worktree creation reported success but '$worktree_path' does not exist." >&2
+  exit 1
+fi
+
+actual_branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$actual_branch" != "$branch" ]; then
+  echo "ERROR [ensure-worktree]: worktree created but is on '$actual_branch' instead of '$branch'." >&2
+  exit 1
+fi
+
+echo "$worktree_path"

--- a/scripts/test-worktree-guard.sh
+++ b/scripts/test-worktree-guard.sh
@@ -154,7 +154,10 @@ echo ""
 
 echo "Test 7: ensure-worktree.sh from an existing worktree → returns current path"
 WTP="$SCRATCH/wt-out/feature-d"
-if [ -d "$WTP" ]; then
+if [ ! -d "$WTP" ]; then
+  # Test 6 failed to provision the worktree — make that explicit so FAILURES increments.
+  fail "Test 7 prerequisite missing: worktree '$WTP' was not created by Test 6"
+else
   cd "$WTP"
   returned=$(WORKTREE_BASE="$SCRATCH/wt-out" "$HELPER" feature-d 2>/dev/null) || true
   # Resolve symlinks before comparing: macOS /var → /private/var etc.

--- a/scripts/test-worktree-guard.sh
+++ b/scripts/test-worktree-guard.sh
@@ -51,9 +51,9 @@ git commit --no-verify -m "init" --quiet
 git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
 
 # Install only the worktree guard section of the hook (not lint-staged which
-# isn't installed in the scratch repo).  We extract everything from the guard
-# comment onward and write it as the hook.
-awk '/── Worktree isolation guard/,0' "$GUARD_HOOK" > .git/hooks/pre-commit
+# isn't installed in the scratch repo).  We extract the guard block using the
+# sentinels embedded in the hook — this is robust to reordering of hook sections.
+awk '/── Worktree isolation guard/{f=1} /── end guard ──/{f=0} f' "$GUARD_HOOK" > .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 
 info "Scratch repo: $SCRATCH"

--- a/scripts/test-worktree-guard.sh
+++ b/scripts/test-worktree-guard.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env sh
+# test-worktree-guard.sh — demonstrate and verify the worktree isolation guard
+#
+# This script is the executable proof that the guard works (acceptance criterion 3).
+# It runs three scenarios against the actual hooks in a temporary scratch repo:
+#
+#   PASS 1: commit on main-branch in main checkout  → allowed
+#   PASS 2: commit from an isolated worktree         → allowed
+#   PASS 3: commit on feature-branch in main checkout → BLOCKED by hook
+#   PASS 4: bypass env-var lifts the block            → allowed with warning
+#
+# Run from the repo root:
+#   scripts/test-worktree-guard.sh
+#
+# Exit 0  → all assertions pass (guard works correctly)
+# Exit 1  → at least one assertion failed
+
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+GUARD_HOOK="$REPO_ROOT/.husky/pre-commit"
+
+# ── colour helpers ───────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
+ok()   { printf "${GREEN}  ✓ %s${RESET}\n" "$*"; }
+fail() { printf "${RED}  ✗ %s${RESET}\n" "$*"; FAILURES=$((FAILURES+1)); }
+info() { printf "${YELLOW}  ▸ %s${RESET}\n" "$*"; }
+
+FAILURES=0
+
+# ── scratch repo setup ───────────────────────────────────────────────────────
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+cd "$SCRATCH"
+git init --quiet
+git config user.email "test@example.com"
+git config user.name "Test"
+git config commit.gpgsign false 2>/dev/null || true
+git remote add origin "https://example.com/repo.git"
+
+# Fake an origin/HEAD → main so the guard can detect the default branch.
+git checkout -b main --quiet
+# Create an initial commit so HEAD is valid.
+printf 'initial\n' > README.txt
+git add README.txt
+# Commit WITHOUT the guard hook first (bootstrap).
+git commit --no-verify -m "init" --quiet
+
+# Point origin/HEAD at main.
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+
+# Install only the worktree guard section of the hook (not lint-staged which
+# isn't installed in the scratch repo).  We extract everything from the guard
+# comment onward and write it as the hook.
+awk '/── Worktree isolation guard/,0' "$GUARD_HOOK" > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+
+info "Scratch repo: $SCRATCH"
+echo ""
+
+# ── Test 1: main branch in main checkout → ALLOWED ──────────────────────────
+echo "Test 1: commit on 'main' in main checkout (should be allowed)"
+printf 'change1\n' > f1.txt; git add f1.txt
+if git commit -m "test1" --quiet 2>/dev/null; then
+  ok "commit allowed on default branch in main checkout"
+else
+  fail "commit was unexpectedly blocked on the default branch"
+fi
+echo ""
+
+# ── Test 2: commit from an isolated worktree → ALLOWED ──────────────────────
+echo "Test 2: commit from an isolated worktree (should be allowed)"
+WORKTREE_DIR="$SCRATCH/wt-feature"
+git worktree add "$WORKTREE_DIR" -b feature-a --quiet 2>/dev/null
+cd "$WORKTREE_DIR"
+printf 'wt-change\n' > wt.txt; git add wt.txt
+if git commit -m "worktree-commit" --quiet 2>/dev/null; then
+  ok "commit allowed from isolated worktree"
+else
+  fail "commit was unexpectedly blocked in a worktree"
+fi
+cd "$SCRATCH"
+echo ""
+
+# ── Test 3: feature branch in main checkout → BLOCKED ───────────────────────
+echo "Test 3: commit on feature branch in main checkout (should be BLOCKED)"
+git checkout -b feature-b --quiet 2>/dev/null
+printf 'main-checkout-change\n' > f2.txt; git add f2.txt
+# Capture stderr; verify that the guard's signature text appears, not just any
+# non-zero exit (which could be a hook syntax error or an unrelated failure).
+_commit_stderr=$(git commit -m "should-fail" 2>&1 >/dev/null || true)
+if echo "$_commit_stderr" | grep -q "WORKTREE ISOLATION GUARD"; then
+  ok "hook blocked the commit with the isolation guard message"
+else
+  # If git commit exited 0, the guard failed to block.  If it exited non-zero
+  # but for a different reason, the guard is not the one firing.
+  if git log --oneline -1 2>/dev/null | grep -q "should-fail"; then
+    fail "hook did NOT block the commit — guard is broken (commit landed)"
+  else
+    fail "commit was blocked but the guard signature was missing — check hook logic (stderr: $(printf '%s' "$_commit_stderr" | head -3))"
+  fi
+fi
+git checkout main --quiet 2>/dev/null
+# Clean up staged file.
+git checkout -- . 2>/dev/null || true
+git branch -D feature-b --quiet 2>/dev/null || true
+echo ""
+
+# ── Test 4: bypass env-var allows the commit ────────────────────────────────
+echo "Test 4: ALLOW_MAIN_CHECKOUT_COMMIT=1 bypasses the block (should be allowed)"
+git checkout -b feature-c --quiet 2>/dev/null
+printf 'bypass-test\n' > f3.txt; git add f3.txt
+# Show stderr (the bypass warning) and verify the commit lands.
+if ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit -m "bypass-test" --quiet; then
+  ok "bypass env-var lifted the block"
+else
+  fail "bypass env-var did not work — check hook logic"
+fi
+git checkout main --quiet 2>/dev/null
+git branch -D feature-c --quiet 2>/dev/null || true
+echo ""
+
+# ── ensure-worktree.sh tests ─────────────────────────────────────────────────
+HELPER="$REPO_ROOT/scripts/ensure-worktree.sh"
+cd "$SCRATCH"
+
+echo "Test 5: ensure-worktree.sh without argument → exits non-zero"
+if "$HELPER" 2>/dev/null; then
+  fail "should have required a branch argument"
+else
+  ok "rejected missing branch argument"
+fi
+echo ""
+
+echo "Test 6: ensure-worktree.sh from main checkout provisions a worktree"
+git checkout main --quiet 2>/dev/null
+# Ensure the branch exists locally so the helper can create a worktree for it.
+git checkout -b feature-d --quiet 2>/dev/null
+git checkout main --quiet 2>/dev/null
+result=$(WORKTREE_BASE="$SCRATCH/wt-out" "$HELPER" feature-d 2>/dev/null) || true
+if [ -d "$result" ] && git -C "$result" rev-parse --verify HEAD >/dev/null 2>&1; then
+  ok "worktree provisioned at: $result"
+  actual_branch=$(git -C "$result" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$actual_branch" = "feature-d" ]; then
+    ok "worktree is on the correct branch (feature-d)"
+  else
+    fail "worktree is on '$actual_branch', expected 'feature-d'"
+  fi
+else
+  fail "ensure-worktree.sh did not produce a valid worktree path (got: '$result')"
+fi
+echo ""
+
+echo "Test 7: ensure-worktree.sh from an existing worktree → returns current path"
+WTP="$SCRATCH/wt-out/feature-d"
+if [ -d "$WTP" ]; then
+  cd "$WTP"
+  returned=$(WORKTREE_BASE="$SCRATCH/wt-out" "$HELPER" feature-d 2>/dev/null) || true
+  # Resolve symlinks before comparing: macOS /var → /private/var etc.
+  canon_expected=$(cd "$WTP" && pwd -P)
+  canon_returned=$(cd "$returned" 2>/dev/null && pwd -P || echo "$returned")
+  if [ "$canon_returned" = "$canon_expected" ]; then
+    ok "already-in-worktree case returned the correct path"
+  else
+    fail "expected '$canon_expected', got '$canon_returned'"
+  fi
+  cd "$SCRATCH"
+fi
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+if [ "$FAILURES" -eq 0 ]; then
+  printf "${GREEN}All tests passed — worktree isolation guard is working.${RESET}\n"
+  exit 0
+else
+  printf "${RED}$FAILURES test(s) failed — guard is NOT working as expected.${RESET}\n"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Problem**: Dispatched agents briefed to "work in a worktree" could silently run in the shared main checkout instead, causing concurrent agents to revert each other's uncommitted work and cross-stack commits onto each other's branch refs (observed: YW-298 / PR #172, 2026-06-25).
- **Root cause**: `isolation: worktree` was a brief instruction, not an enforcement — nothing stopped an agent from proceeding in main if worktree setup failed or was skipped.
- **Fix**: Fail-closed git-layer guard (pre-commit hook) + canonical bootstrap helper that agents call first.

Tracked internally as YW-312.

## Changes

| File | What |
|---|---|
| `.husky/pre-commit` | Added worktree isolation guard: blocks commits on non-default branches in the main checkout. Detection: `git-dir == git-common-dir` (main checkout) vs different (linked worktree). Bypass: `ALLOW_MAIN_CHECKOUT_COMMIT=1`. `bunx lint-staged \|\| exit 1` ensures lint failures still block. |
| `scripts/ensure-worktree.sh` | New proactive bootstrap helper. Agents call this as step zero: provisions `~/worktrees/<project>/<branch>` and prints the path. Hard-exits on any failure. Only stdout is the resolved path. |
| `scripts/test-worktree-guard.sh` | 7-scenario runnable proof. Tests: default-branch commit allowed, worktree commit allowed, feature-branch-in-main blocked (guard signature verified), bypass works, ensure-worktree.sh validation, provisioning, idempotent re-entry. All pass. |
| `CLAUDE.md` | Discoverability note for agents. |
| `docs/audits/worktree-isolation-gap-2026-06-28.md` | Scope boundary doc: what the in-repo guard covers, what the harness-side gap is, and the recommended fix for the cockpit dispatch-discipline brief template. |

## Scope boundary (harness-side gap — finding for the owner)

The pre-commit hook closes the **cross-stacking-commits** failure mode. It does NOT close the **uncommitted-work-revert** failure mode (two agents editing the same files in the shared checkout before either commits). That race is only prevented by provisioning worktrees before agents start writing — option (a) in the ticket's AC — which lives in `~/.claude/skills/cockpit/references/dispatch-discipline.md` (outside this repo). See `docs/audits/worktree-isolation-gap-2026-06-28.md` for the recommended fix.

## Acceptance criteria

- ✅ AC1(b): guard blocks a commit when cwd is the shared main checkout on a feature branch
- ✅ AC2: cross-stacking commits onto another agent's branch ref → blocked
- ⚠️ AC2: uncommitted-work revert → acknowledged gap (harness-side, documented)
- ✅ AC3: `scripts/test-worktree-guard.sh` — all 7 tests pass

## Test plan

- [ ] `bash scripts/test-worktree-guard.sh` → all 7 tests pass
- [ ] Verify pre-commit blocks: on feature branch in main checkout, attempt `git commit` → guard box + exit 1
- [ ] Verify bypass: `ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit` → warns and commits
- [ ] Verify lint-staged still blocks on lint errors (not swallowed)

## Screenshots

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxtmqp5j4xXQG1yxuuF7e6

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a fail-closed worktree isolation guard to prevent concurrent dispatched agents from cross-stacking commits onto each other's branch refs, addressing the root cause of the YW-298/PR #172 incident. It ships a pre-commit hook that blocks feature-branch commits from the shared main checkout, a `scripts/ensure-worktree.sh` bootstrap helper for agents, a 7-scenario test suite, and a scope-boundary audit document.

- `.husky/pre-commit` now detects main-checkout vs. linked-worktree via `--git-dir == --git-common-dir` and blocks non-default-branch commits with a clear diagnostic message; previous issues (unreachable error-handling block, silent Test 7 skip, wrong-branch fail-open path, missing repo-identity check on reuse) are all addressed in this revision.
- `scripts/ensure-worktree.sh` is a well-hardened fail-closed helper; the one remaining gap is that `git fetch origin \"$branch\" || true` silently swallows network failures, which can surface as an opaque `invalid reference: origin/<branch>` error from the subsequent `worktree add` step.
- The PR explicitly acknowledges and documents the uncommitted-work-revert race as an out-of-scope harness-side gap.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the guard logic is correct and previously flagged issues have all been resolved in this revision.

The pre-commit hook detection approach (git-dir vs git-common-dir) is reliable, the bypass is explicit and documented, and the ensure-worktree.sh helper is well-hardened with proper exit codes and repo-identity verification. All previously raised issues are addressed. The one remaining gap (silently swallowed fetch failure producing an opaque worktree-add error) is a diagnostics quality issue that does not cause silent bad behavior.

scripts/ensure-worktree.sh lines 115-120 (fetch-failure diagnostic gap) warrants a follow-up but does not need to block this merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .husky/pre-commit | Prepends worktree isolation guard before existing lint-staged invocation; detection via git-dir == git-common-dir comparison is reliable across subdirectories and worktrees; bypass env-var and default-branch allow-list are correctly implemented. |
| scripts/ensure-worktree.sh | Solid fail-closed bootstrap helper; previous issues (|| _wt_rc=$? fix, wrong-branch exit 1, wt_common_dir repo-identity check, git fetch to populate tracking ref) are all addressed; one P2 remains: silently swallowed fetch failure can produce an opaque worktree-add error. |
| scripts/test-worktree-guard.sh | 7-scenario proof suite against a scratch repo; Test 7 now explicitly calls fail() when the prerequisite worktree from Test 6 is missing, fixing the previous silent-skip gap; awk extraction of the guard block from the hook is correct and sentinel-robust. |
| CLAUDE.md | Adds worktree-isolation bootstrap instructions for dispatched agents; machine-specific absolute path in the prose is noted in a previous thread. |
| docs/audits/worktree-isolation-gap-2026-06-28.md | Clear scope-boundary document distinguishing what the in-repo guard covers (commit-time cross-stacking) from the unaddressed harness-side gap (uncommitted-work races); includes concrete recommended actions for the owner. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(infra): resolve review threads — fai..."](https://github.com/youhaowei/dashframe/commit/fcaacfb3fbfa9b9c3c80461c46883c9f4bef2d23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40340396)</sub>

<!-- /greptile_comment -->