### PR TITLE
fix(engine-server): serialize registerArrowTable to fix concurrent-registration race

### DIFF
--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -400,7 +400,8 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
         ];
       });
 
-      await expect(Promise.all(tasks)).resolves.not.toThrow();
+      // If any registration rejects, Promise.all rejects and the test fails.
+      await Promise.all(tasks);
 
       for (const { name, expectedCounts } of uploads) {
         const result = await engine!.query(

--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -316,10 +316,15 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
     });
 
     it("does not corrupt concurrent registrations of the same table name", async () => {
-      // Two in-flight registrations of the same live table must not clobber
-      // each other's staging table mid-append. Per-call unique staging names
-      // isolate them; the live table ends with one upload's full contents
-      // (last-writer-wins), never a partial/mixed result or a thrown error.
+      // Two in-flight registrations of the same live table must not corrupt
+      // each other. The global registration lock serializes them; the live table
+      // ends with one upload's complete rows (last-writer-wins), never a mix or
+      // a thrown error.
+      //
+      // The NAPI pending-result taint (the corruption mechanism) is Linux-only;
+      // this test passes on macOS regardless of the fix. It documents the
+      // contract and fires on Linux CI as the discriminating run. A higher-
+      // concurrency stress variant below maximises interleaving on both platforms.
       engine = new NativeDuckDBEngine();
 
       const bufferA = tableToIPC(
@@ -352,6 +357,64 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
          WHERE table_name LIKE '__staging_df_concurrent%'`,
       );
       expect(Number(staging.rows[0]?.cnt)).toBe(0);
+    });
+
+    it("handles high-concurrency registrations without corruption or error", async () => {
+      // Stress variant: 8 concurrent uploads across 4 distinct table names
+      // (2 per name) maximise lock-queue depth and appender interleaving.
+      // Contract: each named table ends with one upload's complete row count;
+      // no thrown errors; no leaked staging tables.
+      //
+      // Like the 2-way variant above, the NAPI taint is Linux-only; the
+      // structural argument (global serialization lock) is the durable proof.
+      engine = new NativeDuckDBEngine();
+
+      const uploads: Array<{ name: string; expectedCounts: number[] }> = [
+        { name: "df_stress_a", expectedCounts: [10, 20] },
+        { name: "df_stress_b", expectedCounts: [15, 25] },
+        { name: "df_stress_c", expectedCounts: [12, 30] },
+        { name: "df_stress_d", expectedCounts: [8, 40] },
+      ];
+
+      const tasks = uploads.flatMap(({ name, expectedCounts }) => {
+        const [countA, countB] = expectedCounts;
+        const bufA = tableToIPC(
+          new Table({
+            v: vectorFromArray(
+              Array.from({ length: countA! }, (_, i) => i),
+              new Int32(),
+            ),
+          }),
+        );
+        const bufB = tableToIPC(
+          new Table({
+            v: vectorFromArray(
+              Array.from({ length: countB! }, (_, i) => i + 100),
+              new Int32(),
+            ),
+          }),
+        );
+        return [
+          engine!.registerArrowTable(name, bufA),
+          engine!.registerArrowTable(name, bufB),
+        ];
+      });
+
+      await expect(Promise.all(tasks)).resolves.not.toThrow();
+
+      for (const { name, expectedCounts } of uploads) {
+        const result = await engine!.query(
+          `SELECT COUNT(*) AS cnt FROM "${name}"`,
+        );
+        expect(expectedCounts).toContain(Number(result.rows[0]?.cnt));
+      }
+
+      // No staging tables should survive.
+      const leaked = await engine!.query(
+        `SELECT COUNT(*) AS cnt FROM duckdb_tables()
+         WHERE table_name LIKE '__staging_%'`,
+      );
+      expect(Number(leaked.rows[0]?.cnt)).toBe(0);
     });
   });
 });

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -73,6 +73,21 @@ export class NativeDuckDBEngine implements QueryEngine {
    * answer `hasTable`/`getTableNames` without an async DB round-trip.
    */
   private _registeredTables = new Set<string>();
+  /**
+   * Global serializer for `registerArrowTable`. DuckDB appenders are not
+   * concurrent-safe on a shared connection — two in-flight registrations sharing
+   * `this.connection` can trigger the "pending-result" NAPI taint that kills the
+   * next operation (same mechanism as YW-307, concurrent-registration path).
+   *
+   * The lock is a promise chain: each caller captures the previous tail, then
+   * installs a new tail whose resolution (`unlock`) it calls in `finally`. Only
+   * one registration runs at a time; arrivals queue in order.
+   *
+   * Global (not per-name) because the taint is per-connection, not per-table:
+   * two concurrent registrations for *different* names share the same
+   * `this.connection` and race just as badly.
+   */
+  private _registrationLock: Promise<void> = Promise.resolve();
 
   constructor(options: NativeDuckDBEngineOptions = {}) {
     this.databasePath = options.databasePath ?? ":memory:";
@@ -189,103 +204,119 @@ export class NativeDuckDBEngine implements QueryEngine {
    */
   async registerArrowTable(name: string, arrow: Uint8Array): Promise<void> {
     await this.initialize();
+
+    // Serialize all registrations through a global promise-chain lock. DuckDB
+    // appenders are not concurrent-safe on a shared connection — two in-flight
+    // registrations both using `this.connection` can trigger the Linux
+    // "pending-result" NAPI taint (same mechanism as YW-307), corrupting the
+    // next operation on the connection. Global (not per-name): the taint is
+    // per-connection, not per-table, so two different-name concurrent uploads
+    // race just as badly.
+    const gate = this._registrationLock;
+    let unlock!: () => void;
+    this._registrationLock = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    await gate;
+
     const conn = this.conn();
-
-    // Decode the Arrow IPC stream buffer.
-    const arrowTable = tableFromIPC(arrow);
-    const fields = arrowTable.schema.fields;
-    if (fields.length === 0) {
-      throw new Error(`Arrow buffer for table "${name}" has no columns`);
-    }
-
-    // Create a session-scoped TEMP table for staging — if the append fails
-    // partway through, the live table is untouched (atomic all-or-nothing).
-    // TEMP tables are connection-local: DuckDB drops them automatically when
-    // the owning connection closes. On the success path, the explicit DROP after
-    // the swap keeps stale staging tables from accumulating across repeated
-    // registerArrowTable calls. On the failure path, the catch block disconnects
-    // and replaces this.connection, so the staging table is dropped then too.
-    //
-    // The staging name carries a per-call unique suffix. Two concurrent
-    // registrations of the SAME live table would otherwise share one
-    // deterministic staging name and clobber each other's rows mid-append
-    // (CREATE OR REPLACE on the second call drops the first's staging table
-    // while its appender is still flushing) → intermittent failures or wrong
-    // contents. A unique suffix isolates each upload's staging table; the final
-    // CREATE OR REPLACE of the live table is naturally last-writer-wins.
-    const stagingName = `__staging_${name}_${nextStagingId()}`;
-    const columnDefs = fields
-      .map((f) => `${quoteIdent(f.name)} ${arrowFieldToDuckDBType(f)}`)
-      .join(", ");
-    await conn.run(
-      `CREATE OR REPLACE TEMP TABLE ${quoteIdent(stagingName)} (${columnDefs})`,
-    );
-
-    // Stream rows into the staging table — no disk, no string round-trip.
-    const appender = await conn.createAppender(stagingName);
     try {
-      const columns = fields.map((f) => ({
-        field: f,
-        vector: arrowTable.getChild(f.name),
-      }));
-      const rowCount = arrowTable.numRows;
-      for (let i = 0; i < rowCount; i++) {
-        for (const col of columns) {
-          appendArrowValue(appender, col.field, col.vector?.get(i));
-        }
-        appender.endRow();
+      // Decode the Arrow IPC stream buffer.
+      const arrowTable = tableFromIPC(arrow);
+      const fields = arrowTable.schema.fields;
+      if (fields.length === 0) {
+        throw new Error(`Arrow buffer for table "${name}" has no columns`);
       }
-      appender.flushSync();
-    } catch (err) {
-      // Append failed — staging table may be partially written.
+
+      // Create a session-scoped TEMP table for staging — if the append fails
+      // partway through, the live table is untouched (atomic all-or-nothing).
+      // TEMP tables are connection-local: DuckDB drops them automatically when
+      // the owning connection closes. On the success path, the explicit DROP after
+      // the swap keeps stale staging tables from accumulating across repeated
+      // registerArrowTable calls. On the failure path, the catch block disconnects
+      // and replaces this.connection, so the staging table is dropped then too.
+      //
+      // The staging name carries a per-call unique suffix so that the
+      // intermediate per-table catalog entry is distinct per upload even though
+      // only one registration runs at a time (the suffix is still useful if the
+      // same engine is ever queried while a registration is in-flight, and it
+      // documents intent clearly).
+      const stagingName = `__staging_${name}_${nextStagingId()}`;
+      const columnDefs = fields
+        .map((f) => `${quoteIdent(f.name)} ${arrowFieldToDuckDBType(f)}`)
+        .join(", ");
+      await conn.run(
+        `CREATE OR REPLACE TEMP TABLE ${quoteIdent(stagingName)} (${columnDefs})`,
+      );
+
+      // Stream rows into the staging table — no disk, no string round-trip.
+      const appender = await conn.createAppender(stagingName);
+      try {
+        const columns = fields.map((f) => ({
+          field: f,
+          vector: arrowTable.getChild(f.name),
+        }));
+        const rowCount = arrowTable.numRows;
+        for (let i = 0; i < rowCount; i++) {
+          for (const col of columns) {
+            appendArrowValue(appender, col.field, col.vector?.get(i));
+          }
+          appender.endRow();
+        }
+        appender.flushSync();
+      } catch (err) {
+        // Append failed — staging table may be partially written.
+        try {
+          appender.closeSync();
+        } catch {
+          // ignore close error — propagate original
+        }
+        // On Linux, duckdb_appender_close() on a failed appender marks the
+        // connection with a pending-result error. The next duckdb_query() on the
+        // same connection fails with "Attempting to execute an unsuccessful or
+        // closed pending query result" — emitted as an unhandled NAPI-layer
+        // rejection that bypasses the surrounding try/catch.
+        //
+        // `conn` is `this.connection` — the PERSISTENT connection reused for the
+        // whole session (query, queryArrow, registerArrowTable). Leaving it tainted
+        // relocates the flake to the NEXT operation instead of killing it.
+        //
+        // Fix: disconnect the tainted connection and replace it with a fresh one
+        // from the same instance. When the old connection closes, DuckDB drops all
+        // its TEMP tables — including the partial staging table — so the cleanup
+        // also happens for free.
+        try {
+          this.connection!.disconnectSync();
+        } catch {
+          // best-effort — continue to reconnect even if disconnect throws
+        }
+        this.connection = null;
+        try {
+          this.connection = await this.instance!.connect();
+        } catch {
+          // Reconnect failed — engine is unusable; surface on next call via conn()
+        }
+        throw err;
+      }
+      // Flush succeeded — close the appender before the swap.
       try {
         appender.closeSync();
       } catch {
-        // ignore close error — propagate original
+        // close failure after a successful flush must not abort the swap
       }
-      // On Linux, duckdb_appender_close() on a failed appender marks the
-      // connection with a pending-result error. The next duckdb_query() on the
-      // same connection fails with "Attempting to execute an unsuccessful or
-      // closed pending query result" — emitted as an unhandled NAPI-layer
-      // rejection that bypasses the surrounding try/catch.
-      //
-      // `conn` is `this.connection` — the PERSISTENT connection reused for the
-      // whole session (query, queryArrow, registerArrowTable). Leaving it tainted
-      // relocates the flake to the NEXT operation instead of killing it.
-      //
-      // Fix: disconnect the tainted connection and replace it with a fresh one
-      // from the same instance. When the old connection closes, DuckDB drops all
-      // its TEMP tables — including the partial staging table — so the cleanup
-      // also happens for free.
-      try {
-        this.connection!.disconnectSync();
-      } catch {
-        // best-effort — continue to reconnect even if disconnect throws
-      }
-      this.connection = null;
-      try {
-        this.connection = await this.instance!.connect();
-      } catch {
-        // Reconnect failed — engine is unusable; surface on next call via conn()
-      }
-      throw err;
-    }
-    // Flush succeeded — close the appender before the swap.
-    try {
-      appender.closeSync();
-    } catch {
-      // close failure after a successful flush must not abort the swap
-    }
 
-    // Atomic swap: replace the live table with the fully-ingested staging copy.
-    // Both DDL statements run in the same connection, so the live table is never
-    // observable in a half-replaced state.
-    await conn.run(
-      `CREATE OR REPLACE TABLE ${quoteIdent(name)} AS SELECT * FROM ${quoteIdent(stagingName)}`,
-    );
-    await conn.run(`DROP TABLE IF EXISTS ${quoteIdent(stagingName)}`);
+      // Atomic swap: replace the live table with the fully-ingested staging copy.
+      // Both DDL statements run in the same connection, so the live table is never
+      // observable in a half-replaced state.
+      await conn.run(
+        `CREATE OR REPLACE TABLE ${quoteIdent(name)} AS SELECT * FROM ${quoteIdent(stagingName)}`,
+      );
+      await conn.run(`DROP TABLE IF EXISTS ${quoteIdent(stagingName)}`);
 
-    this._registeredTables.add(name);
+      this._registeredTables.add(name);
+    } finally {
+      unlock();
+    }
   }
 
   async registerTable(_name: string, _dataFrame: DataFrame): Promise<void> {

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -77,7 +77,7 @@ export class NativeDuckDBEngine implements QueryEngine {
    * Global serializer for `registerArrowTable`. DuckDB appenders are not
    * concurrent-safe on a shared connection — two in-flight registrations sharing
    * `this.connection` can trigger the "pending-result" NAPI taint that kills the
-   * next operation (same mechanism as YW-307, concurrent-registration path).
+   * next operation on the connection.
    *
    * The lock is a promise chain: each caller captures the previous tail, then
    * installs a new tail whose resolution (`unlock`) it calls in `finally`. Only
@@ -208,7 +208,7 @@ export class NativeDuckDBEngine implements QueryEngine {
     // Serialize all registrations through a global promise-chain lock. DuckDB
     // appenders are not concurrent-safe on a shared connection — two in-flight
     // registrations both using `this.connection` can trigger the Linux
-    // "pending-result" NAPI taint (same mechanism as YW-307), corrupting the
+    // "pending-result" NAPI taint on the shared connection, corrupting the
     // next operation on the connection. Global (not per-name): the taint is
     // per-connection, not per-table, so two different-name concurrent uploads
     // race just as badly.

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -219,8 +219,8 @@ export class NativeDuckDBEngine implements QueryEngine {
     });
     await gate;
 
-    const conn = this.conn();
     try {
+      const conn = this.conn();
       // Decode the Arrow IPC stream buffer.
       const arrowTable = tableFromIPC(arrow);
       const fields = arrowTable.schema.fields;


### PR DESCRIPTION
Fixes the intermittent \`"Attempting to execute an unsuccessful or closed pending query result"\` flake in the **"does not corrupt concurrent registrations of the same table name"** test — the same NAPI taint mechanism as YW-307, but on the concurrent-registration path that YW-307's atomic-ingest fix did not cover.

## Changes

- **\`native-engine.ts\`**: Added a global promise-chain registration lock (\`_registrationLock\`). Each \`registerArrowTable()\` call awaits the previous tail before entering the body, so only one appender is ever open on \`this.connection\` at a time. Global (not per-name): the NAPI taint is per-connection, so two concurrent uploads for *different* table names race just as badly. YW-307's catch-block disconnect+reconnect is retained unchanged for the single-registration appender-failure path.
- **\`native-engine.test.ts\`**: Existing 2-way concurrent test comment updated to document the macOS/Linux distinction. New \`"handles high-concurrency registrations"\` stress test: 8 simultaneous uploads across 4 table names maximises lock-queue depth and interleaving.

## Root cause

Two concurrent \`registerArrowTable()\` calls both captured \`this.connection\` via \`this.conn()\`. On Linux, \`duckdb_appender_close()\` on a failed (or racing) appender marks the connection with a pending-result error. The second concurrent appender's \`flushSync()\` then hits that error — emitted as an unhandled NAPI-layer rejection bypassing the surrounding \`try/catch\`. Same mechanism as YW-307; different trigger (concurrent appenders vs. single failed append).

## Screenshots

No UI change — \`engine-server\` internals only.

## Verification

**25/25 consecutive local passes** (macOS arm64):
\`\`\`
=== RESULT: 25/25 passed, 0/25 failed ===
\`\`\`
Run: \`for i in $(seq 1 25); do npx vitest run src/native-engine.test.ts; done\` in \`packages/engine-server\`.

**macOS note**: The NAPI pending-result taint is Linux-only; macOS appender state is not corrupted by concurrent usage, so the test passes on macOS regardless of the fix. The 25/25 confirms no regression on the success path and that the serialization lock itself is correct. **Linux CI is the discriminating run** — the structural argument is that only one appender can be open on \`this.connection\` at a time, which eliminates the concurrent-access root cause.

YW-307's atomic-ingest regression test (\`"atomic ingest — a failed append leaves the prior table intact"\`) still passes — 21/21 tests green.

Tracked internally as YW-353.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR serializes `registerArrowTable` calls behind a global promise-chain lock (`_registrationLock`) to prevent the DuckDB NAPI "pending-result" taint that occurs when two concurrent appenders share the same connection on Linux. A complementary stress test (8 concurrent uploads across 4 table names) is added alongside an updated comment on the existing 2-way concurrent test.

- **`native-engine.ts`**: Adds a `_registrationLock` promise-chain field; each `registerArrowTable` call enqueues itself, awaits the previous tail, and releases via `finally { unlock() }`. The `conn()` call is placed inside the `try` block so lock release is guaranteed even if a prior failed registration left `this.connection` null and reconnect also fails.
- **`native-engine.test.ts`**: Updates the 2-way concurrency test comment to document the macOS/Linux behaviour difference; adds a new high-concurrency (8-way) stress test that verifies correct row counts and no leaked staging tables after all registrations complete.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the lock is structurally sound, and the two concerns from the prior review round (lock leak on conn() throw, ticket IDs in source) have both been addressed in this revision.

The promise-chain lock is correctly implemented: each caller enqueues before awaiting, and conn() is inside the try block so finally { unlock() } fires even when a previous registration ended in a failed reconnect. No YW-/TASK- identifiers remain in any source file. The disconnect-and-reconnect recovery path is unchanged and still interacts correctly with the lock. The new 8-way stress test adds meaningful coverage.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/engine-server/src/native-engine.ts | Adds a correct promise-chain serialization lock around registerArrowTable; conn() is safely inside try/finally; no ticket-ID references remain; disconnect/reconnect error-recovery path is unchanged and works correctly with the new lock. |
| packages/engine-server/src/native-engine.test.ts | Adds an 8-way concurrent stress test that validates last-writer-wins semantics and absence of leaked staging tables; existing 2-way test comment updated with Linux/macOS platform notes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant Lock as _registrationLock
    participant DB as DuckDB Connection

    C1->>Lock: capture gate (resolved), install new tail P1
    C1->>Lock: await gate (resolves immediately)
    C2->>Lock: "capture gate = P1, install new tail P2"
    C2->>Lock: await gate P1 (blocks)

    Note over C1,DB: C1 holds the lock
    C1->>DB: conn() → CREATE TEMP TABLE staging_A_1
    C1->>DB: createAppender + flushSync
    C1->>DB: "CREATE OR REPLACE TABLE A AS SELECT * FROM staging_A_1"
    C1->>DB: DROP TABLE staging_A_1
    C1->>Lock: finally → unlock() resolves P1

    Note over C2,DB: C2 now holds the lock
    C2->>DB: conn() → CREATE TEMP TABLE staging_A_2
    C2->>DB: createAppender + flushSync
    C2->>DB: "CREATE OR REPLACE TABLE A AS SELECT * FROM staging_A_2"
    C2->>DB: DROP TABLE staging_A_2
    C2->>Lock: finally → unlock() resolves P2
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant Lock as _registrationLock
    participant DB as DuckDB Connection

    C1->>Lock: capture gate (resolved), install new tail P1
    C1->>Lock: await gate (resolves immediately)
    C2->>Lock: "capture gate = P1, install new tail P2"
    C2->>Lock: await gate P1 (blocks)

    Note over C1,DB: C1 holds the lock
    C1->>DB: conn() → CREATE TEMP TABLE staging_A_1
    C1->>DB: createAppender + flushSync
    C1->>DB: "CREATE OR REPLACE TABLE A AS SELECT * FROM staging_A_1"
    C1->>DB: DROP TABLE staging_A_1
    C1->>Lock: finally → unlock() resolves P1

    Note over C2,DB: C2 now holds the lock
    C2->>DB: conn() → CREATE TEMP TABLE staging_A_2
    C2->>DB: createAppender + flushSync
    C2->>DB: "CREATE OR REPLACE TABLE A AS SELECT * FROM staging_A_2"
    C2->>DB: DROP TABLE staging_A_2
    C2->>Lock: finally → unlock() resolves P2
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(engine-server): plug registration-lo..."](https://github.com/youhaowei/dashframe/commit/4b5e748acff63a469840f8ad8aa88f9462b652d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40351754)</sub>

<!-- /greptile_comment -->