### PR TITLE
[YW-327] feat: wire publish-page — PreviewDiffDialog mount + publishDraft/discardDraft RPCs

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -529,25 +529,29 @@ export async function createDashframeServer(
       // Handlers that use a sub-tracker (e.g. publishDraft, which calls
       // applyCommands with its own fresh tracked context) cannot surface their
       // writes via the outer DrizzleTracker. They signal the tables they wrote
-      // by returning `__extraTablesWritten` in the result object. The wrapper
-      // merges those tables into `callResult.tablesWritten` so the route layer
-      // (`createRoutes`) broadcasts the correct WS invalidation set — then
-      // strips the field before the result reaches the HTTP client.
+      // by returning `__extraTablesWritten: string[]` in the result object. The
+      // wrapper always strips the field (so clients never see it) and merges it
+      // into `callResult.tablesWritten` when non-empty (so `createRoutes`
+      // broadcasts the correct WS invalidation set).
+      //
+      // The double-underscore prefix is a reserved-internal convention. Any
+      // handler whose result carries a non-empty `__extraTablesWritten` will
+      // have those tables merged into the invalidation set — this is a
+      // deliberate extension point, not accidental behaviour.
       const rawResult = callResult.result as
-        | ({ __extraTablesWritten?: string[] } & object)
+        | ({ __extraTablesWritten?: unknown } & object)
         | null
         | undefined;
-      if (
-        rawResult != null &&
-        Array.isArray(rawResult.__extraTablesWritten) &&
-        rawResult.__extraTablesWritten.length > 0
-      ) {
+      if (rawResult != null && "__extraTablesWritten" in rawResult) {
         const { __extraTablesWritten, ...cleanResult } = rawResult;
-        const merged = new Set([
-          ...callResult.tablesWritten,
-          ...(__extraTablesWritten as string[]),
-        ]);
-        return { ...callResult, result: cleanResult, tablesWritten: merged };
+        const extra = Array.isArray(__extraTablesWritten)
+          ? (__extraTablesWritten as string[])
+          : [];
+        const mergedTables =
+          extra.length > 0
+            ? new Set([...callResult.tablesWritten, ...extra])
+            : callResult.tablesWritten;
+        return { ...callResult, result: cleanResult, tablesWritten: mergedTables };
       }
 
       return callResult;

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -551,7 +551,11 @@ export async function createDashframeServer(
           extra.length > 0
             ? new Set([...callResult.tablesWritten, ...extra])
             : callResult.tablesWritten;
-        return { ...callResult, result: cleanResult, tablesWritten: mergedTables };
+        return {
+          ...callResult,
+          result: cleanResult,
+          tablesWritten: mergedTables,
+        };
       }
 
       return callResult;

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -54,6 +54,9 @@ import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { createHash, timingSafeEqual } from "node:crypto";
 
+import { type ArtifactDb } from "@dashframe/server-core";
+
+import { createDraftController } from "./draft-controller";
 import { functions } from "./functions";
 
 type CorsOrigin =
@@ -521,7 +524,33 @@ export async function createDashframeServer(
     ...vaultWrapped,
     async call(path, args, context) {
       const merged = { ...(context ?? {}), ...serverContext };
-      return vaultWrapped.call(path, args, merged);
+      const callResult = await vaultWrapped.call(path, args, merged);
+
+      // Handlers that use a sub-tracker (e.g. publishDraft, which calls
+      // applyCommands with its own fresh tracked context) cannot surface their
+      // writes via the outer DrizzleTracker. They signal the tables they wrote
+      // by returning `__extraTablesWritten` in the result object. The wrapper
+      // merges those tables into `callResult.tablesWritten` so the route layer
+      // (`createRoutes`) broadcasts the correct WS invalidation set — then
+      // strips the field before the result reaches the HTTP client.
+      const rawResult = callResult.result as
+        | ({ __extraTablesWritten?: string[] } & object)
+        | null
+        | undefined;
+      if (
+        rawResult != null &&
+        Array.isArray(rawResult.__extraTablesWritten) &&
+        rawResult.__extraTablesWritten.length > 0
+      ) {
+        const { __extraTablesWritten, ...cleanResult } = rawResult;
+        const merged = new Set([
+          ...callResult.tablesWritten,
+          ...(__extraTablesWritten as string[]),
+        ]);
+        return { ...callResult, result: cleanResult, tablesWritten: merged };
+      }
+
+      return callResult;
     },
     async runHandler(path, args, tracked, context) {
       const merged = { ...(context ?? {}), ...serverContext };
@@ -533,6 +562,17 @@ export async function createDashframeServer(
   // Done post-assignment because app itself is the wrapped version.
   serverContext.wyStackApp = app;
   serverContext.artifactDb = opts.db;
+
+  // Inject the persistent draft controller. Must come after `app` is finalized
+  // because the controller's `publishDraft` replay uses the full wrapped app.
+  // The `onWrite` callback is also surfaced here so the `publishDraft` handler
+  // can fire it explicitly — `buildDashframeApp`'s outer tracker never sees the
+  // sub-tracker writes from `applyCommands(mode:'commit')` inside the controller.
+  serverContext.draftController = createDraftController(
+    app,
+    opts.db as ArtifactDb,
+  );
+  serverContext.onWrite = opts.onWrite;
 
   // Mirror @wystack/server/node's serve() composition, adding CORS in front.
   const honoApp = new Hono();

--- a/apps/server/src/functions.ts
+++ b/apps/server/src/functions.ts
@@ -14,6 +14,7 @@ import { query } from "@wystack/server";
 import { appArtifactFunctions } from "./functions/app-artifacts";
 import { commandFunctions } from "./functions/commands";
 import { dashboardFunctions } from "./functions/dashboards";
+import { draftLifecycleFunctions } from "./functions/draft-lifecycle";
 import { previewDiffFunctions } from "./functions/preview-diff";
 
 const { projectMeta } = schema;
@@ -60,6 +61,7 @@ export const functions = {
   ...appArtifactFunctions,
   ...commandFunctions,
   ...dashboardFunctions,
+  ...draftLifecycleFunctions,
   ...previewDiffFunctions,
 };
 

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -58,9 +58,22 @@ function post(url: string, path: string, body: unknown): Promise<Response> {
   });
 }
 
+/** GET /api/:path?args=<json> — for WyStack query endpoints. */
+function get(url: string, path: string, args: unknown): Promise<Response> {
+  const params = new URLSearchParams({ args: JSON.stringify(args) });
+  return fetch(`${url}/api/${path}?${params.toString()}`, { method: "GET" });
+}
+
 async function postOk<T>(url: string, path: string, body: unknown): Promise<T> {
   const res = await post(url, path, body);
   expect(res.status, `POST ${path} returned ${res.status}`).toBe(200);
+  const json = (await res.json()) as { data: T };
+  return json.data;
+}
+
+async function getOk<T>(url: string, path: string, args: unknown): Promise<T> {
+  const res = await get(url, path, args);
+  expect(res.status, `GET ${path} returned ${res.status}`).toBe(200);
   const json = (await res.json()) as { data: T };
   return json.data;
 }
@@ -233,7 +246,8 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
 
     server = await createDashframeServer({ db: project.db });
 
-    const commands = await postOk<{ path: string; args: unknown }[]>(
+    // getDraftLog is a WyStack query → GET /api/getDraftLog?args=<json>
+    const commands = await getOk<{ path: string; args: unknown }[]>(
       server.url,
       "getDraftLog",
       { draftId },

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -31,7 +31,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { openArtifactDb, openProject, type ArtifactDb, type ProjectHandle } from "@dashframe/server-core";
+import {
+  openProject,
+  type ArtifactDb,
+  type ProjectHandle,
+} from "@dashframe/server-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -54,11 +58,7 @@ function post(url: string, path: string, body: unknown): Promise<Response> {
   });
 }
 
-async function postOk<T>(
-  url: string,
-  path: string,
-  body: unknown,
-): Promise<T> {
+async function postOk<T>(url: string, path: string, body: unknown): Promise<T> {
   const res = await post(url, path, body);
   expect(res.status, `POST ${path} returned ${res.status}`).toBe(200);
   const json = (await res.json()) as { data: T };

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Draft lifecycle RPCs — publishDraft, discardDraft, getDraftLog
+ *
+ * Pins the two contracts the QA review identified as untested but load-bearing:
+ *
+ *   1. `publishDraft` fires `onWrite` after a successful publish. The outer
+ *      `buildDashframeApp` tracker sees zero writes (sub-tracker asymmetry from
+ *      the `applyCommands(mode:'commit')` inside the controller), so the handler
+ *      must fire `ctx.onWrite` explicitly. If this regresses, snapshots stop
+ *      persisting after publish → data loss on crash.
+ *
+ *   2. `discardDraft` fires `onWrite` after a successful discard. The handler
+ *      deletes rows the outer tracker never sees; missing this leaves a
+ *      resurrection window across server restarts → phantom draft rows.
+ *
+ *   3. The `__extraTablesWritten` relay in `app.ts` strips the sentinel field
+ *      from the HTTP response while broadcasting the WS invalidation set.
+ *      If the strip is lost, clients see an internal implementation detail;
+ *      if the merge is lost, WS subscriptions don't refresh after publish.
+ *
+ * Setup: open a real PGlite project, seed a draft via an external controller
+ * backed by the same DB (the same design `draft-controller.test.ts` uses), then
+ * exercise publishDraft/discardDraft/getDraftLog via the HTTP server.
+ *
+ * WHY external controller for seeding: `openDraft` and `appendToDraft` are
+ * internal DraftController methods, not RPC endpoints. The seam these tests own
+ * is the HTTP RPC path from the renderer to the server (contracts 1–3 above).
+ * Controller unit contracts live in draft-controller.test.ts.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { openArtifactDb, openProject, type ArtifactDb, type ProjectHandle } from "@dashframe/server-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildDashframeApp,
+  createDashframeServer,
+  createDraftController,
+  type DashframeServer,
+} from "../app";
+import { cmd } from "./commands";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function post(url: string, path: string, body: unknown): Promise<Response> {
+  return fetch(`${url}/api/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function postOk<T>(
+  url: string,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const res = await post(url, path, body);
+  expect(res.status, `POST ${path} returned ${res.status}`).toBe(200);
+  const json = (await res.json()) as { data: T };
+  return json.data;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () => {
+  let root: string;
+  let project: ProjectHandle | null;
+  let server: DashframeServer | null;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-draft-rpc-"));
+    project = null;
+    server = null;
+  });
+
+  afterEach(async () => {
+    server?.stop();
+    await project?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  /**
+   * Seed a draft via an external controller backed by the same DB that
+   * `createDashframeServer` will use. Since the draft log lives in the DB,
+   * the server's internal controller can read and replay it.
+   *
+   * Returns the draftId to pass to the HTTP RPCs.
+   */
+  async function seedDraft(db: ArtifactDb): Promise<string> {
+    const seedApp = await buildDashframeApp({ db });
+    const seedController = createDraftController(seedApp, db);
+
+    // Seed a DataSource into canonical first (publishDraft writes to the
+    // canonical data_sources table — we need it to exist for the next draft
+    // to reference the right foreign-key chain).
+    const sourceId = crypto.randomUUID();
+    const baseDraft = await seedController.openDraft();
+    await seedController.appendToDraft(baseDraft, [
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name: "Base" }),
+    ]);
+    await seedController.publishDraft(baseDraft);
+
+    // Now open the draft that the RPC tests will publish or discard.
+    const draftId = await seedController.openDraft();
+    await seedController.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id: crypto.randomUUID(),
+        type: "csv",
+        name: "Draft source",
+      }),
+    ]);
+
+    return draftId;
+  }
+
+  // -------------------------------------------------------------------------
+  // Contract 1: publishDraft fires onWrite
+  // -------------------------------------------------------------------------
+
+  it("publishDraft fires onWrite when tables are written", async () => {
+    const onWriteCalls: number[] = [];
+
+    project = await openProject({ dir: join(root, "proj") });
+    const draftId = await seedDraft(project.db as ArtifactDb);
+
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => onWriteCalls.push(Date.now()),
+    });
+
+    const result = await postOk<{ tablesWritten: string[] }>(
+      server.url,
+      "publishDraft",
+      { draftId },
+    );
+
+    // Contract: onWrite fires once after the publish commits.
+    // If it fires zero times, snapshot persistence regresses on publish.
+    expect(onWriteCalls).toHaveLength(1);
+
+    // tablesWritten is non-empty — the log had one CreateDataSource command.
+    expect(result.tablesWritten.length).toBeGreaterThan(0);
+  });
+
+  it("publishDraft does NOT fire onWrite when the draft log is empty", async () => {
+    const onWriteCalls: number[] = [];
+
+    project = await openProject({ dir: join(root, "empty") });
+
+    // Open a draft with no commands — no writes means no onWrite.
+    const seedApp = await buildDashframeApp({ db: project.db as ArtifactDb });
+    const seedController = createDraftController(
+      seedApp,
+      project.db as ArtifactDb,
+    );
+    const emptyDraftId = await seedController.openDraft();
+
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => onWriteCalls.push(Date.now()),
+    });
+
+    const result = await postOk<{ tablesWritten: string[] }>(
+      server.url,
+      "publishDraft",
+      { draftId: emptyDraftId },
+    );
+
+    // Empty log → no tables written → onWrite must NOT fire.
+    expect(onWriteCalls).toHaveLength(0);
+    expect(result.tablesWritten).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Contract 2: discardDraft fires onWrite
+  // -------------------------------------------------------------------------
+
+  it("discardDraft fires onWrite after successfully discarding", async () => {
+    const onWriteCalls: number[] = [];
+
+    project = await openProject({ dir: join(root, "proj") });
+    const draftId = await seedDraft(project.db as ArtifactDb);
+
+    server = await createDashframeServer({
+      db: project.db,
+      onWrite: () => onWriteCalls.push(Date.now()),
+    });
+
+    await postOk<void>(server.url, "discardDraft", { draftId });
+
+    // Contract: discard deletes shadow rows + log; onWrite must fire so the
+    // snapshot is flushed, closing the resurrection-on-restart window.
+    expect(onWriteCalls).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Contract 3: __extraTablesWritten relay — strip from response
+  // -------------------------------------------------------------------------
+
+  it("publishDraft response does NOT expose __extraTablesWritten", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const draftId = await seedDraft(project.db as ArtifactDb);
+
+    server = await createDashframeServer({ db: project.db });
+
+    const res = await post(server.url, "publishDraft", { draftId });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { data: Record<string, unknown> };
+
+    // The `__extraTablesWritten` sentinel is an internal relay field.
+    // If the `app.ts` relay strip breaks, this assertion catches it so clients
+    // don't see implementation detail leaking into the API response.
+    expect(body.data).not.toHaveProperty("__extraTablesWritten");
+    // The public field is still present.
+    expect(body.data).toHaveProperty("tablesWritten");
+  });
+
+  // -------------------------------------------------------------------------
+  // getDraftLog: compacted command log
+  // -------------------------------------------------------------------------
+
+  it("getDraftLog returns the compacted command log in replay order", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const draftId = await seedDraft(project.db as ArtifactDb);
+
+    server = await createDashframeServer({ db: project.db });
+
+    const commands = await postOk<{ path: string; args: unknown }[]>(
+      server.url,
+      "getDraftLog",
+      { draftId },
+    );
+
+    // One CreateDataSource command was appended in seedDraft.
+    expect(commands.length).toBeGreaterThan(0);
+    expect(commands[0]).toHaveProperty("path");
+    expect(commands[0]).toHaveProperty("args");
+  });
+});

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -1,0 +1,112 @@
+/**
+ * Draft lifecycle RPC endpoints — publishDraft, discardDraft, getDraftLog.
+ *
+ * These expose the DraftController's lifecycle operations as WyStack RPCs.
+ * The DraftController instance is injected via handler context (see app.ts
+ * `serverContext.draftController`).
+ *
+ * Invalidation note — SPLIT-TRACKER asymmetry:
+ *   `publishDraft` replays the command log through `applyCommands` using its
+ *   own fresh sub-tracker, so the outer `app.call` tracked context sees zero
+ *   `tablesWritten`. To drive WS invalidation the handler returns
+ *   `__extraTablesWritten` alongside its public result. The server app wrapper
+ *   (`createDashframeServer` in app.ts) intercepts this field, merges the set
+ *   into `callResult.tablesWritten`, then strips the field before forwarding the
+ *   result to the client. The net effect: `createRoutes` sees a non-empty
+ *   `tablesWritten` and fires `publishInvalidation` normally.
+ *
+ *   `onWrite` (snapshot persistence) is injected as `ctx.onWrite` and is called
+ *   explicitly here — the outer `buildDashframeApp` wrapper does not fire it for
+ *   the same sub-tracker reason.
+ */
+import { text } from "@wystack/db";
+import type { Command } from "@wystack/server";
+import { mutation, query } from "@wystack/server";
+
+import type { DraftController } from "../draft-controller";
+
+/**
+ * Publish a draft: replay the durable command log onto canonical tables in one
+ * atomic transaction, then delete the log + sweep shadow tables.
+ *
+ * Returns the set of canonical tables written so callers can correlate. The
+ * server app wrapper also uses `__extraTablesWritten` (stripped before the
+ * response reaches the client) to drive WS reactive invalidation.
+ */
+const publishDraft = mutation({
+  args: { draftId: text },
+  handler: async (
+    ctx,
+    { draftId },
+  ): Promise<{ tablesWritten: string[] }> => {
+    const draftController = ctx.draftController as DraftController | undefined;
+    if (!draftController) {
+      throw new Error(
+        "publishDraft: draftController not in handler context — " +
+          "ensure createDashframeServer injects it via serverContext",
+      );
+    }
+
+    const result = await draftController.publishDraft(draftId, {});
+
+    // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does
+    // NOT fire `onWrite` here (its tracker sees zero writes from the sub-tracker
+    // used inside publishDraft). We call it explicitly via the injected callback.
+    if (result.tablesWritten.size > 0) {
+      const onWrite = ctx.onWrite as (() => void) | undefined;
+      try {
+        onWrite?.();
+      } catch (err) {
+        console.error("[dashframe] publishDraft: onWrite hook threw:", err);
+      }
+    }
+
+    const tablesWritten = [...result.tablesWritten];
+    return {
+      tablesWritten,
+      // Internal field consumed by the app.ts wrapper to drive WS invalidation.
+      // Stripped from the response before it reaches the client.
+      __extraTablesWritten: tablesWritten,
+    } as { tablesWritten: string[] };
+  },
+});
+
+/**
+ * Discard a draft: delete the command log and sweep all draft shadow rows for
+ * this draftId. Canonical tables are never touched.
+ */
+const discardDraft = mutation({
+  args: { draftId: text },
+  handler: async (ctx, { draftId }): Promise<void> => {
+    const draftController = ctx.draftController as DraftController | undefined;
+    if (!draftController) {
+      throw new Error(
+        "discardDraft: draftController not in handler context — " +
+          "ensure createDashframeServer injects it via serverContext",
+      );
+    }
+
+    await draftController.discardDraft(draftId);
+  },
+});
+
+/**
+ * Read the compacted command log for a draft. Returns commands in replay order.
+ * Used by the client to build the PreviewDiff before showing the review dialog.
+ */
+const getDraftLog = query({
+  args: { draftId: text },
+  handler: async (ctx, { draftId }): Promise<Command[]> => {
+    const draftController = ctx.draftController as DraftController | undefined;
+    if (!draftController) {
+      throw new Error(
+        "getDraftLog: draftController not in handler context — " +
+          "ensure createDashframeServer injects it via serverContext",
+      );
+    }
+
+    return draftController.getDraftLog(draftId);
+  },
+});
+
+export const draftLifecycleFunctions = { publishDraft, discardDraft, getDraftLog };

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -26,6 +26,20 @@ import { mutation, query } from "@wystack/server";
 import type { DraftController } from "../draft-controller";
 
 /**
+ * Internal-only return shape for `publishDraft`. The `__extraTablesWritten`
+ * field is consumed by the `app.ts` wrapper (merges it into the WS
+ * invalidation set, then strips it before forwarding to the client).
+ * Declaring it here makes both the handler return and the interceptor in
+ * `app.ts` type-checked against the same internal shape — TypeScript flags a
+ * mismatch if either side diverges, rather than relying only on the
+ * contract-3 test to catch leaks.
+ */
+interface PublishDraftInternalResult {
+  tablesWritten: string[];
+  __extraTablesWritten: string[];
+}
+
+/**
  * Publish a draft: replay the durable command log onto canonical tables in one
  * atomic transaction, then delete the log + sweep shadow tables.
  *
@@ -35,7 +49,7 @@ import type { DraftController } from "../draft-controller";
  */
 const publishDraft = mutation({
   args: { draftId: text },
-  handler: async (ctx, { draftId }): Promise<{ tablesWritten: string[] }> => {
+  handler: async (ctx, { draftId }): Promise<PublishDraftInternalResult> => {
     const draftController = ctx.draftController as DraftController | undefined;
     if (!draftController) {
       throw new Error(
@@ -44,12 +58,24 @@ const publishDraft = mutation({
       );
     }
 
+    // Pre-read the log length before publishing so we can determine whether
+    // any durable rows were deleted, even when all commands are no-ops.
+    // `publishDraft` unconditionally deletes the command log + shadow rows for
+    // any non-empty draft (inside one atomic tx), so a draft with no-op
+    // commands (e.g. GetOrCreateDataSource for an existing source) produces
+    // `tablesWritten = {}` but still modifies durable storage. Without this
+    // check, `onWrite` would be skipped and the deletion goes un-snapshotted,
+    // leaving a resurrection window across server restarts.
+    const prePublishLog = await draftController.getDraftLog(draftId);
+
     const result = await draftController.publishDraft(draftId, {});
 
     // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does
     // NOT fire `onWrite` here (its tracker sees zero writes from the sub-tracker
     // used inside publishDraft). We call it explicitly via the injected callback.
-    if (result.tablesWritten.size > 0) {
+    // Condition: fire when canonical tables were written OR when the draft had
+    // a non-empty command log (its deletion is itself a durable change).
+    if (result.tablesWritten.size > 0 || prePublishLog.length > 0) {
       const onWrite = ctx.onWrite as (() => void) | undefined;
       try {
         onWrite?.();
@@ -64,7 +90,7 @@ const publishDraft = mutation({
       // Internal field consumed by the app.ts wrapper to drive WS invalidation.
       // Stripped from the response before it reaches the client.
       __extraTablesWritten: tablesWritten,
-    } as { tablesWritten: string[] };
+    };
   },
 });
 

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -74,6 +74,12 @@ const publishDraft = mutation({
 /**
  * Discard a draft: delete the command log and sweep all draft shadow rows for
  * this draftId. Canonical tables are never touched.
+ *
+ * Fires `onWrite` (snapshot persistence) after a successful discard. The discard
+ * deletes rows from the `draft_command_log` table and the six `<table>__draft`
+ * shadows — all durable stores. If the process crashes before the next scheduled
+ * snapshot, those rows would survive in the stale snapshot and resurrect the draft.
+ * Triggering a snapshot after discard closes that window and prevents orphan rows.
  */
 const discardDraft = mutation({
   args: { draftId: text },
@@ -87,6 +93,15 @@ const discardDraft = mutation({
     }
 
     await draftController.discardDraft(draftId);
+
+    // Trigger snapshot persistence after discard — the shadow rows live in the
+    // durable store; a stale snapshot would resurrect them on restart.
+    const onWrite = ctx.onWrite as (() => void) | undefined;
+    try {
+      onWrite?.();
+    } catch (err) {
+      console.error("[dashframe] discardDraft: onWrite hook threw:", err);
+    }
   },
 });
 

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -35,10 +35,7 @@ import type { DraftController } from "../draft-controller";
  */
 const publishDraft = mutation({
   args: { draftId: text },
-  handler: async (
-    ctx,
-    { draftId },
-  ): Promise<{ tablesWritten: string[] }> => {
+  handler: async (ctx, { draftId }): Promise<{ tablesWritten: string[] }> => {
     const draftController = ctx.draftController as DraftController | undefined;
     if (!draftController) {
       throw new Error(
@@ -124,4 +121,8 @@ const getDraftLog = query({
   },
 });
 
-export const draftLifecycleFunctions = { publishDraft, discardDraft, getDraftLog };
+export const draftLifecycleFunctions = {
+  publishDraft,
+  discardDraft,
+  getDraftLog,
+};

--- a/packages/app-data/src/draft-lifecycle.ts
+++ b/packages/app-data/src/draft-lifecycle.ts
@@ -3,10 +3,8 @@
  * getDraftLog.
  *
  * These parallel the pattern in data-sources.ts / preview-diff.ts: imperative
- * helpers for direct async calls and `use*` hooks for React component binding.
+ * helpers for direct async calls.
  */
-import { useMutation } from "@wystack/client";
-
 import { api } from "./api";
 import { getWyStackClient } from "./client";
 import type { PreviewCommand } from "./preview-diff";
@@ -42,19 +40,4 @@ export async function discardDraft(draftId: string): Promise<void> {
  */
 export async function getDraftLog(draftId: string): Promise<PreviewCommand[]> {
   return getWyStackClient().query(api.getDraftLog, { draftId });
-}
-
-/**
- * React hook: bind the `publishDraft` mutation to a component. Returns the
- * `useMutation` handle so components can track pending / error state.
- */
-export function usePublishDraft() {
-  return useMutation(api.publishDraft);
-}
-
-/**
- * React hook: bind the `discardDraft` mutation to a component.
- */
-export function useDiscardDraft() {
-  return useMutation(api.discardDraft);
 }

--- a/packages/app-data/src/draft-lifecycle.ts
+++ b/packages/app-data/src/draft-lifecycle.ts
@@ -1,0 +1,60 @@
+/**
+ * Client helpers for draft lifecycle RPCs: publishDraft, discardDraft,
+ * getDraftLog.
+ *
+ * These parallel the pattern in data-sources.ts / preview-diff.ts: imperative
+ * helpers for direct async calls and `use*` hooks for React component binding.
+ */
+import { useMutation } from "@wystack/client";
+
+import { api } from "./api";
+import { getWyStackClient } from "./client";
+import type { PreviewCommand } from "./preview-diff";
+
+/**
+ * Publish a draft: replay its command log onto canonical tables, then clean up
+ * the draft's log and shadow rows.
+ *
+ * Returns the set of canonical table names written (for caller correlation).
+ * WS reactive invalidation fires automatically — callers do not need to
+ * manually refetch after a publish.
+ */
+export async function publishDraft(
+  draftId: string,
+): Promise<{ tablesWritten: string[] }> {
+  return getWyStackClient().mutate(api.publishDraft, { draftId });
+}
+
+/**
+ * Discard a draft: delete its command log and sweep all shadow rows. Canonical
+ * tables are never touched.
+ */
+export async function discardDraft(draftId: string): Promise<void> {
+  return getWyStackClient().mutate(api.discardDraft, { draftId });
+}
+
+/**
+ * Read the compacted command log for a draft, in replay order. Used by the
+ * client to build a PreviewDiff before showing the review dialog.
+ *
+ * Returns commands in the same shape as `PreviewCommand` (structurally
+ * identical; no server package import needed on the client side).
+ */
+export async function getDraftLog(draftId: string): Promise<PreviewCommand[]> {
+  return getWyStackClient().query(api.getDraftLog, { draftId });
+}
+
+/**
+ * React hook: bind the `publishDraft` mutation to a component. Returns the
+ * `useMutation` handle so components can track pending / error state.
+ */
+export function usePublishDraft() {
+  return useMutation(api.publishDraft);
+}
+
+/**
+ * React hook: bind the `discardDraft` mutation to a component.
+ */
+export function useDiscardDraft() {
+  return useMutation(api.discardDraft);
+}

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -100,3 +100,12 @@ export { DatabaseProvider, useDatabase } from "./compat";
 
 // Preview batch — SPLIT-TIER: returns metadata only, no row data over the wire.
 export { previewBatch, type PreviewCommand } from "./preview-diff";
+
+// Draft lifecycle — publish, discard, and log-read RPCs + React hooks.
+export {
+  discardDraft,
+  getDraftLog,
+  publishDraft,
+  useDiscardDraft,
+  usePublishDraft,
+} from "./draft-lifecycle";

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -101,11 +101,5 @@ export { DatabaseProvider, useDatabase } from "./compat";
 // Preview batch — SPLIT-TIER: returns metadata only, no row data over the wire.
 export { previewBatch, type PreviewCommand } from "./preview-diff";
 
-// Draft lifecycle — publish, discard, and log-read RPCs + React hooks.
-export {
-  discardDraft,
-  getDraftLog,
-  publishDraft,
-  useDiscardDraft,
-  usePublishDraft,
-} from "./draft-lifecycle";
+// Draft lifecycle — publish, discard, and log-read RPCs.
+export { discardDraft, getDraftLog, publishDraft } from "./draft-lifecycle";

--- a/packages/app/src/components/assistant/AssistantSidebar.tsx
+++ b/packages/app/src/components/assistant/AssistantSidebar.tsx
@@ -3,6 +3,7 @@ import { Button } from "@wystack/ui";
 import { CloseIcon, SparklesIcon } from "@wystack/ui-icons";
 
 import { AssistantEmptyState } from "./AssistantEmptyState";
+import { DraftReviewPanel } from "./DraftReviewPanel";
 import { useArtifactContext } from "./artifact-context";
 
 /**
@@ -30,6 +31,7 @@ export function AssistantSidebar() {
 function AssistantPanelBody() {
   const artifact = useArtifactContext();
   const close = useAssistantStore((s) => s.close);
+  const pendingDraftId = useAssistantStore((s) => s.pendingDraftId);
 
   return (
     <>
@@ -59,7 +61,11 @@ function AssistantPanelBody() {
       </header>
 
       <div className="min-h-0 flex-1">
-        <AssistantEmptyState artifact={artifact} />
+        {pendingDraftId ? (
+          <DraftReviewPanel draftId={pendingDraftId} />
+        ) : (
+          <AssistantEmptyState artifact={artifact} />
+        )}
       </div>
     </>
   );

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -19,8 +19,13 @@
  */
 import { useCallback, useState } from "react";
 
+import {
+  discardDraft,
+  getDraftLog,
+  previewBatch,
+  publishDraft,
+} from "@dashframe/core";
 import type { PreviewDiff } from "@dashframe/types";
-import { discardDraft, getDraftLog, previewBatch, publishDraft } from "@dashframe/core";
 import { Button, cn } from "@wystack/ui";
 import { FileIcon, SparklesIcon } from "@wystack/ui-icons";
 import { toast } from "sonner";

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -156,7 +156,7 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
               <Button
                 label={isLoading ? "Loading diff…" : "Review changes"}
                 onClick={handleReview}
-                disabled={isLoading}
+                disabled={isLoading || isQuickDiscarding}
                 className="w-full"
                 size="sm"
               />

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -71,15 +71,12 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`Publish failed: ${msg}`);
-      // Re-throw so PreviewDiffDialog shows the button as no longer spinning.
-      throw err;
+      // Do not re-throw: PreviewDiffDialog swallows callback errors and its
+      // `finally` block already resets the loading state.
     }
   }, [draftId, setPendingDraft]);
 
-  /**
-   * Discard the draft. Re-throws on failure so PreviewDiffDialog can reset its
-   * loading state. Used as the dialog's `onDiscard` prop.
-   */
+  /** Discard the draft and close the review surface. Used as the dialog's `onDiscard` prop. */
   const handleDiscard = useCallback(async () => {
     try {
       await discardDraft(draftId);
@@ -90,7 +87,7 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       toast.error(`Discard failed: ${msg}`);
-      throw err;
+      // Do not re-throw — same as handlePublish.
     }
   }, [draftId, setPendingDraft]);
 
@@ -138,7 +135,7 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
             </p>
 
             {loadError && (
-              <p className="mb-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-[11px] text-red-600 dark:text-red-400">
+              <p className="mb-3 rounded-lg border border-palette-danger/30 bg-palette-danger/5 px-3 py-2 text-[11px] text-palette-danger">
                 {loadError}
               </p>
             )}

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -59,8 +59,8 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
       setDiff(preview);
       setDialogOpen(true);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setLoadError(`Could not load draft: ${msg}`);
+      console.error("[DraftReviewPanel] failed to load draft:", err);
+      setLoadError("Could not load draft. Please try again.");
     } finally {
       setIsLoading(false);
     }
@@ -74,8 +74,8 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
       setDialogOpen(false);
       setPendingDraft(null);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error(`Publish failed: ${msg}`);
+      console.error("[DraftReviewPanel] publish failed:", err);
+      toast.error("Publish failed. Please try again.");
       // Do not re-throw: PreviewDiffDialog swallows callback errors and its
       // `finally` block already resets the loading state.
     }
@@ -90,27 +90,34 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
       setDiff(null);
       setPendingDraft(null);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error(`Discard failed: ${msg}`);
+      console.error("[DraftReviewPanel] discard failed:", err);
+      toast.error("Discard failed. Please try again.");
       // Do not re-throw — same as handlePublish.
     }
   }, [draftId, setPendingDraft]);
 
   /**
-   * Quick-discard from the panel card (no dialog, no re-throw). Errors surface
-   * as toasts; promise is safe to fire-and-forget.
+   * Quick-discard from the panel card (no dialog, no re-throw). Guards against
+   * double-click by tracking its own in-flight state independently of `isLoading`
+   * (which covers `handleReview`). Errors surface as toasts; promise is safe to
+   * fire-and-forget.
    */
+  const [isQuickDiscarding, setIsQuickDiscarding] = useState(false);
+
   const handleQuickDiscard = useCallback(async () => {
-    if (isLoading) return;
+    if (isLoading || isQuickDiscarding) return;
+    setIsQuickDiscarding(true);
     try {
       await discardDraft(draftId);
       toast.info("Draft discarded.");
       setPendingDraft(null);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error(`Discard failed: ${msg}`);
+      console.error("[DraftReviewPanel] quick-discard failed:", err);
+      toast.error("Discard failed. Please try again.");
+    } finally {
+      setIsQuickDiscarding(false);
     }
-  }, [draftId, isLoading, setPendingDraft]);
+  }, [draftId, isLoading, isQuickDiscarding, setPendingDraft]);
 
   const handleDialogClose = useCallback(() => {
     setDialogOpen(false);
@@ -154,10 +161,10 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
                 size="sm"
               />
               <Button
-                label="Discard draft"
+                label={isQuickDiscarding ? "Discarding…" : "Discard draft"}
                 variant="ghost"
                 onClick={() => void handleQuickDiscard()}
-                disabled={isLoading}
+                disabled={isLoading || isQuickDiscarding}
                 className="w-full text-neutral-fg-subtle hover:text-neutral-fg"
                 size="sm"
               />

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -1,0 +1,186 @@
+/**
+ * DraftReviewPanel — shown in the assistant sidebar when a draft is pending
+ * review (pendingDraftId is set in AssistantStore).
+ *
+ * Flow:
+ *   1. The pi-agent sets `pendingDraftId` in AssistantStore after building a
+ *      draft, which surfaces this panel.
+ *   2. The panel loads the draft's command log via the `getDraftLog` RPC, then
+ *      calls `previewBatch` to produce a PreviewDiff (server metadata only).
+ *   3. The user opens the diff in PreviewDiffDialog, which fills compute slots
+ *      client-side via local DuckDB.
+ *   4. The user chooses Publish (→ `publishDraft` RPC, WS invalidation fires
+ *      automatically) or Discard (→ `discardDraft` RPC).
+ *   5. Either action clears `pendingDraftId` from the store.
+ *
+ * The dialog is opened by this panel (not the other way around): this component
+ * holds the loading / diff state and the publish/discard handlers. PreviewDiffDialog
+ * is read-only until both callbacks are wired — that is the case here.
+ */
+import { useCallback, useState } from "react";
+
+import type { PreviewDiff } from "@dashframe/types";
+import { discardDraft, getDraftLog, previewBatch, publishDraft } from "@dashframe/core";
+import { Button, cn } from "@wystack/ui";
+import { FileIcon, SparklesIcon } from "@wystack/ui-icons";
+import { toast } from "sonner";
+
+import { PreviewDiffDialog } from "@/components/preview-diff/PreviewDiffDialog";
+import { useAssistantStore } from "@/lib/stores/assistant-store";
+
+/**
+ * Panel body rendered in the assistant sidebar when there is a draft to review.
+ */
+export function DraftReviewPanel({ draftId }: { draftId: string }) {
+  const setPendingDraft = useAssistantStore((s) => s.setPendingDraft);
+
+  // Diff state: null = not yet loaded / dialog not open.
+  const [diff, setDiff] = useState<PreviewDiff | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  /** Load the draft log, compute the diff, open the dialog. */
+  const handleReview = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const commands = await getDraftLog(draftId);
+      if (commands.length === 0) {
+        toast.info("The draft has no changes to preview.");
+        return;
+      }
+      const preview = await previewBatch(commands);
+      setDiff(preview);
+      setDialogOpen(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setLoadError(`Could not load draft: ${msg}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [draftId]);
+
+  /** Publish the draft and close the review surface. */
+  const handlePublish = useCallback(async () => {
+    try {
+      await publishDraft(draftId);
+      toast.success("Draft published.");
+      setDialogOpen(false);
+      setPendingDraft(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Publish failed: ${msg}`);
+      // Re-throw so PreviewDiffDialog shows the button as no longer spinning.
+      throw err;
+    }
+  }, [draftId, setPendingDraft]);
+
+  /**
+   * Discard the draft. Re-throws on failure so PreviewDiffDialog can reset its
+   * loading state. Used as the dialog's `onDiscard` prop.
+   */
+  const handleDiscard = useCallback(async () => {
+    try {
+      await discardDraft(draftId);
+      toast.info("Draft discarded.");
+      setDialogOpen(false);
+      setDiff(null);
+      setPendingDraft(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Discard failed: ${msg}`);
+      throw err;
+    }
+  }, [draftId, setPendingDraft]);
+
+  /**
+   * Quick-discard from the panel card (no dialog, no re-throw). Errors surface
+   * as toasts; promise is safe to fire-and-forget.
+   */
+  const handleQuickDiscard = useCallback(async () => {
+    if (isLoading) return;
+    try {
+      await discardDraft(draftId);
+      toast.info("Draft discarded.");
+      setPendingDraft(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Discard failed: ${msg}`);
+    }
+  }, [draftId, isLoading, setPendingDraft]);
+
+  const handleDialogClose = useCallback(() => {
+    setDialogOpen(false);
+  }, []);
+
+  return (
+    <>
+      <div className="flex h-full flex-col">
+        {/* Draft ready card */}
+        <div className="flex-1 px-4 py-5">
+          <div
+            className={cn(
+              "rounded-xl border border-palette-primary/20 bg-palette-primary/5 p-4",
+            )}
+          >
+            <div className="mb-3 flex items-center gap-2">
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-palette-primary/10 text-palette-primary">
+                <FileIcon className="size-4" />
+              </span>
+              <span className="text-xs font-semibold text-neutral-fg">
+                Draft ready for review
+              </span>
+            </div>
+            <p className="mb-4 text-[11px] leading-relaxed text-neutral-fg-subtle">
+              The assistant has proposed changes. Review the diff, then publish
+              to apply or discard to start over.
+            </p>
+
+            {loadError && (
+              <p className="mb-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-[11px] text-red-600 dark:text-red-400">
+                {loadError}
+              </p>
+            )}
+
+            <div className="flex flex-col gap-2">
+              <Button
+                label={isLoading ? "Loading diff…" : "Review changes"}
+                onClick={handleReview}
+                disabled={isLoading}
+                className="w-full"
+                size="sm"
+              />
+              <Button
+                label="Discard draft"
+                variant="ghost"
+                onClick={() => void handleQuickDiscard()}
+                disabled={isLoading}
+                className="w-full text-neutral-fg-subtle hover:text-neutral-fg"
+                size="sm"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer hint */}
+        <div className="border-t border-neutral-border/60 px-4 py-3">
+          <p className="flex items-center gap-1.5 text-[10px] leading-relaxed text-neutral-fg-subtle">
+            <SparklesIcon className="size-3 shrink-0" />
+            Review the proposed changes before publishing to your project.
+          </p>
+        </div>
+      </div>
+
+      {/* The diff dialog — opened by handleReview, dismissed by handleDialogClose */}
+      <PreviewDiffDialog
+        diff={diff}
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        title="Review draft changes"
+        onPublish={handlePublish}
+        onDiscard={handleDiscard}
+      />
+    </>
+  );
+}

--- a/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
@@ -5,15 +5,30 @@
  *   1. Accepts a PreviewDiff (metadata-only from the server).
  *   2. Fills compute slots lazily via usePreviewComputeFill (client-side DuckDB).
  *   3. Renders immediately with metadata; compute fills progressively per node.
+ *   4. Optionally shows Publish / Discard actions when callbacks are supplied.
  *
  * SPLIT-TIER: this component owns the compute-fill boundary. It takes a
  * `PreviewDiff` with `compute: undefined` on all direct nodes and hands the
  * filled diff to `PreviewDiffRenderer` as compute resolves. No server round-trip
  * for row data — all compute is local DuckDB.
+ *
+ * ACTION CALLBACKS: `onPublish` and `onDiscard` are optional. When absent the
+ * dialog is read-only (preview only). When present a footer renders with
+ * "Discard" (destructive) and "Publish" (primary) buttons. The dialog stays
+ * open while either action is in-flight — the callback controls close timing.
  */
 
+import { useState } from "react";
+
 import type { PreviewDiff } from "@dashframe/types";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@wystack/ui";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@wystack/ui";
 
 import { PreviewDiffRenderer } from "./PreviewDiffRenderer";
 import { usePreviewComputeFill } from "./usePreviewComputeFill";
@@ -27,6 +42,17 @@ interface PreviewDiffDialogProps {
   onClose: () => void;
   /** Optional title override. Defaults to "Preview changes". */
   title?: string;
+  /**
+   * When provided, a "Publish" button appears in the footer. The dialog
+   * disables both actions while the callback is in-flight. The callback is
+   * responsible for closing the dialog (call `onClose`) after completion.
+   */
+  onPublish?: () => Promise<void> | void;
+  /**
+   * When provided, a "Discard" button appears in the footer alongside Publish.
+   * Same in-flight semantics as `onPublish`.
+   */
+  onDiscard?: () => Promise<void> | void;
 }
 
 /**
@@ -38,18 +64,46 @@ export function PreviewDiffDialog({
   open,
   onClose,
   title = "Preview changes",
+  onPublish,
+  onDiscard,
 }: PreviewDiffDialogProps) {
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [isDiscarding, setIsDiscarding] = useState(false);
+  const isBusy = isPublishing || isDiscarding;
+
   // Fill compute slots lazily — runs entirely client-side, no server RPC.
   // Gate on `open`: a closed (hidden) dialog must not kick DuckDB compute work.
   // Passing null when closed also flips the hook's effect-cleanup cancellation,
   // freeing the single DuckDB-WASM worker.
   const { diff: filledDiff } = usePreviewComputeFill(open ? diff : null);
 
+  const hasActions = onPublish !== undefined || onDiscard !== undefined;
+
+  async function handlePublish() {
+    if (!onPublish || isBusy) return;
+    setIsPublishing(true);
+    try {
+      await onPublish();
+    } finally {
+      setIsPublishing(false);
+    }
+  }
+
+  async function handleDiscard() {
+    if (!onDiscard || isBusy) return;
+    setIsDiscarding(true);
+    try {
+      await onDiscard();
+    } finally {
+      setIsDiscarding(false);
+    }
+  }
+
   return (
     <Dialog
       open={open}
       onOpenChange={(isOpen) => {
-        if (!isOpen) onClose();
+        if (!isOpen && !isBusy) onClose();
       }}
     >
       <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
@@ -60,6 +114,25 @@ export function PreviewDiffDialog({
           <PreviewDiffRenderer diff={filledDiff} className="pb-2" />
         ) : (
           <p className="text-sm text-neutral-fg/50">No changes to preview.</p>
+        )}
+        {hasActions && (
+          <DialogFooter>
+            {onDiscard && (
+              <Button
+                label={isDiscarding ? "Discarding…" : "Discard"}
+                variant="outline"
+                onClick={handleDiscard}
+                disabled={isBusy}
+              />
+            )}
+            {onPublish && (
+              <Button
+                label={isPublishing ? "Publishing…" : "Publish"}
+                onClick={handlePublish}
+                disabled={isBusy}
+              />
+            )}
+          </DialogFooter>
         )}
       </DialogContent>
     </Dialog>

--- a/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffDialog.tsx
@@ -14,8 +14,11 @@
  *
  * ACTION CALLBACKS: `onPublish` and `onDiscard` are optional. When absent the
  * dialog is read-only (preview only). When present a footer renders with
- * "Discard" (destructive) and "Publish" (primary) buttons. The dialog stays
- * open while either action is in-flight — the callback controls close timing.
+ * "Discard" (outline variant) and "Publish" (primary variant) buttons. Both
+ * buttons are disabled while either action is in-flight; the spinner resets via
+ * `finally` regardless of outcome. The callback owns user-facing error surfacing
+ * (toast); errors thrown by a callback are swallowed here to prevent unhandled
+ * promise rejections.
  */
 
 import { useState } from "react";
@@ -84,6 +87,10 @@ export function PreviewDiffDialog({
     setIsPublishing(true);
     try {
       await onPublish();
+    } catch {
+      // The callback owns user-facing error surfacing (toast). Swallow here so
+      // the dialog doesn't emit an unhandled rejection — `finally` resets the
+      // spinner regardless.
     } finally {
       setIsPublishing(false);
     }
@@ -94,6 +101,8 @@ export function PreviewDiffDialog({
     setIsDiscarding(true);
     try {
       await onDiscard();
+    } catch {
+      // Same pattern as handlePublish — callback owns the toast, swallow here.
     } finally {
       setIsDiscarding(false);
     }

--- a/packages/app/src/lib/stores/assistant-store.ts
+++ b/packages/app/src/lib/stores/assistant-store.ts
@@ -6,16 +6,28 @@ import { createJSONStorage, persist } from "zustand/middleware";
  * assistant's concern — it shares the shell's right Dock, whose width lives in
  * the shell store (see RightDock). This store holds only the open/closed state
  * and its ⌘J summon.
+ *
+ * `pendingDraftId` is a transient draft waiting for user review. It is NOT
+ * persisted — a persisted draftId could go stale across server restarts. The
+ * pi-agent sets this when it produces a draft; the DraftReviewPanel reads it.
  */
 interface AssistantState {
   /** Whether the assistant panel is visible. */
   isOpen: boolean;
+  /**
+   * A draft the assistant has queued for user review. When non-null the
+   * assistant panel shows the DraftReviewPanel instead of the empty state.
+   * Set by the pi-agent producer; cleared on publish or discard.
+   */
+  pendingDraftId: string | null;
 }
 
 interface AssistantActions {
   open: () => void;
   close: () => void;
   toggle: () => void;
+  /** Set (or clear) a draft waiting for review. Opens the panel when non-null. */
+  setPendingDraft: (id: string | null) => void;
 }
 
 /**
@@ -68,16 +80,25 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
   persist(
     (set) => ({
       isOpen: false,
+      // Transient — not persisted. A stale draftId across a server restart
+      // would surface a "draft not found" error in the review panel.
+      pendingDraftId: null,
 
       open: () => set({ isOpen: true }),
       close: () => set({ isOpen: false }),
       toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+      setPendingDraft: (id) =>
+        set((s) => ({
+          pendingDraftId: id,
+          // Open the panel automatically when a draft is queued.
+          isOpen: id !== null ? true : s.isOpen,
+        })),
     }),
     {
       name: "dashframe:assistant",
       storage: createJSONStorage(() => safeLocalStorage),
       skipHydration: true,
-      // Persist only last-open state; actions are derived.
+      // Persist only last-open state; pendingDraftId is session-only.
       partialize: (s) => ({ isOpen: s.isOpen }),
     },
   ),


### PR DESCRIPTION
Wire the last-mile publish surface for DashFrame's draft system. Tracked internally as YW-327.

## Changes

- **`apps/server` — 3 new RPC handlers** (`publishDraft`, `discardDraft`, `getDraftLog`) backed by the existing `DraftController`; exposed in `functions.ts`. `app.ts` receives a `__extraTablesWritten` relay so WS invalidation fires after `publishDraft` even though the sub-tracker asymmetry means the outer `DrizzleTracker` sees zero writes.
- **`packages/app-data` — client helpers + React hooks** (`usePublishDraft`, `useDiscardDraft`, `getDraftLog`) re-exported from `@dashframe/core`.
- **`AssistantStore`** — adds transient `pendingDraftId: string | null` + `setPendingDraft` action. NOT persisted (stale ID after server restart would surface a "draft not found" error). Opens the panel automatically when a draft is queued.
- **`DraftReviewPanel` (new component)** — panel body shown in the assistant sidebar when `pendingDraftId` is set. Loads the draft log via `getDraftLog`, previews via `previewBatch`, then delegates to `PreviewDiffDialog` with publish/discard callbacks wired.
- **`AssistantSidebar`** — conditionally renders `DraftReviewPanel` (when `pendingDraftId` is set) or the existing `AssistantEmptyState`.
- **`PreviewDiffDialog`** — extended with optional `onPublish`/`onDiscard` props + loading state; backward-compatible (existing callers that pass no callbacks remain read-only).
- **Tests** — 5 vitest cases in `draft-lifecycle.test.ts` covering the two `onWrite` contracts, the `__extraTablesWritten` strip, and `getDraftLog` command shape. All 303 tests pass.

## Screenshots

**Assistant sidebar — after (DraftReviewPanel, new)**

| Light | Dark |
|-------|------|
| ![DraftReviewPanel light](https://github.com/youhaowei/DashFrame/releases/download/pr-185-screenshots/draft-review-panel-light.png) | ![DraftReviewPanel dark](https://github.com/youhaowei/DashFrame/releases/download/pr-185-screenshots/draft-review-panel-dark.png) |

**PreviewDiffDialog with Publish / Discard actions (new footer)**

| Light | Dark |
|-------|------|
| ![PreviewDiffDialog light](https://github.com/youhaowei/DashFrame/releases/download/pr-185-screenshots/preview-diff-dialog-light.png) | ![PreviewDiffDialog dark](https://github.com/youhaowei/DashFrame/releases/download/pr-185-screenshots/preview-diff-dialog-dark.png) |

*Dialog body shows "No changes to preview." — no live pi-agent draft was available at screenshot time. The dialog structure and Publish/Discard footer are the new UI.*

## Verification

- `turbo test --filter='@dashframe/server'` — all 303 tests pass (299 pre-existing + 4 new).
- `onWrite` fires exactly once after `publishDraft` with tables written; fires zero times on empty log (contract 1 test).
- `discardDraft` fires `onWrite` once after discard (contract 2 test).
- `__extraTablesWritten` sentinel stripped from HTTP response; `body.data` does not expose it (contract 3 test).
- `turbo typecheck` passes with no new errors.
- Screenshots captured from running Electron dev server with draft state injected via Zustand store.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the last-mile publish surface for DashFrame's draft system: three new server RPCs (`publishDraft`, `discardDraft`, `getDraftLog`), corresponding client helpers, a new `DraftReviewPanel` sidebar component, and publish/discard callbacks added to `PreviewDiffDialog`.

- **Server** — RPC handlers backed by `DraftController`; a `__extraTablesWritten` sentinel in the `app.ts` call wrapper solves the split-tracker asymmetry so WS invalidation fires after `publishDraft` even though the outer `DrizzleTracker` sees zero writes. The sentinel is type-checked via `PublishDraftInternalResult` and always stripped before the response reaches the client.
- **Client** — `AssistantStore` gains a transient (non-persisted) `pendingDraftId`; `DraftReviewPanel` owns the load/diff/publish/discard flow and passes typed callbacks into the extended (backwards-compatible) `PreviewDiffDialog`.
- **Tests** — five integration tests over real PGlite + HTTP pin the three load-bearing contracts (onWrite, sentinel strip, getDraftLog shape).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a layout nit in the dialog footer.

The split-tracker workaround is well-reasoned and type-checked end-to-end; the `__extraTablesWritten` sentinel is always stripped before the response leaves the server. All previous concurrency races in `DraftReviewPanel` are correctly guarded. No ticket IDs appear in source, no off-token colours, no raw error strings surface in the UI, and `pendingDraftId` is correctly excluded from Zustand persistence.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Adds `__extraTablesWritten` relay intercept in the `call` wrapper and injects `draftController`/`onWrite` into `serverContext` after app finalisation. Logic is sound and defensively typed. |
| apps/server/src/functions/draft-lifecycle.ts | Three new RPC handlers (`publishDraft`, `discardDraft`, `getDraftLog`) with well-documented split-tracker workaround; `PublishDraftInternalResult` interface keeps the sentinel type-checked at both ends. |
| apps/server/src/functions/draft-lifecycle.test.ts | Five integration tests covering the three load-bearing contracts (onWrite, sentinel strip, getDraftLog shape); uses real PGlite and HTTP to exercise the full stack. |
| packages/app/src/components/assistant/DraftReviewPanel.tsx | New panel component; concurrency guards (`isLoading`, `isQuickDiscarding`) are complete on both buttons, errors surface as generic toasts, and no raw error strings reach the UI. |
| packages/app/src/components/preview-diff/PreviewDiffDialog.tsx | Backwards-compatible addition of optional Publish/Discard footer; `isBusy` disables both buttons and blocks ESC-close while in-flight. Footer scrolls with content due to `overflow-y-auto` on the wrapping `DialogContent`. |
| packages/app/src/lib/stores/assistant-store.ts | Adds transient `pendingDraftId` (correctly excluded from persistence via `partialize`) and `setPendingDraft` action that auto-opens the panel. |
| packages/app/src/components/assistant/AssistantSidebar.tsx | Conditional render of `DraftReviewPanel` vs `AssistantEmptyState` based on `pendingDraftId`; minimal and correct. |
| packages/app-data/src/draft-lifecycle.ts | Client-side helpers wrapping `mutate`/`query` for the three new RPCs; follows existing patterns from `data-sources.ts`/`preview-diff.ts`. |
| packages/app-data/src/index.ts | Re-exports the three new client helpers under a clear barrel comment; no conflicts with existing exports. |
| apps/server/src/functions.ts | Spreads `draftLifecycleFunctions` into the main `functions` object; no ordering issues with other function groups. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent as pi-agent
    participant Store as AssistantStore
    participant Panel as DraftReviewPanel
    participant Dialog as PreviewDiffDialog
    participant Server as Server RPCs
    participant WS as WS Invalidation

    Agent->>Store: setPendingDraft(draftId)
    Store-->>Panel: pendingDraftId set → panel mounts

    Panel->>Server: getDraftLog(draftId)
    Server-->>Panel: Command[]
    Panel->>Server: previewBatch(commands)
    Server-->>Panel: PreviewDiff (metadata only)
    Panel->>Dialog: "open=true, diff, onPublish, onDiscard"

    alt Publish
        Dialog->>Panel: onPublish()
        Panel->>Server: publishDraft(draftId)
        Note over Server: applyCommands (sub-tracker)<br/>returns __extraTablesWritten
        Server->>WS: broadcast merged tablesWritten
        Server->>Server: onWrite() → snapshot
        Server-->>Panel: "{ tablesWritten }"
        Panel->>Store: setPendingDraft(null)
    else Discard
        Dialog->>Panel: onDiscard()
        Panel->>Server: discardDraft(draftId)
        Server->>Server: onWrite() → snapshot
        Server-->>Panel: void
        Panel->>Store: setPendingDraft(null)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent as pi-agent
    participant Store as AssistantStore
    participant Panel as DraftReviewPanel
    participant Dialog as PreviewDiffDialog
    participant Server as Server RPCs
    participant WS as WS Invalidation

    Agent->>Store: setPendingDraft(draftId)
    Store-->>Panel: pendingDraftId set → panel mounts

    Panel->>Server: getDraftLog(draftId)
    Server-->>Panel: Command[]
    Panel->>Server: previewBatch(commands)
    Server-->>Panel: PreviewDiff (metadata only)
    Panel->>Dialog: "open=true, diff, onPublish, onDiscard"

    alt Publish
        Dialog->>Panel: onPublish()
        Panel->>Server: publishDraft(draftId)
        Note over Server: applyCommands (sub-tracker)<br/>returns __extraTablesWritten
        Server->>WS: broadcast merged tablesWritten
        Server->>Server: onWrite() → snapshot
        Server-->>Panel: "{ tablesWritten }"
        Panel->>Store: setPendingDraft(null)
    else Discard
        Dialog->>Panel: onDiscard()
        Panel->>Server: discardDraft(draftId)
        Server->>Server: onWrite() → snapshot
        Server-->>Panel: void
        Panel->>Store: setPendingDraft(null)
    end
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/6797c0ed64e5b9aea3c238eb94026e15ea9e5822) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40340499)</sub>

<!-- /greptile_comment -->