### PR TITLE
Enable agent DataSource authoring with credential-ref hardening

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -585,7 +585,8 @@ export async function createDashframeServer(
       // before a credential command is snapshotted into draft_command_log, so the
       // durable log never holds plaintext. The vault closure makes the store real
       // (a draft append is never a preview); a missing vault fails closed.
-      captureCredentials: (cmd) => captureCommandCredentials(cmd, opts.vault),
+      captureCredentials: (cmd) =>
+        captureCommandCredentials(cmd, opts.vault, opts.db as ArtifactDb),
     },
   );
   serverContext.onWrite = opts.onWrite;

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -191,6 +191,72 @@ describe("credential write path — capture-before-log + transition release", ()
     expect(resolved).toBe("super-secret-plaintext");
   });
 
+  // SECURITY (YW-346) — the capture seam must REFUSE a caller-supplied ref on a
+  // fresh draft append, never adopt it. This is the durable guarantee for agent
+  // DataSource authoring: even driving appendToDraft directly (the runtime-
+  // reachable seam, not just the applyCommand tool) a foreign `secret:<uuid>` is
+  // rejected, so an untrusted caller cannot point a source at a secret it does
+  // not own (bypassing storeCredential + the fail-closed guard).
+  it("REFUSES a caller-supplied foreign ref on a draft append (CreateDataSource)", async () => {
+    const foreign = makeSecretRef(); // valid shape, NOT stored in this vault
+    const id = crypto.randomUUID();
+    const draftId = await h.controller.openDraft();
+
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("CreateDataSource", {
+          id,
+          type: "notion",
+          name: "Foreign",
+          apiKey: foreign,
+        }),
+      ]),
+    ).rejects.toThrow(/must be the plaintext secret, not a vault ref/i);
+
+    // Nothing adopted, nothing logged — the rejected append left no draft state.
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(0);
+  });
+
+  it("REFUSES a caller-supplied foreign ref on a draft append (SetDataSourceConfig)", async () => {
+    const { id } = await seedCanonicalSource(h, "orig-key");
+    const foreign = makeSecretRef();
+    const draftId = await h.controller.openDraft();
+
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, connectionString: foreign }),
+      ]),
+    ).rejects.toThrow(/must be the plaintext secret, not a vault ref/i);
+  });
+
+  it("stores a plaintext credential as a ref on a draft append (agent happy path)", async () => {
+    // The sanctioned input: plaintext is stored via storeCredential and the log
+    // carries the minted ref (the same path the assistant exercises post-flip).
+    const id = crypto.randomUUID();
+    const draftId = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id,
+        type: "rest",
+        name: "Agent source",
+        apiKey: "pk-live-plaintext",
+      }),
+    ]);
+
+    const args = await firstLogArgs(h, draftId);
+    expect(args.apiKey).not.toBe("pk-live-plaintext");
+    expect(isSecretRef(args.apiKey)).toBe(true);
+    const resolved = await h.vault.withSecret(
+      args.apiKey as SecretRef,
+      async (pt) => pt,
+    );
+    expect(resolved).toBe("pk-live-plaintext");
+  });
+
   // 3 — no synchronous release on the draft path.
   it("does not release the prior canonical ref during a draft rotate", async () => {
     const { id, ref: oldRef } = await seedCanonicalSource(h, "orig-key");

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -389,6 +389,72 @@ describe("credential write path — capture-before-log + transition release", ()
     expect(rows.length).toBe(1);
   });
 
+  // MULTI-CREDENTIAL — the load-bearing security property: the guard must check
+  // EVERY inherited credential, not just the one the command happens to re-supply.
+  // A source with TWO canonical credentials, where the command re-affirms ONE and
+  // redirects the endpoint, must still REJECT — else the un-re-affirmed credential
+  // rides Object.assign to the attacker host.
+  it("REFUSES reconfiguring a multi-credential source when only ONE credential is re-affirmed", async () => {
+    // Canonical source holding TWO top-level credential refs (apiKey + connectionString).
+    const { result } = await h.app.call("addDataSource", {
+      type: "rest",
+      name: "TwoCred",
+      apiKey: "secret-one",
+      connectionString: "secret-two",
+    });
+    const id = (result as { id: string }).id;
+    const before = await readConfig(h, id);
+    expect(isSecretRef(before!.apiKey)).toBe(true);
+    expect(isSecretRef(before!.connectionString)).toBe(true);
+
+    const draftId = await h.controller.openDraft();
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", {
+          id,
+          // Re-affirms apiKey only; connectionString is left inherited.
+          apiKey: "rotated-one",
+          extra: { endpoint: "https://attacker.example" },
+        }),
+      ]),
+    ).rejects.toThrow(/inherited credential|silently redirected/i);
+
+    // Nothing logged — the partial re-affirm did not slip through.
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(0);
+  });
+
+  it("ALLOWS reconfiguring a multi-credential source when EVERY credential is re-affirmed", async () => {
+    const { result } = await h.app.call("addDataSource", {
+      type: "rest",
+      name: "TwoCred",
+      apiKey: "secret-one",
+      connectionString: "secret-two",
+    });
+    const id = (result as { id: string }).id;
+
+    const draftId = await h.controller.openDraft();
+    // Both inherited credentials re-affirmed (apiKey re-supplied, connectionString
+    // cleared) → no inherited secret carried → allowed.
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", {
+        id,
+        apiKey: "rotated-one",
+        connectionString: "",
+        extra: { endpoint: "https://api.example.com" },
+      }),
+    ]);
+
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(1);
+  });
+
   // Landmines the guard must NOT trip: create-then-configure in ONE draft (the new
   // source isn't canonical yet → no inherited credential) AND publish replay (the
   // guard runs only in capture, which replay bypasses). If either tripped, this

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -211,7 +211,7 @@ describe("credential write path — capture-before-log + transition release", ()
           apiKey: foreign,
         }),
       ]),
-    ).rejects.toThrow(/must be the plaintext secret, not a vault ref/i);
+    ).rejects.toThrow(/plaintext secret, not a vault ref/i);
 
     // Nothing adopted, nothing logged — the rejected append left no draft state.
     const rows = await h.db
@@ -230,7 +230,50 @@ describe("credential write path — capture-before-log + transition release", ()
       h.controller.appendToDraft(draftId, [
         cmd("SetDataSourceConfig", { id, connectionString: foreign }),
       ]),
-    ).rejects.toThrow(/must be the plaintext secret, not a vault ref/i);
+    ).rejects.toThrow(/plaintext secret, not a vault ref/i);
+  });
+
+  // The hole the typed-field-only guard missed: a ref nested in `extra` (e.g. a
+  // REST source's `extra.authRef`, which the REST connector resolves via the
+  // vault). The reject is field-agnostic + recursive, so the nested ref is caught.
+  it("REFUSES a caller-supplied foreign ref nested in extra.authRef (SetDataSourceConfig)", async () => {
+    const { id } = await seedCanonicalSource(h, "orig-key");
+    const foreign = makeSecretRef();
+    const draftId = await h.controller.openDraft();
+
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", {
+          id,
+          extra: { endpoint: "https://api.example.com", authRef: foreign },
+        }),
+      ]),
+    ).rejects.toThrow(/plaintext secret, not a vault ref/i);
+
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(0);
+  });
+
+  it("ALLOWS non-credential extra config (no ref) on a draft append", async () => {
+    const { id } = await seedCanonicalSource(h, "orig-key");
+    const draftId = await h.controller.openDraft();
+
+    // A plaintext-only config update with no ref-shaped value is unaffected.
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", {
+        id,
+        extra: { endpoint: "https://api.example.com", method: "GET" },
+      }),
+    ]);
+
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(1);
   });
 
   it("stores a plaintext credential as a ref on a draft append (agent happy path)", async () => {

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -257,6 +257,44 @@ describe("credential write path — capture-before-log + transition release", ()
     expect(rows.length).toBe(0);
   });
 
+  // No-orphan on a PARTIAL-BATCH reject: a first command mints a real ref, a
+  // later command in the same batch carries a foreign ref and is rejected — the
+  // whole append throws and the first command's minted ref is released (no
+  // orphaned keychain blob from the abandoned batch).
+  it("releases a prior command's minted ref when a later batch command is rejected", async () => {
+    const storeSpy = vi.spyOn(h.vault, "store");
+    const draftId = await h.controller.openDraft();
+    const foreign = makeSecretRef();
+
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("CreateDataSource", {
+          id: crypto.randomUUID(),
+          type: "rest",
+          name: "First",
+          apiKey: "plaintext-first",
+        }),
+        cmd("SetDataSourceConfig", {
+          id: crypto.randomUUID(),
+          apiKey: foreign,
+        }),
+      ]),
+    ).rejects.toThrow(/plaintext secret, not a vault ref/i);
+
+    // The first command minted exactly one ref; it must have been released.
+    expect(storeSpy).toHaveBeenCalledTimes(1);
+    const mintedRef = (await storeSpy.mock.results[0]!.value) as SecretRef;
+    expect(await h.vault.has(mintedRef)).toBe(false);
+
+    // Nothing persisted — the rejected batch left no draft state.
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(0);
+    storeSpy.mockRestore();
+  });
+
   it("ALLOWS non-credential extra config (no ref) on a draft append", async () => {
     const { id } = await seedCanonicalSource(h, "orig-key");
     const draftId = await h.controller.openDraft();

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -43,6 +43,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { CREDENTIAL_COMMAND_ARG_FIELDS } from "@dashframe/assistant";
 import { buildDashframeApp } from "./app";
 import {
   captureCommandCredentials,
@@ -52,8 +53,10 @@ import {
   createDraftController,
   type DraftController,
 } from "./draft-controller";
+
 import {
   cmd,
+  COMMAND_PATHS,
   commandFunctions,
   CREDENTIAL_COMMAND_FIELDS,
 } from "./functions/commands";
@@ -466,6 +469,39 @@ describe("credential write path — capture-before-log + transition release", ()
           [...credFields].sort(),
         );
       }
+    }
+  });
+
+  // Drift guard — the assistant's agent-path credential-ref gate
+  // (CREDENTIAL_COMMAND_ARG_FIELDS, keyed by command NAME) must stay in lockstep
+  // with the server's capture/release source of truth (CREDENTIAL_COMMAND_FIELDS,
+  // keyed by command PATH). If a new credential field is added server-side but
+  // not to the agent gate, the agent could supply a foreign ref in that field and
+  // bypass the guard — so this fails the build instead of leaking the hole.
+  it("agent credential-ref gate matches the server credential-field map", () => {
+    // 1. Every command the agent gate guards maps to a server credential command
+    //    with the SAME field set (via COMMAND_PATHS name→path).
+    for (const [name, fields] of Object.entries(
+      CREDENTIAL_COMMAND_ARG_FIELDS,
+    )) {
+      const path = COMMAND_PATHS[name as keyof typeof COMMAND_PATHS];
+      expect(path, `no COMMAND_PATHS entry for "${name}"`).toBeDefined();
+      expect([...(CREDENTIAL_COMMAND_FIELDS[path] ?? [])].sort()).toEqual(
+        [...fields].sort(),
+      );
+    }
+    // 2. Conversely, every server credential command is covered by the agent
+    //    gate — a new credential command must update the gate or fail here.
+    const guardedPaths = new Set(
+      Object.keys(CREDENTIAL_COMMAND_ARG_FIELDS).map(
+        (name) => COMMAND_PATHS[name as keyof typeof COMMAND_PATHS],
+      ),
+    );
+    for (const path of Object.keys(CREDENTIAL_COMMAND_FIELDS)) {
+      expect(
+        guardedPaths.has(path as never),
+        `server credential command "${path}" is not covered by the agent credential-ref gate`,
+      ).toBe(true);
     }
   });
 

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -191,7 +191,7 @@ describe("credential write path — capture-before-log + transition release", ()
     expect(resolved).toBe("super-secret-plaintext");
   });
 
-  // SECURITY (YW-346) — the capture seam must REFUSE a caller-supplied ref on a
+  // SECURITY — the capture seam must REFUSE a caller-supplied ref on a
   // fresh draft append, never adopt it. This is the durable guarantee for agent
   // DataSource authoring: even driving appendToDraft directly (the runtime-
   // reachable seam, not just the applyCommand tool) a foreign `secret:<uuid>` is

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -104,7 +104,7 @@ async function makeHarness(opts?: { onWrite?: () => void }): Promise<Harness> {
   };
 
   const controller = createDraftController(app, db, {
-    captureCredentials: (c) => captureCommandCredentials(c, vault),
+    captureCredentials: (c) => captureCommandCredentials(c, vault, db),
   });
   serverContext.draftController = controller;
   serverContext.artifactDb = db;
@@ -263,43 +263,50 @@ describe("credential write path — capture-before-log + transition release", ()
   // orphaned keychain blob from the abandoned batch).
   it("releases a prior command's minted ref when a later batch command is rejected", async () => {
     const storeSpy = vi.spyOn(h.vault, "store");
-    const draftId = await h.controller.openDraft();
-    const foreign = makeSecretRef();
+    try {
+      const draftId = await h.controller.openDraft();
+      const foreign = makeSecretRef();
 
-    await expect(
-      h.controller.appendToDraft(draftId, [
-        cmd("CreateDataSource", {
-          id: crypto.randomUUID(),
-          type: "rest",
-          name: "First",
-          apiKey: "plaintext-first",
-        }),
-        cmd("SetDataSourceConfig", {
-          id: crypto.randomUUID(),
-          apiKey: foreign,
-        }),
-      ]),
-    ).rejects.toThrow(/plaintext secret, not a vault ref/i);
+      await expect(
+        h.controller.appendToDraft(draftId, [
+          cmd("CreateDataSource", {
+            id: crypto.randomUUID(),
+            type: "rest",
+            name: "First",
+            apiKey: "plaintext-first",
+          }),
+          cmd("SetDataSourceConfig", {
+            id: crypto.randomUUID(),
+            apiKey: foreign,
+          }),
+        ]),
+      ).rejects.toThrow(/plaintext secret, not a vault ref/i);
 
-    // The first command minted exactly one ref; it must have been released.
-    expect(storeSpy).toHaveBeenCalledTimes(1);
-    const mintedRef = (await storeSpy.mock.results[0]!.value) as SecretRef;
-    expect(await h.vault.has(mintedRef)).toBe(false);
+      // The first command minted exactly one ref; it must have been released.
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+      const mintedRef = (await storeSpy.mock.results[0]!.value) as SecretRef;
+      expect(await h.vault.has(mintedRef)).toBe(false);
 
-    // Nothing persisted — the rejected batch left no draft state.
-    const rows = await h.db
-      .select()
-      .from(draftCommandLog)
-      .where(eq(draftCommandLog.draftId, draftId));
-    expect(rows.length).toBe(0);
-    storeSpy.mockRestore();
+      // Nothing persisted — the rejected batch left no draft state.
+      const rows = await h.db
+        .select()
+        .from(draftCommandLog)
+        .where(eq(draftCommandLog.draftId, draftId));
+      expect(rows.length).toBe(0);
+    } finally {
+      storeSpy.mockRestore();
+    }
   });
 
-  it("ALLOWS non-credential extra config (no ref) on a draft append", async () => {
-    const { id } = await seedCanonicalSource(h, "orig-key");
+  it("ALLOWS endpoint/extra config on a NON-credentialed source", async () => {
+    // No inherited credential → nothing to exfil → the config change is allowed.
+    const { result } = await h.app.call("addDataSource", {
+      type: "rest",
+      name: "NoCred",
+    });
+    const id = (result as { id: string }).id;
     const draftId = await h.controller.openDraft();
 
-    // A plaintext-only config update with no ref-shaped value is unaffected.
     await h.controller.appendToDraft(draftId, [
       cmd("SetDataSourceConfig", {
         id,
@@ -312,6 +319,103 @@ describe("credential write path — capture-before-log + transition release", ()
       .from(draftCommandLog)
       .where(eq(draftCommandLog.draftId, draftId));
     expect(rows.length).toBe(1);
+  });
+
+  // SECURITY — endpoint-redirect exfil of an INHERITED credential. A
+  // SetDataSourceConfig that changes config (e.g. a new endpoint) on an EXISTING
+  // credentialed source WITHOUT re-affirming the credential would carry the user's
+  // secret to the new target (the connector resolves config.<cred> and sends it to
+  // config.endpoint; the SSRF guard is private-range-only, a public host passes).
+  // Same threat class as the foreign-ref hole — the foreign-ENDPOINT variant.
+  it("REFUSES reconfiguring a credentialed source without re-affirming the credential", async () => {
+    const { id, ref } = await seedCanonicalSource(h, "user-secret");
+    const draftId = await h.controller.openDraft();
+
+    await expect(
+      h.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", {
+          id,
+          extra: { endpoint: "https://attacker.example" },
+        }),
+      ]),
+    ).rejects.toThrow(/inherited credential|silently redirected/i);
+
+    // Nothing logged; the user's secret is untouched and still live.
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(0);
+    expect(await h.vault.has(ref)).toBe(true);
+  });
+
+  it("ALLOWS reconfiguring a credentialed source when the credential is RE-SUPPLIED", async () => {
+    const { id } = await seedCanonicalSource(h, "user-secret");
+    const draftId = await h.controller.openDraft();
+
+    // Re-supplying apiKey (plaintext) in the same command re-affirms the credential.
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", {
+        id,
+        apiKey: "rotated",
+        extra: { endpoint: "https://api.example.com" },
+      }),
+    ]);
+
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(1);
+  });
+
+  it("ALLOWS reconfiguring a credentialed source when the credential is CLEARED", async () => {
+    const { id } = await seedCanonicalSource(h, "user-secret");
+    const draftId = await h.controller.openDraft();
+
+    // Clearing apiKey ("") drops the inherited secret → nothing carried → allowed.
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", {
+        id,
+        apiKey: "",
+        extra: { endpoint: "https://api.example.com" },
+      }),
+    ]);
+
+    const rows = await h.db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    expect(rows.length).toBe(1);
+  });
+
+  // Landmines the guard must NOT trip: create-then-configure in ONE draft (the new
+  // source isn't canonical yet → no inherited credential) AND publish replay (the
+  // guard runs only in capture, which replay bypasses). If either tripped, this
+  // throws.
+  it("ALLOWS create-then-configure in one draft and PUBLISHES (canonical-keyed + replay-exempt)", async () => {
+    const id = crypto.randomUUID();
+    const draftId = await h.controller.openDraft();
+
+    await h.controller.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id,
+        type: "rest",
+        name: "Agent REST",
+        apiKey: "agent-secret",
+      }),
+      cmd("SetDataSourceConfig", {
+        id,
+        extra: { endpoint: "https://api.example.com" },
+      }),
+    ]);
+
+    await h.app.call("publishDraft", { draftId });
+
+    const config = await readConfig(h, id);
+    expect(config).not.toBeNull();
+    expect(config!.endpoint).toBe("https://api.example.com");
+    expect(isSecretRef(config!.apiKey)).toBe(true);
   });
 
   it("stores a plaintext credential as a ref on a draft append (agent happy path)", async () => {

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -45,7 +45,7 @@ import { isSecretRef } from "@wystack/secret-vault";
 import type { Command, DraftCommand } from "@wystack/server";
 import { eq, ne } from "drizzle-orm";
 
-import { CREDENTIAL_COMMAND_FIELDS } from "./functions/commands";
+import { COMMAND_PATHS, CREDENTIAL_COMMAND_FIELDS } from "./functions/commands";
 import {
   isRecord,
   storeCredential,
@@ -90,6 +90,98 @@ function assertNoSecretRefDeep(value: unknown, path: string): void {
   }
   if (isRecord(value)) {
     for (const item of Object.values(value)) assertNoSecretRefDeep(item, path);
+  }
+}
+
+/**
+ * Refuse a fresh-append `SetDataSourceConfig` that would carry an INHERITED
+ * canonical credential into a reconfigured source without re-affirming it.
+ *
+ * The exfil this closes: a `SetDataSourceConfig` that supplies NO credential (just
+ * `extra`, e.g. a new `endpoint`) keeps the source's existing canonical credential
+ * via `{...current.config}` + `Object.assign(config, extra)` in the handler. An
+ * agent could thus redirect a user-authored, credentialed source at an attacker
+ * endpoint, and the connector would resolve and send the user's secret there (the
+ * REST SSRF guard is a private-range denylist — a public attacker host passes).
+ * Same threat class as the foreign-ref hole, the foreign-ENDPOINT variant.
+ *
+ * Shape (confirmed against the credential-seam review):
+ *  - CANONICAL-keyed: reads RAW canonical (not the draft-coalesced handle), so the
+ *    create-then-configure happy path — `CreateDataSource` then `SetDataSourceConfig`
+ *    in ONE draft — is allowed (the new source isn't canonical yet).
+ *  - FRESH-APPEND-only: this runs inside capture, which only the append path calls;
+ *    publish replay (`applyCommands`) bypasses it, so replay never trips the guard.
+ *  - TRIGGER = `extra` supplied: the untyped connector-config bag is the ONLY
+ *    vector that can introduce a new DESTINATION (e.g. a REST `endpoint`) for an
+ *    inherited credential. The typed fields (apiKey/connectionString) are
+ *    credentials, not destinations — setting one re-affirms a credential, it does
+ *    not redirect another (so a typed-only edit, e.g. rotating connectionString
+ *    while apiKey is inherited, is NOT a redirect and is allowed). Within `extra`
+ *    the check is field-AGNOSTIC (endpoint / baseUrl / webhookUrl all count — no
+ *    per-key allow-list, the enumeration trap that let authRef slip).
+ *  - CREDENTIAL = ANY canonical `SecretRef` (covers apiKey / connectionString /
+ *    authRef without enumeration).
+ *  - REQUIRE RE-AFFIRM: every inherited credential must be re-supplied (plaintext)
+ *    or cleared in THIS command; an untouched one is carried verbatim → reject.
+ */
+async function assertNoInheritedCredentialExfil(
+  cmd: DraftCommand,
+  args: Record<string, unknown>,
+  db: ArtifactDb | undefined,
+): Promise<void> {
+  // Only SetDataSourceConfig reconfigures an EXISTING source. CreateDataSource
+  // inserts a new row (a colliding id throws in the handler), so it cannot inherit
+  // a canonical credential.
+  if (cmd.path !== COMMAND_PATHS.SetDataSourceConfig) return;
+  const id = typeof args.id === "string" ? args.id : undefined;
+  if (id === undefined) return; // malformed — the handler's own validation rejects it
+
+  // Only an `extra` change can introduce a new destination for an inherited
+  // credential; a typed-credential-only update redirects nothing. No `extra` →
+  // not a redirect → nothing to guard.
+  const extra = isRecord(args.extra) ? args.extra : undefined;
+  if (extra === undefined || Object.keys(extra).length === 0) return;
+
+  if (db == null) {
+    // Fail-closed: the guard needs canonical state to reason about. Production
+    // always injects the artifact db; its absence is a wiring error, not licence
+    // to skip a credential guard.
+    throw new Error(
+      `[secret-vault] cannot verify inherited-credential safety for '${cmd.path}' ` +
+        "— no artifact db injected into the capture seam.",
+    );
+  }
+
+  const rows = await db
+    .select({ config: dataSources.config })
+    .from(dataSources)
+    .where(eq(dataSources.id, id));
+  const canonical = rows[0]?.config;
+  // No existing canonical source (e.g. created in this same draft) → nothing to
+  // inherit, nothing to exfil.
+  if (!isRecord(canonical)) return;
+
+  // Field-agnostic credential detection: any canonical config value that is a
+  // SecretRef is an inherited credential (apiKey / connectionString / authRef / …).
+  const inheritedCredFields = Object.keys(canonical).filter((k) =>
+    isSecretRef(canonical[k]),
+  );
+  if (inheritedCredFields.length === 0) return; // source holds no credential
+
+  // The command must RE-AFFIRM every inherited credential — supply (plaintext) or
+  // clear it in THIS command (a typed arg, or the same key under `extra`). A field
+  // the command leaves untouched is carried verbatim into the new config: reject.
+  const reaffirmed = (k: string): boolean =>
+    (k in args && args[k] !== undefined) || k in extra;
+  const carried = inheritedCredFields.filter((k) => !reaffirmed(k));
+  if (carried.length > 0) {
+    throw new Error(
+      `[secret-vault] SetDataSourceConfig on credentialed source '${id}' would carry ` +
+        `inherited credential(s) [${carried.join(", ")}] unchanged while reconfiguring ` +
+        "it — refusing so an inherited secret cannot be silently redirected to a new " +
+        "endpoint/target. Re-supply the credential as plaintext, or clear it, in the " +
+        "same command.",
+    );
   }
 }
 
@@ -143,6 +235,7 @@ async function releaseRefsBestEffort(
 export async function captureCommandCredentials(
   cmd: DraftCommand,
   vault: SecretVault | undefined,
+  db?: ArtifactDb,
 ): Promise<CapturedCommand> {
   const fields = CREDENTIAL_COMMAND_FIELDS[cmd.path];
   const args = cmd.args;
@@ -170,6 +263,18 @@ export async function captureCommandCredentials(
   // letting a caller point a source at a secret it does not own (the foreign-ref
   // hole). Runs BEFORE any mint, so nothing needs releasing on this throw.
   assertNoSecretRefDeep(args, cmd.path);
+
+  // SECURITY (fail-closed) — refuse to silently carry an INHERITED credential
+  // into a reconfigured source. The foreign-REF variant above is closed, but a
+  // SetDataSourceConfig that supplies NO credential (just `extra`, e.g. a new
+  // `endpoint`) keeps the existing canonical credential via `{...current.config}`
+  // + `Object.assign` — so an agent could redirect a credentialed source at an
+  // attacker endpoint and the connector would send the user's secret there (the
+  // SSRF guard is a private-range denylist; a public attacker host passes). Runs
+  // ONLY on a fresh append (replay bypasses capture), reads RAW canonical, and is
+  // field-agnostic on BOTH sides (credential = any SecretRef in canonical; target
+  // = any config change) so a future connector target field cannot reopen it.
+  await assertNoInheritedCredentialExfil(cmd, args, db);
 
   const minted: SecretRef[] = [];
   let nextArgs: Record<string, unknown> | undefined;

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -81,13 +81,27 @@ async function releaseRefsBestEffort(
 /**
  * Rewrite a draft command's PLAINTEXT credential args to vault refs, returning a
  * NEW command (the input is never mutated) plus a rollback for the minted refs.
- * Non-credential commands, empty-string (clear), undefined, and already-ref values
- * pass through untouched.
+ * Non-credential commands, empty-string (clear), and undefined pass through
+ * untouched.
  *
  * Called by `appendToDraft` BEFORE the command is run and snapshotted, so the
  * command that reaches the handler — and the durable log — carries a ref. The
  * vault store is real (a draft append is never a preview): a plaintext credential
  * with no vault throws (fail-closed, via {@link storeCredential}).
+ *
+ * SECURITY — REFUSE A CALLER-SUPPLIED REF (fail-closed). A ref-shaped credential
+ * value reaching capture is never legitimate: capture runs ONLY on a FRESH draft
+ * append (publish replay bypasses it — it replays the already-captured durable log
+ * via `applyCommands`, never `appendToDraft`), and a fresh credential write must
+ * carry plaintext. Adopting a caller-supplied `secret:<uuid>` would let an
+ * (untrusted) caller — e.g. the assistant, once `CreateDataSource` /
+ * `SetDataSourceConfig` are agent-emittable — point a source at a secret it does
+ * NOT own, skipping `storeCredential` and the fail-closed vault guard (the
+ * foreign-ref hole). So a ref-shaped value is REJECTED here, mirroring the
+ * direct-canonical-path principle ("store/verify a ref-shaped input, never adopt
+ * an unverified one"). The agent additionally gets an earlier, clearer rejection
+ * at the `applyCommand` tool boundary, but THIS seam is the durable guarantee:
+ * every `appendToDraft` caller is covered, not just the tool.
  *
  * ATOMIC per command: if storing a later field throws, the refs already minted for
  * this command are released before the error propagates — a partially-captured
@@ -129,8 +143,17 @@ export async function captureCommandCredentials(
       const value = args[field];
       // undefined (not part of this write) and "" (clear) carry no plaintext.
       if (typeof value !== "string" || value.length === 0) continue;
-      // Already a ref (idempotent re-capture / pre-bound) — leave it.
-      if (isSecretRef(value)) continue;
+      // Refuse a caller-supplied ref (fail-closed) — see the SECURITY note above.
+      // A fresh credential write must be plaintext; a ref-shaped value here would
+      // be adopted unverified, the foreign-ref hole. Thrown inside the try so any
+      // ref minted for an earlier field in this command is released first.
+      if (isSecretRef(value)) {
+        throw new Error(
+          `[secret-vault] credential command '${cmd.path}' field '${field}' must ` +
+            "be the plaintext secret, not a vault ref — refusing to adopt a " +
+            "caller-supplied ref (it would skip storeCredential + the fail-closed guard).",
+        );
+      }
       const id = typeof args.id === "string" ? args.id : "unknown";
       const ref = await storeCredential(vault, value, `${field}-${id}`, false);
       minted.push(ref);

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -139,6 +139,11 @@ async function assertNoInheritedCredentialExfil(
   // Only an `extra` change can introduce a new destination for an inherited
   // credential; a typed-credential-only update redirects nothing. No `extra` →
   // not a redirect → nothing to guard.
+  // NOTE: target-side check is field-agnostic — ANY extra-key change on a credentialed
+  // source forces credential re-affirm, including non-destination edits (e.g. postgres
+  // defaultSchema, REST pagination/rowPath). When an extra-only editor for such fields
+  // is built, have the UI re-send the credential (or revisit this guard), else legitimate
+  // non-destination edits will error.
   const extra = isRecord(args.extra) ? args.extra : undefined;
   if (extra === undefined || Object.keys(extra).length === 0) return;
 
@@ -166,6 +171,10 @@ async function assertNoInheritedCredentialExfil(
   const inheritedCredFields = Object.keys(canonical).filter((k) =>
     isSecretRef(canonical[k]),
   );
+  // NOTE: inherited-credential detection scans TOP-LEVEL canonical keys only. If a
+  // future connector nests a credential SecretRef below top-level, mirror
+  // assertNoSecretRefDeep's recursive scan here — otherwise this inherited-exfil
+  // check is silently bypassed.
   if (inheritedCredFields.length === 0) return; // source holds no credential
 
   // The command must RE-AFFIRM every inherited credential — supply (plaintext) or

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -69,6 +69,30 @@ export interface CapturedCommand {
   rollback: () => Promise<void>;
 }
 
+/**
+ * Throw if ANY string anywhere in `value` is a {@link SecretRef} (recursive over
+ * arrays + plain objects). The fail-closed primitive behind the capture seam's
+ * caller-supplied-ref refusal: it does not care WHICH field holds the ref, so a
+ * ref-shaped connector slot outside the typed credential fields (e.g. a REST
+ * source's `extra.authRef`) is caught the same as `apiKey` / `connectionString`.
+ */
+function assertNoSecretRefDeep(value: unknown, path: string): void {
+  if (isSecretRef(value)) {
+    throw new Error(
+      `[secret-vault] credential command '${path}' must be given the plaintext ` +
+        "secret, not a vault ref — refusing to adopt a caller-supplied ref " +
+        "(it would skip storeCredential + the fail-closed guard).",
+    );
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) assertNoSecretRefDeep(item, path);
+    return;
+  }
+  if (isRecord(value)) {
+    for (const item of Object.values(value)) assertNoSecretRefDeep(item, path);
+  }
+}
+
 /** Best-effort delete of refs (idempotent); swallows errors (cleanup path). */
 async function releaseRefsBestEffort(
   vault: SecretVault | undefined,
@@ -136,24 +160,26 @@ export async function captureCommandCredentials(
     );
   }
 
+  // SECURITY (fail-closed) — refuse a caller-supplied ref ANYWHERE in the args.
+  // FIELD-AGNOSTIC + RECURSIVE on purpose: the typed credential fields
+  // (apiKey/connectionString) are not the only ref-shaped slots — a connector
+  // config carries its own (e.g. a REST source's `extra.authRef`, which the REST
+  // connector resolves via the vault). Enumerating fields would let any such slot
+  // not in CREDENTIAL_COMMAND_FIELDS slip the guard (authRef did). A fresh
+  // credential write must carry plaintext; a ref here would be adopted unverified,
+  // letting a caller point a source at a secret it does not own (the foreign-ref
+  // hole). Runs BEFORE any mint, so nothing needs releasing on this throw.
+  assertNoSecretRefDeep(args, cmd.path);
+
   const minted: SecretRef[] = [];
   let nextArgs: Record<string, unknown> | undefined;
   try {
     for (const field of fields) {
       const value = args[field];
       // undefined (not part of this write) and "" (clear) carry no plaintext.
+      // Ref-shaped values are already rejected by assertNoSecretRefDeep above, so
+      // every non-empty string reaching here is plaintext to store.
       if (typeof value !== "string" || value.length === 0) continue;
-      // Refuse a caller-supplied ref (fail-closed) — see the SECURITY note above.
-      // A fresh credential write must be plaintext; a ref-shaped value here would
-      // be adopted unverified, the foreign-ref hole. Thrown inside the try so any
-      // ref minted for an earlier field in this command is released first.
-      if (isSecretRef(value)) {
-        throw new Error(
-          `[secret-vault] credential command '${cmd.path}' field '${field}' must ` +
-            "be the plaintext secret, not a vault ref — refusing to adopt a " +
-            "caller-supplied ref (it would skip storeCredential + the fail-closed guard).",
-        );
-      }
       const id = typeof args.id === "string" ? args.id : "unknown";
       const ref = await storeCredential(vault, value, `${field}-${id}`, false);
       minted.push(ref);

--- a/bun.lock
+++ b/bun.lock
@@ -466,6 +466,7 @@
         "@dashframe/types": "workspace:*",
         "@earendil-works/pi-agent-core": "0.79.6",
         "@earendil-works/pi-ai": "0.79.6",
+        "@wystack/secret-vault": "workspace:*",
         "typebox": "1.1.38",
       },
       "devDependencies": {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -23,6 +23,7 @@
     "@dashframe/types": "workspace:*",
     "@earendil-works/pi-agent-core": "0.79.6",
     "@earendil-works/pi-ai": "0.79.6",
+    "@wystack/secret-vault": "workspace:*",
     "typebox": "1.1.38"
   },
   "devDependencies": {

--- a/packages/assistant/src/apply-command-tool.test.ts
+++ b/packages/assistant/src/apply-command-tool.test.ts
@@ -614,6 +614,85 @@ describe("createApplyCommandTool — credential-ref gate (agent authoring)", () 
 });
 
 // ---------------------------------------------------------------------------
+// 5b. Agent-provenance stamp — CreateDataSource is marked agent-authored
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — agent provenance stamp", () => {
+  it("stamps createdBy:{kind:'agent'} into CreateDataSource args", async () => {
+    const controller = makeMockController();
+    const buildCommandSpy = vi.fn(buildCommand);
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-prov",
+      buildCommand: buildCommandSpy,
+    });
+
+    await tool.execute("call-prov", {
+      type: "CreateDataSource",
+      args: { id: "ds-1", type: "rest", name: "API", apiKey: "plaintext" },
+    });
+
+    // The command built (and thus appended) carries agent provenance so the row
+    // is auditably agent-authored after publish replay.
+    expect(buildCommandSpy).toHaveBeenCalledWith(
+      "CreateDataSource",
+      expect.objectContaining({ createdBy: { kind: "agent" } }),
+    );
+  });
+
+  it("OVERRIDES a caller-supplied createdBy — the agent cannot claim user authorship", async () => {
+    const controller = makeMockController();
+    const buildCommandSpy = vi.fn(buildCommand);
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-prov-override",
+      buildCommand: buildCommandSpy,
+    });
+
+    await tool.execute("call-prov-override", {
+      type: "CreateDataSource",
+      args: {
+        id: "ds-2",
+        type: "rest",
+        name: "API",
+        apiKey: "plaintext",
+        createdBy: { kind: "user" },
+      },
+    });
+
+    const passedArgs = buildCommandSpy.mock.calls[0]![1] as {
+      createdBy: unknown;
+    };
+    expect(passedArgs.createdBy).toEqual({ kind: "agent" });
+  });
+
+  it("does NOT stamp provenance on a non-provenance command", async () => {
+    const controller = makeMockController();
+    const buildCommandSpy = vi.fn(buildCommand);
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-prov-none",
+      buildCommand: buildCommandSpy,
+    });
+
+    await tool.execute("call-prov-none", {
+      type: "CreateInsight",
+      args: {
+        id: "i-1",
+        name: "Trend",
+        source: { sourceType: "dataTable", sourceId: "t-1" },
+      },
+    });
+
+    const passedArgs = buildCommandSpy.mock.calls[0]![1] as Record<
+      string,
+      unknown
+    >;
+    expect(passedArgs).not.toHaveProperty("createdBy");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 6. Tool metadata — executionMode, name (as a single invariant group)
 // ---------------------------------------------------------------------------
 

--- a/packages/assistant/src/apply-command-tool.test.ts
+++ b/packages/assistant/src/apply-command-tool.test.ts
@@ -208,13 +208,13 @@ describe("createApplyCommandTool — error propagation", () => {
 
     // An unknown type must throw — no false success, no canonical write.
     // The allow-list gate fires BEFORE buildCommand, so the error comes from
-    // the gate ("not available to the assistant") rather than from buildCommand.
+    // the gate ("not draft-safe") rather than from buildCommand.
     await expect(
       tool.execute("call-bad-type", {
         type: "NonExistentCommand",
         args: {},
       }),
-    ).rejects.toThrow(/not available to the assistant/);
+    ).rejects.toThrow(/not draft-safe/);
 
     // appendToDraft was NOT called (gate rejected before reaching appendToDraft).
     expect(controller.appendCalls).toHaveLength(0);
@@ -412,12 +412,10 @@ describe("createApplyCommandTool — DRAFT_SAFE_COMMANDS allow-list gate", () =>
         buildCommand: buildCommandSpy,
       });
 
-      // Must throw — describing the command as unavailable to the assistant.
+      // Must throw — describing the command as not draft-safe for the assistant.
       await expect(
         tool.execute("call-deny", { type: commandType, args: {} }),
-      ).rejects.toThrow(
-        /not available to the assistant.*credential operations/i,
-      );
+      ).rejects.toThrow(/not draft-safe for the assistant/i);
 
       // CRITICAL: buildCommand must NOT have been called (gate fires before it).
       expect(buildCommandSpy).not.toHaveBeenCalled();
@@ -439,7 +437,7 @@ describe("createApplyCommandTool — DRAFT_SAFE_COMMANDS allow-list gate", () =>
         type: "SomeUnknownCommand",
         args: {},
       }),
-    ).rejects.toThrow(/not available to the assistant/i);
+    ).rejects.toThrow(/not draft-safe/i);
 
     expect(controller.appendCalls).toHaveLength(0);
   });

--- a/packages/assistant/src/apply-command-tool.test.ts
+++ b/packages/assistant/src/apply-command-tool.test.ts
@@ -16,11 +16,14 @@
  *      no silent mutation or drop.
  *   7. An empty `appendToDraft` result array is a host contract violation and
  *      throws rather than silently returning null.
- *   8. Credential commands (CreateDataSource, SetDataSourceConfig, DeleteNode)
- *      are DENIED at the allow-list gate — no vault call, no appendToDraft call.
+ *   8. DeleteNode is DENIED at the allow-list gate — no vault call, no append.
  *   9. Unlisted arbitrary command types are DENIED at the gate (default-deny).
  *  10. Draft-safe artifact commands (CreateInsight, etc.) pass the gate and
  *      append normally.
+ *  11. Credential commands (CreateDataSource, SetDataSourceConfig) are allowed
+ *      with PLAINTEXT credentials, but a caller-supplied ref-shaped credential
+ *      is REJECTED at the credential-ref gate — before buildCommand / append —
+ *      so the agent cannot adopt a foreign/arbitrary vault ref.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -84,6 +87,8 @@ const TEST_COMMANDS: Record<string, string> = {
   CreateVisualization: "createVisualizationCmd",
   AddDashboardItem: "addDashboardItemCmd",
   CreateDashboard: "createDashboardCmd",
+  CreateDataSource: "createDataSourceCmd",
+  SetDataSourceConfig: "setDataSourceConfigCmd",
 };
 
 const buildCommand = makeBuildCommand(TEST_COMMANDS);
@@ -381,20 +386,20 @@ describe("createApplyCommandTool — multi-command drive loop", () => {
 
 describe("createApplyCommandTool — DRAFT_SAFE_COMMANDS allow-list gate", () => {
   /**
-   * The three command types that are explicitly DENIED:
+   * `DeleteNode` is explicitly DENIED:
+   *   - on a DataSource it calls vault.delete as an OS-keychain side effect the
+   *     draft overlay does not draft or roll back;
+   *   - on Insight / DataTable it uses non-PK cascade ops the overlay cannot
+   *     safely replicate.
    *
-   *   CreateDataSource    — vault.store OS-keychain side effect (not drafted)
-   *   SetDataSourceConfig — vault.store OS-keychain side effect (not drafted)
-   *   DeleteNode          — vault.delete (DataSource path) + non-PK cascade ops
+   * (CreateDataSource / SetDataSourceConfig are NO LONGER denied — they are
+   * draft-safe on the capture-before-log credential path; the credential-ref
+   * gate below covers their security boundary instead.)
    *
-   * The tool must reject these BEFORE calling buildCommand or appendToDraft
+   * The tool must reject DeleteNode BEFORE calling buildCommand or appendToDraft
    * so that no vault state is created from a supposed sandbox operation.
    */
-  const deniedCredentialCommands = [
-    "CreateDataSource",
-    "SetDataSourceConfig",
-    "DeleteNode",
-  ] as const;
+  const deniedCredentialCommands = ["DeleteNode"] as const;
 
   it.each(deniedCredentialCommands)(
     "denies credential/unsafe command '%s' with an honest error — no appendToDraft, no buildCommand",
@@ -465,6 +470,121 @@ describe("createApplyCommandTool — DRAFT_SAFE_COMMANDS allow-list gate", () =>
     // Result details reflect the handler value.
     expect(result.details.commandType).toBe("CreateInsight");
     expect(result.details.commandResult).toEqual({ id: "i-allow-1" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Credential-ref gate — agent must supply plaintext, never a ref
+// ---------------------------------------------------------------------------
+
+describe("createApplyCommandTool — credential-ref gate (agent authoring)", () => {
+  // A valid-shaped SecretRef (`secret:<uuid>`) the agent does NOT own — the
+  // foreign-ref attack the gate must block.
+  const FOREIGN_REF = "secret:11111111-1111-4111-8111-111111111111";
+
+  const refRejectionCases = [
+    { type: "CreateDataSource", field: "apiKey" },
+    { type: "CreateDataSource", field: "connectionString" },
+    { type: "SetDataSourceConfig", field: "apiKey" },
+    { type: "SetDataSourceConfig", field: "connectionString" },
+  ] as const;
+
+  it.each(refRejectionCases)(
+    "REJECTS a caller-supplied ref in $type.$field — no buildCommand, no appendToDraft",
+    async ({ type, field }) => {
+      const controller = makeMockController();
+      const buildCommandSpy = vi.fn(buildCommand);
+      const tool = createApplyCommandTool({
+        controller,
+        draftId: "draft-cred-reject",
+        buildCommand: buildCommandSpy,
+      });
+
+      // A ref-shaped credential value must be rejected so the agent cannot adopt
+      // a foreign/arbitrary vault ref (bypassing storeCredential + fail-closed guard).
+      await expect(
+        tool.execute("call-cred-reject", {
+          type,
+          args: { id: "ds-1", type: "rest", name: "X", [field]: FOREIGN_REF },
+        }),
+      ).rejects.toThrow(/must be the plaintext credential, not a vault ref/i);
+
+      // CRITICAL: rejected BEFORE buildCommand and BEFORE appendToDraft — no
+      // command is constructed, nothing reaches the draft / capture seam.
+      expect(buildCommandSpy).not.toHaveBeenCalled();
+      expect(controller.appendCalls).toHaveLength(0);
+    },
+  );
+
+  it("ALLOWS a plaintext credential — the agent can author a data source", async () => {
+    const controller = makeMockController({
+      appendResult: [{ value: { id: "ds-plain" } }],
+    });
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-cred-allow",
+      buildCommand,
+    });
+
+    // Plaintext (not ref-shaped) is the sanctioned input — passes the gate and
+    // appends; the server's capture-before-log path stores it as a vault ref.
+    const result = await tool.execute("call-cred-allow", {
+      type: "CreateDataSource",
+      args: {
+        id: "ds-plain",
+        type: "rest",
+        name: "My API",
+        apiKey: "sk-live-super-secret-plaintext",
+      },
+    });
+
+    expect(controller.appendCalls).toHaveLength(1);
+    expect(controller.appendCalls[0]!.batch[0]!.path).toBe(
+      "createDataSourceCmd",
+    );
+    expect(result.details.commandType).toBe("CreateDataSource");
+    expect(result.details.commandResult).toEqual({ id: "ds-plain" });
+  });
+
+  it("ALLOWS a plaintext-only SetDataSourceConfig (no credential field) through", async () => {
+    const controller = makeMockController({
+      appendResult: [{ value: { ok: true } }],
+    });
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-cred-noncred",
+      buildCommand,
+    });
+
+    // A config update that touches no credential field is unaffected by the gate.
+    await tool.execute("call-cred-noncred", {
+      type: "SetDataSourceConfig",
+      args: { id: "ds-1", extra: { database: "analytics" } },
+    });
+
+    expect(controller.appendCalls).toHaveLength(1);
+  });
+
+  it("does not reject a NON-credential command carrying a ref-shaped string field", async () => {
+    const controller = makeMockController();
+    const tool = createApplyCommandTool({
+      controller,
+      draftId: "draft-cred-unrelated",
+      buildCommand,
+    });
+
+    // The gate is scoped to credential commands' credential fields — an
+    // unrelated command with a coincidentally ref-shaped field is untouched.
+    await tool.execute("call-cred-unrelated", {
+      type: "CreateInsight",
+      args: {
+        id: "secret:22222222-2222-4222-8222-222222222222",
+        name: "Not a credential",
+        source: { sourceType: "dataTable", sourceId: "t-1" },
+      },
+    });
+
+    expect(controller.appendCalls).toHaveLength(1);
   });
 });
 

--- a/packages/assistant/src/apply-command-tool.test.ts
+++ b/packages/assistant/src/apply-command-tool.test.ts
@@ -482,16 +482,37 @@ describe("createApplyCommandTool — credential-ref gate (agent authoring)", () 
   // foreign-ref attack the gate must block.
   const FOREIGN_REF = "secret:11111111-1111-4111-8111-111111111111";
 
+  // Each case puts a foreign ref in a different slot — the typed credential
+  // fields AND a nested connector field (`extra.authRef`, which the REST connector
+  // resolves via the vault). The gate is field-agnostic + recursive, so every slot
+  // is caught — enumerating only apiKey/connectionString is what let authRef slip.
   const refRejectionCases = [
-    { type: "CreateDataSource", field: "apiKey" },
-    { type: "CreateDataSource", field: "connectionString" },
-    { type: "SetDataSourceConfig", field: "apiKey" },
-    { type: "SetDataSourceConfig", field: "connectionString" },
+    {
+      type: "CreateDataSource",
+      args: { id: "d", type: "rest", name: "X", apiKey: "" },
+    },
+    {
+      type: "SetDataSourceConfig",
+      args: { id: "d", connectionString: "" },
+    },
+    {
+      type: "SetDataSourceConfig",
+      args: { id: "d", extra: { endpoint: "https://x", authRef: "" } },
+    },
+    {
+      type: "CreateDataSource",
+      args: {
+        id: "d",
+        type: "rest",
+        name: "X",
+        extra: { nested: { authRef: "" } },
+      },
+    },
   ] as const;
 
   it.each(refRejectionCases)(
-    "REJECTS a caller-supplied ref in $type.$field — no buildCommand, no appendToDraft",
-    async ({ type, field }) => {
+    "REJECTS a caller-supplied ref anywhere in $type args — no buildCommand, no appendToDraft",
+    async ({ type, args }) => {
       const controller = makeMockController();
       const buildCommandSpy = vi.fn(buildCommand);
       const tool = createApplyCommandTool({
@@ -500,14 +521,18 @@ describe("createApplyCommandTool — credential-ref gate (agent authoring)", () 
         buildCommand: buildCommandSpy,
       });
 
-      // A ref-shaped credential value must be rejected so the agent cannot adopt
-      // a foreign/arbitrary vault ref (bypassing storeCredential + fail-closed guard).
+      // Inject the foreign ref into whichever slot the case left empty.
+      const withRef = JSON.parse(
+        JSON.stringify(args).replace('""', `"${FOREIGN_REF}"`),
+      );
+
+      // A ref-shaped value must be rejected so the agent cannot adopt a
+      // foreign/arbitrary vault ref (bypassing storeCredential + fail-closed guard).
       await expect(
-        tool.execute("call-cred-reject", {
-          type,
-          args: { id: "ds-1", type: "rest", name: "X", [field]: FOREIGN_REF },
-        }),
-      ).rejects.toThrow(/must be the plaintext credential, not a vault ref/i);
+        tool.execute("call-cred-reject", { type, args: withRef }),
+      ).rejects.toThrow(
+        /must carry the plaintext credential, not a.*vault ref/is,
+      );
 
       // CRITICAL: rejected BEFORE buildCommand and BEFORE appendToDraft — no
       // command is constructed, nothing reaches the draft / capture seam.

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -169,30 +169,19 @@ export const DRAFT_SAFE_COMMANDS = new Set([
 // ---------------------------------------------------------------------------
 
 /**
- * The credential-bearing arg fields of each allow-listed command, BY command
- * name. The agent-path security boundary: for a command in this map, any field
- * here whose value is a ref-shaped string (`secret:<uuid>`) is REJECTED before
- * the command reaches `buildCommand` / `appendToDraft` (see {@link execute}).
+ * Commands that author connector credentials, mapped to their TYPED credential
+ * fields (`apiKey` / `connectionString`). This map serves two purposes:
+ *   - membership: a command listed here is credential-bearing, so the
+ *     credential-ref gate ({@link assertNoCallerSuppliedRefs}) runs on it;
+ *   - drift guard: it MIRRORS the server's `CREDENTIAL_COMMAND_FIELDS` (the
+ *     capture/release lifecycle source of truth), bridged by a server-side test
+ *     so the two cannot diverge.
  *
- * **WHY (the foreign-ref threat)** — the server's draft credential path captures
- * a PLAINTEXT credential to a vault ref before the log snapshot, but it ADOPTS a
- * value that is ALREADY a ref (capture-before-log + `applyCredentialField`'s
- * deferred-release branch both pass a ref through verbatim, to carry a
- * legitimately-captured / replayed ref). That adopt seam is safe for the trusted
- * human UI, but the instant the agent can emit `CreateDataSource` /
- * `SetDataSourceConfig` it could supply an arbitrary or FOREIGN `secret:<uuid>`
- * instead of plaintext — adopting a ref it does not own, skipping
- * `storeCredential` and the fail-closed vault guard. The agent has NO legitimate
- * reason to supply a pre-existing ref (it authors fresh credentials), so we
- * FORBID caller-supplied refs entirely on the agent path: plaintext only, which
- * the server then stores via the sanctioned `storeCredential` choke point.
- *
- * The applyCommand tool is the only sanctioned agent write path, so enforcing
- * here is fail-closed by construction — no host wiring or context flag required.
- *
- * MIRRORS the server's `CREDENTIAL_COMMAND_FIELDS` (the capture/release source of
- * truth). A server-side bridging test asserts the two stay in lockstep, so a new
- * credential field added server-side without updating this map fails the build.
+ * NOTE the gate's reject is field-AGNOSTIC (see {@link assertNoCallerSuppliedRefs})
+ * — it does not rely on this field list. The typed fields here only document the
+ * plaintext-capture lifecycle; the reject scans the whole args, because a connector
+ * config carries ref-shaped slots beyond these (e.g. a REST source's
+ * `extra.authRef`) that must be guarded too.
  */
 export const CREDENTIAL_COMMAND_ARG_FIELDS: Readonly<
   Record<string, ReadonlyArray<"apiKey" | "connectionString">>
@@ -201,24 +190,45 @@ export const CREDENTIAL_COMMAND_ARG_FIELDS: Readonly<
   SetDataSourceConfig: ["apiKey", "connectionString"],
 };
 
+/** True if any string anywhere in `value` is a SecretRef (recursive). */
+function hasSecretRefDeep(value: unknown): boolean {
+  if (isSecretRef(value)) return true;
+  if (Array.isArray(value)) return value.some(hasSecretRefDeep);
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value).some(hasSecretRefDeep);
+  }
+  return false;
+}
+
 /**
- * Reject a credential command whose credential arg is a caller-supplied ref.
- * No-op for commands with no credential fields. Throws an honest, actionable
- * error (the agent should supply the plaintext secret, not a ref) — surfaced to
- * the agent as a tool error so it can correct and retry.
+ * Reject a credential command whose args carry a caller-supplied vault ref —
+ * ANYWHERE, recursively (a typed field OR a nested connector slot like
+ * `extra.authRef`). No-op for non-credential commands.
+ *
+ * **WHY (the foreign-ref threat)** — the server's draft credential path stores a
+ * PLAINTEXT credential to a vault ref before the log snapshot. The agent has NO
+ * legitimate reason to supply a pre-existing ref — it authors fresh credentials —
+ * and a caller-supplied `secret:<uuid>` would let it point a source at a secret it
+ * does NOT own (e.g. a REST `extra.authRef` the connector resolves and sends to an
+ * agent-controlled endpoint), skipping `storeCredential` + the fail-closed guard.
+ * So we FORBID caller-supplied refs on the agent path: plaintext only.
+ *
+ * Field-agnostic on purpose — enumerating credential fields is what let `authRef`
+ * (not in the typed field map) slip past an earlier version of this guard.
+ *
+ * This is the agent's EARLY, clear error; the server capture seam enforces the
+ * same rule as the durable guarantee for every `appendToDraft` caller. Thrown as a
+ * tool error so the agent can correct and retry.
  */
 function assertNoCallerSuppliedRefs(type: string, args: unknown): void {
-  const fields = CREDENTIAL_COMMAND_ARG_FIELDS[type];
-  if (!fields || typeof args !== "object" || args === null) return;
-  const record = args as Record<string, unknown>;
-  for (const field of fields) {
-    if (isSecretRef(record[field])) {
-      throw new Error(
-        `applyCommand: command "${type}" field "${field}" must be the plaintext ` +
-          "credential, not a vault ref. The assistant cannot adopt a pre-existing " +
-          "secret ref — supply the raw secret value and it will be stored securely.",
-      );
-    }
+  if (!(type in CREDENTIAL_COMMAND_ARG_FIELDS)) return;
+  if (hasSecretRefDeep(args)) {
+    throw new Error(
+      `applyCommand: command "${type}" must carry the plaintext credential, not a ` +
+        "vault ref. The assistant cannot adopt a pre-existing secret ref (in any " +
+        "field, including nested connector config) — supply the raw secret value " +
+        "and it will be stored securely.",
+    );
   }
 }
 

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -44,6 +44,8 @@
  * the assistant package carries no server import.
  */
 
+import { isSecretRef } from "@wystack/secret-vault";
+
 import { defineToolHandler, Type } from "./tool.js";
 
 // ---------------------------------------------------------------------------
@@ -87,33 +89,42 @@ export interface DraftAppender {
  *
  * **WHY a separate allow-list (not the full vocabulary)**
  *
- * Two command categories are NOT safe for agent-driven draft execution:
+ * 1. Credential commands — `CreateDataSource` and `SetDataSourceConfig` are
+ *    draft-safe ON THE CREDENTIAL WRITE PATH built for them: their plaintext
+ *    credential args are captured to vault refs BEFORE the draft log snapshot
+ *    (plaintext-never-at-rest), and ref RELEASE is deferred to a lifecycle
+ *    transition (publish/discard) gated by a cross-draft reference check — so a
+ *    discarded draft leaves no orphaned keychain blob and a draft credential is
+ *    never released while still live. They are therefore in the allow-list, BUT
+ *    only when the agent supplies PLAINTEXT: a caller-supplied ref-shaped value
+ *    (`secret:<uuid>`) is REJECTED at the credential-ref gate below (see
+ *    {@link CREDENTIAL_COMMAND_ARG_FIELDS}) so the agent cannot adopt a foreign /
+ *    arbitrary ref and bypass `storeCredential` + the fail-closed vault guard.
  *
- * 1. Credential commands — `CreateDataSource`, `SetDataSourceConfig`, and
- *    `DeleteNode` on a DataSource call `vault.store` / `vault.delete` /
- *    `releaseCredentialRefs` as OS-keychain side effects OUTSIDE the DB
- *    transaction. The draft overlay only drafts DB writes; vault ops are NOT
- *    drafted and NOT rolled back on discard. Allowing the agent to invoke these
- *    would create real credential state from a supposed sandbox operation.
- *
- * 2. Draft-overlay-unsafe deletes — `DeleteNode` on Insight or DataTable
- *    uses non-PK-filtered cascade operations (e.g. DataFrame cleanup by
- *    `insightId`, Visualization scan by `insightId`) that the draft overlay
- *    cannot safely replicate. The draft handle does not emulate FK cascades,
- *    so delete cascades inside a draft can produce incorrect results.
+ * 2. Draft-overlay-unsafe deletes — `DeleteNode` on a DataSource calls
+ *    `vault.delete` / `releaseCredentialRefs` as an OS-keychain side effect that
+ *    the draft overlay does NOT draft or roll back, and `DeleteNode` on Insight
+ *    or DataTable uses non-PK-filtered cascade operations (e.g. DataFrame cleanup
+ *    by `insightId`, Visualization scan by `insightId`) the draft overlay cannot
+ *    safely replicate. So `DeleteNode` stays DENIED.
  *
  * `GetOrCreateDataSource` (no vault, PK-only insert) is excluded from the
- * allow-list because DataSource creation is a human-owned credential setup
- * step — even without a vault side-effect today, it creates a data-access
- * reference that the human must review. The assistant works with existing
- * DataSources/DataTables, not mint new ones.
+ * allow-list because its create half is the legacy coarse path that lacks the
+ * capture-before-log credential treatment; the assistant authors via the typed
+ * `CreateDataSource` / `SetDataSourceConfig` commands instead.
  *
- * This set is the exhaustive additive/update artifact vocabulary the
- * assistant can safely draft. New commands must be reviewed against the two
- * categories above before being added here.
+ * This set is the exhaustive additive/update artifact vocabulary the assistant
+ * can safely draft. New commands must be reviewed against the categories above
+ * before being added here — and any command with credential-bearing args must
+ * also be registered in {@link CREDENTIAL_COMMAND_ARG_FIELDS}.
  */
 export const DRAFT_SAFE_COMMANDS = new Set([
-  // DataTable (existing — assistant does not create/configure data sources)
+  // DataSource (credential write path — capture-before-log + transition-time
+  // release; agent-supplied refs are REJECTED at the credential-ref gate, agent
+  // must supply plaintext which routes through storeCredential + fail-closed guard)
+  "CreateDataSource",
+  "SetDataSourceConfig",
+  // DataTable
   "CreateDataTable",
   "SetDataTableSchema",
   "RefreshDataTable",
@@ -148,12 +159,68 @@ export const DRAFT_SAFE_COMMANDS = new Set([
   "RenameNode",
   //
   // NOT ALLOWED (default-deny for unlisted commands):
-  //   GetOrCreateDataSource — human-owned data-source creation step
-  //   CreateDataSource      — vault.store side-effect (not drafted)
-  //   SetDataSourceConfig   — vault.store side-effect (not drafted)
+  //   GetOrCreateDataSource — legacy coarse create, no capture-before-log path
   //   DeleteNode            — vault.delete (DataSource path) + non-PK cascade
   //                           (Insight/DataTable paths); draft-overlay-unsafe
 ]);
+
+// ---------------------------------------------------------------------------
+// Credential-ref gate — agent must supply plaintext, never a ref
+// ---------------------------------------------------------------------------
+
+/**
+ * The credential-bearing arg fields of each allow-listed command, BY command
+ * name. The agent-path security boundary: for a command in this map, any field
+ * here whose value is a ref-shaped string (`secret:<uuid>`) is REJECTED before
+ * the command reaches `buildCommand` / `appendToDraft` (see {@link execute}).
+ *
+ * **WHY (the foreign-ref threat)** — the server's draft credential path captures
+ * a PLAINTEXT credential to a vault ref before the log snapshot, but it ADOPTS a
+ * value that is ALREADY a ref (capture-before-log + `applyCredentialField`'s
+ * deferred-release branch both pass a ref through verbatim, to carry a
+ * legitimately-captured / replayed ref). That adopt seam is safe for the trusted
+ * human UI, but the instant the agent can emit `CreateDataSource` /
+ * `SetDataSourceConfig` it could supply an arbitrary or FOREIGN `secret:<uuid>`
+ * instead of plaintext — adopting a ref it does not own, skipping
+ * `storeCredential` and the fail-closed vault guard. The agent has NO legitimate
+ * reason to supply a pre-existing ref (it authors fresh credentials), so we
+ * FORBID caller-supplied refs entirely on the agent path: plaintext only, which
+ * the server then stores via the sanctioned `storeCredential` choke point.
+ *
+ * The applyCommand tool is the only sanctioned agent write path, so enforcing
+ * here is fail-closed by construction — no host wiring or context flag required.
+ *
+ * MIRRORS the server's `CREDENTIAL_COMMAND_FIELDS` (the capture/release source of
+ * truth). A server-side bridging test asserts the two stay in lockstep, so a new
+ * credential field added server-side without updating this map fails the build.
+ */
+export const CREDENTIAL_COMMAND_ARG_FIELDS: Readonly<
+  Record<string, ReadonlyArray<"apiKey" | "connectionString">>
+> = {
+  CreateDataSource: ["apiKey", "connectionString"],
+  SetDataSourceConfig: ["apiKey", "connectionString"],
+};
+
+/**
+ * Reject a credential command whose credential arg is a caller-supplied ref.
+ * No-op for commands with no credential fields. Throws an honest, actionable
+ * error (the agent should supply the plaintext secret, not a ref) — surfaced to
+ * the agent as a tool error so it can correct and retry.
+ */
+function assertNoCallerSuppliedRefs(type: string, args: unknown): void {
+  const fields = CREDENTIAL_COMMAND_ARG_FIELDS[type];
+  if (!fields || typeof args !== "object" || args === null) return;
+  const record = args as Record<string, unknown>;
+  for (const field of fields) {
+    if (isSecretRef(record[field])) {
+      throw new Error(
+        `applyCommand: command "${type}" field "${field}" must be the plaintext ` +
+          "credential, not a vault ref. The assistant cannot adopt a pre-existing " +
+          "secret ref — supply the raw secret value and it will be stored securely.",
+      );
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // applyCommand result detail
@@ -267,8 +334,9 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
       "plan as a visible step — nothing is written to canonical until the draft is " +
       "published (a separate, human-gated action). Supply `type` as a command name " +
       '(e.g. "CreateInsight", "AddDashboardItem") and `args` as the matching payload ' +
-      "object for that command. Only draft-safe artifact commands are available — " +
-      "credential and data-source configuration commands are human-only operations. " +
+      "object for that command. Only draft-safe commands are available. To author a " +
+      "data source, supply its credential (apiKey / connectionString) as the raw " +
+      "PLAINTEXT secret — never a vault ref; it is stored securely on your behalf. " +
       "On validation failure the error is returned so you can correct the args and retry. " +
       "NEVER emits to canonical.",
     label: "Apply Command",
@@ -282,7 +350,7 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
           "The command name from the draft-safe DashFrame vocabulary, e.g. " +
           '"CreateInsight", "CreateVisualization", "AddDashboardItem". ' +
           "Must be one of the allowed command names from the command guide. " +
-          "Data-source and credential commands are not available to the assistant.",
+          "For data-source credentials, pass the raw plaintext secret, not a vault ref.",
       }),
       args: Type.Unknown({
         description:
@@ -316,6 +384,13 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
             `Available commands: ${[...DRAFT_SAFE_COMMANDS].sort().join(", ")}`,
         );
       }
+
+      // CREDENTIAL-REF GATE: for a credential command, the agent must supply the
+      // PLAINTEXT secret — a caller-supplied ref (`secret:<uuid>`) is rejected
+      // here, before buildCommand / appendToDraft, so the agent cannot adopt a
+      // foreign / arbitrary vault ref and bypass storeCredential + the
+      // fail-closed guard. See CREDENTIAL_COMMAND_ARG_FIELDS for the threat model.
+      assertNoCallerSuppliedRefs(type, args);
 
       // Build the Command envelope. `buildCommand` is the host-injected bridge
       // to cmd() in commands.ts — the single source of truth for name→path

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -233,6 +233,38 @@ function assertNoCallerSuppliedRefs(type: string, args: unknown): void {
 }
 
 // ---------------------------------------------------------------------------
+// Agent-provenance stamp
+// ---------------------------------------------------------------------------
+
+/**
+ * Commands whose created artifact carries a `createdBy` provenance arg that this
+ * tool stamps as agent-authored. The provenance must travel IN the command (not
+ * the context) so it survives the publish log replay; the tool sets it here so an
+ * agent-created artifact is auditably distinct from a human-created one — without
+ * relying on the model to remember to pass it.
+ *
+ * Stamping OVERRIDES any caller-supplied value: the applyCommand tool IS the agent
+ * write path, so every artifact it creates is agent-authored; a model cannot claim
+ * `{ kind: "user" }`. NOTE provenance is DISPLAY/AUDIT only — it MUST NEVER gate a
+ * trust decision (see the server's coerceProvenance) — so this is for auditability,
+ * not the security guard. Only `CreateDataSource` plumbs `createdBy` among the
+ * allow-listed commands today; the set grows as more create commands do.
+ */
+const AGENT_PROVENANCE_COMMANDS = new Set(["CreateDataSource"]);
+
+/**
+ * Return `args` with `createdBy: { kind: "agent" }` stamped for a provenance-
+ * bearing command, else `args` unchanged. Never mutates the input.
+ */
+function stampAgentProvenance(type: string, args: unknown): unknown {
+  if (!AGENT_PROVENANCE_COMMANDS.has(type)) return args;
+  if (typeof args !== "object" || args === null || Array.isArray(args)) {
+    return args; // malformed args fall through to the handler's own validation
+  }
+  return { ...(args as Record<string, unknown>), createdBy: { kind: "agent" } };
+}
+
+// ---------------------------------------------------------------------------
 // applyCommand result detail
 // ---------------------------------------------------------------------------
 
@@ -402,6 +434,12 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
       // fail-closed guard. See CREDENTIAL_COMMAND_ARG_FIELDS for the threat model.
       assertNoCallerSuppliedRefs(type, args);
 
+      // PROVENANCE: stamp agent authorship into the args for a provenance-bearing
+      // command (e.g. CreateDataSource), overriding any caller value — the tool is
+      // the agent write path, so its artifacts are agent-authored. Audit/display
+      // only; never gates trust (see AGENT_PROVENANCE_COMMANDS).
+      const stampedArgs = stampAgentProvenance(type, args);
+
       // Build the Command envelope. `buildCommand` is the host-injected bridge
       // to cmd() in commands.ts — the single source of truth for name→path
       // mapping. An unknown command type throws here with a clear error before
@@ -409,7 +447,7 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
       //
       // TRANSPARENT: the command is constructed and emitted as an explicit plan
       // step visible in the draft log — no behind-the-scenes canonical write.
-      const command = buildCommand(type, args);
+      const command = buildCommand(type, stampedArgs);
 
       // Emit into the draft via the controller's sanctioned write path.
       // NEVER CANONICAL: appendToDraft → runHandler → withDraft overlay.

--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -405,24 +405,25 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
       const { type, args } = params;
 
       // SECURITY GATE: enforce the draft-safe allow-list BEFORE calling
-      // buildCommand or appendToDraft. This is a default-deny boundary:
+      // buildCommand or appendToDraft. Default-deny — everything not in
+      // DRAFT_SAFE_COMMANDS is rejected. The notable denials:
       //
-      //   - Credential commands (CreateDataSource, SetDataSourceConfig,
-      //     DeleteNode on DataSource) call vault.store/vault.delete as
-      //     OS-keychain side effects OUTSIDE the DB transaction. These ops are
-      //     NOT drafted and NOT rolled back on discard — allowing the agent to
-      //     trigger them would create real credential state from a sandbox.
+      //   - DeleteNode — on a DataSource it calls vault.delete as an OS-keychain
+      //     side effect OUTSIDE the DB transaction (not drafted, not rolled back
+      //     on discard); on Insight/DataTable it uses non-PK-filtered cascade
+      //     operations the draft overlay cannot safely replicate.
+      //   - GetOrCreateDataSource — legacy coarse create with no
+      //     capture-before-log credential path (use CreateDataSource instead).
       //
-      //   - Draft-overlay-unsafe deletes (DeleteNode on Insight/DataTable)
-      //     use non-PK-filtered cascade operations that the draft overlay
-      //     cannot safely replicate.
+      // CreateDataSource / SetDataSourceConfig ARE allow-listed — they route
+      // through the safe credential write path; the credential-ref gate and the
+      // server-side inherited-credential guard are their security boundary.
       //
       // Rejecting here — before buildCommand — means no vault call, no append,
       // no draft mutation: a clean, auditable deny at the tool seam.
       if (!DRAFT_SAFE_COMMANDS.has(type)) {
         throw new Error(
-          `applyCommand: command type "${type}" is not available to the assistant. ` +
-            "Credential operations and data-source configuration are human-only. " +
+          `applyCommand: command type "${type}" is not draft-safe for the assistant. ` +
             `Available commands: ${[...DRAFT_SAFE_COMMANDS].sort().join(", ")}`,
         );
       }

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -37,6 +37,7 @@ export * from "./read/index.js";
 
 // applyCommand mutation tool — the assistant's write surface.
 export {
+  CREDENTIAL_COMMAND_ARG_FIELDS,
   DRAFT_SAFE_COMMANDS,
   createApplyCommandTool,
   type ApplyCommandDetails,

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -60,21 +60,22 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
   // of type "rest" whose config holds { endpoint, method, authRef, pagination,
   // rowPath, fieldMap }; no new connector kind is registered.
   //
-  // ASSISTANT SCOPE (today): these are HUMAN-ONLY operations. They are NOT in the
-  // applyCommand draft-safe allow-list — the assistant works with EXISTING data
-  // sources, it does not mint or configure them. Data-source creation is a
-  // human-owned trust step (a new data-access reference the human must review),
-  // and credential writes hit the OS keychain outside the draft transaction.
-  // These entries document the config CONTRACT (so the agent can read a source's
-  // shape); they are not an instruction that the agent may emit them.
+  // ASSISTANT SCOPE: `CreateDataSource` and `SetDataSourceConfig` ARE draft-safe —
+  // the assistant may author data sources. Credentials must be supplied as raw
+  // PLAINTEXT: the draft path stores them in the vault (capture-before-log) and
+  // releases at the publish/discard transition. NEVER pass a vault ref
+  // (`secret:<uuid>`) in ANY field — including nested connector config such as a
+  // REST source's `extra.authRef` — it is REJECTED (the assistant cannot adopt a
+  // secret it does not own). `GetOrCreateDataSource` stays human-only (legacy
+  // coarse create, no capture-before-log path).
   {
     name: "GetOrCreateDataSource",
     group: "connector",
     summary: "Idempotent upsert of a data source by client-minted id.",
     args: { id: "UUID", type: "connector id", name: "display name" },
     notes:
-      "Human-only (not draft-safe). Safe to retry — finds existing by PK or " +
-      "inserts. No credentials.",
+      "Human-only (NOT draft-safe — legacy coarse create). Use CreateDataSource " +
+      "to author a source. No credentials.",
   },
   {
     name: "CreateDataSource",
@@ -84,13 +85,14 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
       id: "UUID",
       type: "connector id",
       name: "display name",
-      "apiKey?": "secret",
-      "connectionString?": "secret",
+      "apiKey?": "plaintext secret (never a vault ref)",
+      "connectionString?": "plaintext secret (never a vault ref)",
     },
     notes:
-      "Human-only (not draft-safe — vault side-effect + trust step). " +
-      "Credentials go to the vault; never echoed back on read. For a REST " +
-      'source: type "rest", then SetDataSourceConfig writes the endpoint config.',
+      "Draft-safe. Supply credentials as raw PLAINTEXT — the draft path stores " +
+      "them in the vault and never echoes them back on read; a ref-shaped value " +
+      'is rejected. For a REST source: type "rest", then SetDataSourceConfig ' +
+      "writes the endpoint config.",
   },
   {
     name: "SetDataSourceConfig",
@@ -98,19 +100,20 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
     summary: "Replace a data source's credential + non-credential config.",
     args: {
       id: "UUID",
-      "apiKey?": "secret",
-      "connectionString?": "secret",
+      "apiKey?": "plaintext secret (never a vault ref)",
+      "connectionString?": "plaintext secret (never a vault ref)",
       "extra?": "non-credential connector config (e.g. REST endpoint settings)",
     },
     notes:
-      "Human-only (not draft-safe). `extra` carries the declarative connector " +
-      "config and must NOT contain apiKey/connectionString (rejected — use the " +
-      "typed credential fields). REST config shape: { endpoint, method, " +
-      "authRef (a SecretRef id, never a plaintext secret), pagination " +
-      "(offset|cursor|page-number|link-header), rowPath, fieldMap }. The REST " +
-      "connector rejects a private/internal endpoint host at the fetch sink and " +
-      "at config-form validation (SSRF guard); authRef must not be bypassed for " +
-      "authenticated sources.",
+      "Draft-safe. Supply credentials as raw PLAINTEXT. `extra` carries the " +
+      "declarative connector config and must NOT contain apiKey/connectionString " +
+      "(rejected — use the typed fields). REST config shape: { endpoint, method, " +
+      "authRef, pagination (offset|cursor|page-number|link-header), rowPath, " +
+      "fieldMap }. Do NOT supply a vault ref in any field, including " +
+      "`extra.authRef` — caller-supplied refs are rejected; an authenticated REST " +
+      "source's credential is set through the credential write path, not by " +
+      "referencing an existing secret. The REST connector also rejects a " +
+      "private/internal endpoint host (SSRF guard).",
   },
   // --- DataTable ---
   {

--- a/packages/assistant/vitest.config.ts
+++ b/packages/assistant/vitest.config.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -5,5 +7,15 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],
+  },
+  resolve: {
+    alias: {
+      // Resolve the credential-ref guard's shape predicate from source so the
+      // unit tests do not depend on a built wystack dist (mirrors connector-rest).
+      "@wystack/secret-vault": path.resolve(
+        __dirname,
+        "../../libs/wystack/packages/secret-vault/src/index.ts",
+      ),
+    },
   },
 });

--- a/packages/assistant/vitest.config.ts
+++ b/packages/assistant/vitest.config.ts
@@ -1,6 +1,9 @@
-import path from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vitest/config";
+
+const configDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
@@ -12,8 +15,9 @@ export default defineConfig({
     alias: {
       // Resolve the credential-ref guard's shape predicate from source so the
       // unit tests do not depend on a built wystack dist (mirrors connector-rest).
-      "@wystack/secret-vault": path.resolve(
-        __dirname,
+      // ESM-safe base (this package is type:module; no __dirname at runtime).
+      "@wystack/secret-vault": resolve(
+        configDir,
         "../../libs/wystack/packages/secret-vault/src/index.ts",
       ),
     },


### PR DESCRIPTION
Final enablement of agent DataSource authoring (YW-346, on top of YW-345). Adds `CreateDataSource` + `SetDataSourceConfig` to the assistant's `DRAFT_SAFE_COMMANDS`, and — the mandatory security precondition — hardens the credential adopt-seam so an agent cannot supply a foreign/arbitrary vault ref instead of plaintext.

Tracked internally as YW-346.

## Changes

- **Allow-list flip** (`packages/assistant/src/apply-command-tool.ts`): `CreateDataSource` + `SetDataSourceConfig` are now draft-safe (they route through YW-345's capture-before-log + transition-time release path). `DeleteNode` stays denied (vault.delete + non-PK cascade, draft-overlay-unsafe).
- **Seam hardening (the durable guarantee)** (`apps/server/src/credential-release.ts`): `captureCommandCredentials` now **rejects** a ref-shaped credential value instead of adopting it verbatim. Capture runs only on a *fresh* draft append (publish replay bypasses it — it replays the already-captured durable log via `applyCommands`, never `appendToDraft`), so a caller-supplied `secret:<uuid>` is never legitimate there; adopting one was the foreign-ref hole the instant these commands became agent-emittable. Rejecting routes the agent back through `storeCredential` + the fail-closed guard. Mirrors the existing direct-canonical "store/verify, never adopt an unverified ref" principle (YW-345 P2).
- **Agent-boundary guard (early, clear error)** (`apply-command-tool.ts`): `assertNoCallerSuppliedRefs` rejects a ref-shaped `apiKey`/`connectionString` at the `applyCommand` tool before `buildCommand`/`appendToDraft`, so the agent gets an actionable message. Defense-in-depth on top of the seam.
- **Drift guard**: `CREDENTIAL_COMMAND_ARG_FIELDS` (assistant, by command name) is bridged to the server's `CREDENTIAL_COMMAND_FIELDS` (by path) by a bidirectional test, so a new credential field cannot open the guard silently.

### Chosen option: (b) forbid caller-supplied refs
Per the YW-346 threat model, option (b) over (a): the agent has no legitimate reason to supply a pre-existing ref — it authors fresh credentials. Enforced primarily at the seam (covers every `appendToDraft` caller, not just the currently-unwired tool), with the tool guard as the agent-facing early error.

### YW-345 invariants preserved
plaintext-never-at-rest, transition-time release (publish/discard), cross-draft reference check, fail-closed without vault, no `vault.list()`/enumeration, provenance stays caller-asserted (never gates trust).

## Screenshots

No UI change (server + assistant tool-layer only).

## Verification

- **Security (the precondition)** — new server-seam tests in `credential-release.test.ts`: a foreign `secret:<uuid>` driven through `appendToDraft` for `CreateDataSource` and `SetDataSourceConfig` is **rejected** with zero log rows (not adopted). Confirmed a genuine regression guard — it fails against the pre-fix `continue`-adopt code. Tool-boundary reject covered by 4 field cases in `apply-command-tool.test.ts` (no `buildCommand`/`append`).
- **Happy path** — plaintext credential on a draft append is stored as a vault ref (the path the assistant exercises post-flip); the log carries the ref, resolves to the plaintext.
- **Drift** — bidirectional bridging test ties the agent gate to the server credential-field map.
- **Suites** — assistant 82, credential-release 22, regression neighbors (commands / vault-control-plane / draft-controller / draft-lifecycle) 186 — 290 passing, 0 failures. Typecheck + lint + prettier green on touched packages (`@dashframe/assistant`, `@dashframe/server`).
- **Independent credential-seam review (opus)**: SHIP — foreign-ref hole closed on all reachable paths, no legitimate path regressed (human-UI ref round-trip disproven via DTO ref-stripping), atomic on the reject path, bidirectional drift guard. 0 MUST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEqGF2sCLDZhm8yNWZWwxw

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables agent-driven DataSource authoring by adding `CreateDataSource` and `SetDataSourceConfig` to the assistant's `DRAFT_SAFE_COMMANDS`, backed by two layered security guards: a field-agnostic, recursive ref-rejection at both the tool boundary and the `appendToDraft` seam, and a new inherited-credential exfil guard that blocks endpoint-redirect attacks on credentialed sources.

- **Allow-list flip** — `CreateDataSource` + `SetDataSourceConfig` enter `DRAFT_SAFE_COMMANDS`; `DeleteNode` stays denied; error messages are updated to accurately describe the new capability boundaries.
- **Foreign-ref hardening** — `assertNoCallerSuppliedRefs` (tool layer) and `assertNoSecretRefDeep` (seam layer) both reject any `secret:<uuid>`-shaped value anywhere in args, recursively, preventing an agent from adopting a pre-existing vault ref it does not own.
- **Inherited-credential exfil guard** — `assertNoInheritedCredentialExfil` (seam layer) blocks a `SetDataSourceConfig` that changes connector config (`extra`) without re-affirming every inherited canonical credential, closing the endpoint-redirect variant of the exfil threat; drift is pinned by a bidirectional test between `CREDENTIAL_COMMAND_ARG_FIELDS` (assistant) and `CREDENTIAL_COMMAND_FIELDS` (server).
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. Both security seams (tool boundary + capture) are independently fail-closed and field-agnostic; the inherited-credential exfil guard is confirmed by direct inspection of the handler's explicit rejection of credential fields in `extra`.

The credential write path is well-structured with defense-in-depth: the foreign-ref rejection is both at the tool boundary (early error for the agent) and at the capture seam (durable guarantee for all appendToDraft callers). The handler at `setDataSourceConfig` explicitly rejects `apiKey`/`connectionString` in `extra`, confirming the `assertNoInheritedCredentialExfil` guard operates correctly for all current credential fields. The bidirectional drift test ties the two field maps together so a future addition cannot silently open a gap. Test coverage is thorough — foreign-ref, nested-ref, partial-batch rollback, single and multi-credential exfil, create-then-configure, replay, and plaintext happy path are all exercised.

The `reaffirmed` closure in `credential-release.ts` contains a `|| k in extra` branch that is currently unreachable for successful commands (the handler rejects credential fields in `extra`) but could become a real bypass if a future credential field is added without a matching handler-side rejection.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/server/src/credential-release.ts | Adds `assertNoSecretRefDeep` (field-agnostic, recursive ref rejection) and `assertNoInheritedCredentialExfil` (prevents endpoint-redirect exfil of inherited credentials) to the capture seam. The `|| k in extra` branch in `reaffirmed` is inconsistent with the handler's explicit rejection of credential fields in `extra`, making it a dead but potentially misleading code path. |
| packages/assistant/src/apply-command-tool.ts | Adds `CreateDataSource` and `SetDataSourceConfig` to `DRAFT_SAFE_COMMANDS`, introduces `assertNoCallerSuppliedRefs` (field-agnostic, recursive ref rejection at the tool boundary), `CREDENTIAL_COMMAND_ARG_FIELDS` for drift detection, and `stampAgentProvenance` for audit. Error messages updated to correctly reflect the new allow-list state. |
| apps/server/src/credential-release.test.ts | Comprehensive new tests covering: foreign-ref rejection (CreateDataSource + SetDataSourceConfig), nested ref rejection (extra.authRef), partial-batch rollback (no orphaned vault blobs), inherited-credential exfil (single and multi-credential), create-then-configure happy path, plaintext agent happy path, and the bidirectional drift guard. |
| packages/assistant/src/apply-command-tool.test.ts | New test sections cover credential-ref gate (4 field-position cases, plaintext allow, non-credential command unaffected) and agent-provenance stamp (override of caller-supplied value, non-provenance command passthrough). |
| apps/server/src/app.ts | Threads `opts.db` into `captureCommandCredentials` so the inherited-credential exfil guard has access to canonical state. Minimal, correct change. |
| packages/assistant/src/read/command-guide.ts | Updates the command guide: marks CreateDataSource and SetDataSourceConfig as draft-safe, instructs the agent to supply plaintext credentials, clarifies that GetOrCreateDataSource remains human-only (legacy path). |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant ApplyCommandTool
    participant DraftController
    participant CaptureSeam as captureCommandCredentials
    participant Vault
    participant DB

    Agent->>ApplyCommandTool: "execute(CreateDataSource | SetDataSourceConfig, args)"

    ApplyCommandTool->>ApplyCommandTool: DRAFT_SAFE_COMMANDS.has(type)?
    Note over ApplyCommandTool: Gate 1 — deny-list check (DeleteNode stays denied)

    ApplyCommandTool->>ApplyCommandTool: assertNoCallerSuppliedRefs(type, args)
    Note over ApplyCommandTool: Gate 2 — recursive SecretRef scan (tool boundary)

    ApplyCommandTool->>ApplyCommandTool: stampAgentProvenance(type, args)
    Note over ApplyCommandTool: Stamps createdBy:{kind:agent}

    ApplyCommandTool->>DraftController: appendToDraft(draftId, [command])
    DraftController->>CaptureSeam: captureCommandCredentials(cmd, vault, db)

    CaptureSeam->>CaptureSeam: assertNoSecretRefDeep(args, path)
    Note over CaptureSeam: Seam guard 1 — durable ref rejection

    CaptureSeam->>DB: "SELECT canonical config WHERE id=args.id"
    CaptureSeam->>CaptureSeam: assertNoInheritedCredentialExfil(cmd, args, db)
    Note over CaptureSeam: Seam guard 2 — inherited-credential exfil check

    CaptureSeam->>Vault: storeCredential(plaintext)
    Vault-->>CaptureSeam: SecretRef

    CaptureSeam-->>DraftController: "{command with refs, rollback}"
    DraftController->>DB: INSERT draft_command_log (ref, never plaintext)
    DraftController-->>ApplyCommandTool: "[{value: result}]"
    ApplyCommandTool-->>Agent: "{commandType, commandResult}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant ApplyCommandTool
    participant DraftController
    participant CaptureSeam as captureCommandCredentials
    participant Vault
    participant DB

    Agent->>ApplyCommandTool: "execute(CreateDataSource | SetDataSourceConfig, args)"

    ApplyCommandTool->>ApplyCommandTool: DRAFT_SAFE_COMMANDS.has(type)?
    Note over ApplyCommandTool: Gate 1 — deny-list check (DeleteNode stays denied)

    ApplyCommandTool->>ApplyCommandTool: assertNoCallerSuppliedRefs(type, args)
    Note over ApplyCommandTool: Gate 2 — recursive SecretRef scan (tool boundary)

    ApplyCommandTool->>ApplyCommandTool: stampAgentProvenance(type, args)
    Note over ApplyCommandTool: Stamps createdBy:{kind:agent}

    ApplyCommandTool->>DraftController: appendToDraft(draftId, [command])
    DraftController->>CaptureSeam: captureCommandCredentials(cmd, vault, db)

    CaptureSeam->>CaptureSeam: assertNoSecretRefDeep(args, path)
    Note over CaptureSeam: Seam guard 1 — durable ref rejection

    CaptureSeam->>DB: "SELECT canonical config WHERE id=args.id"
    CaptureSeam->>CaptureSeam: assertNoInheritedCredentialExfil(cmd, args, db)
    Note over CaptureSeam: Seam guard 2 — inherited-credential exfil check

    CaptureSeam->>Vault: storeCredential(plaintext)
    Vault-->>CaptureSeam: SecretRef

    CaptureSeam-->>DraftController: "{command with refs, rollback}"
    DraftController->>DB: INSERT draft_command_log (ref, never plaintext)
    DraftController-->>ApplyCommandTool: "[{value: result}]"
    ApplyCommandTool-->>Agent: "{commandType, commandResult}"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/assistant/src/apply-command-tool.ts`, line 380-386 ([link](https://github.com/youhaowei/dashframe/blob/3f6834451e28070a5ae4a301295f607817befd65/packages/assistant/src/apply-command-tool.ts#L380-L386)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The deny-list error message still says "Credential operations and data-source configuration are human-only." but `CreateDataSource` and `SetDataSourceConfig` are now in `DRAFT_SAFE_COMMANDS`. An agent that tries `DeleteNode` (or any other non-listed command) will receive a message telling it credential/data-source work is human-only, directly contradicting the new capability. The agent might conclude it cannot author a data source at all and not retry with the correct command.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/assistant/src/apply-command-tool.ts
   Line: 380-386

   Comment:
   The deny-list error message still says "Credential operations and data-source configuration are human-only." but `CreateDataSource` and `SetDataSourceConfig` are now in `DRAFT_SAFE_COMMANDS`. An agent that tries `DeleteNode` (or any other non-listed command) will receive a message telling it credential/data-source work is human-only, directly contradicting the new capability. The agent might conclude it cannot author a data source at all and not retry with the correct command.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fapply-command-tool.ts%0ALine%3A%20380-386%0A%0AComment%3A%0AThe%20deny-list%20error%20message%20still%20says%20%22Credential%20operations%20and%20data-source%20configuration%20are%20human-only.%22%20but%20%60CreateDataSource%60%20and%20%60SetDataSourceConfig%60%20are%20now%20in%20%60DRAFT_SAFE_COMMANDS%60.%20An%20agent%20that%20tries%20%60DeleteNode%60%20%28or%20any%20other%20non-listed%20command%29%20will%20receive%20a%20message%20telling%20it%20credential%2Fdata-source%20work%20is%20human-only%2C%20directly%20contradicting%20the%20new%20capability.%20The%20agent%20might%20conclude%20it%20cannot%20author%20a%20data%20source%20at%20all%20and%20not%20retry%20with%20the%20correct%20command.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!DRAFT_SAFE_COMMANDS.has%28type%29%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%20%20%20%20%60applyCommand%3A%20command%20type%20%22%24%7Btype%7D%22%20is%20not%20available%20to%20the%20assistant.%20%60%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Only%20the%20listed%20draft-safe%20commands%20are%20available%3B%20vault-delete%20and%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22overlay-unsafe%20cascade%20operations%20%28e.g.%20DeleteNode%29%20remain%20denied.%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%60Available%20commands%3A%20%24%7B%5B...DRAFT_SAFE_COMMANDS%5D.sort%28%29.join%28%22%2C%20%22%29%7D%60%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-346-allowlist-credential-authoring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-346-allowlist-credential-authoring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fapply-command-tool.ts%0ALine%3A%20380-386%0A%0AComment%3A%0AThe%20deny-list%20error%20message%20still%20says%20%22Credential%20operations%20and%20data-source%20configuration%20are%20human-only.%22%20but%20%60CreateDataSource%60%20and%20%60SetDataSourceConfig%60%20are%20now%20in%20%60DRAFT_SAFE_COMMANDS%60.%20An%20agent%20that%20tries%20%60DeleteNode%60%20%28or%20any%20other%20non-listed%20command%29%20will%20receive%20a%20message%20telling%20it%20credential%2Fdata-source%20work%20is%20human-only%2C%20directly%20contradicting%20the%20new%20capability.%20The%20agent%20might%20conclude%20it%20cannot%20author%20a%20data%20source%20at%20all%20and%20not%20retry%20with%20the%20correct%20command.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!DRAFT_SAFE_COMMANDS.has%28type%29%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%20%20%20%20%60applyCommand%3A%20command%20type%20%22%24%7Btype%7D%22%20is%20not%20available%20to%20the%20assistant.%20%60%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Only%20the%20listed%20draft-safe%20commands%20are%20available%3B%20vault-delete%20and%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22overlay-unsafe%20cascade%20operations%20%28e.g.%20DeleteNode%29%20remain%20denied.%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%60Available%20commands%3A%20%24%7B%5B...DRAFT_SAFE_COMMANDS%5D.sort%28%29.join%28%22%2C%20%22%29%7D%60%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fapply-command-tool.ts%0ALine%3A%20380-386%0A%0AComment%3A%0AThe%20deny-list%20error%20message%20still%20says%20%22Credential%20operations%20and%20data-source%20configuration%20are%20human-only.%22%20but%20%60CreateDataSource%60%20and%20%60SetDataSourceConfig%60%20are%20now%20in%20%60DRAFT_SAFE_COMMANDS%60.%20An%20agent%20that%20tries%20%60DeleteNode%60%20%28or%20any%20other%20non-listed%20command%29%20will%20receive%20a%20message%20telling%20it%20credential%2Fdata-source%20work%20is%20human-only%2C%20directly%20contradicting%20the%20new%20capability.%20The%20agent%20might%20conclude%20it%20cannot%20author%20a%20data%20source%20at%20all%20and%20not%20retry%20with%20the%20correct%20command.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!DRAFT_SAFE_COMMANDS.has%28type%29%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20new%20Error%28%0A%20%20%20%20%20%20%20%20%20%20%60applyCommand%3A%20command%20type%20%22%24%7Btype%7D%22%20is%20not%20available%20to%20the%20assistant.%20%60%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Only%20the%20listed%20draft-safe%20commands%20are%20available%3B%20vault-delete%20and%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22overlay-unsafe%20cascade%20operations%20%28e.g.%20DeleteNode%29%20remain%20denied.%20%22%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%60Available%20commands%3A%20%24%7B%5B...DRAFT_SAFE_COMMANDS%5D.sort%28%29.join%28%22%2C%20%22%29%7D%60%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["test(server): cover multi-credential inh..."](https://github.com/youhaowei/dashframe/commit/28c82cdbee66d37a1d58bb9b29ef85d92e2ecda5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40357937)</sub>

<!-- /greptile_comment -->