### PR TITLE
[YW-345] Agent credential write path — transition-time vault-ref release (safe foundation)

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -56,6 +56,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 
 import { type ArtifactDb } from "@dashframe/server-core";
 
+import { captureCommandCredentials } from "./credential-release";
 import { createDraftController } from "./draft-controller";
 import { functions } from "./functions";
 
@@ -579,6 +580,13 @@ export async function createDashframeServer(
   serverContext.draftController = createDraftController(
     app,
     opts.db as ArtifactDb,
+    {
+      // Capture-before-log: rewrite plaintext credential args into vault refs
+      // before a credential command is snapshotted into draft_command_log, so the
+      // durable log never holds plaintext. The vault closure makes the store real
+      // (a draft append is never a preview); a missing vault fails closed.
+      captureCredentials: (cmd) => captureCommandCredentials(cmd, opts.vault),
+    },
   );
   serverContext.onWrite = opts.onWrite;
 

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -441,6 +441,27 @@ describe("credential write path — capture-before-log + transition release", ()
     }
   });
 
+  // Fail-closed — a credential command carrying a compactionKey is rejected before
+  // any ref is minted. compactLog would drop a superseded write whose capture had
+  // already minted a ref, orphaning it (no log row → no transition release). The
+  // reject closes that window; assert no vault store happened (nothing to orphan).
+  it("rejects a credential command that carries a compactionKey, minting nothing", async () => {
+    const storeSpy = vi.spyOn(h.vault, "store");
+    const credCommand = cmd("CreateDataSource", {
+      id: crypto.randomUUID(),
+      type: "notion",
+      name: "Keyed",
+      apiKey: "plaintext",
+    });
+    await expect(
+      captureCommandCredentials(
+        { ...credCommand, compactionKey: "dup-key" },
+        h.vault,
+      ),
+    ).rejects.toThrow(/compactionKey/);
+    expect(storeSpy).not.toHaveBeenCalled(); // failed closed before minting
+  });
+
   // Drift bridge — the config-side credential field list (CREDENTIAL_CONFIG_FIELDS,
   // iterated by refsFromConfig / collectSupersededRefs / the simulate seed) must
   // match the command-side truth (CREDENTIAL_COMMAND_FIELDS). A new credential field

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -30,6 +30,7 @@ import {
 import {
   InMemoryMappingStore,
   isSecretRef,
+  makeSecretRef,
   SecretRegistry,
   SecretVault,
   TestBackend,
@@ -332,6 +333,86 @@ describe("credential write path — capture-before-log + transition release", ()
       .from(dataSources)
       .where(eq(dataSources.id, id));
     expect(rows[0]?.createdBy).toEqual({ kind: "agent" });
+  });
+
+  // P1 — publish releases an intra-draft superseded ref (two writes to one field).
+  it("releases an intermediate ref superseded within the draft on publish", async () => {
+    const { id, ref: refA } = await seedCanonicalSource(h, "key-a");
+
+    const draftId = await h.controller.openDraft();
+    // Two credential writes to the SAME field, no compactionKey → both replayed.
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id, apiKey: "key-b" }),
+    ]);
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id, apiKey: "key-c" }),
+    ]);
+    const logRows = await h.db
+      .select({ args: draftCommandLog.args })
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId))
+      .orderBy(draftCommandLog.seq);
+    const refB = (logRows[0]!.args as Record<string, unknown>)
+      .apiKey as SecretRef;
+    const refC = (logRows[1]!.args as Record<string, unknown>)
+      .apiKey as SecretRef;
+    expect(refB).not.toBe(refC);
+
+    await h.app.call("publishDraft", { draftId });
+
+    // Old canonical (A) AND the superseded intra-draft ref (B) are released; only
+    // the final ref (C) survives and is what canonical points at.
+    expect(await h.vault.has(refA)).toBe(false);
+    expect(await h.vault.has(refB)).toBe(false);
+    expect(await h.vault.has(refC)).toBe(true);
+    expect((await readConfig(h, id))!.apiKey).toBe(refC);
+  });
+
+  // P2 — discard releases a ref a draft only INHERITED (held in shadow, not log).
+  it("releases an inherited shadow ref when the pinning draft is discarded", async () => {
+    const { id, ref: refR } = await seedCanonicalSource(h, "shared-key");
+
+    // Draft A touches only connectionString → its shadow inherits apiKey ref R.
+    const draftA = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftA, [
+      cmd("SetDataSourceConfig", { id, connectionString: "conn-a" }),
+    ]);
+
+    // Draft B rotates apiKey and publishes — R is preserved because A pins it.
+    const draftB = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftB, [
+      cmd("SetDataSourceConfig", { id, apiKey: "rotated" }),
+    ]);
+    await h.app.call("publishDraft", { draftId: draftB });
+    const refR2 = (await readConfig(h, id))!.apiKey as SecretRef;
+    expect(await h.vault.has(refR)).toBe(true); // pinned by A, survived B's publish
+
+    // Discard A — R is now referenced nowhere (canonical moved to R2), so the
+    // shadow-sourced candidate set releases it; the live canonical ref stays.
+    await h.app.call("discardDraft", { draftId: draftA });
+    expect(await h.vault.has(refR)).toBe(false);
+    expect(await h.vault.has(refR2)).toBe(true);
+  });
+
+  // P2 — a direct canonical call must STORE a ref-shaped input, never adopt it.
+  it("stores (not adopts) a ref-shaped credential on a direct canonical call", async () => {
+    const id = crypto.randomUUID();
+    const refShaped = makeSecretRef(); // valid shape, NOT in the vault
+    const { result } = await h.app.call("createDataSource", {
+      id,
+      type: "notion",
+      name: "Direct",
+      apiKey: refShaped,
+    });
+    expect((result as { id: string }).id).toBe(id);
+
+    const stored = (await readConfig(h, id))!.apiKey as SecretRef;
+    // The input was stored as plaintext → a DIFFERENT, real ref that resolves to it.
+    expect(stored).not.toBe(refShaped);
+    expect(isSecretRef(stored)).toBe(true);
+    expect(await h.vault.has(stored)).toBe(true);
+    const resolved = await h.vault.withSecret(stored, async (pt) => pt);
+    expect(resolved).toBe(refShaped);
   });
 
   // Exhaustiveness — the capture map must cover EVERY credential-bearing command.

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -40,7 +40,7 @@ import { eq } from "drizzle-orm";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildDashframeApp } from "./app";
 import { captureCommandCredentials } from "./credential-release";
@@ -48,7 +48,11 @@ import {
   createDraftController,
   type DraftController,
 } from "./draft-controller";
-import { cmd } from "./functions/commands";
+import {
+  cmd,
+  commandFunctions,
+  CREDENTIAL_COMMAND_FIELDS,
+} from "./functions/commands";
 
 const { dataSources } = schema;
 
@@ -300,6 +304,9 @@ describe("credential write path — capture-before-log + transition release", ()
     ).rejects.toThrow();
 
     // Canonical secret intact — a rolled-back publish never deletes a live secret.
+    // (This asserts the OUTCOME; the post-commit ORDERING is enforced structurally
+    // in the publishDraft RPC, which releases only after `await publishDraft`
+    // resolves — a rejected publish skips release entirely.)
     expect(await h.vault.has(canonicalRef)).toBe(true);
     expect((await readConfig(h, id))!.apiKey).toBe(canonicalRef);
   });
@@ -325,5 +332,68 @@ describe("credential write path — capture-before-log + transition release", ()
       .from(dataSources)
       .where(eq(dataSources.id, id));
     expect(rows[0]?.createdBy).toEqual({ kind: "agent" });
+  });
+
+  // Exhaustiveness — the capture map must cover EVERY credential-bearing command.
+  // This is load-bearing for "plaintext never at rest": capture rewrites only
+  // commands in CREDENTIAL_COMMAND_FIELDS, so a credential-bearing command missing
+  // from it would log plaintext. Derive the truth from the command arg schemas so
+  // the linkage cannot silently drift when the vocabulary grows.
+  it("CREDENTIAL_COMMAND_FIELDS covers every credential-bearing command", () => {
+    const CRED = ["apiKey", "connectionString"] as const;
+    for (const [path, def] of Object.entries(commandFunctions)) {
+      const argKeys = Object.keys(
+        (def as { args: Record<string, unknown> }).args,
+      );
+      const credFields = CRED.filter((f) => argKeys.includes(f));
+      if (credFields.length === 0) {
+        expect(CREDENTIAL_COMMAND_FIELDS[path]).toBeUndefined();
+      } else {
+        expect(CREDENTIAL_COMMAND_FIELDS[path]).toBeDefined();
+        expect([...(CREDENTIAL_COMMAND_FIELDS[path] ?? [])].sort()).toEqual(
+          [...credFields].sort(),
+        );
+      }
+    }
+  });
+
+  // Orphan-on-append-failure — capture's rollback releases the minted ref.
+  it("capture rollback releases the ref it minted", async () => {
+    const { command, rollback } = await captureCommandCredentials(
+      cmd("CreateDataSource", {
+        id: crypto.randomUUID(),
+        type: "notion",
+        name: "x",
+        apiKey: "plaintext",
+      }),
+      h.vault,
+    );
+    const ref = (command.args as Record<string, unknown>).apiKey as SecretRef;
+    expect(isSecretRef(ref)).toBe(true);
+    expect(await h.vault.has(ref)).toBe(true);
+    await rollback();
+    expect(await h.vault.has(ref)).toBe(false);
+  });
+
+  it("releases captured refs when a draft command fails before it is logged", async () => {
+    const delSpy = vi.spyOn(h.vault, "delete");
+    const draftId = await h.controller.openDraft();
+    // SetDataSourceConfig on a missing id throws in the handler AFTER capture mints
+    // the ref — the failed append must release it, not orphan it.
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", {
+          id: crypto.randomUUID(),
+          apiKey: "will-fail",
+        }),
+      ]),
+    ).rejects.toThrow();
+
+    expect(delSpy).toHaveBeenCalled(); // rollback released the minted ref
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(0); // nothing logged
   });
 });

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Agent credential write path — capture-before-log + transition-time release.
+ *
+ * Tests the security invariants that make agent-authorable credentials safe (the
+ * acceptance criteria of the feature):
+ *
+ *   1. Plaintext NEVER at rest — a credentialed command logged into
+ *      `draft_command_log` carries a vault ref, never the plaintext.
+ *   2. Ref-carrying / no double-wrap — the logged ref resolves to the original
+ *      plaintext (it was stored once, not re-wrapped).
+ *   3. No synchronous release on the draft path — a rotate inside a draft leaves
+ *      the prior canonical secret live; release is deferred to a transition.
+ *   4. Publish releases the REPLACED canonical ref (and only it).
+ *   5. Discard never deletes a live secret; it releases only draft-minted refs.
+ *   6. Cross-draft safety — a ref another open draft references survives a release.
+ *   7. Publish ROLLBACK never deletes a live secret — if replay rolls back, the
+ *      replaced ref is NOT released (release is post-commit).
+ *   8. Read-deny holds — the read DTO never surfaces a raw ref (regression).
+ *   9. Provenance — an agent-context create stamps `createdBy: { kind: "agent" }`.
+ *
+ * Harness: a socket-less mirror of `createDashframeServer`'s context wiring — the
+ * vault seam (`buildDashframeApp`) plus the `serverContext` injection
+ * (draftController / artifactDb / onWrite) the draft RPC handlers read.
+ */
+import {
+  draftCommandLog,
+  openArtifactDb,
+  schema,
+} from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  isSecretRef,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+  type SecretRef,
+} from "@wystack/secret-vault";
+import type { WyStackApp } from "@wystack/server";
+import { eq } from "drizzle-orm";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildDashframeApp } from "./app";
+import { captureCommandCredentials } from "./credential-release";
+import {
+  createDraftController,
+  type DraftController,
+} from "./draft-controller";
+import { cmd } from "./functions/commands";
+
+const { dataSources } = schema;
+
+function makeTestVault(): { vault: SecretVault; backend: TestBackend } {
+  const backend = new TestBackend();
+  const registry = new SecretRegistry();
+  registry.register("test", backend, { fallback: true });
+  registry.setClassDefault("connector-key", "test");
+  const vault = new SecretVault(registry, new InMemoryMappingStore());
+  return { vault, backend };
+}
+
+interface Harness {
+  dir: string;
+  db: Awaited<ReturnType<typeof openArtifactDb>>;
+  vault: SecretVault;
+  app: WyStackApp;
+  controller: DraftController;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "dashframe-cred-release-"));
+  const db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+  const { vault } = makeTestVault();
+
+  const baseApp = await buildDashframeApp({ db, vault });
+
+  // Mirror createDashframeServer's serverContext seam (without a socket): the
+  // draft RPC handlers read draftController / artifactDb from the call context.
+  const serverContext: Record<string, unknown> = {};
+  const app: WyStackApp = {
+    ...baseApp,
+    async call(path, args, ctx) {
+      return baseApp.call(path, args, { ...(ctx ?? {}), ...serverContext });
+    },
+    async runHandler(path, args, tracked, ctx) {
+      return baseApp.runHandler(path, args, tracked, {
+        ...(ctx ?? {}),
+        ...serverContext,
+      });
+    },
+  };
+
+  const controller = createDraftController(app, db, {
+    captureCredentials: (c) => captureCommandCredentials(c, vault),
+  });
+  serverContext.draftController = controller;
+  serverContext.artifactDb = db;
+
+  return { dir, db, vault, app, controller };
+}
+
+/** Read the raw stored config jsonb for a canonical data-source row. */
+async function readConfig(
+  h: Harness,
+  id: string,
+): Promise<Record<string, unknown> | null> {
+  const rows = await h.db
+    .select()
+    .from(dataSources)
+    .where(eq(dataSources.id, id));
+  return rows[0] ? (rows[0].config as Record<string, unknown>) : null;
+}
+
+/** Read the first persisted draft-command-log args for a draft (asserts present). */
+async function firstLogArgs(
+  h: Harness,
+  draftId: string,
+): Promise<Record<string, unknown>> {
+  const rows = await h.db
+    .select({ args: draftCommandLog.args })
+    .from(draftCommandLog)
+    .where(eq(draftCommandLog.draftId, draftId));
+  const args = rows[0]?.args;
+  if (args == null || typeof args !== "object") {
+    throw new Error(`no log args for draft ${draftId}`);
+  }
+  return args as Record<string, unknown>;
+}
+
+/** Seed a canonical data source with a credential via the live (legacy) path. */
+async function seedCanonicalSource(
+  h: Harness,
+  apiKey: string,
+): Promise<{ id: string; ref: SecretRef }> {
+  const { result } = await h.app.call("addDataSource", {
+    type: "notion",
+    name: "Seed",
+    apiKey,
+  });
+  const id = (result as { id: string }).id;
+  const config = await readConfig(h, id);
+  return { id, ref: config!.apiKey as SecretRef };
+}
+
+describe("credential write path — capture-before-log + transition release", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => {
+    await h.db.$client.close();
+    rmSync(h.dir, { recursive: true, force: true });
+  });
+
+  // 1 + 2 — plaintext never at rest; the logged ref resolves to the plaintext.
+  it("logs a vault ref (never plaintext) for a credentialed draft command", async () => {
+    const id = crypto.randomUUID();
+    const draftId = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id,
+        type: "notion",
+        name: "Drafted",
+        apiKey: "super-secret-plaintext",
+      }),
+    ]);
+
+    const args = await firstLogArgs(h, draftId);
+    expect(args).toBeDefined();
+    // Plaintext NEVER at rest in the log.
+    expect(args.apiKey).not.toBe("super-secret-plaintext");
+    expect(isSecretRef(args.apiKey)).toBe(true);
+
+    // Ref-carrying / no double-wrap: the logged ref resolves to the plaintext.
+    const ref = args.apiKey as SecretRef;
+    const resolved = await h.vault.withSecret(ref, async (pt) => pt);
+    expect(resolved).toBe("super-secret-plaintext");
+  });
+
+  // 3 — no synchronous release on the draft path.
+  it("does not release the prior canonical ref during a draft rotate", async () => {
+    const { id, ref: oldRef } = await seedCanonicalSource(h, "orig-key");
+
+    const draftId = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+    ]);
+
+    // The old canonical secret is STILL live — release is deferred to publish.
+    expect(await h.vault.has(oldRef)).toBe(true);
+
+    // The draft minted a fresh ref (captured), distinct from the old one.
+    const args = await firstLogArgs(h, draftId);
+    const newRef = args.apiKey as SecretRef;
+    expect(isSecretRef(newRef)).toBe(true);
+    expect(newRef).not.toBe(oldRef);
+    expect(await h.vault.has(newRef)).toBe(true);
+  });
+
+  // 4 + 8 — publish releases the replaced canonical ref; read DTO hides the ref.
+  it("releases the replaced canonical ref on publish and keeps the new one", async () => {
+    const { id, ref: oldRef } = await seedCanonicalSource(h, "orig-key");
+
+    const draftId = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+    ]);
+    const args = await firstLogArgs(h, draftId);
+    const newRef = args.apiKey as SecretRef;
+
+    await h.app.call("publishDraft", { draftId });
+
+    // Old ref released, new ref live, canonical points at the new ref.
+    expect(await h.vault.has(oldRef)).toBe(false);
+    expect(await h.vault.has(newRef)).toBe(true);
+    const config = await readConfig(h, id);
+    expect(config!.apiKey).toBe(newRef);
+
+    // Read-deny: the DTO never surfaces a raw ref.
+    const { result } = await h.app.call("getDataSource", { id });
+    const dto = result as { config: Record<string, unknown> };
+    expect(dto.config.apiKey).toBeUndefined();
+    expect(dto.config.hasApiKey).toBe(true);
+  });
+
+  // 5 — discard never deletes a live secret; releases only draft-minted refs.
+  it("releases draft-minted refs on discard but never the live canonical one", async () => {
+    const { id, ref: oldRef } = await seedCanonicalSource(h, "orig-key");
+
+    const draftId = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+    ]);
+    const args = await firstLogArgs(h, draftId);
+    const mintedRef = args.apiKey as SecretRef;
+
+    await h.app.call("discardDraft", { draftId });
+
+    // Draft-minted ref released; the live canonical secret survives untouched.
+    expect(await h.vault.has(mintedRef)).toBe(false);
+    expect(await h.vault.has(oldRef)).toBe(true);
+    const config = await readConfig(h, id);
+    expect(config!.apiKey).toBe(oldRef);
+  });
+
+  // 6 — cross-draft safety: a ref another open draft's shadow references survives.
+  it("does not release a ref another open draft still references (publish)", async () => {
+    const { id, ref: sharedRef } = await seedCanonicalSource(h, "shared-key");
+
+    // Draft A touches ONLY connectionString — its shadow inherits the apiKey ref.
+    const draftA = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftA, [
+      cmd("SetDataSourceConfig", { id, connectionString: "conn-a" }),
+    ]);
+
+    // Draft B rotates apiKey and publishes — it would release the old shared ref,
+    // but draft A's shadow still references it, so it must survive.
+    const draftB = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftB, [
+      cmd("SetDataSourceConfig", { id, apiKey: "rotated-by-b" }),
+    ]);
+    await h.app.call("publishDraft", { draftId: draftB });
+
+    expect(await h.vault.has(sharedRef)).toBe(true);
+  });
+
+  // 7 — publish ROLLBACK never deletes a live secret (release is post-commit).
+  it("does not release the replaced ref when publish rolls back", async () => {
+    const id = crypto.randomUUID();
+
+    // Publish a CreateDataSource for `id` → canonical row with a live ref.
+    const draftA = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftA, [
+      cmd("CreateDataSource", {
+        id,
+        type: "notion",
+        name: "A",
+        apiKey: "key-a",
+      }),
+    ]);
+    await h.app.call("publishDraft", { draftId: draftA });
+    const canonicalRef = (await readConfig(h, id))!.apiKey as SecretRef;
+    expect(await h.vault.has(canonicalRef)).toBe(true);
+
+    // A second draft re-creates the SAME id → replay hits a duplicate PK → the
+    // publish transaction rolls back. The replaced-ref release must NOT run.
+    const draftB = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftB, [
+      cmd("CreateDataSource", {
+        id,
+        type: "notion",
+        name: "B",
+        apiKey: "key-b",
+      }),
+    ]);
+    await expect(
+      h.app.call("publishDraft", { draftId: draftB }),
+    ).rejects.toThrow();
+
+    // Canonical secret intact — a rolled-back publish never deletes a live secret.
+    expect(await h.vault.has(canonicalRef)).toBe(true);
+    expect((await readConfig(h, id))!.apiKey).toBe(canonicalRef);
+  });
+
+  // 9 — provenance: an agent-context create is auditably distinct.
+  it("stamps agent provenance when the create runs in an agent context", async () => {
+    const id = crypto.randomUUID();
+    const draftId = await h.controller.openDraft();
+    // The agent enablement EMITS createdBy in the command, so it survives the
+    // publish log replay onto the canonical row.
+    await h.controller.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id,
+        type: "notion",
+        name: "Agent Src",
+        createdBy: { kind: "agent" },
+      }),
+    ]);
+    await h.app.call("publishDraft", { draftId });
+
+    const rows = await h.db
+      .select({ createdBy: dataSources.createdBy })
+      .from(dataSources)
+      .where(eq(dataSources.id, id));
+    expect(rows[0]?.createdBy).toEqual({ kind: "agent" });
+  });
+});

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -477,4 +477,79 @@ describe("credential write path — capture-before-log + transition release", ()
       .where(eq(draftCommandLog.draftId, draftId));
     expect(rows.length).toBe(0); // nothing logged
   });
+
+  // P2 (fix #3) — the rollback must also cover LOG PERSISTENCE, not just the
+  // handler run. If writeLog throws AFTER capture minted a ref and the handler
+  // wrote the shadow, the ref is in the vault but in no durable log — discard /
+  // publish could never find it for transition release (orphan). The rollback
+  // stays armed through writeLog, so a log-persistence failure releases the ref.
+  it("releases captured refs when log persistence fails after the handler runs", async () => {
+    const id = crypto.randomUUID();
+    const storeSpy = vi.spyOn(h.vault, "store");
+    const delSpy = vi.spyOn(h.vault, "delete");
+    // writeLog is the only `db.transaction` call in appendToDraft — runHandler
+    // opens no transaction and readLog uses select — so failing the first
+    // `transaction` fails writeLog specifically, AFTER the handler committed the
+    // shadow row. (The shadow-row assertion below is the discriminator: if this
+    // mock ever fired during the handler instead, no shadow row would exist and
+    // this test would fail loudly rather than silently testing the wrong path.)
+    const txSpy = vi
+      .spyOn(h.db, "transaction")
+      .mockRejectedValueOnce(new Error("simulated writeLog failure"));
+
+    const draftId = await h.controller.openDraft();
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("CreateDataSource", {
+          id,
+          type: "notion",
+          name: "X",
+          apiKey: "secret-plaintext",
+        }),
+      ]),
+    ).rejects.toThrow(/simulated writeLog failure/);
+
+    // Capture minted a ref before writeLog failed, and the rollback released it.
+    expect(storeSpy).toHaveBeenCalled();
+    const mintedRef = (await storeSpy.mock.results[0]!.value) as SecretRef;
+    expect(isSecretRef(mintedRef)).toBe(true);
+    expect(delSpy).toHaveBeenCalled();
+    expect(await h.vault.has(mintedRef)).toBe(false); // no orphan
+
+    // DISCRIMINATOR: the shadow row exists → the handler committed before the
+    // failure → the failure was at writeLog (not the handler). Proves this test
+    // exercises the log-persistence path, not the already-covered handler path.
+    const shadowRows = await h.db
+      .select()
+      .from(schema.dataSourcesDraft)
+      .where(eq(schema.dataSourcesDraft.draftId, draftId));
+    expect(shadowRows.length).toBe(1);
+
+    // The durable log is empty — writeLog never committed.
+    const logRows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(logRows.length).toBe(0);
+
+    txSpy.mockRestore();
+  });
+
+  // P2 (fix #2) — fail-closed on the DIRECT path: a ref-shaped input on a direct
+  // canonical call with NO vault injected must THROW (route through
+  // storeCredential's guard), never silently adopt the ref. This is the security
+  // half of the adoption gate: with the bug, the ref pass-through would accept a
+  // ref-shaped value even absent a vault, persisting config that points at an
+  // unverified/nonexistent secret. Pairs with the "stores (not adopts)" test.
+  it("rejects a ref-shaped credential on a direct call when no vault is injected", async () => {
+    const noVaultApp = await buildDashframeApp({ db: h.db }); // no vault injected
+    await expect(
+      noVaultApp.call("createDataSource", {
+        id: crypto.randomUUID(),
+        type: "notion",
+        name: "NoVault",
+        apiKey: makeSecretRef(), // valid ref shape, must NOT be adopted
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -77,7 +77,7 @@ interface Harness {
   controller: DraftController;
 }
 
-async function makeHarness(): Promise<Harness> {
+async function makeHarness(opts?: { onWrite?: () => void }): Promise<Harness> {
   const dir = mkdtempSync(join(tmpdir(), "dashframe-cred-release-"));
   const db = await openArtifactDb({ path: join(dir, "artifacts.db") });
   const { vault } = makeTestVault();
@@ -105,6 +105,7 @@ async function makeHarness(): Promise<Harness> {
   });
   serverContext.draftController = controller;
   serverContext.artifactDb = db;
+  if (opts?.onWrite) serverContext.onWrite = opts.onWrite;
 
   return { dir, db, vault, app, controller };
 }
@@ -336,6 +337,33 @@ describe("credential write path — capture-before-log + transition release", ()
       .from(dataSources)
       .where(eq(dataSources.id, id));
     expect(rows[0]?.createdBy).toEqual({ kind: "agent" });
+  });
+
+  // Snapshot-persistence gate — if onWrite (snapshot) throws, the replaced ref is
+  // NOT released, so a stale-snapshot restore can't dangle a still-referenced ref.
+  it("does not release the replaced ref when snapshot persistence fails", async () => {
+    const failing = await makeHarness({
+      onWrite: () => {
+        throw new Error("snapshot persistence failed");
+      },
+    });
+    try {
+      const { id, ref: oldRef } = await seedCanonicalSource(
+        failing,
+        "orig-key",
+      );
+      const draftId = await failing.controller.openDraft();
+      await failing.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+      ]);
+      // Publish commits, but onWrite throws → snapshot not persisted → release is
+      // skipped, leaving the old ref live (inert orphan) rather than dangling.
+      await failing.app.call("publishDraft", { draftId });
+      expect(await failing.vault.has(oldRef)).toBe(true);
+    } finally {
+      await failing.db.$client.close();
+      rmSync(failing.dir, { recursive: true, force: true });
+    }
   });
 
   // P1 — publish releases an intra-draft superseded ref (two writes to one field).

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -44,7 +44,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildDashframeApp } from "./app";
-import { captureCommandCredentials } from "./credential-release";
+import {
+  captureCommandCredentials,
+  CREDENTIAL_CONFIG_FIELDS,
+} from "./credential-release";
 import {
   createDraftController,
   type DraftController,
@@ -436,6 +439,20 @@ describe("credential write path — capture-before-log + transition release", ()
         );
       }
     }
+  });
+
+  // Drift bridge — the config-side credential field list (CREDENTIAL_CONFIG_FIELDS,
+  // iterated by refsFromConfig / collectSupersededRefs / the simulate seed) must
+  // match the command-side truth (CREDENTIAL_COMMAND_FIELDS). A new credential field
+  // added to commands but not to the config-reader list would make
+  // collectReferencedRefs silently stop protecting it → a live secret released while
+  // another draft still references it. Bridge the two so that drift fails the build.
+  it("CREDENTIAL_CONFIG_FIELDS matches the command-side credential fields", () => {
+    const commandSide = new Set(
+      Object.values(CREDENTIAL_COMMAND_FIELDS).flat(),
+    );
+    const configSide = new Set<string>(CREDENTIAL_CONFIG_FIELDS);
+    expect(configSide).toEqual(commandSide);
   });
 
   // Orphan-on-append-failure — capture's rollback releases the minted ref.

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -55,38 +55,74 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
+ * The result of capturing one command's credentials: the command to run + log
+ * (with plaintext rewritten to refs), and a rollback that releases the refs this
+ * capture MINTED. `appendToDraft` calls `rollback` if the command's run fails
+ * before the batch is persisted to the durable log — the minted ref would
+ * otherwise be in the vault but in no log, so the discard path (which reads the
+ * log) could never find it. Best-effort: a rollback failure leaves an inert orphan.
+ */
+export interface CapturedCommand {
+  command: DraftCommand;
+  rollback: () => Promise<void>;
+}
+
+/** Best-effort delete of refs (idempotent); swallows errors (cleanup path). */
+async function releaseRefsBestEffort(
+  vault: SecretVault | undefined,
+  refs: SecretRef[],
+): Promise<void> {
+  if (vault == null || refs.length === 0) return;
+  await Promise.allSettled(refs.map((ref) => vault.delete(ref)));
+}
+
+/**
  * Rewrite a draft command's PLAINTEXT credential args to vault refs, returning a
- * new command (the input is never mutated). Non-credential commands, empty-string
- * (clear), undefined, and already-ref values pass through untouched.
+ * NEW command (the input is never mutated) plus a rollback for the minted refs.
+ * Non-credential commands, empty-string (clear), undefined, and already-ref values
+ * pass through untouched.
  *
  * Called by `appendToDraft` BEFORE the command is run and snapshotted, so the
  * command that reaches the handler — and the durable log — carries a ref. The
  * vault store is real (a draft append is never a preview): a plaintext credential
  * with no vault throws (fail-closed, via {@link storeCredential}).
+ *
+ * ATOMIC per command: if storing a later field throws, the refs already minted for
+ * this command are released before the error propagates — a partially-captured
+ * command never leaks a ref.
  */
 export async function captureCommandCredentials(
   cmd: DraftCommand,
   vault: SecretVault | undefined,
-): Promise<DraftCommand> {
+): Promise<CapturedCommand> {
   const fields = CREDENTIAL_COMMAND_FIELDS[cmd.path];
-  if (!fields) return cmd;
   const args = cmd.args;
-  if (!isRecord(args)) return cmd;
-
-  let nextArgs: Record<string, unknown> | undefined;
-  for (const field of fields) {
-    const value = args[field];
-    // undefined (not part of this write) and "" (clear) carry no plaintext.
-    if (typeof value !== "string" || value.length === 0) continue;
-    // Already a ref (idempotent re-capture / pre-bound) — leave it.
-    if (isSecretRef(value)) continue;
-    const id = typeof args.id === "string" ? args.id : "unknown";
-    const ref = await storeCredential(vault, value, `${field}-${id}`, false);
-    nextArgs ??= { ...args };
-    nextArgs[field] = ref;
+  if (!fields || !isRecord(args)) {
+    return { command: cmd, rollback: async () => {} };
   }
-  if (!nextArgs) return cmd;
-  return { ...cmd, args: nextArgs };
+
+  const minted: SecretRef[] = [];
+  let nextArgs: Record<string, unknown> | undefined;
+  try {
+    for (const field of fields) {
+      const value = args[field];
+      // undefined (not part of this write) and "" (clear) carry no plaintext.
+      if (typeof value !== "string" || value.length === 0) continue;
+      // Already a ref (idempotent re-capture / pre-bound) — leave it.
+      if (isSecretRef(value)) continue;
+      const id = typeof args.id === "string" ? args.id : "unknown";
+      const ref = await storeCredential(vault, value, `${field}-${id}`, false);
+      minted.push(ref);
+      nextArgs ??= { ...args };
+      nextArgs[field] = ref;
+    }
+  } catch (err) {
+    await releaseRefsBestEffort(vault, minted);
+    throw err;
+  }
+
+  const command = nextArgs ? { ...cmd, args: nextArgs } : cmd;
+  return { command, rollback: () => releaseRefsBestEffort(vault, minted) };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -93,13 +93,14 @@ async function releaseRefsBestEffort(
  * this command are released before the error propagates — a partially-captured
  * command never leaks a ref.
  *
- * INVARIANT — a credential command MUST NOT carry a `compactionKey`. The current
- * vocabulary (`cmd()` builder) sets none, so two credential writes to one field are
- * both kept in the log and {@link collectSupersededRefs} releases the intermediate
- * ref. If a credential command ever adopted a `compactionKey`, `compactLog` would
- * DROP the earlier write — orphaning the ref it minted here (the log no longer
- * references it, so no transition releases it). Keep credential commands
- * compaction-free, or teach capture to release a ref whose command is compacted away.
+ * INVARIANT (enforced below) — a credential command MUST NOT carry a
+ * `compactionKey`. The vocabulary (`cmd()` builder) sets none, so two credential
+ * writes to one field are both kept in the log and {@link collectSupersededRefs}
+ * releases the intermediate ref. If a credential command carried a `compactionKey`,
+ * `compactLog` would DROP the earlier write — orphaning the ref it minted here (the
+ * log no longer references it, so no transition releases it). Rather than rely on a
+ * convention, we FAIL CLOSED: a credential command with a `compactionKey` is
+ * rejected before any ref is minted, so the orphan window cannot open.
  */
 export async function captureCommandCredentials(
   cmd: DraftCommand,
@@ -109,6 +110,16 @@ export async function captureCommandCredentials(
   const args = cmd.args;
   if (!fields || !isRecord(args)) {
     return { command: cmd, rollback: async () => {} };
+  }
+
+  // Fail closed on a compacted credential command: `compactLog` would drop a
+  // superseded write whose capture already minted a ref, orphaning it (no log row
+  // → no transition release). Reject BEFORE minting so nothing leaks.
+  if (cmd.compactionKey != null) {
+    throw new Error(
+      `[secret-vault] credential command '${cmd.path}' must not carry a ` +
+        `compactionKey: a compacted-away write would orphan its minted vault ref.`,
+    );
   }
 
   const minted: SecretRef[] = [];

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -19,12 +19,14 @@
  *
  *   2. TRANSITION-TIME RELEASE ({@link releaseRefsAtTransition} + collectors) —
  *      orchestrated by the draft RPC handlers, POST the authoritative transition:
- *        - publish: release the canonical ref each command REPLACES, collected
- *          BEFORE replay (the replay overwrites it) and released AFTER the publish
- *          transaction commits — so a rolled-back publish never deletes a still-
- *          live secret.
- *        - discard: release the refs the draft MINTED (read from its log), after
- *          the draft's log + shadow are dropped.
+ *        - publish ({@link collectSupersededRefs}): release every ref the replay
+ *          SUPERSEDES — the prior canonical ref AND any ref minted intra-draft then
+ *          overwritten — collected BEFORE replay and released AFTER the publish
+ *          transaction commits, so a rolled-back publish never deletes a live secret.
+ *        - discard ({@link collectDiscardCandidateRefs}): release the refs the draft
+ *          holds, from BOTH its log and its shadow config (so an inherited-only ref
+ *          is reconsidered when the draft that pinned it closes), after the draft's
+ *          log + shadow are dropped.
  *      Both are gated by {@link collectReferencedRefs}: a ref still referenced by
  *      canonical or by another OPEN draft's shadow/log is never released.
  *
@@ -151,53 +153,110 @@ function refsFromConfig(config: unknown): SecretRef[] {
   return refs;
 }
 
+const CREDENTIAL_FIELDS = ["apiKey", "connectionString"] as const;
+type CredentialField = (typeof CREDENTIAL_FIELDS)[number];
+type SimulatedConfig = Partial<Record<CredentialField, SecretRef | undefined>>;
+
+/** The data-source id a credential command targets, or undefined if not one. */
+function credentialCommandId(cmd: Command): string | undefined {
+  if (!CREDENTIAL_COMMAND_FIELDS[cmd.path] || !isRecord(cmd.args))
+    return undefined;
+  return typeof cmd.args.id === "string" ? cmd.args.id : undefined;
+}
+
 /**
- * Refs a DISCARD should release: the refs this draft MINTED, read from its own
- * compacted command log. (A captured plaintext arg becomes a fresh ref in the
- * log; an existing canonical ref never enters a draft's log via capture.) The
+ * Refs a DISCARD should release: every ref the draft holds, from BOTH its log AND
+ * its `data_sources__draft` shadow config. The shadow is load-bearing — a ref a
+ * draft only INHERITED (e.g. it touched connectionString and the coalesced shadow
+ * carries the canonical apiKey ref) is not in the draft's log, so a log-only
+ * candidate set would leak it forever once the canonical owner moves on. The
  * cross-draft + canonical guard in {@link collectReferencedRefs} is the backstop
- * that prevents releasing any ref still in use elsewhere.
+ * that keeps a still-referenced ref (incl. the live canonical one) from release.
+ *
+ * Reads must run BEFORE the discard drops the log + shadow.
  */
-export function extractDraftMintedRefs(log: Command[]): SecretRef[] {
+export async function collectDiscardCandidateRefs(
+  db: ArtifactDb,
+  draftId: string,
+  log: Command[],
+): Promise<SecretRef[]> {
   const refs: SecretRef[] = [];
   for (const cmd of log) refs.push(...refsFromCommandArgs(cmd.path, cmd.args));
+  const shadows = await db
+    .select({ config: dataSourcesDraft.config })
+    .from(dataSourcesDraft)
+    .where(eq(dataSourcesDraft.draftId, draftId));
+  for (const row of shadows) refs.push(...refsFromConfig(row.config));
   return refs;
 }
 
 /**
- * Refs a PUBLISH should release: the canonical ref each command in the log will
- * REPLACE. Read BEFORE replay (replay overwrites canonical). A ref is a candidate
- * only for a credential field the command actually SETS (non-undefined — a
- * connectionString-only command must not trigger an apiKey release; `apiKey: ""`
- * (clear) counts as set). A CreateDataSource targets a not-yet-existing row, so it
- * yields no candidate. Reads committed canonical state via the raw artifact db.
+ * Refs a PUBLISH should release: every ref SUPERSEDED by replaying the log. Seeds a
+ * simulated per-source `field → ref` map from the PRE-publish canonical config, then
+ * walks the log in replay order; any ref a later write replaces — whether the prior
+ * CANONICAL ref OR a ref minted earlier in this same draft (two credential writes to
+ * one field, which `compactLog` keeps when no `compactionKey` is set) — is a release
+ * candidate. The pre-publish read alone misses the intra-draft case, leaking the
+ * intermediate ref. The final surviving ref is protected post-commit by
+ * {@link collectReferencedRefs} (it is the one now in canonical). A `CreateDataSource`
+ * seeds from an empty canonical, so its first write yields no candidate.
+ *
+ * Reads committed canonical state via the raw artifact db, BEFORE replay.
  */
-export async function collectOldCanonicalRefs(
+export async function collectSupersededRefs(
   db: ArtifactDb,
   log: Command[],
 ): Promise<SecretRef[]> {
-  const refs: SecretRef[] = [];
+  const simulated = await seedSimulatedConfigs(db, log);
+  const candidates: SecretRef[] = [];
   for (const cmd of log) {
-    const fields = CREDENTIAL_COMMAND_FIELDS[cmd.path];
-    const args = cmd.args;
-    if (!fields || !isRecord(args)) continue;
-    const id = args.id;
-    if (typeof id !== "string") continue;
-    // Only read canonical when at least one credential field is actually set.
-    const setFields = fields.filter((f) => args[f] !== undefined);
-    if (setFields.length === 0) continue;
+    const id = credentialCommandId(cmd);
+    const cur = id !== undefined ? simulated.get(id) : undefined;
+    if (!cur || !isRecord(cmd.args)) continue;
+    for (const field of CREDENTIAL_FIELDS) {
+      supersedeField(cur, field, cmd.args[field], candidates);
+    }
+  }
+  return candidates;
+}
+
+/** Seed each touched source's simulated field→ref map from pre-publish canonical. */
+async function seedSimulatedConfigs(
+  db: ArtifactDb,
+  log: Command[],
+): Promise<Map<string, SimulatedConfig>> {
+  const simulated = new Map<string, SimulatedConfig>();
+  for (const cmd of log) {
+    const id = credentialCommandId(cmd);
+    if (id === undefined || simulated.has(id)) continue;
     const rows = await db
       .select({ config: dataSources.config })
       .from(dataSources)
       .where(eq(dataSources.id, id));
-    const config = rows[0]?.config;
-    if (config == null) continue; // no canonical row yet (e.g. a fresh create)
-    const c = (config ?? {}) as DataSourceConfig;
-    for (const field of setFields) {
-      if (isSecretRef(c[field])) refs.push(c[field]);
-    }
+    const c = (rows[0]?.config ?? {}) as DataSourceConfig;
+    const seed: SimulatedConfig = {};
+    for (const f of CREDENTIAL_FIELDS)
+      seed[f] = isSecretRef(c[f]) ? c[f] : undefined;
+    simulated.set(id, seed);
   }
-  return refs;
+  return simulated;
+}
+
+/**
+ * Apply one field write to the simulated config: if it supersedes a prior ref
+ * (different from the new value), record that prior ref as a release candidate.
+ */
+function supersedeField(
+  cur: SimulatedConfig,
+  field: CredentialField,
+  value: unknown,
+  candidates: SecretRef[],
+): void {
+  if (value === undefined) return; // field not set by this command
+  const next = isSecretRef(value) ? value : undefined; // ref set, or clear / non-ref
+  const prior = cur[field];
+  if (prior && prior !== next) candidates.push(prior);
+  cur[field] = next;
 }
 
 /**

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -1,0 +1,280 @@
+/**
+ * Credential vault-ref lifecycle for the draft command path — capture-before-log
+ * and transition-time release.
+ *
+ * The model (owner decision 2026-06-28): a connector credential is stored as a
+ * vault REF; the draft carries the ref, never plaintext; ref RELEASES happen at
+ * lifecycle TRANSITIONS (publish / discard), never synchronously inside a draft
+ * append and never via a vault-wide scan (the SecretVault `No list()` invariant
+ * stays intact — this module enumerates DRAFTS and SOURCES, not vault secrets).
+ *
+ * Two seams:
+ *
+ *   1. CAPTURE-BEFORE-LOG ({@link captureCommandCredentials}) — host-injected into
+ *      `DraftController.appendToDraft`. Before a credential command is run +
+ *      snapshotted into `draft_command_log`, its plaintext credential args are
+ *      stored to the vault and rewritten to refs. The command that lands in the
+ *      log therefore carries a ref, not plaintext (the plaintext-never-at-rest
+ *      invariant rides on this).
+ *
+ *   2. TRANSITION-TIME RELEASE ({@link releaseRefsAtTransition} + collectors) —
+ *      orchestrated by the draft RPC handlers, POST the authoritative transition:
+ *        - publish: release the canonical ref each command REPLACES, collected
+ *          BEFORE replay (the replay overwrites it) and released AFTER the publish
+ *          transaction commits — so a rolled-back publish never deletes a still-
+ *          live secret.
+ *        - discard: release the refs the draft MINTED (read from its log), after
+ *          the draft's log + shadow are dropped.
+ *      Both are gated by {@link collectReferencedRefs}: a ref still referenced by
+ *      canonical or by another OPEN draft's shadow/log is never released.
+ *
+ * Shares its release mechanism (transaction-aware credential cleanup) with the
+ * commit-mode batch-rollback orphan case tracked separately; kept as standalone
+ * helpers so that work can reuse them.
+ */
+import {
+  dataSources,
+  dataSourcesDraft,
+  draftCommandLog,
+  type ArtifactDb,
+} from "@dashframe/server-core";
+import type { SecretRef, SecretVault } from "@wystack/secret-vault";
+import { isSecretRef } from "@wystack/secret-vault";
+import type { Command, DraftCommand } from "@wystack/server";
+import { eq, ne } from "drizzle-orm";
+
+import { CREDENTIAL_COMMAND_FIELDS } from "./functions/commands";
+import {
+  isRecord,
+  storeCredential,
+  type DataSourceConfig,
+} from "./functions/utils";
+
+// ---------------------------------------------------------------------------
+// Seam 1 — capture-before-log
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite a draft command's PLAINTEXT credential args to vault refs, returning a
+ * new command (the input is never mutated). Non-credential commands, empty-string
+ * (clear), undefined, and already-ref values pass through untouched.
+ *
+ * Called by `appendToDraft` BEFORE the command is run and snapshotted, so the
+ * command that reaches the handler — and the durable log — carries a ref. The
+ * vault store is real (a draft append is never a preview): a plaintext credential
+ * with no vault throws (fail-closed, via {@link storeCredential}).
+ */
+export async function captureCommandCredentials(
+  cmd: DraftCommand,
+  vault: SecretVault | undefined,
+): Promise<DraftCommand> {
+  const fields = CREDENTIAL_COMMAND_FIELDS[cmd.path];
+  if (!fields) return cmd;
+  const args = cmd.args;
+  if (!isRecord(args)) return cmd;
+
+  let nextArgs: Record<string, unknown> | undefined;
+  for (const field of fields) {
+    const value = args[field];
+    // undefined (not part of this write) and "" (clear) carry no plaintext.
+    if (typeof value !== "string" || value.length === 0) continue;
+    // Already a ref (idempotent re-capture / pre-bound) — leave it.
+    if (isSecretRef(value)) continue;
+    const id = typeof args.id === "string" ? args.id : "unknown";
+    const ref = await storeCredential(vault, value, `${field}-${id}`, false);
+    nextArgs ??= { ...args };
+    nextArgs[field] = ref;
+  }
+  if (!nextArgs) return cmd;
+  return { ...cmd, args: nextArgs };
+}
+
+// ---------------------------------------------------------------------------
+// Seam 2 — transition-time release: candidate collection
+// ---------------------------------------------------------------------------
+
+/** Collect the credential refs carried in one command's args (by command path). */
+function refsFromCommandArgs(path: string, args: unknown): SecretRef[] {
+  const fields = CREDENTIAL_COMMAND_FIELDS[path];
+  if (!fields || !isRecord(args)) return [];
+  const refs: SecretRef[] = [];
+  for (const field of fields) {
+    const v = args[field];
+    if (isSecretRef(v)) refs.push(v);
+  }
+  return refs;
+}
+
+/** Collect the credential refs held in a stored DataSource config. */
+function refsFromConfig(config: unknown): SecretRef[] {
+  if (!isRecord(config)) return [];
+  const c = config as DataSourceConfig;
+  const refs: SecretRef[] = [];
+  if (isSecretRef(c.apiKey)) refs.push(c.apiKey);
+  if (isSecretRef(c.connectionString)) refs.push(c.connectionString);
+  return refs;
+}
+
+/**
+ * Refs a DISCARD should release: the refs this draft MINTED, read from its own
+ * compacted command log. (A captured plaintext arg becomes a fresh ref in the
+ * log; an existing canonical ref never enters a draft's log via capture.) The
+ * cross-draft + canonical guard in {@link collectReferencedRefs} is the backstop
+ * that prevents releasing any ref still in use elsewhere.
+ */
+export function extractDraftMintedRefs(log: Command[]): SecretRef[] {
+  const refs: SecretRef[] = [];
+  for (const cmd of log) refs.push(...refsFromCommandArgs(cmd.path, cmd.args));
+  return refs;
+}
+
+/**
+ * Refs a PUBLISH should release: the canonical ref each command in the log will
+ * REPLACE. Read BEFORE replay (replay overwrites canonical). A ref is a candidate
+ * only for a credential field the command actually SETS (non-undefined — a
+ * connectionString-only command must not trigger an apiKey release; `apiKey: ""`
+ * (clear) counts as set). A CreateDataSource targets a not-yet-existing row, so it
+ * yields no candidate. Reads committed canonical state via the raw artifact db.
+ */
+export async function collectOldCanonicalRefs(
+  db: ArtifactDb,
+  log: Command[],
+): Promise<SecretRef[]> {
+  const refs: SecretRef[] = [];
+  for (const cmd of log) {
+    const fields = CREDENTIAL_COMMAND_FIELDS[cmd.path];
+    const args = cmd.args;
+    if (!fields || !isRecord(args)) continue;
+    const id = args.id;
+    if (typeof id !== "string") continue;
+    // Only read canonical when at least one credential field is actually set.
+    const setFields = fields.filter((f) => args[f] !== undefined);
+    if (setFields.length === 0) continue;
+    const rows = await db
+      .select({ config: dataSources.config })
+      .from(dataSources)
+      .where(eq(dataSources.id, id));
+    const config = rows[0]?.config;
+    if (config == null) continue; // no canonical row yet (e.g. a fresh create)
+    const c = (config ?? {}) as DataSourceConfig;
+    for (const field of setFields) {
+      if (isSecretRef(c[field])) refs.push(c[field]);
+    }
+  }
+  return refs;
+}
+
+/**
+ * Every credential ref still referenced anywhere it must SURVIVE a release:
+ *   - canonical `data_sources` config;
+ *   - any OTHER open draft's `data_sources__draft` shadow config (the shadow holds
+ *     the coalesced config, so it carries inherited refs a draft's log omits —
+ *     this is the load-bearing cross-draft check);
+ *   - any OTHER open draft's `draft_command_log` args (covers a crash-divergence
+ *     where a log row outlives its shadow).
+ *
+ * The published/discarded draft is excluded by `excludeDraftId` (and is usually
+ * already gone by the time this runs). No `vault.list()` — drafts and sources are
+ * enumerated, not vault secrets.
+ */
+export async function collectReferencedRefs(
+  db: ArtifactDb,
+  excludeDraftId: string,
+): Promise<Set<string>> {
+  const referenced = new Set<string>();
+
+  const canonical = await db
+    .select({ config: dataSources.config })
+    .from(dataSources);
+  for (const row of canonical) {
+    for (const ref of refsFromConfig(row.config)) referenced.add(ref);
+  }
+
+  const shadows = await db
+    .select({ config: dataSourcesDraft.config })
+    .from(dataSourcesDraft)
+    .where(ne(dataSourcesDraft.draftId, excludeDraftId));
+  for (const row of shadows) {
+    for (const ref of refsFromConfig(row.config)) referenced.add(ref);
+  }
+
+  const logs = await db
+    .select({ path: draftCommandLog.path, args: draftCommandLog.args })
+    .from(draftCommandLog)
+    .where(ne(draftCommandLog.draftId, excludeDraftId));
+  for (const row of logs) {
+    for (const ref of refsFromCommandArgs(row.path, row.args)) {
+      referenced.add(ref);
+    }
+  }
+
+  return referenced;
+}
+
+// ---------------------------------------------------------------------------
+// Seam 2 — transition-time release: the release itself
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete every candidate ref that is NOT in the `referenced` set. Deduped;
+ * `vault.delete` is idempotent (a missing ref is a no-op). Every delete is
+ * attempted (allSettled) so one failure does not skip the rest; an aggregate
+ * error is thrown if any failed (the caller decides whether to surface it).
+ *
+ * Throws if a ref must be released but no vault is injected — symmetric with the
+ * fail-closed store (a ref can only exist because a vault was present at store).
+ */
+export async function releaseUnreferenced(
+  vault: SecretVault | undefined,
+  candidates: SecretRef[],
+  referenced: ReadonlySet<string>,
+): Promise<void> {
+  const toRelease = [...new Set(candidates)].filter((r) => !referenced.has(r));
+  if (toRelease.length === 0) return;
+  if (vault == null) {
+    throw new Error(
+      "[secret-vault] cannot release credential refs at transition: no vault " +
+        "injected, but refs are slated for release. A vault present at store " +
+        "time must also be present at release time.",
+    );
+  }
+  const results = await Promise.allSettled(
+    toRelease.map((ref) => vault.delete(ref)),
+  );
+  const failures = results.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((f) => f.reason),
+      `[secret-vault] failed to release ${failures.length} of ${toRelease.length} credential ref(s) at transition`,
+    );
+  }
+}
+
+/**
+ * Release `candidates` that are referenced nowhere else — the post-transition
+ * (post-commit / post-discard) cleanup step. BEST-EFFORT BY DESIGN: the
+ * authoritative transition has already committed, so a release failure must NOT
+ * fail the RPC. The worst case of a failure is an inert, idempotent-recoverable
+ * orphan; the worst case of failing the RPC would be reporting a committed
+ * publish as failed. So failures are logged, not thrown.
+ */
+export async function releaseRefsAtTransition(
+  db: ArtifactDb,
+  vault: SecretVault | undefined,
+  candidates: SecretRef[],
+  excludeDraftId: string,
+): Promise<void> {
+  if (candidates.length === 0) return;
+  try {
+    const referenced = await collectReferencedRefs(db, excludeDraftId);
+    await releaseUnreferenced(vault, candidates, referenced);
+  } catch (err) {
+    console.error(
+      "[dashframe] credential transition release failed " +
+        "(orphaned ref left behind — inert, recoverable):",
+      err,
+    );
+  }
+}

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -92,6 +92,14 @@ async function releaseRefsBestEffort(
  * ATOMIC per command: if storing a later field throws, the refs already minted for
  * this command are released before the error propagates — a partially-captured
  * command never leaks a ref.
+ *
+ * INVARIANT — a credential command MUST NOT carry a `compactionKey`. The current
+ * vocabulary (`cmd()` builder) sets none, so two credential writes to one field are
+ * both kept in the log and {@link collectSupersededRefs} releases the intermediate
+ * ref. If a credential command ever adopted a `compactionKey`, `compactLog` would
+ * DROP the earlier write — orphaning the ref it minted here (the log no longer
+ * references it, so no transition releases it). Keep credential commands
+ * compaction-free, or teach capture to release a ref whose command is compacted away.
  */
 export async function captureCommandCredentials(
   cmd: DraftCommand,
@@ -143,19 +151,32 @@ function refsFromCommandArgs(path: string, args: unknown): SecretRef[] {
   return refs;
 }
 
+/**
+ * The credential ref-bearing fields of `DataSourceConfig` — the SINGLE source of
+ * truth every ref-lifecycle reader iterates: {@link refsFromConfig} (cross-draft
+ * protection), {@link collectSupersededRefs}, and the simulate seed. Hardcoding the
+ * field set in each reader independently was the silent-drift hazard: adding a third
+ * field (e.g. `oauthToken`) to one reader but not another would let
+ * `collectReferencedRefs` stop protecting it and release a still-live secret.
+ *
+ * `credential-release.test.ts` BRIDGES this to the command-side truth
+ * (`CREDENTIAL_COMMAND_FIELDS`), so a new credential field added to commands but
+ * not here (or vice-versa) fails the build, not a production secret.
+ */
+export const CREDENTIAL_CONFIG_FIELDS = ["apiKey", "connectionString"] as const;
+type CredentialField = (typeof CREDENTIAL_CONFIG_FIELDS)[number];
+type SimulatedConfig = Partial<Record<CredentialField, SecretRef | undefined>>;
+
 /** Collect the credential refs held in a stored DataSource config. */
 function refsFromConfig(config: unknown): SecretRef[] {
   if (!isRecord(config)) return [];
   const c = config as DataSourceConfig;
   const refs: SecretRef[] = [];
-  if (isSecretRef(c.apiKey)) refs.push(c.apiKey);
-  if (isSecretRef(c.connectionString)) refs.push(c.connectionString);
+  for (const field of CREDENTIAL_CONFIG_FIELDS) {
+    if (isSecretRef(c[field])) refs.push(c[field]);
+  }
   return refs;
 }
-
-const CREDENTIAL_FIELDS = ["apiKey", "connectionString"] as const;
-type CredentialField = (typeof CREDENTIAL_FIELDS)[number];
-type SimulatedConfig = Partial<Record<CredentialField, SecretRef | undefined>>;
 
 /** The data-source id a credential command targets, or undefined if not one. */
 function credentialCommandId(cmd: Command): string | undefined {
@@ -213,7 +234,7 @@ export async function collectSupersededRefs(
     const id = credentialCommandId(cmd);
     const cur = id !== undefined ? simulated.get(id) : undefined;
     if (!cur || !isRecord(cmd.args)) continue;
-    for (const field of CREDENTIAL_FIELDS) {
+    for (const field of CREDENTIAL_CONFIG_FIELDS) {
       supersedeField(cur, field, cmd.args[field], candidates);
     }
   }
@@ -235,7 +256,7 @@ async function seedSimulatedConfigs(
       .where(eq(dataSources.id, id));
     const c = (rows[0]?.config ?? {}) as DataSourceConfig;
     const seed: SimulatedConfig = {};
-    for (const f of CREDENTIAL_FIELDS)
+    for (const f of CREDENTIAL_CONFIG_FIELDS)
       seed[f] = isSecretRef(c[f]) ? c[f] : undefined;
     simulated.set(id, seed);
   }

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -348,11 +348,12 @@ export function createDraftController(
       // form. `structuredClone` handles nested args; commands are plain JSON-ish
       // envelopes (path/args/id/compactionKey/kind) so it round-trips cleanly.
       const ranSnapshots: DraftCommand[] = [];
-      // Rollbacks for credentials captured in this batch — invoked only if a
-      // command fails before the batch is persisted to the log (the minted ref
-      // would otherwise be in the vault but in no log, so the log-driven discard
-      // release could never find it). On batch success they are dropped (the refs
-      // are legitimately in the log).
+      // Rollbacks for credentials captured in this batch — invoked if ANYTHING
+      // throws before the durable log write succeeds (capture, handler run, OR log
+      // persistence). Until writeLog commits, a minted ref is in the vault but in
+      // no log, so the log-driven discard release could never find it. The rollback
+      // stays armed across the whole append; on success (after writeLog) the refs
+      // are legitimately in the log and the rollbacks are dropped.
       const captureRollbacks: Array<() => Promise<void>> = [];
       try {
         for (const cmd of batch) {
@@ -373,6 +374,14 @@ export function createDraftController(
           ranSnapshots.push(structuredClone(captured.command) as DraftCommand);
           results.push({ id: captured.command.id, value });
         }
+        // Project the compacted full log into draft_command_log. Read the prior
+        // log, concat the snapshots of what just ran, compact (wystack's exported
+        // algorithm), replace-all (atomically — see writeLog). INSIDE the try so a
+        // log-persistence failure also triggers the capture rollback below.
+        const prior = await readLog(draftId);
+        const compacted = compactLog([...prior, ...ranSnapshots]);
+        await writeLog(draftId, compacted);
+        return results;
       } catch (err) {
         // The batch is non-atomic by contract (recovery = re-append, which
         // re-mints); release the refs captured so far so a failed append leaves
@@ -382,13 +391,6 @@ export function createDraftController(
         }
         throw err;
       }
-      // Project the compacted full log into draft_command_log. Read the prior
-      // log, concat the snapshots of what just ran, compact (wystack's exported
-      // algorithm), replace-all (atomically — see writeLog).
-      const prior = await readLog(draftId);
-      const compacted = compactLog([...prior, ...ranSnapshots]);
-      await writeLog(draftId, compacted);
-      return results;
     },
 
     async publishDraft(draftId, context = {}) {

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -183,10 +183,14 @@ export interface CreateDraftControllerOptions {
    * Pre-bind seam: rewrite a command BEFORE it is run + snapshotted into the log.
    * The host uses this to capture plaintext credential args into vault refs so the
    * durable log carries a ref, never plaintext (capture-before-log). Returns the
-   * command to run + snapshot; the controller stays free of credential knowledge.
-   * Absent → commands are run and logged verbatim.
+   * command to run + snapshot, plus a `rollback` the controller invokes if the
+   * command's run fails before the batch is logged (so a captured-but-unlogged ref
+   * does not orphan). The controller stays free of credential knowledge — the
+   * rollback is opaque. Absent → commands are run and logged verbatim.
    */
-  captureCredentials?: (cmd: DraftCommand) => Promise<DraftCommand>;
+  captureCredentials?: (
+    cmd: DraftCommand,
+  ) => Promise<{ command: DraftCommand; rollback: () => Promise<void> }>;
 }
 
 /**
@@ -344,20 +348,39 @@ export function createDraftController(
       // form. `structuredClone` handles nested args; commands are plain JSON-ish
       // envelopes (path/args/id/compactionKey/kind) so it round-trips cleanly.
       const ranSnapshots: DraftCommand[] = [];
-      for (const cmd of batch) {
-        // Capture-before-log: the host may rewrite plaintext credential args into
-        // vault refs BEFORE the command runs and is snapshotted, so the durable
-        // log never holds plaintext. The rewritten command is what the handler
-        // runs AND what we snapshot — shadow, log, and handler all see the ref.
-        const bound = captureCredentials ? await captureCredentials(cmd) : cmd;
-        const value = await app.runHandler(
-          bound.path,
-          bound.args,
-          baseDb,
-          draftContext,
-        );
-        ranSnapshots.push(structuredClone(bound) as DraftCommand);
-        results.push({ id: bound.id, value });
+      // Rollbacks for credentials captured in this batch — invoked only if a
+      // command fails before the batch is persisted to the log (the minted ref
+      // would otherwise be in the vault but in no log, so the log-driven discard
+      // release could never find it). On batch success they are dropped (the refs
+      // are legitimately in the log).
+      const captureRollbacks: Array<() => Promise<void>> = [];
+      try {
+        for (const cmd of batch) {
+          // Capture-before-log: the host may rewrite plaintext credential args
+          // into vault refs BEFORE the command runs and is snapshotted, so the
+          // durable log never holds plaintext. The rewritten command is what the
+          // handler runs AND what we snapshot — shadow, log, handler all see the ref.
+          const captured = captureCredentials
+            ? await captureCredentials(cmd)
+            : { command: cmd, rollback: async () => {} };
+          captureRollbacks.push(captured.rollback);
+          const value = await app.runHandler(
+            captured.command.path,
+            captured.command.args,
+            baseDb,
+            draftContext,
+          );
+          ranSnapshots.push(structuredClone(captured.command) as DraftCommand);
+          results.push({ id: captured.command.id, value });
+        }
+      } catch (err) {
+        // The batch is non-atomic by contract (recovery = re-append, which
+        // re-mints); release the refs captured so far so a failed append leaves
+        // no orphaned secret. Best-effort — a release failure leaves an inert orphan.
+        for (const rollback of captureRollbacks) {
+          await rollback().catch(() => {});
+        }
+        throw err;
       }
       // Project the compacted full log into draft_command_log. Read the prior
       // log, concat the snapshots of what just ran, compact (wystack's exported

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -175,6 +175,21 @@ export interface DraftController {
 }
 
 /**
+ * Optional hooks the host injects into the controller without coupling it to
+ * DashFrame-specific command knowledge.
+ */
+export interface CreateDraftControllerOptions {
+  /**
+   * Pre-bind seam: rewrite a command BEFORE it is run + snapshotted into the log.
+   * The host uses this to capture plaintext credential args into vault refs so the
+   * durable log carries a ref, never plaintext (capture-before-log). Returns the
+   * command to run + snapshot; the controller stays free of credential knowledge.
+   * Absent → commands are run and logged verbatim.
+   */
+  captureCredentials?: (cmd: DraftCommand) => Promise<DraftCommand>;
+}
+
+/**
  * Build the persistent draft controller over a WyStack app + the project's
  * artifact DB. The app resolves command paths and backs both the shadow writes
  * (via `withDraft`) and the publish replay; the typed `ArtifactDb` is the durable
@@ -183,7 +198,9 @@ export interface DraftController {
 export function createDraftController(
   app: WyStackApp,
   db: ArtifactDb,
+  options: CreateDraftControllerOptions = {},
 ): DraftController {
+  const { captureCredentials } = options;
   /** Read the draft's persisted command log, ordered for replay. */
   async function readLog(draftId: string): Promise<DraftCommand[]> {
     const rows = await db
@@ -328,14 +345,19 @@ export function createDraftController(
       // envelopes (path/args/id/compactionKey/kind) so it round-trips cleanly.
       const ranSnapshots: DraftCommand[] = [];
       for (const cmd of batch) {
+        // Capture-before-log: the host may rewrite plaintext credential args into
+        // vault refs BEFORE the command runs and is snapshotted, so the durable
+        // log never holds plaintext. The rewritten command is what the handler
+        // runs AND what we snapshot — shadow, log, and handler all see the ref.
+        const bound = captureCredentials ? await captureCredentials(cmd) : cmd;
         const value = await app.runHandler(
-          cmd.path,
-          cmd.args,
+          bound.path,
+          bound.args,
           baseDb,
           draftContext,
         );
-        ranSnapshots.push(structuredClone(cmd) as DraftCommand);
-        results.push({ id: cmd.id, value });
+        ranSnapshots.push(structuredClone(bound) as DraftCommand);
+        results.push({ id: bound.id, value });
       }
       // Project the compacted full log into draft_command_log. Read the prior
       // log, concat the snapshots of what just ran, compact (wystack's exported

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -78,7 +78,7 @@
  * source the two are interchangeable, for an Insight source `baseTableId` holds
  * the upstream insight id.
  */
-import { schema } from "@dashframe/server-core";
+import { type ArtifactProvenance, schema } from "@dashframe/server-core";
 import type {
   ArtifactKind,
   Field,
@@ -100,11 +100,13 @@ import { z } from "zod";
 
 import {
   applyCredentialField,
+  coerceProvenance,
   type DataSourceConfig,
   isRecord,
   modeFromCtx,
   releaseCredentialRefs,
   requireRecordWithId,
+  shouldDeferRelease,
   vaultFromCtx,
 } from "./utils";
 
@@ -356,13 +358,20 @@ const createDataSource = mutation({
     name: text,
     apiKey: text.optional(),
     connectionString: text.optional(),
+    /** Artifact provenance carried by the emitter (agent vs user). */
+    createdBy: jsonb.optional(),
   },
   handler: async (
     ctx,
-    { id, type, name, apiKey, connectionString },
+    { id, type, name, apiKey, connectionString, createdBy },
   ): Promise<{ id: string }> => {
     const vault = vaultFromCtx(ctx);
     const preview = modeFromCtx(ctx) === "preview";
+    // On the draft / publish-replay path, a captured credential arrives here AS a
+    // ref (pass-through, no re-store) and the prior-ref release is deferred to the
+    // lifecycle transition; on a direct canonical call, release is synchronous.
+    // (A fresh create has no prior ref, so deferral only matters for symmetry.)
+    const deferRelease = shouldDeferRelease(ctx);
     const config: DataSourceConfig = {};
     // store non-empty / skip-on-empty (applyCredentialField). On a fresh config an
     // empty string is a no-op. A real store fails closed when no vault is injected.
@@ -376,6 +385,7 @@ const createDataSource = mutation({
       vault,
       `apiKey-${id}`,
       preview,
+      deferRelease,
     );
     await applyCredentialField(
       config,
@@ -384,14 +394,18 @@ const createDataSource = mutation({
       vault,
       `connectionString-${id}`,
       preview,
+      deferRelease,
     );
     const [row] = (await ctx.db.into(dataSources).insert({
       id,
       name,
       kind: type,
       storage: "live",
+      // Agent-emitted creates carry agent provenance (in the command, so it
+      // survives the publish log replay) so agent-authored sources are auditably
+      // distinct; an absent/malformed value defaults to user.
+      createdBy: coerceProvenance(createdBy),
       config,
-      createdBy: { kind: "user" },
     })) as DataSourceRow[];
     if (!row) throw new Error("insert returned no row");
     return { id: row.id };
@@ -420,6 +434,9 @@ const setDataSourceConfig = mutation({
   ): Promise<{ ok: true }> => {
     const vault = vaultFromCtx(ctx);
     const preview = modeFromCtx(ctx) === "preview";
+    // Defer prior-ref release to the publish/discard transition on the draft path;
+    // release synchronously on a direct canonical call (see createDataSource).
+    const deferRelease = shouldDeferRelease(ctx);
     const current = (await ctx.db
       .from(dataSources)
       .where(eq("id", id))
@@ -427,11 +444,11 @@ const setDataSourceConfig = mutation({
     if (!current) throw new Error(`Data source ${id} not found`);
     const config = { ...((current.config ?? {}) as DataSourceConfig) };
     // Sink guard FIRST: callers may not sneak credential keys in via `extra`.
-    // This validation must run BEFORE applyCredentialField, because a clear/rotate
-    // releases the prior vault ref (an irreversible keychain side-effect). If the
-    // guard threw after the release, a rejected request would have already deleted
-    // the live secret while the DB row still pointed at it — a dangling ref.
-    // Validation before side-effects keeps a rejected write fully consistent.
+    // This validation must run BEFORE applyCredentialField, because a rotate stores
+    // a NEW vault ref (an irreversible keychain side-effect). If the guard threw
+    // after the store, a rejected request would have already minted an orphan
+    // secret. Validation before side-effects keeps a rejected write fully consistent.
+    // (Prior-ref release is deferred to the publish transition, not run here.)
     if (isRecord(extra) && ("apiKey" in extra || "connectionString" in extra)) {
       throw new Error(
         "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, not extra",
@@ -441,11 +458,13 @@ const setDataSourceConfig = mutation({
     // (releases the prior vault ref + deletes the config key so hasApiKey reads false)
     // / leave-on-undefined.
     // applyCredentialField is the single choke point; a real store fails closed when
-    // no vault is injected. The prior vault ref (on replace or clear) is released
-    // inside applyCredentialField after the new ref is stored (rotate) or before
-    // the key is dropped (clear). The release fires only once the store/validation
-    // above has succeeded.
-    // In preview mode vault writes and releases are skipped (keychain is not transactional).
+    // no vault is injected. A captured/replayed ref passes through verbatim (no
+    // re-store, no plaintext in the log). On the draft path the prior canonical ref
+    // is NOT released here (deferRelease): release is the publish transition's job
+    // (it releases the replaced canonical ref post-commit, with a cross-draft-
+    // reference check) so a rolled-back publish never deletes a still-live secret.
+    // On a direct canonical call, the prior ref is released synchronously.
+    // In preview mode vault writes are skipped (keychain is not transactional).
     await applyCredentialField(
       config,
       "apiKey",
@@ -453,6 +472,7 @@ const setDataSourceConfig = mutation({
       vault,
       `apiKey-${id}`,
       preview,
+      deferRelease,
     );
     await applyCredentialField(
       config,
@@ -461,6 +481,7 @@ const setDataSourceConfig = mutation({
       vault,
       `connectionString-${id}`,
       preview,
+      deferRelease,
     );
     // Merge non-credential keys from `extra` into the config (guarded above).
     if (isRecord(extra)) {
@@ -2240,6 +2261,8 @@ export interface CommandPayloads {
     name: string;
     apiKey?: string;
     connectionString?: string;
+    /** Provenance of the emitter — `{ kind: "agent" }` for agent-authored. */
+    createdBy?: ArtifactProvenance;
   };
   SetDataSourceConfig: {
     id: UUID;
@@ -2390,3 +2413,22 @@ export function cmd<K extends CommandName>(
 ): Command {
   return { path: COMMAND_PATHS[name], args: payload };
 }
+
+/**
+ * Which credential fields each command's `args` may carry, keyed by the REGISTRY
+ * PATH the command dispatches against (`COMMAND_PATHS` value, the same string
+ * stored in `draft_command_log.path`). The single source of truth tying a
+ * command path to its credential-bearing arg fields.
+ *
+ * Used by both the capture-before-log seam (rewrite plaintext args → vault refs
+ * before the command is snapshotted into the log) and the transition-release
+ * mechanism (extract draft-minted / replaced refs from the durable log). Keeping
+ * this with the vocabulary keeps the credential-field set in lockstep with the
+ * command handlers that read those fields.
+ */
+export const CREDENTIAL_COMMAND_FIELDS: Readonly<
+  Record<string, ReadonlyArray<"apiKey" | "connectionString">>
+> = {
+  [COMMAND_PATHS.CreateDataSource]: ["apiKey", "connectionString"],
+  [COMMAND_PATHS.SetDataSourceConfig]: ["apiKey", "connectionString"],
+};

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -19,11 +19,19 @@
  *   explicitly here — the outer `buildDashframeApp` wrapper does not fire it for
  *   the same sub-tracker reason.
  */
+import type { ArtifactDb } from "@dashframe/server-core";
 import { text } from "@wystack/db";
+import type { SecretVault } from "@wystack/secret-vault";
 import type { Command } from "@wystack/server";
 import { mutation, query } from "@wystack/server";
 
+import {
+  collectOldCanonicalRefs,
+  extractDraftMintedRefs,
+  releaseRefsAtTransition,
+} from "../credential-release";
 import type { DraftController } from "../draft-controller";
+import { PUBLISH_REPLAY_CONTEXT_KEY } from "./utils";
 
 /**
  * Internal-only return shape for `publishDraft`. The `__extraTablesWritten`
@@ -68,7 +76,22 @@ const publishDraft = mutation({
     // leaving a resurrection window across server restarts.
     const prePublishLog = await draftController.getDraftLog(draftId);
 
-    const result = await draftController.publishDraft(draftId, {});
+    // TRANSITION-TIME RELEASE — publish half. Collect the canonical refs each
+    // command will REPLACE *before* replay overwrites them; release runs only
+    // AFTER the publish transaction commits (below), so a rolled-back publish
+    // never deletes a still-live secret.
+    const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
+    const vault = ctx.vault as SecretVault | undefined;
+    const replacedRefs =
+      artifactDb != null
+        ? await collectOldCanonicalRefs(artifactDb, prePublishLog)
+        : [];
+
+    // Mark the replay as the sanctioned canonical-commit path so the credential
+    // command handlers' direct-call guard accepts it (release is handled here).
+    const result = await draftController.publishDraft(draftId, {
+      [PUBLISH_REPLAY_CONTEXT_KEY]: true,
+    });
 
     // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does
     // NOT fire `onWrite` here (its tracker sees zero writes from the sub-tracker
@@ -82,6 +105,13 @@ const publishDraft = mutation({
       } catch (err) {
         console.error("[dashframe] publishDraft: onWrite hook threw:", err);
       }
+    }
+
+    // Publish has committed: release the replaced canonical refs that are no
+    // longer referenced by canonical or any other open draft (best-effort —
+    // a release failure leaves an inert orphan, never fails the committed publish).
+    if (artifactDb != null) {
+      await releaseRefsAtTransition(artifactDb, vault, replacedRefs, draftId);
     }
 
     const tablesWritten = [...result.tablesWritten];
@@ -115,7 +145,22 @@ const discardDraft = mutation({
       );
     }
 
+    // TRANSITION-TIME RELEASE — discard half. Read the draft-minted credential
+    // refs from its log BEFORE the discard drops the log + shadow; release them
+    // AFTER the draft is gone (best-effort), gated so a ref another open draft
+    // still references is never deleted.
+    const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
+    const vault = ctx.vault as SecretVault | undefined;
+    const mintedRefs =
+      artifactDb != null
+        ? extractDraftMintedRefs(await draftController.getDraftLog(draftId))
+        : [];
+
     await draftController.discardDraft(draftId);
+
+    if (artifactDb != null) {
+      await releaseRefsAtTransition(artifactDb, vault, mintedRefs, draftId);
+    }
 
     // Trigger snapshot persistence after discard — the shadow rows live in the
     // durable store; a stale snapshot would resurrect them on restart.

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -26,8 +26,8 @@ import type { Command } from "@wystack/server";
 import { mutation, query } from "@wystack/server";
 
 import {
-  collectOldCanonicalRefs,
-  extractDraftMintedRefs,
+  collectDiscardCandidateRefs,
+  collectSupersededRefs,
   releaseRefsAtTransition,
 } from "../credential-release";
 import type { DraftController } from "../draft-controller";
@@ -84,7 +84,7 @@ const publishDraft = mutation({
     const vault = ctx.vault as SecretVault | undefined;
     const replacedRefs =
       artifactDb != null
-        ? await collectOldCanonicalRefs(artifactDb, prePublishLog)
+        ? await collectSupersededRefs(artifactDb, prePublishLog)
         : [];
 
     // Mark the replay as the sanctioned canonical-commit path so the credential
@@ -153,7 +153,11 @@ const discardDraft = mutation({
     const vault = ctx.vault as SecretVault | undefined;
     const mintedRefs =
       artifactDb != null
-        ? extractDraftMintedRefs(await draftController.getDraftLog(draftId))
+        ? await collectDiscardCandidateRefs(
+            artifactDb,
+            draftId,
+            await draftController.getDraftLog(draftId),
+          )
         : [];
 
     await draftController.discardDraft(draftId);

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -98,11 +98,13 @@ const publishDraft = mutation({
     // used inside publishDraft). We call it explicitly via the injected callback.
     // Condition: fire when canonical tables were written OR when the draft had
     // a non-empty command log (its deletion is itself a durable change).
+    let snapshotPersisted = true;
     if (result.tablesWritten.size > 0 || prePublishLog.length > 0) {
       const onWrite = ctx.onWrite as (() => void) | undefined;
       try {
         onWrite?.();
       } catch (err) {
+        snapshotPersisted = false;
         console.error("[dashframe] publishDraft: onWrite hook threw:", err);
       }
     }
@@ -110,7 +112,11 @@ const publishDraft = mutation({
     // Publish has committed: release the replaced canonical refs that are no
     // longer referenced by canonical or any other open draft (best-effort —
     // a release failure leaves an inert orphan, never fails the committed publish).
-    if (artifactDb != null) {
+    // GATED on snapshot persistence: if onWrite failed, the post-publish state was
+    // not durably snapshotted, so a restart could restore the PRE-publish snapshot
+    // (old canonical ref) — releasing that ref now would dangle it. Skip the
+    // release (leave an inert orphan) rather than risk a dangling live reference.
+    if (artifactDb != null && snapshotPersisted) {
       await releaseRefsAtTransition(artifactDb, vault, replacedRefs, draftId);
     }
 
@@ -162,17 +168,25 @@ const discardDraft = mutation({
 
     await draftController.discardDraft(draftId);
 
-    if (artifactDb != null) {
-      await releaseRefsAtTransition(artifactDb, vault, mintedRefs, draftId);
-    }
-
     // Trigger snapshot persistence after discard — the shadow rows live in the
-    // durable store; a stale snapshot would resurrect them on restart.
+    // durable store; a stale snapshot would resurrect them on restart. This MUST
+    // run before the credential release below: if the post-discard state is not
+    // snapshotted, a restart restores the draft (referencing its refs), so those
+    // refs must not have been released yet.
+    let snapshotPersisted = true;
     const onWrite = ctx.onWrite as (() => void) | undefined;
     try {
       onWrite?.();
     } catch (err) {
+      snapshotPersisted = false;
       console.error("[dashframe] discardDraft: onWrite hook threw:", err);
+    }
+
+    // Release the draft-minted refs now that the draft is gone AND that removal is
+    // durably snapshotted (best-effort; gated so a stale-snapshot restore cannot
+    // resurrect a draft referencing an already-released secret).
+    if (artifactDb != null && snapshotPersisted) {
+      await releaseRefsAtTransition(artifactDb, vault, mintedRefs, draftId);
     }
   },
 });

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -65,9 +65,10 @@ export function modeFromCtx(
  * context — so every replayed handler sees it.
  *
  * It is the signal credential command handlers use to recognise the one
- * sanctioned canonical-commit path. Credential commands DEFER ref release to a
- * lifecycle transition; a *direct* canonical commit (no draft, no replay) would
- * orphan a replaced ref, so {@link assertDeferredReleaseContext} refuses it.
+ * sanctioned canonical-commit path: {@link shouldDeferRelease} returns true on it,
+ * so the replay defers the replaced ref's release to the publish RPC (which runs
+ * the release post-commit). A *direct* canonical commit (no draft, no replay)
+ * defers nothing and releases the prior ref synchronously.
  */
 export const PUBLISH_REPLAY_CONTEXT_KEY = "__publishReplay";
 
@@ -110,6 +111,14 @@ export function shouldDeferRelease(ctx: FunctionContext): boolean {
  * `createdBy: { kind: "agent" }` as a command arg; it round-trips through the log
  * to the canonical row. A malformed/absent value falls back to user (fail-safe:
  * an unrecognised provenance is never silently trusted as agent).
+ *
+ * INVARIANT — provenance is CALLER-ASSERTED, not authenticated. `kind` travels in
+ * the command (it must, to survive publish replay), so any emitter can claim
+ * `agent`. This is a DISPLAY/AUDIT signal ONLY and MUST NEVER gate a privileged
+ * operation or a trust decision. Authenticating the emitter belongs with the
+ * agent-dispatch seam (a context flag the dispatcher sets, which this would then
+ * consult) — that seam is not built yet, so the field stays caller-asserted until
+ * it exists. See PR #188 review thread (provenance spoofing).
  */
 export function coerceProvenance(value: unknown): ArtifactProvenance {
   if (isRecord(value) && (value.kind === "user" || value.kind === "agent")) {

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -272,13 +272,12 @@ export async function releaseCredentialRefs(
  *   deferred-release credential commands (CreateDataSource/SetDataSourceConfig)
  *   pass this; the legacy coarse handlers leave it `false` (synchronous release).
  *
- * **Ref pass-through (capture-before-log):** when `value` is already a
- * `SecretRef` — the credential was captured to a ref before the command was
- * snapshotted into `draft_command_log`, or the command is being replayed from
- * that log on publish — it is ADOPTED verbatim, never re-stored. Re-storing a ref
- * string would double-wrap it as plaintext (the historical rotate-branch trap)
- * AND write the ref into the durable log. Pass-through is the seam that keeps
- * plaintext out of the log.
+ * **Ref pass-through (capture-before-log):** on the deferred path (`deferRelease`
+ * — a draft append or publish replay) a `SecretRef` value is ADOPTED verbatim,
+ * never re-stored (re-storing double-wraps it as plaintext and writes the ref into
+ * the durable log). This is the seam that keeps plaintext out of the log. The gate
+ * is deliberate: on a DIRECT canonical call a ref-shaped input is treated as
+ * plaintext and stored, so the fail-closed vault guard cannot be bypassed.
  */
 export async function applyCredentialField(
   config: DataSourceConfig,
@@ -301,13 +300,20 @@ export async function applyCredentialField(
     delete config[field]; // explicit clear
     return;
   }
-  if (isSecretRef(value)) {
-    // PASS-THROUGH: the value is already a vault ref (captured before the log
-    // snapshot, or replayed from the durable log). Adopt it; never re-store.
+  if (isSecretRef(value) && deferRelease) {
+    // PASS-THROUGH — ONLY on the deferred (draft / publish-replay) path, where a
+    // ref-valued credential was minted by capture-before-log or replayed from the
+    // durable log. Adopt it; never re-store (re-storing double-wraps it as plaintext
+    // and writes it into the log). The deferRelease gate is load-bearing: on a
+    // DIRECT canonical call a ref-shaped input must NOT be adopted — otherwise a
+    // user-supplied "secret:<uuid>" string would skip storeCredential, bypassing the
+    // fail-closed vault guard and (on rotate) releasing the old live ref while the
+    // config points at an unverified secret. Direct calls fall to the store branch.
     config[field] = value;
   } else {
-    // ROTATE/SET branch: plaintext → store, adopt the returned ref.
-    // store-new-first preserves the new secret if a later release fails.
+    // ROTATE/SET branch: plaintext (or a ref-shaped input on a direct call) → store,
+    // adopt the returned ref. store-new-first preserves the new secret if a later
+    // release fails.
     config[field] = await storeCredential(vault, value, locatorHint, preview);
   }
   // Release the prior ref unless it is unchanged (idempotent re-set of the same

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -3,6 +3,7 @@
  * the command vocabulary (`commands.ts`) while both write paths coexist
  * (transition window while legacy coarse handlers and the command vocabulary coexist).
  */
+import type { ArtifactProvenance } from "@dashframe/server-core";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { isSecretRef } from "@wystack/secret-vault";
 import type { FunctionContext } from "@wystack/server";
@@ -54,6 +55,70 @@ export function modeFromCtx(
   const m = ctx.mode;
   if (m === "preview" || m === "commit") return m;
   return undefined;
+}
+
+/**
+ * Context key marking a handler invocation as the PUBLISH REPLAY of a draft's
+ * command log (not a direct canonical call). The draft RPC `publishDraft` passes
+ * `{ [PUBLISH_REPLAY_CONTEXT_KEY]: true }` into `DraftController.publishDraft`,
+ * which forwards it (minus `draftId`) into the `applyCommands(mode:'commit')`
+ * context — so every replayed handler sees it.
+ *
+ * It is the signal credential command handlers use to recognise the one
+ * sanctioned canonical-commit path. Credential commands DEFER ref release to a
+ * lifecycle transition; a *direct* canonical commit (no draft, no replay) would
+ * orphan a replaced ref, so {@link assertDeferredReleaseContext} refuses it.
+ */
+export const PUBLISH_REPLAY_CONTEXT_KEY = "__publishReplay";
+
+/**
+ * True when the handler is running inside a draft append — `appendToDraft` threads
+ * the `draftId` into the handler context. On this path credential writes are
+ * captured to refs BEFORE the log snapshot and their release is deferred to the
+ * publish/discard transition, so synchronous release must NOT fire here.
+ */
+export function inDraftContext(ctx: FunctionContext): boolean {
+  return (ctx as Record<string, unknown>).draftId != null;
+}
+
+/** True when the handler is running as the publish replay of a draft log. */
+export function isPublishReplay(ctx: FunctionContext): boolean {
+  return (ctx as Record<string, unknown>)[PUBLISH_REPLAY_CONTEXT_KEY] === true;
+}
+
+/**
+ * Whether a credential command should DEFER release of the prior vault ref to a
+ * lifecycle transition instead of releasing it synchronously. True on the two
+ * transition-backed paths:
+ *   - a draft append (`inDraftContext`)  — discard/publish releases later;
+ *   - the publish replay (`isPublishReplay`) — the RPC releases post-commit, with
+ *     the cross-draft check.
+ * A DIRECT canonical call is neither, so it keeps synchronous release (the prior
+ * ref is released inline — no transition will run to clean it up).
+ */
+export function shouldDeferRelease(ctx: FunctionContext): boolean {
+  return inDraftContext(ctx) || isPublishReplay(ctx);
+}
+
+/**
+ * Validate a raw artifact-provenance value (carried in a command's args by the
+ * EMITTER) into an {@link ArtifactProvenance}, defaulting to `{ kind: "user" }`.
+ *
+ * Provenance must travel IN the command, not the handler context: publish replays
+ * the durable command log, and the append-time context is not persisted — so a
+ * context-only provenance would be lost on publish. The agent enablement emits
+ * `createdBy: { kind: "agent" }` as a command arg; it round-trips through the log
+ * to the canonical row. A malformed/absent value falls back to user (fail-safe:
+ * an unrecognised provenance is never silently trusted as agent).
+ */
+export function coerceProvenance(value: unknown): ArtifactProvenance {
+  if (isRecord(value) && (value.kind === "user" || value.kind === "agent")) {
+    const prov: ArtifactProvenance = { kind: value.kind };
+    if (typeof value.id === "string") prov.id = value.id;
+    if (typeof value.runId === "string") prov.runId = value.runId;
+    return prov;
+  }
+  return { kind: "user" };
 }
 
 /**
@@ -201,6 +266,19 @@ export async function releaseCredentialRefs(
  * @param preview When `true` (preview-mode execution) the vault write is skipped
  *   and a no-op placeholder ref is stored instead. See {@link storeCredential}.
  *   Vault releases are also skipped in preview mode.
+ * @param deferRelease When `true`, the release of the PRIOR ref (clear / rotate)
+ *   is SKIPPED — it is deferred to a lifecycle transition (publish releases the
+ *   replaced canonical ref; discard releases the draft-minted ref). The
+ *   deferred-release credential commands (CreateDataSource/SetDataSourceConfig)
+ *   pass this; the legacy coarse handlers leave it `false` (synchronous release).
+ *
+ * **Ref pass-through (capture-before-log):** when `value` is already a
+ * `SecretRef` — the credential was captured to a ref before the command was
+ * snapshotted into `draft_command_log`, or the command is being replayed from
+ * that log on publish — it is ADOPTED verbatim, never re-stored. Re-storing a ref
+ * string would double-wrap it as plaintext (the historical rotate-branch trap)
+ * AND write the ref into the durable log. Pass-through is the seam that keeps
+ * plaintext out of the log.
  */
 export async function applyCredentialField(
   config: DataSourceConfig,
@@ -209,23 +287,33 @@ export async function applyCredentialField(
   vault: SecretVault | undefined,
   locatorHint: string,
   preview = false,
+  deferRelease = false,
 ): Promise<void> {
   if (value === undefined) return; // not part of this write
+  const prior = config[field];
   if (value.length === 0) {
     // CLEAR branch: release the prior vault ref before dropping the config key.
-    // Only attempted in commit mode — preview transactions roll back and must not
-    // produce keychain side-effects.
-    if (!preview) {
-      await releaseCredentialRefs({ [field]: config[field] }, vault);
+    // Release is skipped in preview (rolled back) and when deferred to a
+    // transition (the publish/discard path releases the prior ref instead).
+    if (!preview && !deferRelease) {
+      await releaseCredentialRefs({ [field]: prior }, vault);
     }
     delete config[field]; // explicit clear
     return;
   }
-  // ROTATE branch: capture prior ref before overwriting, store new first,
-  // then release old (store-new-then-release-old preserves the new secret on failure).
-  const prior = config[field];
-  config[field] = await storeCredential(vault, value, locatorHint, preview);
-  if (!preview) {
+  if (isSecretRef(value)) {
+    // PASS-THROUGH: the value is already a vault ref (captured before the log
+    // snapshot, or replayed from the durable log). Adopt it; never re-store.
+    config[field] = value;
+  } else {
+    // ROTATE/SET branch: plaintext → store, adopt the returned ref.
+    // store-new-first preserves the new secret if a later release fails.
+    config[field] = await storeCredential(vault, value, locatorHint, preview);
+  }
+  // Release the prior ref unless it is unchanged (idempotent re-set of the same
+  // ref — releasing it would destroy the live secret the new config points at),
+  // skipped in preview, or deferred to a lifecycle transition.
+  if (!preview && !deferRelease && prior !== config[field]) {
     await releaseCredentialRefs({ [field]: prior }, vault);
   }
 }


### PR DESCRIPTION
Implements the safe foundation for assistant-authored DataSources with user-supplied credentials — everything EXCEPT the agent allow-list flip (sibling YW-346, gated on this). A credential is stored as a vault **ref**; the draft carries the ref, never plaintext; ref releases happen at lifecycle **transitions** (publish/discard), never synchronously inside a draft and never via a vault-wide scan (the SecretVault no-`list()` invariant stays intact).

Built on top of #185's publish path (draft-lifecycle RPCs + sub-tracker write relay). Path is built but NOT yet agent-reachable (allow-list unchanged).

Tracked internally as YW-345.

## Changes

- **Capture-before-log** — a host-injected pre-bind seam on `appendToDraft` rewrites plaintext credential args to vault refs BEFORE the command is snapshotted into `draft_command_log`, so the durable log carries a ref. Atomic + reversible: capture returns a rollback the controller invokes if a command fails before the batch is logged (no orphan-on-append-failure).
- **Ref-carrying commands** — `applyCredentialField` adopts an existing ref verbatim (no re-store / double-wrap).
- **Drop synchronous release on the draft path** — `createDataSource`/`setDataSourceConfig` defer prior-ref release on the draft + publish-replay paths; a direct canonical call keeps synchronous release.
- **Transition-time release** — the publish/discard RPCs release the replaced (publish, POST-commit) or draft-minted (discard) refs, gated by a cross-draft-reference check over canonical config + other open drafts' shadow/log.
- **Agent provenance** — `createDataSource` stamps `createdBy` from the emitted command (survives the publish log replay), defaulting to user.
- New module `apps/server/src/credential-release.ts` holds the capture + transition-release mechanism; the generic `DraftController` stays free of credential knowledge.

## Screenshots

No UI change — backend (server) only.

## Verification

- New `credential-release.test.ts` (10 tests) exercises each security invariant end-to-end through the real controller + draft RPCs with a TestBackend-backed vault:
  - plaintext never at rest in `draft_command_log.args` (logged ref resolves to the plaintext, no double-wrap);
  - no synchronous release on the draft path;
  - publish releases only the replaced canonical ref; read DTO never surfaces a raw ref;
  - discard releases only draft-minted refs, never a live secret;
  - cross-draft safety (a ref another open draft's shadow references survives);
  - publish ROLLBACK (duplicate-PK replay) leaves the canonical secret intact (release is post-commit);
  - `CREDENTIAL_COMMAND_FIELDS` exhaustiveness derived from arg schemas (capture can't silently drift);
  - capture rollback releases minted refs; agent provenance round-trips to canonical.
- Full `@dashframe/server` suite: 318 passing. Full-graph `turbo typecheck` (48 packages) + server lint clean.
- A focused independent opus review confirmed all five security invariants hold; its MUST (exhaustiveness) and SHOULD (orphan-on-failure) findings are resolved in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEqGF2sCLDZhm8yNWZWwxw

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR builds the credential vault-ref lifecycle for the agent write path: plaintext credential args are captured into vault refs before being snapshotted to `draft_command_log` (capture-before-log), and refs are released at lifecycle transitions (publish/discard) rather than synchronously during a draft append.

- **Capture-before-log** (`credential-release.ts`, `draft-controller.ts`): `captureCommandCredentials` rewrites plaintext args to refs before the handler runs; a rollback armed across both handler execution and log persistence releases minted refs on any pre-log failure.
- **Transition-time release** (`draft-lifecycle.ts`): publish collects superseded canonical refs (log-driven, pre-commit) and releases them post-commit; discard collects refs from both the log AND the shadow (to catch inherited refs) and releases them post-discard \u2014 both gated on snapshot persistence and cross-draft reference checks.
- **Deferred vs. synchronous release** (`functions/utils.ts`, `functions/commands.ts`): `shouldDeferRelease` distinguishes draft-append and publish-replay paths (defer) from direct canonical calls (release synchronously); `applyCredentialField` gains a ref-pass-through branch that prevents double-wrapping on the deferred path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the inherited-shadow-ref gap noted; no plaintext escapes to the log and no live secret is ever synchronously deleted.

The design is sound and the five core security invariants are well-tested. One gap: when a draft publishes and its shadow is dropped, any credential ref the shadow inherited (but whose field the draft never commanded on) is never added to the publish release candidates, becoming a permanent vault orphan. The discard path explicitly reads the shadow via collectDiscardCandidateRefs for exactly this reason, but the publish path only calls collectSupersededRefs (log-only). An old credential rotated via one draft can remain in the vault indefinitely if a concurrently open non-credential-change draft later publishes.

apps/server/src/functions/draft-lifecycle.ts (publish half of transition-time release) and apps/server/src/credential-release.ts (collectSupersededRefs) need the shadow-read extension analogous to what collectDiscardCandidateRefs already does.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/credential-release.ts | New module implementing capture-before-log and transition-time ref release. The discard path correctly reads log + shadow for candidates, but the publish path (collectSupersededRefs) is log-only, orphaning inherited shadow refs when a non-credential-command draft publishes and its shadow is dropped. |
| apps/server/src/functions/draft-lifecycle.ts | Adds transition-time credential release to publishDraft and discardDraft. The publish path calls only collectSupersededRefs (log-only), while the discard path calls collectDiscardCandidateRefs (log + shadow) — creating an asymmetry that leaks inherited shadow refs on publish. |
| apps/server/src/draft-controller.ts | Integrates capture-before-log with a catch-all rollback that spans both handler execution and log persistence, ensuring minted refs are released on any failure before the durable log write commits. |
| apps/server/src/functions/commands.ts | Adds createdBy arg to createDataSource, defers prior-ref release via shouldDeferRelease, and exports CREDENTIAL_COMMAND_FIELDS as the single source of truth for credential-bearing arg fields. |
| apps/server/src/functions/utils.ts | Adds context-signal helpers (inDraftContext, isPublishReplay, shouldDeferRelease), coerceProvenance with an explicit caller-asserted disclaimer, and updates applyCredentialField with ref-pass-through on the deferred path and synchronous release on direct calls. |
| apps/server/src/credential-release.test.ts | Comprehensive test suite covering 10+ security invariants including plaintext-never-at-rest, cross-draft protection, rollback, and provenance. Missing a publish-path test for the inherited-shadow-ref orphan scenario (covered only for discard at line 435). |
| apps/server/src/app.ts | Injects captureCommandCredentials as the captureCredentials hook on createDraftController; straightforward wiring change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant DraftController
    participant CaptureHook as captureCommandCredentials
    participant Vault
    participant DB
    participant PublishRPC as publishDraft RPC

    Client->>DraftController: appendToDraft([cmd with plaintext])
    DraftController->>CaptureHook: captureCommandCredentials(cmd)
    CaptureHook->>Vault: "store(plaintext) -> SecretRef"
    CaptureHook-->>DraftController: "{command: cmd_with_ref, rollback}"
    DraftController->>DB: runHandler(cmd_with_ref) shadow updated
    alt handler or log write fails
        DraftController->>CaptureHook: rollback()
        CaptureHook->>Vault: delete(minted ref)
    else success
        DraftController->>DB: writeLog(cmd_with_ref)
        DraftController-->>Client: result
    end

    Client->>PublishRPC: publishDraft(draftId)
    PublishRPC->>DB: collectSupersededRefs(log) supersededRefs
    Note over PublishRPC,DB: reads pre-publish canonical state (log-only)
    PublishRPC->>DraftController: "publishDraft(draftId, {__publishReplay: true})"
    DraftController->>DB: replay log onto canonical (atomic tx)
    DB-->>DraftController: committed
    PublishRPC->>DB: onWrite() snapshot persisted
    PublishRPC->>DB: collectReferencedRefs(exclude draftId)
    PublishRPC->>Vault: delete(supersededRefs minus referencedSet)

    Client->>PublishRPC: discardDraft(draftId)
    PublishRPC->>DB: collectDiscardCandidateRefs(log + shadow)
    Note over PublishRPC,DB: reads BOTH log and shadow for inherited refs
    PublishRPC->>DraftController: discardDraft(draftId)
    DraftController->>DB: drop log + shadow rows
    PublishRPC->>DB: onWrite() snapshot persisted
    PublishRPC->>DB: collectReferencedRefs(exclude draftId)
    PublishRPC->>Vault: delete(mintedRefs minus referencedSet)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant DraftController
    participant CaptureHook as captureCommandCredentials
    participant Vault
    participant DB
    participant PublishRPC as publishDraft RPC

    Client->>DraftController: appendToDraft([cmd with plaintext])
    DraftController->>CaptureHook: captureCommandCredentials(cmd)
    CaptureHook->>Vault: "store(plaintext) -> SecretRef"
    CaptureHook-->>DraftController: "{command: cmd_with_ref, rollback}"
    DraftController->>DB: runHandler(cmd_with_ref) shadow updated
    alt handler or log write fails
        DraftController->>CaptureHook: rollback()
        CaptureHook->>Vault: delete(minted ref)
    else success
        DraftController->>DB: writeLog(cmd_with_ref)
        DraftController-->>Client: result
    end

    Client->>PublishRPC: publishDraft(draftId)
    PublishRPC->>DB: collectSupersededRefs(log) supersededRefs
    Note over PublishRPC,DB: reads pre-publish canonical state (log-only)
    PublishRPC->>DraftController: "publishDraft(draftId, {__publishReplay: true})"
    DraftController->>DB: replay log onto canonical (atomic tx)
    DB-->>DraftController: committed
    PublishRPC->>DB: onWrite() snapshot persisted
    PublishRPC->>DB: collectReferencedRefs(exclude draftId)
    PublishRPC->>Vault: delete(supersededRefs minus referencedSet)

    Client->>PublishRPC: discardDraft(draftId)
    PublishRPC->>DB: collectDiscardCandidateRefs(log + shadow)
    Note over PublishRPC,DB: reads BOTH log and shadow for inherited refs
    PublishRPC->>DraftController: discardDraft(draftId)
    DraftController->>DB: drop log + shadow rows
    PublishRPC->>DB: onWrite() snapshot persisted
    PublishRPC->>DB: collectReferencedRefs(exclude draftId)
    PublishRPC->>Vault: delete(mintedRefs minus referencedSet)
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/1630b7d22043ef11b8a2f211db56ffbabaec867e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40348244)</sub>

<!-- /greptile_comment -->