### PR TITLE
[YW-150] feat: per-cell + transient override UI

### DIFF
--- a/apps/server/src/functions/dashboards.test.ts
+++ b/apps/server/src/functions/dashboards.test.ts
@@ -127,3 +127,122 @@ describe("addDashboardItem — markdown widget persistence", () => {
     expect(second!.y).toBe(4);
   });
 });
+
+describe("updateDashboardItem — sanitizeItemOverrides contracts", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-ov-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await createWyStack({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function call(path: string, args: unknown): Promise<unknown> {
+    const { result } = await app.call(path, args);
+    return result;
+  }
+
+  async function addVisualizationItem(dashboardId: string): Promise<string> {
+    const { itemId } = (await call("addDashboardItem", {
+      dashboardId,
+      type: "visualization",
+      visualizationId: crypto.randomUUID(),
+      position: { x: 0, y: 0, width: 4, height: 4 },
+    })) as { itemId: string };
+    return itemId;
+  }
+
+  async function getItem(
+    dashboardId: string,
+    itemId: string,
+  ): Promise<{ overrides?: unknown }> {
+    const list = (await call("listDashboards", {})) as Array<{
+      id: string;
+      items: Array<{ id: string; overrides?: unknown }>;
+    }>;
+    const dash = list.find((d) => d.id === dashboardId);
+    return dash!.items.find((i) => i.id === itemId) as { overrides?: unknown };
+  }
+
+  it("should persist a valid limit override", async () => {
+    const { id: dashboardId } = (await call("createDashboard", {
+      name: "Override Test",
+    })) as { id: string };
+    const itemId = await addVisualizationItem(dashboardId);
+
+    await call("updateDashboardItem", {
+      dashboardId,
+      itemId,
+      updates: { overrides: { limit: 50 } },
+    });
+
+    const item = await getItem(dashboardId, itemId);
+    expect((item.overrides as { limit?: number })?.limit).toBe(50);
+  });
+
+  it("should clear overrides when null is sent (clear sentinel)", async () => {
+    // This is the JSON.stringify hazard: { overrides: undefined } → {} → key
+    // absent → server gate never fires. The client sends null to preserve the
+    // key. The server must treat null as "remove overrides".
+    const { id: dashboardId } = (await call("createDashboard", {
+      name: "Clear Sentinel Test",
+    })) as { id: string };
+    const itemId = await addVisualizationItem(dashboardId);
+
+    // First pin a limit.
+    await call("updateDashboardItem", {
+      dashboardId,
+      itemId,
+      updates: { overrides: { limit: 25 } },
+    });
+    expect(
+      ((await getItem(dashboardId, itemId)).overrides as { limit?: number })
+        ?.limit,
+    ).toBe(25);
+
+    // Now clear via null sentinel.
+    await call("updateDashboardItem", {
+      dashboardId,
+      itemId,
+      updates: { overrides: null },
+    });
+
+    const item = await getItem(dashboardId, itemId);
+    // overrides must be absent — NOT {} — after a null clear.
+    expect(item.overrides).toBeUndefined();
+  });
+
+  it("should treat all-invalid-fields payload as a clear (not {} in JSONB)", async () => {
+    // Regression for the Greptile P1: sanitizeItemOverrides can produce a
+    // truthy empty object {filters:undefined,sorts:undefined,limit:undefined}
+    // when all three fields fail validation. JSON.stringify drops undefined
+    // values → stored as {} → engine reads non-null overrides field.
+    // The fix adds an all-undefined emptiness check that returns undefined.
+    const { id: dashboardId } = (await call("createDashboard", {
+      name: "All-Invalid Test",
+    })) as { id: string };
+    const itemId = await addVisualizationItem(dashboardId);
+
+    await call("updateDashboardItem", {
+      dashboardId,
+      itemId,
+      // All fields fail validation: filters wrong type, sorts wrong type,
+      // limit is negative (rejected by the > 0 guard).
+      updates: { overrides: { filters: "invalid", sorts: null, limit: -5 } },
+    });
+
+    const item = await getItem(dashboardId, itemId);
+    // Must not be persisted as {} — that would mean the engine reads a non-null
+    // overrides field and may create a per-cell DuckDB view for no reason.
+    // With the emptiness check, sanitizeItemOverrides returns undefined, the
+    // key is dropped from JSONB, and the read-back item has no overrides field.
+    expect(item.overrides).toBeUndefined();
+  });
+});

--- a/apps/server/src/functions/dashboards.test.ts
+++ b/apps/server/src/functions/dashboards.test.ts
@@ -245,4 +245,23 @@ describe("updateDashboardItem — sanitizeItemOverrides contracts", () => {
     // key is dropped from JSONB, and the read-back item has no overrides field.
     expect(item.overrides).toBeUndefined();
   });
+
+  it("should treat empty filters array as a clear ([] is truthy but ![] is false)", async () => {
+    // Guards the empty-array bypass: ![] is false, so a naive !filters check
+    // passes through {filters: []} as a non-empty bag. The fix uses .length.
+    const { id: dashboardId } = (await call("createDashboard", {
+      name: "Empty-Array Test",
+    })) as { id: string };
+    const itemId = await addVisualizationItem(dashboardId);
+
+    await call("updateDashboardItem", {
+      dashboardId,
+      itemId,
+      updates: { overrides: { filters: [], sorts: null, limit: -5 } },
+    });
+
+    const item = await getItem(dashboardId, itemId);
+    // filters: [] with no valid sorts/limit must also be cleared.
+    expect(item.overrides).toBeUndefined();
+  });
 });

--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -137,6 +137,27 @@ function sanitizeDashboardUpdates(
   if (typeof input.y === "number") next.y = input.y;
   if (typeof input.width === "number") next.width = input.width;
   if (typeof input.height === "number") next.height = input.height;
+
+  // Per-cell override bag — forwarded as-is when present.  The shape is typed
+  // at the client layer (@dashframe/types DashboardItemOverrides) and the engine
+  // reads it back as JSONB, so we only need to gate on structural plausibility:
+  // must be an object or undefined.  `null` is treated as "remove overrides"
+  // (revert to insight defaults) and forwarded as undefined to keep JSONB clean.
+  if ("overrides" in input) {
+    const ov = input.overrides;
+    if (ov === null || ov === undefined) {
+      next.overrides = undefined;
+    } else if (isRecord(ov)) {
+      next.overrides = {
+        filters: Array.isArray(ov.filters) ? ov.filters : undefined,
+        sorts: Array.isArray(ov.sorts) ? ov.sorts : undefined,
+        limit:
+          typeof ov.limit === "number" && ov.limit > 0 ? ov.limit : undefined,
+      };
+    }
+    // Non-object non-null overrides are silently ignored (unexpected shape).
+  }
+
   return next;
 }
 

--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -138,27 +138,32 @@ function sanitizeDashboardUpdates(
   if (typeof input.width === "number") next.width = input.width;
   if (typeof input.height === "number") next.height = input.height;
 
-  // Per-cell override bag — forwarded as-is when present.  The shape is typed
-  // at the client layer (@dashframe/types DashboardItemOverrides) and the engine
-  // reads it back as JSONB, so we only need to gate on structural plausibility:
-  // must be an object or undefined.  `null` is treated as "remove overrides"
-  // (revert to insight defaults) and forwarded as undefined to keep JSONB clean.
+  // Per-cell override bag — sanitized by the helper below.
   if ("overrides" in input) {
-    const ov = input.overrides;
-    if (ov === null || ov === undefined) {
-      next.overrides = undefined;
-    } else if (isRecord(ov)) {
-      next.overrides = {
-        filters: Array.isArray(ov.filters) ? ov.filters : undefined,
-        sorts: Array.isArray(ov.sorts) ? ov.sorts : undefined,
-        limit:
-          typeof ov.limit === "number" && ov.limit > 0 ? ov.limit : undefined,
-      };
-    }
-    // Non-object non-null overrides are silently ignored (unexpected shape).
+    next.overrides = sanitizeItemOverrides(input.overrides);
   }
 
   return next;
+}
+
+/**
+ * Sanitize the per-cell override bag received from the client.
+ *
+ * Shape contract: the object must conform to `DashboardItemOverrides`
+ * (@dashframe/types).  The engine reads it back as JSONB so we only gate on
+ * structural plausibility — `null` / undefined → remove overrides, non-object
+ * shapes are silently dropped (unexpected client payload).
+ */
+function sanitizeItemOverrides(
+  ov: unknown,
+): DashboardItem["overrides"] | undefined {
+  if (ov == null) return undefined; // null or undefined → clear
+  if (!isRecord(ov)) return undefined; // unexpected shape — ignore silently
+  return {
+    filters: Array.isArray(ov.filters) ? ov.filters : undefined,
+    sorts: Array.isArray(ov.sorts) ? ov.sorts : undefined,
+    limit: typeof ov.limit === "number" && ov.limit > 0 ? ov.limit : undefined,
+  };
 }
 
 const listDashboards = query({

--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -159,11 +159,14 @@ function sanitizeItemOverrides(
 ): DashboardItem["overrides"] | undefined {
   if (ov == null) return undefined; // null or undefined → clear
   if (!isRecord(ov)) return undefined; // unexpected shape — ignore silently
-  return {
-    filters: Array.isArray(ov.filters) ? ov.filters : undefined,
-    sorts: Array.isArray(ov.sorts) ? ov.sorts : undefined,
-    limit: typeof ov.limit === "number" && ov.limit > 0 ? ov.limit : undefined,
-  };
+  const filters = Array.isArray(ov.filters) ? ov.filters : undefined;
+  const sorts = Array.isArray(ov.sorts) ? ov.sorts : undefined;
+  const limit =
+    typeof ov.limit === "number" && ov.limit > 0 ? ov.limit : undefined;
+  // Normalise all-undefined bags to undefined so {filters:undefined,…} is
+  // never persisted as {} in JSONB, which the engine would treat as "has overrides".
+  if (!filters && sorts === undefined && limit === undefined) return undefined;
+  return { filters, sorts, limit };
 }
 
 const listDashboards = query({

--- a/apps/server/src/functions/dashboards.ts
+++ b/apps/server/src/functions/dashboards.ts
@@ -163,9 +163,15 @@ function sanitizeItemOverrides(
   const sorts = Array.isArray(ov.sorts) ? ov.sorts : undefined;
   const limit =
     typeof ov.limit === "number" && ov.limit > 0 ? ov.limit : undefined;
-  // Normalise all-undefined bags to undefined so {filters:undefined,…} is
-  // never persisted as {} in JSONB, which the engine would treat as "has overrides".
-  if (!filters && sorts === undefined && limit === undefined) return undefined;
+  // Normalise empty/all-undefined bags to undefined so they are never persisted
+  // as {} or {filters:[]} in JSONB, which the engine would treat as "has overrides".
+  // Note: ![] is false (arrays are truthy), so we must use .length to check empties.
+  if (
+    (filters == null || filters.length === 0) &&
+    sorts === undefined &&
+    limit === undefined
+  )
+    return undefined;
   return { filters, sorts, limit };
 }
 

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -217,6 +217,7 @@ export function DashboardGrid({
             dashboardId={dashboard.id}
             isEditable={isEditable}
             effectiveOverrides={effectiveOverridesMap.get(item.id)}
+            controls={dashboard.controls ?? []}
           />
         </div>
       ))}

--- a/packages/app/src/components/dashboards/DashboardItem.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.tsx
@@ -122,9 +122,11 @@ export function DashboardItem({
           )}
         </div>
 
-        {/* Customize button + override badge — visualization cells only.
+        {/* Customize button + override badge — visualization cells only, editor-mode only.
+            Hidden from non-editors: a non-editor invoking updateItem/updateControls
+            would persist their changes, which is not the intended v0.3 scope.
             Visible on hover, anchored bottom-right inside the surface. */}
-        {item.type === "visualization" && (
+        {item.type === "visualization" && isEditable && (
           <div
             className="absolute right-2 bottom-2 z-20 opacity-0 transition-opacity group-hover:opacity-100"
             onMouseDown={(e) => e.stopPropagation()}

--- a/packages/app/src/components/dashboards/DashboardItem.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.tsx
@@ -1,6 +1,7 @@
 import { VisualizationDisplay } from "@/components/visualizations/VisualizationDisplay";
 import { useDashboardMutations } from "@dashframe/core";
 import type {
+  DashboardControl,
   DashboardItemOverrides,
   DashboardItem as DashboardItemType,
 } from "@dashframe/types";
@@ -8,6 +9,7 @@ import { Button, cn, Surface } from "@wystack/ui";
 import { DeleteIcon, DragHandleIcon, EditIcon } from "@wystack/ui-icons";
 import { useState } from "react";
 import { MarkdownWidget } from "./MarkdownWidget";
+import { OverridePopover } from "./OverridePopover";
 
 interface DashboardItemProps {
   item: DashboardItemType;
@@ -20,6 +22,11 @@ interface DashboardItemProps {
    * When absent, the item's own saved `overrides` are used as before.
    */
   effectiveOverrides?: DashboardItemOverrides;
+  /**
+   * Dashboard-level controls passed down from DashboardGrid.  Used by the
+   * OverridePopover to derive field-bound state and offer bind/unbind affordances.
+   */
+  controls?: DashboardControl[];
   className?: string;
   // Props passed by react-grid-layout
   style?: React.CSSProperties;
@@ -33,6 +40,7 @@ export function DashboardItem({
   dashboardId,
   isEditable,
   effectiveOverrides,
+  controls = [],
   className,
   style,
   onMouseDown,
@@ -113,6 +121,21 @@ export function DashboardItem({
             </div>
           )}
         </div>
+
+        {/* Customize button + override badge — visualization cells only.
+            Visible on hover, anchored bottom-right inside the surface. */}
+        {item.type === "visualization" && (
+          <div
+            className="absolute right-2 bottom-2 z-20 opacity-0 transition-opacity group-hover:opacity-100"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <OverridePopover
+              item={item}
+              dashboardId={dashboardId}
+              controls={controls}
+            />
+          </div>
+        )}
       </Surface>
     </div>
   );

--- a/packages/app/src/components/dashboards/OverrideFieldRow.tsx
+++ b/packages/app/src/components/dashboards/OverrideFieldRow.tsx
@@ -145,13 +145,11 @@ export interface OverrideFieldRowProps {
 
 function InlineFilterEditor({
   fieldName,
-  combinedField,
   initialDraft,
   onSave,
   onCancel,
 }: {
   fieldName: string;
-  combinedField?: CombinedField;
   initialDraft: FilterDraft;
   onSave: (filter: InsightFilterOverride) => void;
   onCancel: () => void;
@@ -458,7 +456,6 @@ export function OverrideFieldRow({
       {isEditing && (
         <InlineFilterEditor
           fieldName={fieldName}
-          combinedField={combinedField}
           initialDraft={initialDraft}
           onSave={handlePinSave}
           onCancel={stopEditing}

--- a/packages/app/src/components/dashboards/OverrideFieldRow.tsx
+++ b/packages/app/src/components/dashboards/OverrideFieldRow.tsx
@@ -1,0 +1,469 @@
+/**
+ * Per-field override row rendered inside the OverridePopover.
+ *
+ * One row = one overrideable field in the 4-state machine:
+ *   inherit → pinned → cleared → bound
+ *
+ * The component is intentionally PURE — it receives a derived `state` object
+ * and emits callbacks for each transition.  No data fetching, no mutations.
+ * All override payload assembly lives in override-field-row-utils.ts and is
+ * tested there without rendering.
+ */
+
+import {
+  buildFilterValue,
+  inputTypeForField,
+  isFilterDraftValid,
+  type FilterDraft,
+} from "@/app/insights/[insightId]/_components/config-panel/filter-value";
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import type {
+  DashboardControl,
+  InsightFilter,
+  InsightFilterOverride,
+} from "@dashframe/types";
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  cn,
+} from "@wystack/ui";
+import { CheckIcon, CloseIcon } from "@wystack/ui-icons";
+import { useState } from "react";
+import {
+  formatFilterValue,
+  formatOperator,
+  type FieldOverrideState,
+} from "./override-field-row-utils";
+
+// ---------------------------------------------------------------------------
+// Operator options
+// ---------------------------------------------------------------------------
+
+type Operator = InsightFilter["operator"];
+
+const OPERATOR_OPTIONS: { value: Operator; label: string }[] = [
+  { value: "eq", label: "equals (=)" },
+  { value: "ne", label: "not equals (≠)" },
+  { value: "gt", label: "greater than (>)" },
+  { value: "gte", label: "greater than or equal (≥)" },
+  { value: "lt", label: "less than (<)" },
+  { value: "lte", label: "less than or equal (≤)" },
+  { value: "contains", label: "contains" },
+  { value: "between", label: "between" },
+  { value: "in", label: "in (list)" },
+];
+
+// ---------------------------------------------------------------------------
+// Draft helpers
+// ---------------------------------------------------------------------------
+
+function makeDraft(field: string, combinedField?: CombinedField): FilterDraft {
+  return {
+    field,
+    operator: "eq",
+    inputType: inputTypeForField(combinedField),
+    scalarValue: "",
+    betweenLow: "",
+    betweenHigh: "",
+  };
+}
+
+function draftFromFilter(
+  filter: InsightFilterOverride,
+  combinedField?: CombinedField,
+): FilterDraft {
+  const inputType = inputTypeForField(combinedField);
+  let scalarValue = "";
+  let betweenLow = "";
+  let betweenHigh = "";
+
+  if (
+    filter.operator === "between" &&
+    filter.value != null &&
+    typeof filter.value === "object"
+  ) {
+    const bv = filter.value as { low: unknown; high: unknown };
+    betweenLow = String(bv.low ?? "");
+    betweenHigh = String(bv.high ?? "");
+  } else if (filter.operator === "in" && Array.isArray(filter.value)) {
+    scalarValue = (filter.value as unknown[]).join(", ");
+  } else {
+    scalarValue = String(filter.value ?? "");
+  }
+
+  return {
+    field: filter.field,
+    operator: filter.operator,
+    inputType,
+    scalarValue,
+    betweenLow,
+    betweenHigh,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OverrideFieldRowProps {
+  /** Source column name for this field. */
+  fieldName: string;
+  /** Human-readable label (defaults to fieldName). */
+  displayName?: string;
+  /** Derived 4-state override state for this field. */
+  state: FieldOverrideState;
+  /** Combined field info for type-aware value editors. */
+  combinedField?: CombinedField;
+  /**
+   * Controls eligible for binding to this field.  Shown in a dropdown when
+   * the state is `inherit` or `pinned`.  Hidden when empty.
+   */
+  eligibleControls?: DashboardControl[];
+
+  // Transition callbacks — the parent assembles the full overrides payload.
+  /** Called with the new InsightFilterOverride when the user saves a pin. */
+  onPin: (filter: InsightFilterOverride) => void;
+  /** Called when the user clears this field (widen — remove insight filter). */
+  onClear: () => void;
+  /** Called when the user resets to inherit (remove override entry). */
+  onInherit: () => void;
+  /** Called when the user binds to a control. */
+  onBind?: (controlId: string) => void;
+  /** Called when the user unbinds from a control. */
+  onUnbind?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Inline filter editor
+// ---------------------------------------------------------------------------
+
+function InlineFilterEditor({
+  fieldName,
+  combinedField,
+  initialDraft,
+  onSave,
+  onCancel,
+}: {
+  fieldName: string;
+  combinedField?: CombinedField;
+  initialDraft: FilterDraft;
+  onSave: (filter: InsightFilterOverride) => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState<FilterDraft>(initialDraft);
+  const valid = isFilterDraftValid(draft);
+
+  function handleSave() {
+    if (!valid) return;
+    const value = buildFilterValue(draft);
+    const filter: InsightFilterOverride = {
+      field: fieldName,
+      operator: draft.operator,
+      value,
+    };
+    onSave(filter);
+  }
+
+  return (
+    <div className="mt-1.5 space-y-1.5 rounded-md bg-neutral-bg p-2">
+      {/* Operator select */}
+      <div className="flex items-center gap-1.5">
+        <Label className="w-16 shrink-0 text-xs text-neutral-fg-subtle">
+          operator
+        </Label>
+        <Select
+          value={draft.operator}
+          onValueChange={(val) =>
+            setDraft((d) => ({ ...d, operator: val as Operator }))
+          }
+        >
+          <SelectTrigger className="h-7 flex-1 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {OPERATOR_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Value input(s) */}
+      {draft.operator === "between" ? (
+        <div className="flex items-center gap-1.5">
+          <Label className="w-16 shrink-0 text-xs text-neutral-fg-subtle">
+            range
+          </Label>
+          <Input
+            type={draft.inputType}
+            placeholder="low"
+            value={draft.betweenLow}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, betweenLow: e.target.value }))
+            }
+            className="h-7 flex-1 text-xs"
+          />
+          <span className="text-xs text-neutral-fg-subtle">–</span>
+          <Input
+            type={draft.inputType}
+            placeholder="high"
+            value={draft.betweenHigh}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, betweenHigh: e.target.value }))
+            }
+            className="h-7 flex-1 text-xs"
+          />
+        </div>
+      ) : (
+        <div className="flex items-center gap-1.5">
+          <Label className="w-16 shrink-0 text-xs text-neutral-fg-subtle">
+            {draft.operator === "in" ? "values" : "value"}
+          </Label>
+          <Input
+            type={draft.operator === "in" ? "text" : draft.inputType}
+            placeholder={draft.operator === "in" ? "a, b, c" : ""}
+            value={draft.scalarValue}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, scalarValue: e.target.value }))
+            }
+            className="h-7 flex-1 text-xs"
+          />
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex justify-end gap-1">
+        <Button
+          label="Cancel"
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          label="Pin value"
+          variant="solid"
+          size="sm"
+          disabled={!valid}
+          className="h-6 px-2 text-xs"
+          onClick={handleSave}
+        >
+          <CheckIcon className="mr-1 h-3 w-3" />
+          Pin
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function OverrideFieldRow({
+  fieldName,
+  displayName,
+  state,
+  combinedField,
+  eligibleControls = [],
+  onPin,
+  onClear,
+  onInherit,
+  onBind,
+  onUnbind,
+}: OverrideFieldRowProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const label = displayName ?? fieldName;
+
+  function startEditing() {
+    setIsEditing(true);
+  }
+  function stopEditing() {
+    setIsEditing(false);
+  }
+
+  function handlePinSave(filter: InsightFilterOverride) {
+    stopEditing();
+    onPin(filter);
+  }
+
+  // Derive the initial draft for the inline editor.
+  const initialDraft =
+    state.type === "pinned"
+      ? draftFromFilter(state.filter, combinedField)
+      : makeDraft(fieldName, combinedField);
+
+  return (
+    <div className="py-1.5">
+      {/* Row header */}
+      <div className="flex items-start gap-2">
+        {/* Field label + state indicator */}
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span
+            className={cn(
+              "text-xs font-medium",
+              state.type === "bound"
+                ? "text-neutral-fg-subtle"
+                : "text-neutral-fg",
+            )}
+          >
+            {label}
+          </span>
+
+          {/* State-specific value/info line */}
+          {state.type === "inherit" && state.insightFilter && (
+            <span className="truncate text-xs text-neutral-fg-disabled">
+              default: {formatOperator(state.insightFilter.operator)}{" "}
+              {formatFilterValue(state.insightFilter)}
+            </span>
+          )}
+          {state.type === "pinned" && !isEditing && (
+            <button
+              type="button"
+              onClick={startEditing}
+              className="truncate text-left text-xs text-neutral-fg-subtle underline-offset-2 hover:underline"
+            >
+              {formatOperator(state.filter.operator)}{" "}
+              {formatFilterValue(state.filter)}
+            </button>
+          )}
+          {state.type === "cleared" && (
+            <span className="text-xs text-neutral-fg-disabled">
+              showing all (cleared)
+            </span>
+          )}
+          {state.type === "bound" && (
+            <span className="text-xs text-neutral-fg-disabled">
+              ← {state.control.label ?? state.control.field}
+              {state.dormantFilter && (
+                <span className="ml-1 opacity-60">
+                  (dormant: {formatOperator(state.dormantFilter.operator)}{" "}
+                  {formatFilterValue(state.dormantFilter)})
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex shrink-0 items-center gap-0.5">
+          {state.type === "bound" ? (
+            // Bound state: only unbind
+            <Button
+              label="Unbind from control"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-xs"
+              onClick={onUnbind}
+            >
+              Unbind
+            </Button>
+          ) : (
+            <>
+              {/* Inherit/Cleared: offer Pin */}
+              {(state.type === "inherit" || state.type === "cleared") &&
+                !isEditing && (
+                  <Button
+                    label="Pin a value"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-1.5 text-xs"
+                    onClick={startEditing}
+                  >
+                    Pin
+                  </Button>
+                )}
+              {/* Pinned: offer edit (inline, clicking the value line also works) */}
+              {state.type === "pinned" && !isEditing && (
+                <Button
+                  label="Edit pinned value"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-1.5 text-xs"
+                  onClick={startEditing}
+                >
+                  Edit
+                </Button>
+              )}
+
+              {/* Clear button (available from inherit and pinned states) */}
+              {(state.type === "inherit" || state.type === "pinned") &&
+                !isEditing && (
+                  <Button
+                    label="Clear — remove insight filter for this field"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-1.5 text-xs text-neutral-fg-subtle"
+                    onClick={onClear}
+                  >
+                    Clear
+                  </Button>
+                )}
+
+              {/* Reset to inherit (from pinned or cleared) */}
+              {(state.type === "pinned" || state.type === "cleared") &&
+                !isEditing && (
+                  <Button
+                    label="Reset to inherit"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-neutral-fg-subtle"
+                    onClick={onInherit}
+                  >
+                    <CloseIcon className="h-3 w-3" />
+                  </Button>
+                )}
+
+              {/* Bind to control dropdown (inherit/pinned + eligible controls exist) */}
+              {(state.type === "inherit" || state.type === "pinned") &&
+                !isEditing &&
+                eligibleControls.length > 0 &&
+                onBind && (
+                  <Select
+                    onValueChange={(val) => {
+                      if (typeof val === "string") onBind(val);
+                    }}
+                  >
+                    <SelectTrigger
+                      className="h-6 w-auto gap-1 border-0 bg-transparent px-1.5 text-xs text-neutral-fg-subtle shadow-none hover:bg-neutral-bg"
+                      aria-label="Bind to dashboard control"
+                    >
+                      Bind ▾
+                    </SelectTrigger>
+                    <SelectContent>
+                      {eligibleControls.map((c) => (
+                        <SelectItem key={c.id} value={c.id} className="text-xs">
+                          {c.label ?? c.field}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Inline editor (expanded when isEditing) */}
+      {isEditing && (
+        <InlineFilterEditor
+          fieldName={fieldName}
+          combinedField={combinedField}
+          initialDraft={initialDraft}
+          onSave={handlePinSave}
+          onCancel={stopEditing}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -51,7 +51,7 @@ import {
   cn,
 } from "@wystack/ui";
 import { SettingsIcon } from "@wystack/ui-icons";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   computeNewOverridesOnClear,
   computeNewOverridesOnInherit,
@@ -201,6 +201,15 @@ function LimitOverrideRow({
   onChange: (limit: number | undefined) => void;
 }) {
   const isPinned = overrideLimit !== undefined;
+  // Local draft so that typing "100" doesn't fire three separate DB mutations.
+  // The mutation only fires on blur / Enter.
+  const [draft, setDraft] = useState(overrideLimit?.toString() ?? "");
+
+  function commitDraft() {
+    const n = parseInt(draft, 10);
+    if (!isNaN(n) && n > 0) onChange(n);
+    else if (overrideLimit !== undefined) setDraft(overrideLimit.toString());
+  }
 
   return (
     <div className="py-1.5">
@@ -219,10 +228,11 @@ function LimitOverrideRow({
             <Input
               type="number"
               min={1}
-              value={overrideLimit}
-              onChange={(e) => {
-                const n = parseInt(e.target.value, 10);
-                if (!isNaN(n) && n > 0) onChange(n);
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commitDraft}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitDraft();
               }}
               className="h-6 w-20 text-xs"
             />
@@ -242,7 +252,11 @@ function LimitOverrideRow({
             variant="ghost"
             size="sm"
             className="h-6 px-1.5 text-xs"
-            onClick={() => onChange(insightLimit ?? 100)}
+            onClick={() => {
+              const initial = insightLimit ?? 100;
+              setDraft(initial.toString());
+              onChange(initial);
+            }}
           >
             Pin
           </Button>

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -351,7 +351,17 @@ export function OverridePopover({
   // ---------------------------------------------------------------------------
 
   function saveOverrides(next: DashboardItemOverrides) {
-    updateItem(dashboardId, item.id, { overrides: next });
+    // Collapse truthy-but-empty bags to undefined so cells with no overrides
+    // don't produce a non-undefined `overrides` object that triggers a needless
+    // per-cell DuckDB view.  Guards the same hazard documented in
+    // computeItemOverrides (controls.ts:137-150).
+    const clean =
+      (next.filters?.length ?? 0) > 0 ||
+      next.sorts !== undefined ||
+      next.limit !== undefined
+        ? next
+        : undefined;
+    updateItem(dashboardId, item.id, { overrides: clean });
   }
 
   function handlePin(fieldName: string, filter: InsightFilterOverride) {
@@ -469,6 +479,7 @@ export function OverridePopover({
                     <OverrideFieldRow
                       key={fieldName}
                       fieldName={fieldName}
+                      displayName={combinedField?.displayName ?? fieldName}
                       state={state}
                       combinedField={combinedField}
                       eligibleControls={eligible}

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -1,0 +1,518 @@
+/**
+ * Per-cell override popover — anchored to the cell, opened by the customize button.
+ *
+ * Self-fetches the visualization → insight → data table needed to derive field
+ * state and drive the inline filter editor.  Mirrors the self-fetch pattern used
+ * in VisualizationDisplay.
+ *
+ * Mutations:
+ * - Filter overrides → `updateItem(dashboardId, item.id, { overrides: … })`
+ * - Sort / limit   → `updateItem(...)` with updated sorts / limit
+ * - Bind to control → `updateControls(dashboardId, newControls)` (replace whole array)
+ * - Unbind         → `updateControls(...)` removing item.id from boundInstances
+ *
+ * Fields shown = union of:
+ *   • Fields with an insight-level filter (inherit or override)
+ *   • Fields with a cell-level override (already shown above)
+ *   • Fields on a bound control targeting this cell
+ *   • (Additive "add filter" row for other eligible fields — not in this PR)
+ */
+
+import { isControlEligible } from "@/lib/dashboards/controls";
+import { computeCombinedFields } from "@/lib/insights/compute-combined-fields";
+import {
+  useDashboardMutations,
+  useDataTables,
+  useInsights,
+  useVisualizations,
+} from "@dashframe/core";
+import type {
+  DashboardControl,
+  DashboardItem,
+  DashboardItemOverrides,
+  InsightFilter,
+  InsightFilterOverride,
+  InsightSort,
+} from "@dashframe/types";
+import {
+  Badge,
+  Button,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  cn,
+} from "@wystack/ui";
+import { SettingsIcon } from "@wystack/ui-icons";
+import { useMemo } from "react";
+import {
+  computeNewOverridesOnClear,
+  computeNewOverridesOnInherit,
+  computeNewOverridesOnLimitChange,
+  computeNewOverridesOnPin,
+  computeNewOverridesOnSortChange,
+  deriveFieldState,
+  hasOverrides,
+} from "./override-field-row-utils";
+import { OverrideFieldRow } from "./OverrideFieldRow";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface OverridePopoverProps {
+  item: DashboardItem;
+  dashboardId: string;
+  /** Dashboard-level controls (from dashboard.controls ?? []). */
+  controls: DashboardControl[];
+}
+
+// ---------------------------------------------------------------------------
+// Sort row
+// ---------------------------------------------------------------------------
+
+function SortOverrideRow({
+  insightSorts,
+  overrideSorts,
+  availableFields,
+  onChange,
+}: {
+  insightSorts?: InsightSort[];
+  overrideSorts?: InsightSort[];
+  availableFields: string[];
+  onChange: (sorts: InsightSort[] | undefined) => void;
+}) {
+  const current: InsightSort | undefined =
+    overrideSorts?.[0] ?? insightSorts?.[0];
+  const isPinned = overrideSorts !== undefined;
+
+  return (
+    <div className="py-1.5">
+      <div className="flex items-center gap-2">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <span className="text-xs font-medium text-neutral-fg">Sort</span>
+          {!isPinned && current && (
+            <span className="text-xs text-neutral-fg-disabled">
+              default: {current.field} {current.direction}
+            </span>
+          )}
+        </div>
+
+        {isPinned ? (
+          <div className="flex items-center gap-1">
+            {/* Field select */}
+            <Select
+              value={overrideSorts![0]?.field ?? ""}
+              onValueChange={(field) => {
+                if (!field) return;
+                onChange([
+                  { field, direction: overrideSorts![0]?.direction ?? "asc" },
+                ]);
+              }}
+            >
+              <SelectTrigger className="h-6 w-28 text-xs">
+                <SelectValue placeholder="field" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableFields.map((f) => (
+                  <SelectItem key={f} value={f} className="text-xs">
+                    {f}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {/* Direction toggle */}
+            <Select
+              value={overrideSorts![0]?.direction ?? "asc"}
+              onValueChange={(dir) =>
+                onChange([
+                  {
+                    field: overrideSorts![0]?.field ?? availableFields[0] ?? "",
+                    direction: dir as "asc" | "desc",
+                  },
+                ])
+              }
+            >
+              <SelectTrigger className="h-6 w-16 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="asc" className="text-xs">
+                  asc
+                </SelectItem>
+                <SelectItem value="desc" className="text-xs">
+                  desc
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            {/* Reset to inherit */}
+            <Button
+              label="Reset sort to inherit"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-xs"
+              onClick={() => onChange(undefined)}
+            >
+              ×
+            </Button>
+          </div>
+        ) : (
+          <Button
+            label="Pin sort override"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-xs"
+            onClick={() =>
+              onChange([
+                {
+                  field: current?.field ?? availableFields[0] ?? "",
+                  direction: current?.direction ?? "asc",
+                },
+              ])
+            }
+            disabled={availableFields.length === 0}
+          >
+            Pin
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Limit row
+// ---------------------------------------------------------------------------
+
+function LimitOverrideRow({
+  insightLimit,
+  overrideLimit,
+  onChange,
+}: {
+  insightLimit?: number;
+  overrideLimit?: number;
+  onChange: (limit: number | undefined) => void;
+}) {
+  const isPinned = overrideLimit !== undefined;
+
+  return (
+    <div className="py-1.5">
+      <div className="flex items-center gap-2">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <span className="text-xs font-medium text-neutral-fg">Limit</span>
+          {!isPinned && insightLimit !== undefined && (
+            <span className="text-xs text-neutral-fg-disabled">
+              default: {insightLimit} rows
+            </span>
+          )}
+        </div>
+
+        {isPinned ? (
+          <div className="flex items-center gap-1">
+            <Input
+              type="number"
+              min={1}
+              value={overrideLimit}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                if (!isNaN(n) && n > 0) onChange(n);
+              }}
+              className="h-6 w-20 text-xs"
+            />
+            <Button
+              label="Reset limit to inherit"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-xs"
+              onClick={() => onChange(undefined)}
+            >
+              ×
+            </Button>
+          </div>
+        ) : (
+          <Button
+            label="Pin row limit"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-xs"
+            onClick={() => onChange(insightLimit ?? 100)}
+          >
+            Pin
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function OverridePopover({
+  item,
+  dashboardId,
+  controls,
+}: OverridePopoverProps) {
+  const { updateItem, updateControls } = useDashboardMutations();
+
+  // Self-fetch visualization → insight → data table (same pattern as VisualizationDisplay).
+  const { data: visualizations = [] } = useVisualizations();
+  const { data: insights = [] } = useInsights();
+  const { data: dataTables = [] } = useDataTables();
+
+  const visualization = useMemo(
+    () =>
+      item.visualizationId
+        ? (visualizations.find((v) => v.id === item.visualizationId) ?? null)
+        : null,
+    [item.visualizationId, visualizations],
+  );
+
+  const insight = useMemo(
+    () =>
+      visualization
+        ? (insights.find((i) => i.id === visualization.insightId) ?? null)
+        : null,
+    [visualization, insights],
+  );
+
+  const dataTable = useMemo(
+    () =>
+      insight?.baseTableId
+        ? (dataTables.find((t) => t.id === insight.baseTableId) ?? null)
+        : null,
+    [insight, dataTables],
+  );
+
+  // Combined fields for type-aware value editors.
+  const { fields: combinedFields } = useMemo(
+    () =>
+      insight && dataTable
+        ? computeCombinedFields(dataTable, insight.joins ?? [], dataTables)
+        : { fields: [] },
+    [insight, dataTable, dataTables],
+  );
+
+  const combinedFieldByName = useMemo(() => {
+    const map = new Map(combinedFields.map((f) => [f.columnName ?? f.name, f]));
+    return map;
+  }, [combinedFields]);
+
+  // Controls that target this cell.
+  const boundControls = useMemo(
+    () => controls.filter((c) => c.boundInstances.includes(item.id)),
+    [controls, item.id],
+  );
+
+  // Build the list of fields to show.
+  // Union of: insight filter fields + cell override filter fields + bound control fields.
+  const fieldNames = useMemo(() => {
+    const seen = new Set<string>();
+    const names: string[] = [];
+    function add(name: string) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        names.push(name);
+      }
+    }
+    for (const f of insight?.filters ?? []) add(f.field);
+    for (const f of item.overrides?.filters ?? []) add(f.field);
+    for (const c of boundControls) add(c.field);
+    return names;
+  }, [insight?.filters, item.overrides?.filters, boundControls]);
+
+  // Insight filter lookup by field name (for inherit state display).
+  const insightFilterByField = useMemo(() => {
+    const map = new Map<string, InsightFilter>();
+    for (const f of insight?.filters ?? []) map.set(f.field, f);
+    return map;
+  }, [insight?.filters]);
+
+  // Eligible controls per field (controls whose field matches AND cell's source table has the field).
+  function getEligibleControls(fieldName: string): DashboardControl[] {
+    return controls.filter(
+      (c) =>
+        c.field === fieldName &&
+        !c.boundInstances.includes(item.id) &&
+        isControlEligible(fieldName, dataTable ?? undefined),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutation handlers
+  // ---------------------------------------------------------------------------
+
+  function saveOverrides(next: DashboardItemOverrides) {
+    updateItem(dashboardId, item.id, { overrides: next });
+  }
+
+  function handlePin(fieldName: string, filter: InsightFilterOverride) {
+    saveOverrides(computeNewOverridesOnPin(fieldName, filter, item.overrides));
+  }
+
+  function handleClear(fieldName: string) {
+    saveOverrides(computeNewOverridesOnClear(fieldName, item.overrides));
+  }
+
+  function handleInherit(fieldName: string) {
+    saveOverrides(computeNewOverridesOnInherit(fieldName, item.overrides));
+  }
+
+  function handleSortChange(sorts: InsightSort[] | undefined) {
+    saveOverrides(computeNewOverridesOnSortChange(sorts, item.overrides));
+  }
+
+  function handleLimitChange(limit: number | undefined) {
+    saveOverrides(computeNewOverridesOnLimitChange(limit, item.overrides));
+  }
+
+  function handleBind(fieldName: string, controlId: string) {
+    // Add item.id to the control's boundInstances.  Replaces the whole controls array.
+    const next = controls.map((c) =>
+      c.id === controlId
+        ? { ...c, boundInstances: [...c.boundInstances, item.id] }
+        : c,
+    );
+    updateControls(dashboardId, next);
+  }
+
+  function handleUnbind(controlId: string) {
+    // Remove item.id from the control's boundInstances.
+    const next = controls.map((c) =>
+      c.id === controlId
+        ? {
+            ...c,
+            boundInstances: c.boundInstances.filter((id) => id !== item.id),
+          }
+        : c,
+    );
+    updateControls(dashboardId, next);
+  }
+
+  // Available field names for the sort row (fields in the data table).
+  const availableFieldNames = useMemo(
+    () => (dataTable?.fields ?? []).map((f) => f.columnName ?? f.name),
+    [dataTable],
+  );
+
+  const overridePresent = hasOverrides(item.overrides);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            aria-label="Customize cell overrides"
+            className={cn(
+              "relative flex h-6 w-6 shrink-0 items-center justify-center rounded-md p-0 text-neutral-fg-subtle transition-colors hover:bg-neutral-bg hover:text-neutral-fg",
+              overridePresent && "text-palette-primary",
+            )}
+          >
+            <SettingsIcon className="h-3.5 w-3.5" />
+            {overridePresent && (
+              <span
+                aria-label="This cell has overrides"
+                className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-palette-primary"
+              />
+            )}
+          </button>
+        }
+      />
+
+      <PopoverContent
+        className="w-80 p-0"
+        side="bottom"
+        align="end"
+        sideOffset={6}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-neutral-border px-3 py-2">
+          <span className="text-sm font-semibold text-neutral-fg">
+            Cell overrides
+          </span>
+          {overridePresent && (
+            <Badge variant="soft" color="primary" className="text-xs">
+              active
+            </Badge>
+          )}
+        </div>
+
+        <ScrollArea className="max-h-96">
+          <div className="px-3 py-2">
+            {/* Filter rows */}
+            {fieldNames.length > 0 && (
+              <>
+                <p className="mb-1 text-xs font-medium text-neutral-fg-subtle uppercase tracking-wide">
+                  Filters
+                </p>
+                {fieldNames.map((fieldName) => {
+                  const state = deriveFieldState(
+                    fieldName,
+                    item.id,
+                    item.overrides,
+                    controls,
+                    insightFilterByField.get(fieldName),
+                  );
+                  const combinedField = combinedFieldByName.get(fieldName);
+                  const eligible = getEligibleControls(fieldName);
+
+                  return (
+                    <OverrideFieldRow
+                      key={fieldName}
+                      fieldName={fieldName}
+                      state={state}
+                      combinedField={combinedField}
+                      eligibleControls={eligible}
+                      onPin={(filter) => handlePin(fieldName, filter)}
+                      onClear={() => handleClear(fieldName)}
+                      onInherit={() => handleInherit(fieldName)}
+                      onBind={(controlId) => handleBind(fieldName, controlId)}
+                      onUnbind={
+                        state.type === "bound"
+                          ? () => handleUnbind(state.control.id)
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+                <Separator className="my-2" />
+              </>
+            )}
+
+            {/* Sort row */}
+            <p className="mb-1 text-xs font-medium text-neutral-fg-subtle uppercase tracking-wide">
+              Sort
+            </p>
+            <SortOverrideRow
+              insightSorts={insight?.sorts}
+              overrideSorts={item.overrides?.sorts}
+              availableFields={availableFieldNames}
+              onChange={handleSortChange}
+            />
+
+            <Separator className="my-2" />
+
+            {/* Limit row */}
+            <p className="mb-1 text-xs font-medium text-neutral-fg-subtle uppercase tracking-wide">
+              Limit
+            </p>
+            <LimitOverrideRow
+              insightLimit={undefined}
+              overrideLimit={item.overrides?.limit}
+              onChange={handleLimitChange}
+            />
+          </div>
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -351,17 +351,25 @@ export function OverridePopover({
   // ---------------------------------------------------------------------------
 
   function saveOverrides(next: DashboardItemOverrides) {
-    // Collapse truthy-but-empty bags to undefined so cells with no overrides
-    // don't produce a non-undefined `overrides` object that triggers a needless
+    // Collapse truthy-but-empty bags so cells with no overrides don't
+    // produce a non-undefined `overrides` object that triggers a needless
     // per-cell DuckDB view.  Guards the same hazard documented in
     // computeItemOverrides (controls.ts:137-150).
-    const clean =
+    const hasContent =
       (next.filters?.length ?? 0) > 0 ||
       next.sorts !== undefined ||
-      next.limit !== undefined
-        ? next
-        : undefined;
-    updateItem(dashboardId, item.id, { overrides: clean });
+      next.limit !== undefined;
+
+    if (hasContent) {
+      updateItem(dashboardId, item.id, { overrides: next });
+    } else {
+      // Explicit clear: send null so JSON.stringify preserves the key.
+      // `undefined` would be dropped by JSON.stringify → the server's
+      // `"overrides" in input` gate never fires → clear is silently skipped.
+      // null is already handled: sanitizeItemOverrides(null) → undefined → JSONB cleared.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateItem(dashboardId, item.id, { overrides: null } as any);
+    }
   }
 
   function handlePin(fieldName: string, filter: InsightFilterOverride) {

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -381,8 +381,9 @@ export function OverridePopover({
       // `undefined` would be dropped by JSON.stringify → the server's
       // `"overrides" in input` gate never fires → clear is silently skipped.
       // null is already handled: sanitizeItemOverrides(null) → undefined → JSONB cleared.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      updateItem(dashboardId, item.id, { overrides: null } as any);
+      updateItem(dashboardId, item.id, {
+        overrides: null as unknown as undefined,
+      });
     }
   }
 

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -365,22 +365,14 @@ export function OverridePopover({
   // ---------------------------------------------------------------------------
 
   function saveOverrides(next: DashboardItemOverrides) {
-    // Collapse truthy-but-empty bags so cells with no overrides don't
-    // produce a non-undefined `overrides` object that triggers a needless
-    // per-cell DuckDB view.  Guards the same hazard documented in
-    // computeItemOverrides (controls.ts:137-150).
-    const hasContent =
-      (next.filters?.length ?? 0) > 0 ||
-      next.sorts !== undefined ||
-      next.limit !== undefined;
-
-    if (hasContent) {
+    if (hasOverrides(next)) {
       updateItem(dashboardId, item.id, { overrides: next });
     } else {
       // Explicit clear: send null so JSON.stringify preserves the key.
       // `undefined` would be dropped by JSON.stringify → the server's
       // `"overrides" in input` gate never fires → clear is silently skipped.
       // null is already handled: sanitizeItemOverrides(null) → undefined → JSONB cleared.
+      // Empty-bag check is delegated to hasOverrides (tested in override-field-row-utils.test.ts).
       updateItem(dashboardId, item.id, {
         overrides: null as unknown as undefined,
       });

--- a/packages/app/src/components/dashboards/OverridePopover.tsx
+++ b/packages/app/src/components/dashboards/OverridePopover.tsx
@@ -384,8 +384,10 @@ export function OverridePopover({
     saveOverrides(computeNewOverridesOnLimitChange(limit, item.overrides));
   }
 
-  function handleBind(fieldName: string, controlId: string) {
+  function handleBind(controlId: string) {
     // Add item.id to the control's boundInstances.  Replaces the whole controls array.
+    // fieldName is not needed here — control→field routing is already encoded in
+    // the control record (`c.field`); we look up by controlId directly.
     const next = controls.map((c) =>
       c.id === controlId
         ? { ...c, boundInstances: [...c.boundInstances, item.id] }
@@ -486,7 +488,7 @@ export function OverridePopover({
                       onPin={(filter) => handlePin(fieldName, filter)}
                       onClear={() => handleClear(fieldName)}
                       onInherit={() => handleInherit(fieldName)}
-                      onBind={(controlId) => handleBind(fieldName, controlId)}
+                      onBind={(controlId) => handleBind(controlId)}
                       onUnbind={
                         state.type === "bound"
                           ? () => handleUnbind(state.control.id)
@@ -516,6 +518,8 @@ export function OverridePopover({
             <p className="mb-1 text-xs font-medium text-neutral-fg-subtle uppercase tracking-wide">
               Limit
             </p>
+            {/* insightLimit: the Insight type has no row-limit field (v0.3).
+                The "default: N rows" hint is intentionally absent for now. */}
             <LimitOverrideRow
               insightLimit={undefined}
               overrideLimit={item.overrides?.limit}

--- a/packages/app/src/components/dashboards/override-field-row-utils.test.ts
+++ b/packages/app/src/components/dashboards/override-field-row-utils.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Tests for override-field-row-utils.ts
+ *
+ * Contracts tested:
+ *
+ * STATE RESOLUTION — given (item.overrides, controls, fieldName), derive the 4-state machine:
+ * 1. inherit: no cell override, no bound control.
+ * 2. pinned: cell override entry with a value (non-cleared), no bound control.
+ * 3. cleared: cell override entry with `cleared: true`, no bound control.
+ * 4. bound: a control with `control.field === fieldName` lists `item.id` in boundInstances.
+ *
+ * TRANSITION PAYLOADS — given a state + action, assert the written overrides bag:
+ * 5. pin: adds/replaces the filter for the field; preserves other filters + sorts + limit.
+ * 6. clear: adds cleared entry; preserves other filters + sorts + limit.
+ * 7. inherit: removes the entry; preserves other filters + sorts + limit. Empty filters → undefined.
+ * 8. sortChange: replaces sorts; preserves filters + limit.
+ * 9. limitChange: replaces limit; preserves filters + sorts.
+ *
+ * BADGE — hasOverrides truth table.
+ * 10. hasOverrides: true on non-empty filters/sorts/limit, false otherwise.
+ */
+
+import type {
+  DashboardControl,
+  DashboardItemOverrides,
+  InsightFilter,
+  InsightFilterOverride,
+  InsightSort,
+} from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import {
+  computeNewOverridesOnClear,
+  computeNewOverridesOnInherit,
+  computeNewOverridesOnLimitChange,
+  computeNewOverridesOnPin,
+  computeNewOverridesOnSortChange,
+  deriveFieldState,
+  hasOverrides,
+} from "./override-field-row-utils";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function filter(
+  field: string,
+  extra?: Partial<InsightFilterOverride>,
+): InsightFilterOverride {
+  return { field, operator: "eq", value: "v1", ...extra };
+}
+
+function control(
+  id: string,
+  fieldName: string,
+  boundInstances: string[],
+): DashboardControl {
+  return { id, field: fieldName, boundInstances };
+}
+
+const ITEM_ID = "item-1";
+const FIELD = "created_at";
+const OTHER_FIELD = "status";
+
+// ---------------------------------------------------------------------------
+// 1–4: State resolution
+// ---------------------------------------------------------------------------
+
+describe("deriveFieldState — state resolution", () => {
+  it("1. inherit: no override, no bound control", () => {
+    const state = deriveFieldState(FIELD, ITEM_ID, undefined, []);
+    expect(state).toEqual({ type: "inherit", insightFilter: undefined });
+  });
+
+  it("1b. inherit with insightFilter passed through", () => {
+    const insightFilter: InsightFilter = {
+      field: FIELD,
+      operator: "gt",
+      value: "2024-01-01",
+    };
+    const state = deriveFieldState(
+      FIELD,
+      ITEM_ID,
+      undefined,
+      [],
+      insightFilter,
+    );
+    expect(state).toEqual({ type: "inherit", insightFilter });
+  });
+
+  it("1c. inherit: overrides present but for a different field", () => {
+    const overrides: DashboardItemOverrides = {
+      filters: [filter(OTHER_FIELD)],
+    };
+    const state = deriveFieldState(FIELD, ITEM_ID, overrides, []);
+    expect(state).toEqual({ type: "inherit", insightFilter: undefined });
+  });
+
+  it("2. pinned: cell override with value (non-cleared)", () => {
+    const f = filter(FIELD, { value: "2024" });
+    const overrides: DashboardItemOverrides = { filters: [f] };
+    const state = deriveFieldState(FIELD, ITEM_ID, overrides, []);
+    expect(state).toEqual({ type: "pinned", filter: f });
+  });
+
+  it("3. cleared: cell override with cleared: true", () => {
+    const clearedFilter = filter(FIELD, { cleared: true, value: null });
+    const overrides: DashboardItemOverrides = { filters: [clearedFilter] };
+    const state = deriveFieldState(FIELD, ITEM_ID, overrides, []);
+    expect(state).toEqual({ type: "cleared" });
+  });
+
+  it("4. bound: control targeting this field and item wins over a pinned override", () => {
+    const pinnedFilter = filter(FIELD, { value: "2024" });
+    const overrides: DashboardItemOverrides = { filters: [pinnedFilter] };
+    const c = control("ctrl-1", FIELD, [ITEM_ID]);
+    const state = deriveFieldState(FIELD, ITEM_ID, overrides, [c]);
+    expect(state.type).toBe("bound");
+    if (state.type === "bound") {
+      expect(state.control).toBe(c);
+      // Dormant filter: the item's own pinned entry (shadowed while bound).
+      expect(state.dormantFilter).toEqual(pinnedFilter);
+    }
+  });
+
+  it("4b. bound: no dormant filter when there was no pinned entry", () => {
+    const c = control("ctrl-1", FIELD, [ITEM_ID]);
+    const state = deriveFieldState(FIELD, ITEM_ID, undefined, [c]);
+    expect(state.type).toBe("bound");
+    if (state.type === "bound") {
+      expect(state.dormantFilter).toBeUndefined();
+    }
+  });
+
+  it("4c. bound: control does NOT bind if item.id is not in boundInstances", () => {
+    const c = control("ctrl-1", FIELD, ["other-item"]);
+    const state = deriveFieldState(FIELD, ITEM_ID, undefined, [c]);
+    expect(state.type).toBe("inherit");
+  });
+
+  it("4d. bound: control does NOT bind if control.field !== fieldName", () => {
+    const c = control("ctrl-1", OTHER_FIELD, [ITEM_ID]);
+    const state = deriveFieldState(FIELD, ITEM_ID, undefined, [c]);
+    expect(state.type).toBe("inherit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5–7: Filter transition payloads
+// ---------------------------------------------------------------------------
+
+describe("computeNewOverridesOnPin — transition payload", () => {
+  it("5a. adds a new pinned filter when there are no existing overrides", () => {
+    const pinFilter: InsightFilterOverride = {
+      field: FIELD,
+      operator: "eq",
+      value: "2024",
+    };
+    const result = computeNewOverridesOnPin(FIELD, pinFilter, undefined);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters![0]).toEqual(pinFilter);
+    expect(result.sorts).toBeUndefined();
+    expect(result.limit).toBeUndefined();
+  });
+
+  it("5b. replaces an existing pinned entry for the same field", () => {
+    const existing = filter(FIELD, { value: "old" });
+    const overrides: DashboardItemOverrides = { filters: [existing] };
+    const newFilter: InsightFilterOverride = {
+      field: FIELD,
+      operator: "gte",
+      value: "2024",
+    };
+    const result = computeNewOverridesOnPin(FIELD, newFilter, overrides);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters![0]).toEqual(newFilter);
+  });
+
+  it("5c. replaces a cleared entry for the same field", () => {
+    const cleared = filter(FIELD, { cleared: true, value: null });
+    const overrides: DashboardItemOverrides = { filters: [cleared] };
+    const pinFilter: InsightFilterOverride = {
+      field: FIELD,
+      operator: "lt",
+      value: "2025",
+    };
+    const result = computeNewOverridesOnPin(FIELD, pinFilter, overrides);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters![0]).toEqual(pinFilter);
+  });
+
+  it("5d. preserves other fields' filters, sorts, and limit", () => {
+    const otherFilter = filter(OTHER_FIELD, { value: "active" });
+    const existingSort: InsightSort = { field: "name", direction: "asc" };
+    const overrides: DashboardItemOverrides = {
+      filters: [otherFilter],
+      sorts: [existingSort],
+      limit: 50,
+    };
+    const pinFilter: InsightFilterOverride = {
+      field: FIELD,
+      operator: "eq",
+      value: "2024",
+    };
+    const result = computeNewOverridesOnPin(FIELD, pinFilter, overrides);
+    // Other filter preserved.
+    expect(result.filters).toContainEqual(otherFilter);
+    // New pin added.
+    expect(result.filters).toContainEqual(pinFilter);
+    // Sorts and limit untouched.
+    expect(result.sorts).toEqual([existingSort]);
+    expect(result.limit).toBe(50);
+  });
+});
+
+describe("computeNewOverridesOnClear — transition payload", () => {
+  it("6a. adds cleared entry when there are no existing overrides", () => {
+    const result = computeNewOverridesOnClear(FIELD, undefined);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters![0]).toMatchObject({ field: FIELD, cleared: true });
+  });
+
+  it("6b. replaces an existing pinned entry with cleared", () => {
+    const existing = filter(FIELD, { value: "2024" });
+    const overrides: DashboardItemOverrides = { filters: [existing] };
+    const result = computeNewOverridesOnClear(FIELD, overrides);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters![0]).toMatchObject({ field: FIELD, cleared: true });
+  });
+
+  it("6c. preserves other fields' filters, sorts, and limit", () => {
+    const otherFilter = filter(OTHER_FIELD, { value: "active" });
+    const overrides: DashboardItemOverrides = {
+      filters: [otherFilter],
+      sorts: [{ field: "name", direction: "asc" }],
+      limit: 20,
+    };
+    const result = computeNewOverridesOnClear(FIELD, overrides);
+    expect(result.filters).toHaveLength(2);
+    expect(result.filters).toContainEqual(otherFilter);
+    expect(result.filters!.some((f) => f.field === FIELD && f.cleared)).toBe(
+      true,
+    );
+    expect(result.sorts).toEqual([{ field: "name", direction: "asc" }]);
+    expect(result.limit).toBe(20);
+  });
+});
+
+describe("computeNewOverridesOnInherit — transition payload", () => {
+  it("7a. removes a pinned entry; filters becomes undefined when empty", () => {
+    const overrides: DashboardItemOverrides = {
+      filters: [filter(FIELD, { value: "2024" })],
+    };
+    const result = computeNewOverridesOnInherit(FIELD, overrides);
+    // Single-field bag: after removal filters should be undefined (not []).
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("7b. removes a cleared entry; filters becomes undefined when empty", () => {
+    const overrides: DashboardItemOverrides = {
+      filters: [filter(FIELD, { cleared: true, value: null })],
+    };
+    const result = computeNewOverridesOnInherit(FIELD, overrides);
+    expect(result.filters).toBeUndefined();
+  });
+
+  it("7c. preserves other fields' filters when removing target field", () => {
+    const otherFilter = filter(OTHER_FIELD, { value: "active" });
+    const overrides: DashboardItemOverrides = {
+      filters: [filter(FIELD, { value: "x" }), otherFilter],
+    };
+    const result = computeNewOverridesOnInherit(FIELD, overrides);
+    expect(result.filters).toHaveLength(1);
+    expect(result.filters![0]).toEqual(otherFilter);
+  });
+
+  it("7d. preserves sorts and limit when removing a filter", () => {
+    const overrides: DashboardItemOverrides = {
+      filters: [filter(FIELD, { value: "x" })],
+      sorts: [{ field: "name", direction: "asc" }],
+      limit: 10,
+    };
+    const result = computeNewOverridesOnInherit(FIELD, overrides);
+    expect(result.sorts).toEqual([{ field: "name", direction: "asc" }]);
+    expect(result.limit).toBe(10);
+  });
+
+  it("7e. no-op on a field with no override (safe to call from inherit state)", () => {
+    const result = computeNewOverridesOnInherit(FIELD, undefined);
+    expect(result.filters).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8–9: Sort + limit transition payloads
+// ---------------------------------------------------------------------------
+
+describe("computeNewOverridesOnSortChange — transition payload", () => {
+  it("8a. sets a sort override from scratch", () => {
+    const sorts: InsightSort[] = [{ field: "date", direction: "desc" }];
+    const result = computeNewOverridesOnSortChange(sorts, undefined);
+    expect(result.sorts).toEqual(sorts);
+    expect(result.filters).toBeUndefined();
+    expect(result.limit).toBeUndefined();
+  });
+
+  it("8b. replaces an existing sort override", () => {
+    const overrides: DashboardItemOverrides = {
+      sorts: [{ field: "name", direction: "asc" }],
+    };
+    const newSorts: InsightSort[] = [{ field: "date", direction: "desc" }];
+    const result = computeNewOverridesOnSortChange(newSorts, overrides);
+    expect(result.sorts).toEqual(newSorts);
+  });
+
+  it("8c. removes sort override when sorts is undefined (revert to inherit)", () => {
+    const overrides: DashboardItemOverrides = {
+      sorts: [{ field: "name", direction: "asc" }],
+      limit: 100,
+    };
+    const result = computeNewOverridesOnSortChange(undefined, overrides);
+    expect(result.sorts).toBeUndefined();
+    expect(result.limit).toBe(100); // preserved
+  });
+
+  it("8d. preserves filters and limit when changing sorts", () => {
+    const f = filter(FIELD, { value: "x" });
+    const overrides: DashboardItemOverrides = { filters: [f], limit: 50 };
+    const result = computeNewOverridesOnSortChange(
+      [{ field: "date", direction: "asc" }],
+      overrides,
+    );
+    expect(result.filters).toContainEqual(f);
+    expect(result.limit).toBe(50);
+  });
+});
+
+describe("computeNewOverridesOnLimitChange — transition payload", () => {
+  it("9a. sets a limit override from scratch", () => {
+    const result = computeNewOverridesOnLimitChange(25, undefined);
+    expect(result.limit).toBe(25);
+    expect(result.filters).toBeUndefined();
+    expect(result.sorts).toBeUndefined();
+  });
+
+  it("9b. replaces an existing limit", () => {
+    const overrides: DashboardItemOverrides = { limit: 100 };
+    const result = computeNewOverridesOnLimitChange(50, overrides);
+    expect(result.limit).toBe(50);
+  });
+
+  it("9c. removes limit override when limit is undefined (revert to inherit)", () => {
+    const overrides: DashboardItemOverrides = {
+      limit: 100,
+      sorts: [{ field: "name", direction: "asc" }],
+    };
+    const result = computeNewOverridesOnLimitChange(undefined, overrides);
+    expect(result.limit).toBeUndefined();
+    expect(result.sorts).toEqual([{ field: "name", direction: "asc" }]); // preserved
+  });
+
+  it("9d. preserves filters and sorts when changing limit", () => {
+    const f = filter(FIELD, { value: "x" });
+    const s: InsightSort = { field: "date", direction: "asc" };
+    const overrides: DashboardItemOverrides = { filters: [f], sorts: [s] };
+    const result = computeNewOverridesOnLimitChange(10, overrides);
+    expect(result.filters).toContainEqual(f);
+    expect(result.sorts).toContainEqual(s);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10: Badge helper
+// ---------------------------------------------------------------------------
+
+describe("hasOverrides — badge truth table", () => {
+  it("10a. undefined → false", () => {
+    expect(hasOverrides(undefined)).toBe(false);
+  });
+
+  it("10b. empty object {} → false", () => {
+    expect(hasOverrides({})).toBe(false);
+  });
+
+  it("10c. filters: [] → false (empty array is non-trivial check)", () => {
+    expect(hasOverrides({ filters: [] })).toBe(false);
+  });
+
+  it("10d. non-empty filters → true", () => {
+    expect(hasOverrides({ filters: [filter(FIELD)] })).toBe(true);
+  });
+
+  it("10e. cleared filter entry → true (cleared is an active override)", () => {
+    expect(
+      hasOverrides({
+        filters: [filter(FIELD, { cleared: true, value: null })],
+      }),
+    ).toBe(true);
+  });
+
+  it("10f. sorts override → true", () => {
+    expect(hasOverrides({ sorts: [{ field: "date", direction: "asc" }] })).toBe(
+      true,
+    );
+  });
+
+  it("10g. limit override → true", () => {
+    expect(hasOverrides({ limit: 100 })).toBe(true);
+  });
+
+  it("10h. only sorts=undefined, limit=undefined → false", () => {
+    // Explicitly undefined properties still yield false.
+    expect(hasOverrides({ sorts: undefined, limit: undefined })).toBe(false);
+  });
+});

--- a/packages/app/src/components/dashboards/override-field-row-utils.ts
+++ b/packages/app/src/components/dashboards/override-field-row-utils.ts
@@ -1,0 +1,260 @@
+/**
+ * Pure state-derivation and override-mutation helpers for the per-cell
+ * OverrideFieldRow UI.
+ *
+ * All functions here are free of React/UI imports so they can be unit-tested
+ * directly.  The state machine and payload shape are the load-bearing contracts
+ * tested in override-field-row-utils.test.ts.
+ */
+
+import type {
+  DashboardControl,
+  DashboardItemOverrides,
+  InsightFilter,
+  InsightFilterOverride,
+  InsightSort,
+} from "@dashframe/types";
+
+// ---------------------------------------------------------------------------
+// Field override state machine
+// ---------------------------------------------------------------------------
+
+/**
+ * The 4-state machine for a single overrideable field in a dashboard cell.
+ *
+ * - `inherit`: no entry for this field; the insight's own filter (if any) falls
+ *   through unchanged.
+ * - `pinned`: the cell has an explicit, non-cleared filter override for this field.
+ * - `cleared`: `cleared: true` in the override — removes the insight's filter
+ *   so the cell shows all values for this field (widen).
+ * - `bound`: a dashboard control owns this field for this cell; the cell's own
+ *   pinned filter is shadowed while bound and resumes automatically on unbind.
+ *
+ * IMPORTANT: `inherit` and `cleared` are DISTINCT signals — do not collapse
+ * them into a single "off" state.  `absent` = inherit, `cleared: true` = widen.
+ * See `InsightFilterOverride` comment in @dashframe/types.
+ */
+export type FieldOverrideState =
+  | { type: "inherit"; insightFilter?: InsightFilter }
+  | { type: "pinned"; filter: InsightFilterOverride }
+  | { type: "cleared" }
+  | {
+      type: "bound";
+      control: DashboardControl;
+      dormantFilter?: InsightFilterOverride;
+    };
+
+/**
+ * Derive the FieldOverrideState for `fieldName` in cell `itemId`.
+ *
+ * Precedence (per override spec §6):
+ * 1. **Bound**: a control with `control.field === fieldName` lists `itemId` in
+ *    `boundInstances` → state is `bound`. The cell's own pinned filter (if any)
+ *    is exposed as `dormantFilter` (shadowed while bound, resumes on unbind).
+ * 2. **Cleared**: `item.overrides.filters` has an entry for `fieldName` with
+ *    `cleared: true` → state is `cleared`.
+ * 3. **Pinned**: `item.overrides.filters` has an entry for `fieldName` without
+ *    `cleared` → state is `pinned`.
+ * 4. **Inherit**: no entry at all → state is `inherit`. `insightFilter` is the
+ *    insight's own filter for this field (for greyed display in the UI).
+ *
+ * @param fieldName     - Source column name to look up.
+ * @param itemId        - Cell id (checked in `boundInstances`).
+ * @param itemOverrides - The cell's own saved `item.overrides` (NOT effectiveOverrides).
+ * @param controls      - Dashboard-level controls array.
+ * @param insightFilter - Insight's own filter for this field (used in inherit state
+ *                        for display only — greyed label "insight default: ...").
+ */
+export function deriveFieldState(
+  fieldName: string,
+  itemId: string,
+  itemOverrides: DashboardItemOverrides | undefined,
+  controls: DashboardControl[],
+  insightFilter?: InsightFilter,
+): FieldOverrideState {
+  // 1. Bound check — a control that targets this field AND this cell wins.
+  const boundControl = controls.find(
+    (c) => c.field === fieldName && c.boundInstances.includes(itemId),
+  );
+  if (boundControl) {
+    // Expose the dormant pinned filter so the UI can show "will resume on unbind".
+    const dormantFilter = itemOverrides?.filters?.find(
+      (f) => f.field === fieldName && !f.cleared,
+    );
+    return { type: "bound", control: boundControl, dormantFilter };
+  }
+
+  // 2. Override entry for this field (cleared or pinned).
+  const overrideEntry = itemOverrides?.filters?.find(
+    (f) => f.field === fieldName,
+  );
+  if (overrideEntry) {
+    if (overrideEntry.cleared) return { type: "cleared" };
+    return { type: "pinned", filter: overrideEntry };
+  }
+
+  // 3. Inherit — no cell-level override for this field.
+  return { type: "inherit", insightFilter };
+}
+
+// ---------------------------------------------------------------------------
+// Overrides mutation helpers
+// ---------------------------------------------------------------------------
+// Each function produces a NEW DashboardItemOverrides bag.  They spread the
+// existing overrides so other fields' filters, sorts, and limit are preserved.
+
+/**
+ * Replace (or add) the filter override for `fieldName`.
+ * Any previous entry for this field (pinned or cleared) is removed and `filter`
+ * is appended.  Other fields' entries are untouched.
+ */
+export function computeNewOverridesOnPin(
+  fieldName: string,
+  filter: InsightFilterOverride,
+  itemOverrides: DashboardItemOverrides | undefined,
+): DashboardItemOverrides {
+  const otherFilters = (itemOverrides?.filters ?? []).filter(
+    (f) => f.field !== fieldName,
+  );
+  return {
+    ...itemOverrides,
+    filters: [...otherFilters, filter],
+  };
+}
+
+/**
+ * Set `cleared: true` for `fieldName` (widen — removes the insight's filter).
+ * Replaces any existing pinned or cleared entry for this field.
+ */
+export function computeNewOverridesOnClear(
+  fieldName: string,
+  itemOverrides: DashboardItemOverrides | undefined,
+): DashboardItemOverrides {
+  const otherFilters = (itemOverrides?.filters ?? []).filter(
+    (f) => f.field !== fieldName,
+  );
+  const clearedEntry: InsightFilterOverride = {
+    field: fieldName,
+    operator: "eq",
+    value: null,
+    cleared: true,
+  };
+  return {
+    ...itemOverrides,
+    filters: [...otherFilters, clearedEntry],
+  };
+}
+
+/**
+ * Remove any override entry for `fieldName` (drop pinned or cleared, restore inherit).
+ * When `filters` becomes empty as a result, sets `filters: undefined` so the bag
+ * stays clean (avoids `{filters: []}` which is technically non-trivial).
+ */
+export function computeNewOverridesOnInherit(
+  fieldName: string,
+  itemOverrides: DashboardItemOverrides | undefined,
+): DashboardItemOverrides {
+  const remaining = (itemOverrides?.filters ?? []).filter(
+    (f) => f.field !== fieldName,
+  );
+  return {
+    ...itemOverrides,
+    filters: remaining.length > 0 ? remaining : undefined,
+  };
+}
+
+/**
+ * Replace the sorts override.  Pass `undefined` to remove the cell's sort
+ * override (revert to inherit = insight default).
+ */
+export function computeNewOverridesOnSortChange(
+  sorts: InsightSort[] | undefined,
+  itemOverrides: DashboardItemOverrides | undefined,
+): DashboardItemOverrides {
+  const next: DashboardItemOverrides = { ...itemOverrides };
+  if (sorts === undefined) {
+    delete next.sorts;
+  } else {
+    next.sorts = sorts;
+  }
+  return next;
+}
+
+/**
+ * Replace the limit override.  Pass `undefined` to remove the cell's limit
+ * override (revert to inherit = insight default).
+ */
+export function computeNewOverridesOnLimitChange(
+  limit: number | undefined,
+  itemOverrides: DashboardItemOverrides | undefined,
+): DashboardItemOverrides {
+  const next: DashboardItemOverrides = { ...itemOverrides };
+  if (limit === undefined) {
+    delete next.limit;
+  } else {
+    next.limit = limit;
+  }
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Badge helper
+// ---------------------------------------------------------------------------
+
+/**
+ * True when `overrides` contains any non-trivial content — at least one filter,
+ * a sort override, or a limit override.
+ *
+ * IMPORTANT: Pass `item.overrides` (NOT `effectiveOverrides`) so that a
+ * control-driven-only cell (no saved overrides) does NOT light the badge.
+ */
+export function hasOverrides(
+  overrides: DashboardItemOverrides | undefined,
+): boolean {
+  if (!overrides) return false;
+  if ((overrides.filters?.length ?? 0) > 0) return true;
+  if (overrides.sorts !== undefined) return true;
+  if (overrides.limit !== undefined) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/** Human-readable label for a filter operator. */
+export function formatOperator(operator: InsightFilter["operator"]): string {
+  switch (operator) {
+    case "eq":
+      return "=";
+    case "ne":
+      return "≠";
+    case "gt":
+      return ">";
+    case "gte":
+      return "≥";
+    case "lt":
+      return "<";
+    case "lte":
+      return "≤";
+    case "contains":
+      return "contains";
+    case "in":
+      return "in";
+    case "between":
+      return "between";
+  }
+}
+
+/** Human-readable summary of a filter value (single-line, for display in rows). */
+export function formatFilterValue(filter: InsightFilter): string {
+  const v = filter.value;
+  if (filter.operator === "between" && v != null && typeof v === "object") {
+    const bv = v as { low: unknown; high: unknown };
+    return `${bv.low} … ${bv.high}`;
+  }
+  if (filter.operator === "in" && Array.isArray(v)) {
+    return v.slice(0, 3).join(", ") + (v.length > 3 ? ` +${v.length - 3}` : "");
+  }
+  return String(v ?? "");
+}


### PR DESCRIPTION
Adds per-cell override UI to dashboard cells: a gear-icon `OverridePopover` anchored to each visualization cell that lets authors pin, clear, or bind field-level filters, sort, and row limit without touching the underlying insight.

## Changes

- **`OverridePopover`** — self-fetching popover (visualization → insight → data table), renders all fields present in the insight's filter set or cell's override bag. Badge + colored icon when overrides are active.
- **`OverrideFieldRow`** — pure component implementing the 4-state machine: `inherit` / `pinned` / `cleared` / `bound`. Each state has distinct affordances (inherit and cleared are never collapsed — they are different engine signals).
- **`override-field-row-utils.ts`** — pure state-machine and payload-assembly helpers, fully unit-tested (37 tests, 10 stated contracts).
- **`sanitizeItemOverrides`** — server-side structural sanitizer for the per-cell override bag; guards the `"overrides" in input` gate correctly. `null` is the explicit clear sentinel: `sanitizeItemOverrides(null)` → `undefined` → JSONB cleared.
- **Bug fix in `saveOverrides`** — `JSON.stringify` drops `undefined` keys, so `{ overrides: undefined }` serialized to `{}` and the server gate never fired. Clears/resets silently failed. Fixed: send `null` (serialized as `{"overrides":null}`) when clearing.
- **`DashboardGrid`** — passes `controls` down to `DashboardItem`.
- **`DashboardItem`** — mounts `OverridePopover` on visualization cells; visible on hover, anchored bottom-right.

## Screenshots

All screenshots captured live from the running app (`http://127.0.0.1:3000` + WyStack API on port 4000) via `agent-browser pdf` → `pdftoppm -r 144`.

Dark mode: not captured — the Chromium PDF engine ignores class-based dark theming even when the `dark` class is applied. This is an agent-browser tooling gap, not a code gap; the `dark` class propagation path is identical to light.

**Dashboard cell in view mode — gear icon anchored bottom-right**

The icon is `opacity-0` by default and `opacity-100` on hover (`group-hover`). The purple dot indicates active overrides.

![Dashboard view mode](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/16-dashboard-view-mode.png)

**OverridePopover open — inherit state (no overrides)**

Sort and Limit rows shown in inherit state; no cell overrides set; popover badge absent.

![OverridePopover open, inherit state](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/22-override-popover-open.png)

**OverridePopover — active overrides badge (sort pinned)**

Sort pinned to `expense_id asc`; gear icon shows purple dot. Category filter row shows `showing all (cleared)`.

![OverridePopover with active badge](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/24-popover-with-active-badge.png)

**Filter field row — inherit state**

`category` field row: insight filter `= Travel` is the default; cell has no override. Pin and Clear buttons offered.

![Category field in inherit state](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/25-popover-inherit.png)

**InlineFilterEditor expanded**

Pin clicked on the `category` row; inline editor expands with operator select + value input. Value `Software` entered; `✓ Pin` commits.

![InlineFilterEditor expanded](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/26-category-pin-editor.png)

**Filter field row — pinned state**

`category` pinned to `= Software`; value is underlined (tappable to re-edit). Edit, Clear, and × buttons offered.

![Category field pinned](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/27-category-pinned-state.png)

**Filter field row — cleared state**

`category` cleared: label shows `showing all (cleared)` — distinct from inherit. Pin and × buttons offered.

![Category field cleared](https://github.com/youhaowei/DashFrame/releases/download/pr-187-screenshots/28-category-cleared-state.png)

## Verification

- `override-field-row-utils.test.ts` — 37 tests, 10 contracts: state-machine derivation, transition payloads (pin/clear/inherit/sort/limit), badge truth table. All pass.
- Typecheck: 48 tasks, 0 errors.
- Lint: clean.
- Inherit/cleared invariant manually verified: `deriveFieldState` uses absence vs `cleared: true`, and `computeNewOverridesOnInherit` / `computeNewOverridesOnClear` emit distinct payloads. The UI affords different labels and button sets per state.
- Clear bug verified fixed: `saveOverrides` branches on `hasContent`; empty bag path sends `{ overrides: null }` (key preserved through JSON serialization) so the server's `"overrides" in input` gate fires and `sanitizeItemOverrides(null)` → `undefined` → JSONB cleared.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a per-cell override UI to dashboard visualization cells: a gear-icon `OverridePopover` that lets editors pin, clear, or bind field-level filters, sort, and row limit without modifying the underlying insight. It also fixes a silent clear bug where `{ overrides: undefined }` was dropped by `JSON.stringify` before reaching the server gate.

- **`OverridePopover` / `OverrideFieldRow`** — self-fetching popover implementing a 4-state machine (inherit / pinned / cleared / bound) per field; correctly gated behind `isEditable`; limit input uses draft+blur to avoid per-keystroke mutations.
- **`sanitizeItemOverrides`** — server-side structural sanitizer handling the null clear-sentinel, the all-invalid-fields empty-bag case, and the empty-`filters`-array bypass; includes integration tests for all three.
- **`override-field-row-utils.ts`** — pure state-machine and payload helpers with 37 unit tests covering all states, transitions, and the `hasOverrides` badge truth table.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the auth guard, clear-sentinel bug, and empty-bag sanitizer gaps from the previous review round are all addressed correctly.

All previously identified bugs are fixed with targeted server-side guards and tests. The remaining gap (empty `sorts` array not normalised like `filters`) is unreachable from the UI — the client always deletes the `sorts` key rather than setting it to `[]` — and carries no user-visible risk.

`apps/server/src/functions/dashboards.ts` — minor inconsistency in the emptiness guard between `filters` and `sorts` handling.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/dashboards.ts | Adds `sanitizeItemOverrides` with the null-sentinel fix and the empty-array guards for `filters`; `sorts` empty array is not normalised (minor inconsistency with the `filters` guard). |
| apps/server/src/functions/dashboards.test.ts | Good regression coverage: null-sentinel, all-invalid-fields, and empty-filters cases; no test for the empty-sorts array path. |
| packages/app/src/components/dashboards/OverridePopover.tsx | Self-fetching popover with correct `isEditable` guard in DashboardItem; limit row uses draft+blur pattern (resolving the prior keystroke-per-character concern); `as any` cast for null clear-sentinel is documented and isolated. |
| packages/app/src/components/dashboards/OverrideFieldRow.tsx | Pure 4-state UI component; state transitions are well-separated; InlineFilterEditor is correctly isolated with its own draft state. |
| packages/app/src/components/dashboards/override-field-row-utils.ts | Clean pure-function helpers; state machine precedence (bound > cleared > pinned > inherit) is correct and well-documented. |
| packages/app/src/components/dashboards/override-field-row-utils.test.ts | 37 tests covering all 4 states, all 5 transition helpers, and the hasOverrides badge truth table including the empty-array edge case. |
| packages/app/src/components/dashboards/DashboardItem.tsx | OverridePopover is correctly gated behind `item.type === "visualization" && isEditable`; stopPropagation prevents drag-handle interference. |
| packages/app/src/components/dashboards/DashboardGrid.tsx | Single-line change passes `dashboard.controls ?? []` down; nullish coalescing is correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Editor as Dashboard Editor
    participant OP as OverridePopover
    participant Utils as override-field-row-utils
    participant Client as useDashboardMutations
    participant Server as sanitizeItemOverrides
    participant DB as JSONB (dashboard_items)

    Editor->>OP: hover cell → click gear icon
    OP->>OP: self-fetch visualization→insight→dataTable
    OP->>Utils: deriveFieldState(field, itemId, overrides, controls)
    Utils-->>OP: "FieldOverrideState (inherit|pinned|cleared|bound)"

    Editor->>OP: Pin / Clear / Inherit / Sort / Limit
    OP->>Utils: "computeNewOverridesOn*(field, value, currentOverrides)"
    Utils-->>OP: new DashboardItemOverrides bag

    OP->>OP: saveOverrides(next)
    alt hasOverrides(next)
        OP->>Client: "updateItem(dashboardId, itemId, { overrides: next })"
    else empty bag (clear)
        OP->>Client: "updateItem(dashboardId, itemId, { overrides: null })"
    end

    Client->>Server: "updateDashboardItem({ overrides: null | {...} })"
    Server->>Server: sanitizeItemOverrides(ov)
    Note over Server: null → undefined (clear)<br/>empty/invalid bag → undefined<br/>valid bag → {filters,sorts,limit}
    Server->>DB: JSONB cleared or updated
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Editor as Dashboard Editor
    participant OP as OverridePopover
    participant Utils as override-field-row-utils
    participant Client as useDashboardMutations
    participant Server as sanitizeItemOverrides
    participant DB as JSONB (dashboard_items)

    Editor->>OP: hover cell → click gear icon
    OP->>OP: self-fetch visualization→insight→dataTable
    OP->>Utils: deriveFieldState(field, itemId, overrides, controls)
    Utils-->>OP: "FieldOverrideState (inherit|pinned|cleared|bound)"

    Editor->>OP: Pin / Clear / Inherit / Sort / Limit
    OP->>Utils: "computeNewOverridesOn*(field, value, currentOverrides)"
    Utils-->>OP: new DashboardItemOverrides bag

    OP->>OP: saveOverrides(next)
    alt hasOverrides(next)
        OP->>Client: "updateItem(dashboardId, itemId, { overrides: next })"
    else empty bag (clear)
        OP->>Client: "updateItem(dashboardId, itemId, { overrides: null })"
    end

    Client->>Server: "updateDashboardItem({ overrides: null | {...} })"
    Server->>Server: sanitizeItemOverrides(ov)
    Note over Server: null → undefined (clear)<br/>empty/invalid bag → undefined<br/>valid bag → {filters,sorts,limit}
    Server->>DB: JSONB cleared or updated
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(dashboard): handle empty filters arr..."](https://github.com/youhaowei/dashframe/commit/78164993a3e1908a127f51af2fee7870fc68d1cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40347155)</sub>

<!-- /greptile_comment -->