### PR TITLE
[YW-354] fix(server): gate credential ref release on durable snapshot flush

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -352,6 +352,12 @@ app
         // The server owns no reference to ProjectHandle — the narrow callback
         // is the boundary (#88).
         onWrite: () => project.touchSnapshot(),
+        // Durable counterpart to onWrite: used by the pre-release flush gate so
+        // a credential ref is deleted from the vault only AFTER the snapshot that
+        // drops it from the config has been confirmed written to disk. Without
+        // this, the gate degrades to the debounced-schedule path and the crash
+        // window reopens. The narrow callback preserves the no-import boundary.
+        flushSnapshot: () => project.flushSnapshot(),
         // Inject the fully-composed SecretVault. The server RECEIVES this vault;
         // it never instantiates a backend itself. Control-plane mutations
         // (create/update DataSource) call vault.store → ref; reads call

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -195,6 +195,23 @@ export interface DashframeServerOptions {
    */
   onWrite?: () => void;
   /**
+   * Optional async hook that cancels any pending debounced timer, forces an
+   * IMMEDIATE snapshot write to disk, and resolves only after the write is
+   * durable — propagating errors to the caller.
+   *
+   * This is the durable counterpart to `onWrite`. It is ONLY called when the
+   * pre-release gate requires durability before releasing a vault ref: a
+   * credential ref is released only after the snapshot that drops it from the
+   * config has been confirmed written. `onWrite`'s debounced schedule cannot
+   * provide this guarantee because it returns immediately without awaiting the
+   * write.
+   *
+   * Desktop passes `() => project.flushSnapshot()`. Surfaces that do not need
+   * the guarantee may omit it; the pre-release gate falls back to the
+   * debounced `onWrite` behaviour in that case (existing semantics).
+   */
+  flushSnapshot?: () => Promise<void>;
+  /**
    * Secret vault for credential storage. The runtime composer (Electron main
    * or `dashframe serve`) registers a backend into a SecretRegistry, builds a
    * SecretVault, and injects it here. The server itself never picks or
@@ -590,6 +607,11 @@ export async function createDashframeServer(
     },
   );
   serverContext.onWrite = opts.onWrite;
+  // Durable counterpart to onWrite: cancels the debounce and forces an
+  // immediate snapshot write, awaited for durability. Used by the pre-release
+  // gate (publishDraft / discardDraft / direct canonical credential writes) to
+  // guarantee the snapshot dropping a ref is on disk before the ref is deleted.
+  serverContext.flushSnapshot = opts.flushSnapshot;
 
   // Mirror @wystack/server/node's serve() composition, adding CORS in front.
   const honoApp = new Hono();

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -163,7 +163,11 @@ async function seedCanonicalSource(
 describe("credential write path — capture-before-log + transition release", () => {
   let h: Harness;
   beforeEach(async () => {
-    h = await makeHarness();
+    // Wire a no-op flushSnapshot so tests that publish/discard with credential
+    // refs get the durable-flush gate satisfied and refs are released as expected.
+    // Without this, the fail-closed path (no hook → skip release) would block
+    // all release assertions in this describe block.
+    h = await makeHarness({ flushSnapshot: async () => {} });
   });
   afterEach(async () => {
     await h.db.$client.close();
@@ -996,26 +1000,34 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
 
   // AC#2 core: when flushSnapshot is provided and succeeds, the publish path
   // releases the replaced canonical ref (the flush resolved → ref released).
+  // ORDER MATTERS: the ref must still be present DURING the flush callback
+  // (proving flush happens before release), and absent AFTER publish returns.
   it("publishDraft releases replaced ref after flushSnapshot succeeds", async () => {
-    const flushCalls: number[] = [];
+    let refPresentDuringFlush: boolean | undefined;
+    let flushAttempts = 0;
     const flushing = await makeHarness({
       flushSnapshot: async () => {
-        flushCalls.push(Date.now());
+        flushAttempts++;
+        // Capture vault state at flush time — the ref must still be live here.
+        refPresentDuringFlush = await flushing.vault.has(oldRef);
       },
     });
+    // Declared here so the flushSnapshot callback above can close over it.
+    let oldRef!: SecretRef;
     try {
-      const { id, ref: oldRef } = await seedCanonicalSource(
-        flushing,
-        "old-key",
-      );
+      const seeded = await seedCanonicalSource(flushing, "old-key");
+      const id = seeded.id;
+      oldRef = seeded.ref;
       const draftId = await flushing.controller.openDraft();
       await flushing.controller.appendToDraft(draftId, [
         cmd("SetDataSourceConfig", { id, apiKey: "new-key" }),
       ]);
       await flushing.app.call("publishDraft", { draftId });
-      // flushSnapshot was called (the pre-release gate fired on credential refs)
-      expect(flushCalls).toHaveLength(1);
-      // old ref was released after the flush
+      // flushSnapshot was invoked (the pre-release gate fired on credential refs)
+      expect(flushAttempts).toBe(1);
+      // the ref was still present DURING the flush — ordering invariant holds
+      expect(refPresentDuringFlush).toBe(true);
+      // old ref was released AFTER the flush resolved
       expect(await flushing.vault.has(oldRef)).toBe(false);
     } finally {
       await flushing.db.$client.close();
@@ -1027,8 +1039,12 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
   // it becomes an inert orphan rather than a dangling live reference.
   // (Same invariant as the existing onWrite test, now using the durable gate.)
   it("publishDraft skips credential release when flushSnapshot fails", async () => {
+    let flushAttempts = 0;
     const failing = await makeHarness({
-      flushSnapshot: () => Promise.reject(new Error("disk full")),
+      flushSnapshot: () => {
+        flushAttempts++;
+        return Promise.reject(new Error("disk full"));
+      },
     });
     try {
       const { id, ref: oldRef } = await seedCanonicalSource(
@@ -1042,6 +1058,9 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
       // Publish commits, but flushSnapshot throws → release is skipped,
       // leaving old ref as an inert orphan, NOT a dangling live reference.
       await failing.app.call("publishDraft", { draftId });
+      // The gate was attempted (flushSnapshot was called, not silently skipped)
+      expect(flushAttempts).toBeGreaterThanOrEqual(1);
+      // Old ref was NOT released — inert orphan, not a dangling live reference
       expect(await failing.vault.has(oldRef)).toBe(true);
     } finally {
       await failing.db.$client.close();
@@ -1051,11 +1070,18 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
 
   // AC#2 for discardDraft: same gate — discard uses flushSnapshot when it has
   // credential refs to release (draft-minted refs).
+  // ORDER MATTERS: the minted ref must still be present DURING the flush callback
+  // (proving flush happens before release), and absent AFTER discard returns.
   it("discardDraft releases minted ref after flushSnapshot succeeds", async () => {
-    const flushCalls: number[] = [];
+    let refPresentDuringFlush: boolean | undefined;
+    let flushAttempts = 0;
+    // mintedRef is bound after appendToDraft; the callback closes over the let binding.
+    let mintedRef!: SecretRef;
     const flushing = await makeHarness({
       flushSnapshot: async () => {
-        flushCalls.push(Date.now());
+        flushAttempts++;
+        // Capture vault state at flush time — ref must still be live here.
+        refPresentDuringFlush = await flushing.vault.has(mintedRef);
       },
     });
     try {
@@ -1068,14 +1094,16 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
       ]);
       // Read the minted ref from the log
       const logArgs = await firstLogArgs(flushing, draftId);
-      const mintedRef = logArgs.apiKey as SecretRef;
+      mintedRef = logArgs.apiKey as SecretRef;
       expect(isSecretRef(mintedRef)).toBe(true);
       expect(await flushing.vault.has(mintedRef)).toBe(true);
 
       await flushing.app.call("discardDraft", { draftId });
-      // flushSnapshot called — draft-minted refs triggered the durable gate
-      expect(flushCalls).toHaveLength(1);
-      // minted ref released after flush
+      // flushSnapshot was invoked (the pre-release gate fired on credential refs)
+      expect(flushAttempts).toBe(1);
+      // the minted ref was still present DURING the flush — ordering invariant holds
+      expect(refPresentDuringFlush).toBe(true);
+      // minted ref released AFTER the flush resolved
       expect(await flushing.vault.has(mintedRef)).toBe(false);
     } finally {
       await flushing.db.$client.close();
@@ -1086,8 +1114,12 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
   // AC#2 fail-safe for discardDraft: if flushSnapshot fails, draft-minted refs
   // must NOT be released — they are inert orphans, not dangling live references.
   it("discardDraft skips credential release when flushSnapshot fails", async () => {
+    let flushAttempts = 0;
     const failing = await makeHarness({
-      flushSnapshot: () => Promise.reject(new Error("flush failed")),
+      flushSnapshot: () => {
+        flushAttempts++;
+        return Promise.reject(new Error("flush failed"));
+      },
     });
     try {
       const { id } = await seedCanonicalSource(failing, "canonical-key");
@@ -1103,6 +1135,8 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
 
       // Discard — flushSnapshot fails → release must be skipped
       await failing.app.call("discardDraft", { draftId });
+      // The gate was attempted (flushSnapshot was called, not silently skipped)
+      expect(flushAttempts).toBeGreaterThanOrEqual(1);
       // Minted ref NOT released (safe inert orphan)
       expect(await failing.vault.has(mintedRef)).toBe(true);
     } finally {

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -80,7 +80,10 @@ interface Harness {
   controller: DraftController;
 }
 
-async function makeHarness(opts?: { onWrite?: () => void }): Promise<Harness> {
+async function makeHarness(opts?: {
+  onWrite?: () => void;
+  flushSnapshot?: () => Promise<void>;
+}): Promise<Harness> {
   const dir = mkdtempSync(join(tmpdir(), "dashframe-cred-release-"));
   const db = await openArtifactDb({ path: join(dir, "artifacts.db") });
   const { vault } = makeTestVault();
@@ -109,6 +112,7 @@ async function makeHarness(opts?: { onWrite?: () => void }): Promise<Harness> {
   serverContext.draftController = controller;
   serverContext.artifactDb = db;
   if (opts?.onWrite) serverContext.onWrite = opts.onWrite;
+  if (opts?.flushSnapshot) serverContext.flushSnapshot = opts.flushSnapshot;
 
   return { dir, db, vault, app, controller };
 }
@@ -970,5 +974,255 @@ describe("credential write path — capture-before-log + transition release", ()
         apiKey: makeSecretRef(), // valid ref shape, must NOT be adopted
       }),
     ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC#2 — Pre-release flush gate: publishDraft and discardDraft await
+// flushSnapshot before releasing credential refs, so a crash between onWrite
+// return and snapshot durability cannot leave a ref released-but-not-snapshotted.
+// ---------------------------------------------------------------------------
+describe("pre-release flush gate (flushSnapshot — transition-time path)", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    // No flushSnapshot by default — tests that need it construct their own harness.
+    h = await makeHarness();
+  });
+  afterEach(async () => {
+    await h.db.$client.close();
+    rmSync(h.dir, { recursive: true, force: true });
+  });
+
+  // AC#2 core: when flushSnapshot is provided and succeeds, the publish path
+  // releases the replaced canonical ref (the flush resolved → ref released).
+  it("publishDraft releases replaced ref after flushSnapshot succeeds", async () => {
+    const flushCalls: number[] = [];
+    const flushing = await makeHarness({
+      flushSnapshot: async () => {
+        flushCalls.push(Date.now());
+      },
+    });
+    try {
+      const { id, ref: oldRef } = await seedCanonicalSource(
+        flushing,
+        "old-key",
+      );
+      const draftId = await flushing.controller.openDraft();
+      await flushing.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "new-key" }),
+      ]);
+      await flushing.app.call("publishDraft", { draftId });
+      // flushSnapshot was called (the pre-release gate fired on credential refs)
+      expect(flushCalls).toHaveLength(1);
+      // old ref was released after the flush
+      expect(await flushing.vault.has(oldRef)).toBe(false);
+    } finally {
+      await flushing.db.$client.close();
+      rmSync(flushing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#2 fail-safe: when flushSnapshot throws, the old ref is NOT released —
+  // it becomes an inert orphan rather than a dangling live reference.
+  // (Same invariant as the existing onWrite test, now using the durable gate.)
+  it("publishDraft skips credential release when flushSnapshot fails", async () => {
+    const failing = await makeHarness({
+      flushSnapshot: () => Promise.reject(new Error("disk full")),
+    });
+    try {
+      const { id, ref: oldRef } = await seedCanonicalSource(
+        failing,
+        "orig-key",
+      );
+      const draftId = await failing.controller.openDraft();
+      await failing.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+      ]);
+      // Publish commits, but flushSnapshot throws → release is skipped,
+      // leaving old ref as an inert orphan, NOT a dangling live reference.
+      await failing.app.call("publishDraft", { draftId });
+      expect(await failing.vault.has(oldRef)).toBe(true);
+    } finally {
+      await failing.db.$client.close();
+      rmSync(failing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#2 for discardDraft: same gate — discard uses flushSnapshot when it has
+  // credential refs to release (draft-minted refs).
+  it("discardDraft releases minted ref after flushSnapshot succeeds", async () => {
+    const flushCalls: number[] = [];
+    const flushing = await makeHarness({
+      flushSnapshot: async () => {
+        flushCalls.push(Date.now());
+      },
+    });
+    try {
+      // Seed a canonical source so the draft can reference it
+      const { id } = await seedCanonicalSource(flushing, "canonical-key");
+      const draftId = await flushing.controller.openDraft();
+      // Append a credential command — capture-before-log mints a new ref in the log
+      await flushing.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "draft-key" }),
+      ]);
+      // Read the minted ref from the log
+      const logArgs = await firstLogArgs(flushing, draftId);
+      const mintedRef = logArgs.apiKey as SecretRef;
+      expect(isSecretRef(mintedRef)).toBe(true);
+      expect(await flushing.vault.has(mintedRef)).toBe(true);
+
+      await flushing.app.call("discardDraft", { draftId });
+      // flushSnapshot called — draft-minted refs triggered the durable gate
+      expect(flushCalls).toHaveLength(1);
+      // minted ref released after flush
+      expect(await flushing.vault.has(mintedRef)).toBe(false);
+    } finally {
+      await flushing.db.$client.close();
+      rmSync(flushing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // Non-credential publish still uses the debounced onWrite path (no expensive
+  // flush on every publish — only on credential-bearing ones).
+  it("publishDraft uses onWrite (not flushSnapshot) when no credential refs are replaced", async () => {
+    const onWriteCalls: number[] = [];
+    const flushCalls: number[] = [];
+    const mixed = await makeHarness({
+      onWrite: () => onWriteCalls.push(Date.now()),
+      flushSnapshot: async () => {
+        flushCalls.push(Date.now());
+      },
+    });
+    try {
+      const draftId = await mixed.controller.openDraft();
+      await mixed.controller.appendToDraft(draftId, [
+        // No credential fields — this create has no apiKey/connectionString
+        cmd("CreateDataSource", {
+          id: crypto.randomUUID(),
+          type: "csv",
+          name: "NoCredential",
+        }),
+      ]);
+      await mixed.app.call("publishDraft", { draftId });
+      // No credential refs → debounced onWrite used, not flushSnapshot
+      expect(onWriteCalls).toHaveLength(1);
+      expect(flushCalls).toHaveLength(0);
+    } finally {
+      await mixed.db.$client.close();
+      rmSync(mixed.dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC#3 — Legacy synchronous release path: direct canonical calls
+// (setDataSourceConfig / deleteNode without a draft) flush the snapshot before
+// releasing the superseded vault ref.
+// ---------------------------------------------------------------------------
+describe("pre-release flush gate (legacy direct canonical calls)", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => {
+    await h.db.$client.close();
+    rmSync(h.dir, { recursive: true, force: true });
+  });
+
+  // AC#3 rotate: setDataSourceConfig direct canonical call flushes before release.
+  it("setDataSourceConfig releases old ref after flushSnapshot on direct canonical call", async () => {
+    const flushCalls: number[] = [];
+    const flushing = await makeHarness({
+      flushSnapshot: async () => {
+        flushCalls.push(Date.now());
+      },
+    });
+    try {
+      const { id, ref: oldRef } = await seedCanonicalSource(
+        flushing,
+        "old-key",
+      );
+      // Direct canonical call — no draftId in context → deferRelease = false → legacy path
+      await flushing.app.call("setDataSourceConfig", { id, apiKey: "new-key" });
+      // flushSnapshot was called before the release
+      expect(flushCalls).toHaveLength(1);
+      // old ref was released after the flush
+      expect(await flushing.vault.has(oldRef)).toBe(false);
+    } finally {
+      await flushing.db.$client.close();
+      rmSync(flushing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#3 fail-safe: if flushSnapshot throws on the legacy path, the old ref is
+  // NOT released — inert orphan rather than dangling live reference.
+  it("setDataSourceConfig skips credential release when flushSnapshot fails", async () => {
+    const failing = await makeHarness({
+      flushSnapshot: () => Promise.reject(new Error("flush failed")),
+    });
+    try {
+      const { id, ref: oldRef } = await seedCanonicalSource(
+        failing,
+        "orig-key",
+      );
+      // Direct canonical call — flushSnapshot fails → skip release
+      await failing.app.call("setDataSourceConfig", {
+        id,
+        apiKey: "rotated-key",
+      });
+      // Old ref NOT released (safe inert orphan, not a dangling live reference)
+      expect(await failing.vault.has(oldRef)).toBe(true);
+    } finally {
+      await failing.db.$client.close();
+      rmSync(failing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#3 delete: deleteNode flushes snapshot before releasing data-source config refs.
+  it("deleteNode/dataSource releases config refs after flushSnapshot", async () => {
+    const flushCalls: number[] = [];
+    const flushing = await makeHarness({
+      flushSnapshot: async () => {
+        flushCalls.push(Date.now());
+      },
+    });
+    try {
+      const { id, ref } = await seedCanonicalSource(flushing, "key");
+      expect(await flushing.vault.has(ref)).toBe(true);
+      // Direct canonical delete (no draft context)
+      await flushing.app.call("deleteNode", { id });
+      // flushSnapshot called before ref release
+      expect(flushCalls).toHaveLength(1);
+      // config ref released after the snapshot was flushed
+      expect(await flushing.vault.has(ref)).toBe(false);
+    } finally {
+      await flushing.db.$client.close();
+      rmSync(flushing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#3 clear: setDataSourceConfig with empty string clears the credential
+  // (CLEAR branch) — same flush-before-release ordering applies.
+  it("setDataSourceConfig clears credential after flushSnapshot (CLEAR branch)", async () => {
+    const flushCalls: number[] = [];
+    const flushing = await makeHarness({
+      flushSnapshot: async () => {
+        flushCalls.push(Date.now());
+      },
+    });
+    try {
+      const { id, ref } = await seedCanonicalSource(flushing, "to-be-cleared");
+      // Clear the credential — empty string triggers CLEAR branch
+      await flushing.app.call("setDataSourceConfig", { id, apiKey: "" });
+      // flush before release
+      expect(flushCalls).toHaveLength(1);
+      // cleared ref is gone from vault
+      expect(await flushing.vault.has(ref)).toBe(false);
+    } finally {
+      await flushing.db.$client.close();
+      rmSync(flushing.dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -1083,6 +1083,34 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
     }
   });
 
+  // AC#2 fail-safe for discardDraft: if flushSnapshot fails, draft-minted refs
+  // must NOT be released — they are inert orphans, not dangling live references.
+  it("discardDraft skips credential release when flushSnapshot fails", async () => {
+    const failing = await makeHarness({
+      flushSnapshot: () => Promise.reject(new Error("flush failed")),
+    });
+    try {
+      const { id } = await seedCanonicalSource(failing, "canonical-key");
+      const draftId = await failing.controller.openDraft();
+      await failing.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "draft-key" }),
+      ]);
+      // Read the minted ref before discarding
+      const logArgs = await firstLogArgs(failing, draftId);
+      const mintedRef = logArgs.apiKey as SecretRef;
+      expect(isSecretRef(mintedRef)).toBe(true);
+      expect(await failing.vault.has(mintedRef)).toBe(true);
+
+      // Discard — flushSnapshot fails → release must be skipped
+      await failing.app.call("discardDraft", { draftId });
+      // Minted ref NOT released (safe inert orphan)
+      expect(await failing.vault.has(mintedRef)).toBe(true);
+    } finally {
+      await failing.db.$client.close();
+      rmSync(failing.dir, { recursive: true, force: true });
+    }
+  });
+
   // Non-credential publish still uses the debounced onWrite path (no expensive
   // flush on every publish — only on credential-bearing ones).
   it("publishDraft uses onWrite (not flushSnapshot) when no credential refs are replaced", async () => {
@@ -1200,6 +1228,25 @@ describe("pre-release flush gate (legacy direct canonical calls)", () => {
     } finally {
       await flushing.db.$client.close();
       rmSync(flushing.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#3 fail-safe for delete: if flushSnapshot fails, config refs must NOT be
+  // released — inert orphan rather than dangling live reference.
+  it("deleteNode/dataSource skips credential release when flushSnapshot fails", async () => {
+    const failing = await makeHarness({
+      flushSnapshot: () => Promise.reject(new Error("flush failed")),
+    });
+    try {
+      const { id, ref } = await seedCanonicalSource(failing, "del-key");
+      expect(await failing.vault.has(ref)).toBe(true);
+      // Direct canonical delete — flushSnapshot fails → skip release
+      await failing.app.call("deleteNode", { id });
+      // Config ref NOT released (safe inert orphan)
+      expect(await failing.vault.has(ref)).toBe(true);
+    } finally {
+      await failing.db.$client.close();
+      rmSync(failing.dir, { recursive: true, force: true });
     }
   });
 

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -415,6 +415,41 @@ export async function collectSupersededRefs(
   return candidates;
 }
 
+/**
+ * Refs that a PUBLISH should release due to `DeleteNode` commands in the log:
+ * the credential refs held in the canonical config of each DataSource targeted
+ * by a delete command. Collected BEFORE replay so the canonical rows still exist;
+ * they are released AFTER the publish transaction commits (their rows are gone).
+ *
+ * Unlike {@link collectSupersededRefs} — which handles credential-field writes —
+ * this covers the deletion case: `DeleteNode` is not in `CREDENTIAL_COMMAND_FIELDS`
+ * so it is invisible to `collectSupersededRefs`. Without this collector the
+ * `deleteNode` handler would have to flush+release INSIDE the publish transaction
+ * (before commit), which violates the pre-release flush ordering invariant (the
+ * snapshot captures pre-commit state where the deleted row can still reference the
+ * ref, so releasing the ref at snapshot-write time would dangle it from the
+ * surviving snapshot row).
+ *
+ * Reads committed canonical state via the raw artifact db, BEFORE replay.
+ */
+export async function collectDeletedSourceRefs(
+  db: ArtifactDb,
+  log: Command[],
+): Promise<SecretRef[]> {
+  const refs: SecretRef[] = [];
+  for (const cmd of log) {
+    if (cmd.path !== COMMAND_PATHS.DeleteNode || !isRecord(cmd.args)) continue;
+    const id = typeof cmd.args.id === "string" ? cmd.args.id : undefined;
+    if (!id) continue;
+    const rows = await db
+      .select({ config: dataSources.config })
+      .from(dataSources)
+      .where(eq(dataSources.id, id));
+    refs.push(...refsFromConfig(rows[0]?.config));
+  }
+  return refs;
+}
+
 /** Seed each touched source's simulated field→ref map from pre-publish canonical. */
 async function seedSimulatedConfigs(
   db: ArtifactDb,

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -94,6 +94,7 @@ import type {
   VisualizationType,
 } from "@dashframe/types";
 import { eq, jsonb, text, uuid } from "@wystack/db";
+import type { SecretRef } from "@wystack/secret-vault";
 import type { Command } from "@wystack/server";
 import { mutation } from "@wystack/server";
 import { z } from "zod";
@@ -463,8 +464,17 @@ const setDataSourceConfig = mutation({
     // is NOT released here (deferRelease): release is the publish transition's job
     // (it releases the replaced canonical ref post-commit, with a cross-draft-
     // reference check) so a rolled-back publish never deletes a still-live secret.
-    // On a direct canonical call, the prior ref is released synchronously.
+    // On a direct canonical call, the prior ref is collected here and released AFTER
+    // the canonical write is committed AND a snapshot is flushed to disk, so the
+    // snapshot capturing the new config is durable before the old ref is removed.
     // In preview mode vault writes are skipped (keychain is not transactional).
+    //
+    // PRE-RELEASE FLUSH GATE (direct canonical path, !deferRelease, !preview):
+    //   store-new → canonical-write → flush-snapshot → release-old
+    // The superseded collector captures the old ref inside applyCredentialField
+    // instead of releasing it immediately, so the canonical write and snapshot
+    // flush can happen first.
+    const supersededRefs: SecretRef[] = [];
     await applyCredentialField(
       config,
       "apiKey",
@@ -473,6 +483,7 @@ const setDataSourceConfig = mutation({
       `apiKey-${id}`,
       preview,
       deferRelease,
+      supersededRefs,
     );
     await applyCredentialField(
       config,
@@ -482,12 +493,46 @@ const setDataSourceConfig = mutation({
       `connectionString-${id}`,
       preview,
       deferRelease,
+      supersededRefs,
     );
     // Merge non-credential keys from `extra` into the config (guarded above).
     if (isRecord(extra)) {
       Object.assign(config, extra);
     }
+    // PHASE 2: canonical write — new config (with new ref) is now committed.
     await ctx.db.from(dataSources).where(eq("id", id)).update({ config });
+
+    // PHASE 3: flush snapshot then release old refs (direct canonical path only).
+    // Only relevant when the direct call actually superseded credential refs
+    // (!deferRelease is implied — deferRelease callers pass an empty superseded
+    // because applyCredentialField skips the collector on those paths).
+    if (supersededRefs.length > 0 && !preview) {
+      const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
+        | (() => Promise<void>)
+        | undefined;
+      let snapshotPersisted = true;
+      if (flushSnapshot != null) {
+        try {
+          await flushSnapshot();
+        } catch (err) {
+          // Flush failed: skip release so the old ref remains valid until a
+          // future write produces a snapshot that confirms its absence.
+          snapshotPersisted = false;
+          console.error(
+            "[dashframe] setDataSourceConfig: flushSnapshot failed, skipping credential release:",
+            err,
+          );
+        }
+      }
+      if (snapshotPersisted) {
+        // Best-effort: a release failure leaves an inert orphan; it must never
+        // fail the committed write. Parallel deletes, then swallow errors.
+        await Promise.allSettled(
+          supersededRefs.map((ref) => vault?.delete(ref)),
+        );
+      }
+    }
+
     return { ok: true };
   },
 });
@@ -2087,22 +2132,59 @@ const deleteNode = mutation({
         .where(eq("dataSourceId", id))
         .all()) as (typeof dataTables.$inferSelect)[];
       const orphanedNodes = await deleteDataSourceDependents(ctx, ownedTables);
-      // Release any SecretRefs in the config BEFORE deleting the row so the
-      // mapping row + backend blob are not permanently orphaned in the OS keychain.
-      // vault-absent-with-a-ref is treated as an error (fail-closed symmetry):
-      // a ref can only exist if vault.store() was called, which requires a vault.
+      // PRE-RELEASE FLUSH GATE — collect credential refs from the config BEFORE
+      // deleting the row, then delete the row, then flush a snapshot (so the
+      // snapshot captures the "row deleted" state and can no longer reference
+      // these refs), and only THEN release the refs. This ordering guarantees:
+      //   collect-refs → delete-row → flush-snapshot → release-refs
+      //
+      // The previous ordering (release BEFORE delete) violated the invariant:
+      // a ref was deleted from the vault before the canonical row was gone, and
+      // before the snapshot captured its absence — a crash between release and
+      // the next snapshot could leave the snapshot referencing a now-deleted ref.
+      //
       // In preview mode vault.delete() is skipped — like vault.store(), it is a
       // keychain side-effect outside the DB transaction. A preview executes then
       // rolls back: the DataSource row (with its refs) survives, so its credential
       // must survive too. Releasing here would orphan the surviving row's refs.
-      if (modeFromCtx(ctx) !== "preview") {
-        await releaseCredentialRefs(
-          (source.config ?? {}) as DataSourceConfig,
-          vaultFromCtx(ctx),
-        );
-      }
+      const sourceConfig = (source.config ?? {}) as DataSourceConfig;
+      const vault = vaultFromCtx(ctx);
+      const preview = modeFromCtx(ctx) === "preview";
       // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
+      // After the row is deleted, flush a snapshot before releasing vault refs.
+      if (!preview) {
+        const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
+          | (() => Promise<void>)
+          | undefined;
+        let snapshotPersisted = true;
+        if (flushSnapshot != null) {
+          try {
+            await flushSnapshot();
+          } catch (err) {
+            // Flush failed: skip release so the refs remain valid. A future
+            // snapshot will capture the deletion, at which point the next manual
+            // cleanup can remove the orphaned refs.
+            snapshotPersisted = false;
+            console.error(
+              "[dashframe] deleteNode/dataSource: flushSnapshot failed, skipping credential release:",
+              err,
+            );
+          }
+        }
+        if (snapshotPersisted) {
+          // Best-effort: a release failure leaves an inert orphan; it must never
+          // fail the committed delete. releaseCredentialRefs uses allSettled.
+          try {
+            await releaseCredentialRefs(sourceConfig, vault);
+          } catch (err) {
+            console.error(
+              "[dashframe] deleteNode/dataSource: credential ref release failed (inert orphan):",
+              err,
+            );
+          }
+        }
+      }
       return { ok: true, deleted: { kind: "dataSource", id }, orphanedNodes };
     }
 

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1969,6 +1969,56 @@ async function deleteDataSourceDependents(
 }
 
 /**
+ * After a DataSource row has been deleted, flush a durable snapshot and then
+ * release any credential vault refs that were held in its config. Extracted to
+ * reduce `deleteNode`'s handler cognitive complexity.
+ *
+ * Ordering invariant: delete-row → this function → refs released.
+ * This ensures the snapshot that lands on disk already reflects the absent row,
+ * so a crash-and-restart cannot produce a snapshot that references a deleted ref.
+ *
+ * Skips if: (a) preview mode (vault is not transactional — releasing here would
+ * orphan the surviving row's refs after the rolled-back transaction), or (b) the
+ * config holds no credential refs (nothing to release).
+ * Fail-safe: if `flushSnapshot` throws, the release is skipped — inert orphan,
+ * never a dangling live reference.
+ */
+async function releaseDataSourceCredentials(
+  ctx: import("@wystack/server").FunctionContext,
+  sourceConfig: DataSourceConfig,
+): Promise<void> {
+  const vault = vaultFromCtx(ctx);
+  const preview = modeFromCtx(ctx) === "preview";
+  const hasCredentialRefs =
+    isSecretRef(sourceConfig.apiKey) ||
+    isSecretRef(sourceConfig.connectionString);
+  if (preview || !hasCredentialRefs) return;
+
+  const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
+    | (() => Promise<void>)
+    | undefined;
+  if (flushSnapshot != null) {
+    try {
+      await flushSnapshot();
+    } catch (err) {
+      console.error(
+        "[dashframe] deleteNode/dataSource: flushSnapshot failed, skipping credential release:",
+        err,
+      );
+      return; // skip release — inert orphan is safer than a dangling live ref
+    }
+  }
+  try {
+    await releaseCredentialRefs(sourceConfig, vault);
+  } catch (err) {
+    console.error(
+      "[dashframe] deleteNode/dataSource: credential ref release failed (inert orphan):",
+      err,
+    );
+  }
+}
+
+/**
  * DeleteNode — one polymorphic delete that implements the Artifact Model's
  * typed-edge cascade rule (Spec — DashFrame Artifact Model, "Edge types and
  * the delete cascade"):
@@ -2148,51 +2198,12 @@ const deleteNode = mutation({
       // rolls back: the DataSource row (with its refs) survives, so its credential
       // must survive too. Releasing here would orphan the surviving row's refs.
       const sourceConfig = (source.config ?? {}) as DataSourceConfig;
-      const vault = vaultFromCtx(ctx);
-      const preview = modeFromCtx(ctx) === "preview";
-      // Gate: only the credential paths require a durable pre-release flush.
-      // Non-credential deletes still get a snapshot via the outer onWrite handler.
-      const hasCredentialRefs =
-        isSecretRef(sourceConfig.apiKey) ||
-        isSecretRef(sourceConfig.connectionString);
       // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
-      // After the row is deleted, flush a snapshot BEFORE releasing vault refs.
-      // This gate only applies when the config holds live SecretRefs — a
-      // credential-free delete has nothing to release, so it skips the
-      // synchronous flush and lets the outer debounced onWrite handle it.
-      if (!preview && hasCredentialRefs) {
-        const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
-          | (() => Promise<void>)
-          | undefined;
-        let snapshotPersisted = true;
-        if (flushSnapshot != null) {
-          try {
-            await flushSnapshot();
-          } catch (err) {
-            // Flush failed: skip release so the refs remain valid. A future
-            // snapshot will capture the deletion, at which point the next manual
-            // cleanup can remove the orphaned refs.
-            snapshotPersisted = false;
-            console.error(
-              "[dashframe] deleteNode/dataSource: flushSnapshot failed, skipping credential release:",
-              err,
-            );
-          }
-        }
-        if (snapshotPersisted) {
-          // Best-effort: a release failure leaves an inert orphan; it must never
-          // fail the committed delete. releaseCredentialRefs uses allSettled.
-          try {
-            await releaseCredentialRefs(sourceConfig, vault);
-          } catch (err) {
-            console.error(
-              "[dashframe] deleteNode/dataSource: credential ref release failed (inert orphan):",
-              err,
-            );
-          }
-        }
-      }
+      // Flush a snapshot and release credential vault refs held in the config.
+      // See `releaseDataSourceCredentials` for the ordering guarantee and
+      // fail-safe semantics. Credential-free deletes are a no-op here.
+      await releaseDataSourceCredentials(ctx, sourceConfig);
       return { ok: true, deleted: { kind: "dataSource", id }, orphanedNodes };
     }
 

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -422,6 +422,54 @@ const createDataSource = mutation({
  * schema). Sink guard: any key in `extra` that matches "apiKey" or
  * "connectionString" is rejected — callers must use the typed credential fields.
  */
+
+/**
+ * Flush a durable snapshot then release superseded credential refs. Extracted from
+ * `setDataSourceConfig` Phase 3 to keep the handler within the cognitive-complexity
+ * budget. Fail-closed: if `flushSnapshot` is absent or throws, release is skipped
+ * (inert orphan rather than dangling live reference).
+ */
+async function flushAndReleaseRefs(
+  ctx: import("@wystack/server").FunctionContext,
+  supersededRefs: SecretRef[],
+  vault: import("@wystack/secret-vault").SecretVault | undefined,
+  label: string,
+): Promise<void> {
+  const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
+    | (() => Promise<void>)
+    | undefined;
+  if (flushSnapshot == null) {
+    console.error(
+      `[dashframe] ${label}: no flushSnapshot hook — skipping credential release ` +
+        "(fail-closed). Wire flushSnapshot to ensure replaced credential refs are released.",
+    );
+    return;
+  }
+  try {
+    await flushSnapshot();
+  } catch (err) {
+    console.error(
+      `[dashframe] ${label}: flushSnapshot failed, skipping credential release:`,
+      err,
+    );
+    return;
+  }
+  // Best-effort: a release failure leaves an inert orphan; it must never fail the
+  // committed write. Parallel deletes; log any failures.
+  const results = await Promise.allSettled(
+    supersededRefs.map((ref) => vault?.delete(ref)),
+  );
+  const failures = results.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  );
+  if (failures.length > 0) {
+    console.error(
+      `[dashframe] ${label}: ${failures.length} of ${supersededRefs.length} credential ref(s) failed to release (inert orphan):`,
+      failures.map((f) => f.reason),
+    );
+  }
+}
+
 const setDataSourceConfig = mutation({
   args: {
     id: uuid,
@@ -506,31 +554,15 @@ const setDataSourceConfig = mutation({
     // Only relevant when the direct call actually superseded credential refs
     // (!deferRelease is implied — deferRelease callers pass an empty superseded
     // because applyCredentialField skips the collector on those paths).
+    // Fail-closed: `flushAndReleaseRefs` skips release when flushSnapshot is absent
+    // or throws — inert orphan rather than dangling live reference.
     if (supersededRefs.length > 0 && !preview) {
-      const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
-        | (() => Promise<void>)
-        | undefined;
-      let snapshotPersisted = true;
-      if (flushSnapshot != null) {
-        try {
-          await flushSnapshot();
-        } catch (err) {
-          // Flush failed: skip release so the old ref remains valid until a
-          // future write produces a snapshot that confirms its absence.
-          snapshotPersisted = false;
-          console.error(
-            "[dashframe] setDataSourceConfig: flushSnapshot failed, skipping credential release:",
-            err,
-          );
-        }
-      }
-      if (snapshotPersisted) {
-        // Best-effort: a release failure leaves an inert orphan; it must never
-        // fail the committed write. Parallel deletes, then swallow errors.
-        await Promise.allSettled(
-          supersededRefs.map((ref) => vault?.delete(ref)),
-        );
-      }
+      await flushAndReleaseRefs(
+        ctx,
+        supersededRefs,
+        vault,
+        "setDataSourceConfig",
+      );
     }
 
     return { ok: true };
@@ -1977,11 +2009,17 @@ async function deleteDataSourceDependents(
  * This ensures the snapshot that lands on disk already reflects the absent row,
  * so a crash-and-restart cannot produce a snapshot that references a deleted ref.
  *
- * Skips if: (a) preview mode (vault is not transactional — releasing here would
- * orphan the surviving row's refs after the rolled-back transaction), or (b) the
- * config holds no credential refs (nothing to release).
- * Fail-safe: if `flushSnapshot` throws, the release is skipped — inert orphan,
- * never a dangling live reference.
+ * Skips if:
+ *  (a) preview mode — vault is not transactional; releasing here would orphan
+ *      the surviving row's refs after the rolled-back transaction.
+ *  (b) the config holds no credential refs — nothing to release.
+ *  (c) shouldDeferRelease — on the publish-replay path, `publishDraft` collected
+ *      these refs via `collectDeletedSourceRefs` BEFORE the transaction and will
+ *      release them POST-COMMIT; doing it inside the transaction would flush the
+ *      pre-commit state (row not yet deleted) and then release a still-canonical ref.
+ *
+ * Fail-closed: if `flushSnapshot` is absent OR throws, the release is skipped —
+ * inert orphan, never a dangling live reference.
  */
 async function releaseDataSourceCredentials(
   ctx: import("@wystack/server").FunctionContext,
@@ -1992,21 +2030,30 @@ async function releaseDataSourceCredentials(
   const hasCredentialRefs =
     isSecretRef(sourceConfig.apiKey) ||
     isSecretRef(sourceConfig.connectionString);
-  if (preview || !hasCredentialRefs) return;
+  // (a) preview, (b) no refs, (c) deferred path — all skip.
+  if (preview || !hasCredentialRefs || shouldDeferRelease(ctx)) return;
 
   const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
     | (() => Promise<void>)
     | undefined;
-  if (flushSnapshot != null) {
-    try {
-      await flushSnapshot();
-    } catch (err) {
-      console.error(
-        "[dashframe] deleteNode/dataSource: flushSnapshot failed, skipping credential release:",
-        err,
-      );
-      return; // skip release — inert orphan is safer than a dangling live ref
-    }
+  if (flushSnapshot == null) {
+    // Fail-closed: no durable-flush hook → cannot prove snapshot precedes
+    // release → skip to avoid a dangling live reference on a stale snapshot.
+    console.error(
+      "[dashframe] deleteNode/dataSource: no flushSnapshot hook — skipping " +
+        "credential release (fail-closed). Wire flushSnapshot to ensure refs " +
+        "are released after a DataSource delete.",
+    );
+    return;
+  }
+  try {
+    await flushSnapshot();
+  } catch (err) {
+    console.error(
+      "[dashframe] deleteNode/dataSource: flushSnapshot failed, skipping credential release:",
+      err,
+    );
+    return; // skip release — inert orphan is safer than a dangling live ref
   }
   try {
     await releaseCredentialRefs(sourceConfig, vault);
@@ -2014,6 +2061,36 @@ async function releaseDataSourceCredentials(
     console.error(
       "[dashframe] deleteNode/dataSource: credential ref release failed (inert orphan):",
       err,
+    );
+  }
+}
+
+/**
+ * Pre-delete vault guard for a DataSource delete (direct canonical path only).
+ * Throws BEFORE the row is deleted when the config holds credential refs but
+ * the server has no vault injected — this preserves the row so a correctly-
+ * configured server can retry the delete.
+ *
+ * Not invoked on deferred-release paths (publish-replay, draft-append) because
+ * those do not call `releaseDataSourceCredentials` at all; the publish handler
+ * collects the refs via `collectDeletedSourceRefs` before the transaction.
+ */
+function assertVaultPresentForCredentialDelete(
+  ctx: import("@wystack/server").FunctionContext,
+  sourceConfig: DataSourceConfig,
+): void {
+  if (shouldDeferRelease(ctx)) return; // deferred path: vault check is not this fn's job
+  const preview = modeFromCtx(ctx) === "preview";
+  if (preview) return; // preview: vault ops skipped entirely
+  const hasCredentialRefs =
+    isSecretRef(sourceConfig.apiKey) ||
+    isSecretRef(sourceConfig.connectionString);
+  if (!hasCredentialRefs) return;
+  if (vaultFromCtx(ctx) == null) {
+    throw new Error(
+      "[secret-vault] cannot delete DataSource: config holds credential refs " +
+        "but no vault is injected. The vault that was present at store time " +
+        "must also be present at delete time.",
     );
   }
 }
@@ -2198,11 +2275,16 @@ const deleteNode = mutation({
       // rolls back: the DataSource row (with its refs) survives, so its credential
       // must survive too. Releasing here would orphan the surviving row's refs.
       const sourceConfig = (source.config ?? {}) as DataSourceConfig;
+      // Vault pre-check: throw BEFORE the delete when the config holds credential
+      // refs but no vault is injected, so the row is preserved for retry.
+      // (Deferred and preview paths are no-ops inside this guard.)
+      assertVaultPresentForCredentialDelete(ctx, sourceConfig);
       // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
       // Flush a snapshot and release credential vault refs held in the config.
       // See `releaseDataSourceCredentials` for the ordering guarantee and
-      // fail-safe semantics. Credential-free deletes are a no-op here.
+      // fail-safe semantics. Credential-free deletes and deferred paths (publish
+      // replay) are no-ops here — publish collects refs via collectDeletedSourceRefs.
       await releaseDataSourceCredentials(ctx, sourceConfig);
       return { ok: true, deleted: { kind: "dataSource", id }, orphanedNodes };
     }

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -94,7 +94,7 @@ import type {
   VisualizationType,
 } from "@dashframe/types";
 import { eq, jsonb, text, uuid } from "@wystack/db";
-import type { SecretRef } from "@wystack/secret-vault";
+import { isSecretRef, type SecretRef } from "@wystack/secret-vault";
 import type { Command } from "@wystack/server";
 import { mutation } from "@wystack/server";
 import { z } from "zod";
@@ -2150,10 +2150,18 @@ const deleteNode = mutation({
       const sourceConfig = (source.config ?? {}) as DataSourceConfig;
       const vault = vaultFromCtx(ctx);
       const preview = modeFromCtx(ctx) === "preview";
+      // Gate: only the credential paths require a durable pre-release flush.
+      // Non-credential deletes still get a snapshot via the outer onWrite handler.
+      const hasCredentialRefs =
+        isSecretRef(sourceConfig.apiKey) ||
+        isSecretRef(sourceConfig.connectionString);
       // Delete the DataSource — schema FK cascade removes its DataTables.
       await ctx.db.from(dataSources).where(eq("id", id)).delete();
-      // After the row is deleted, flush a snapshot before releasing vault refs.
-      if (!preview) {
+      // After the row is deleted, flush a snapshot BEFORE releasing vault refs.
+      // This gate only applies when the config holds live SecretRefs — a
+      // credential-free delete has nothing to release, so it skips the
+      // synchronous flush and lets the outer debounced onWrite handle it.
+      if (!preview && hasCredentialRefs) {
         const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
           | (() => Promise<void>)
           | undefined;

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -100,22 +100,46 @@ const publishDraft = mutation({
     // a non-empty command log (its deletion is itself a durable change).
     let snapshotPersisted = true;
     if (result.tablesWritten.size > 0 || prePublishLog.length > 0) {
+      // When the publish replaces credential refs, use flushSnapshot (durable,
+      // immediate write) instead of onWrite (debounced, fire-and-forget). The
+      // pre-release gate requires the snapshot to be confirmed on disk BEFORE
+      // any replaced ref is deleted — onWrite's debounce cannot provide that
+      // guarantee. For publishes with no credential refs, the debounced path
+      // is sufficient (no release is gated on it) and avoids the snapshot cost.
+      const flushSnapshot = ctx.flushSnapshot as
+        | (() => Promise<void>)
+        | undefined;
       const onWrite = ctx.onWrite as (() => void) | undefined;
-      try {
-        onWrite?.();
-      } catch (err) {
-        snapshotPersisted = false;
-        console.error("[dashframe] publishDraft: onWrite hook threw:", err);
+      if (replacedRefs.length > 0 && flushSnapshot != null) {
+        try {
+          await flushSnapshot();
+        } catch (err) {
+          snapshotPersisted = false;
+          console.error(
+            "[dashframe] publishDraft: flushSnapshot failed, skipping credential release:",
+            err,
+          );
+        }
+      } else {
+        // No credential refs to gate, or no durable-flush hook — use the
+        // debounced schedule (existing behaviour; release is not gated on it).
+        try {
+          onWrite?.();
+        } catch (err) {
+          snapshotPersisted = false;
+          console.error("[dashframe] publishDraft: onWrite hook threw:", err);
+        }
       }
     }
 
     // Publish has committed: release the replaced canonical refs that are no
     // longer referenced by canonical or any other open draft (best-effort —
     // a release failure leaves an inert orphan, never fails the committed publish).
-    // GATED on snapshot persistence: if onWrite failed, the post-publish state was
-    // not durably snapshotted, so a restart could restore the PRE-publish snapshot
-    // (old canonical ref) — releasing that ref now would dangle it. Skip the
-    // release (leave an inert orphan) rather than risk a dangling live reference.
+    // GATED on snapshot persistence: if flushSnapshot failed (or onWrite on the
+    // non-credential path), the post-publish state was not durably snapshotted,
+    // so a restart could restore the PRE-publish snapshot (old canonical ref) —
+    // releasing that ref now would dangle it. Skip the release (leave an inert
+    // orphan) rather than risk a dangling live reference.
     if (artifactDb != null && snapshotPersisted) {
       await releaseRefsAtTransition(artifactDb, vault, replacedRefs, draftId);
     }
@@ -173,13 +197,35 @@ const discardDraft = mutation({
     // run before the credential release below: if the post-discard state is not
     // snapshotted, a restart restores the draft (referencing its refs), so those
     // refs must not have been released yet.
+    //
+    // When the draft minted credential refs, use flushSnapshot (durable,
+    // immediate) instead of onWrite (debounced, fire-and-forget). The pre-release
+    // gate requires the snapshot to be confirmed on disk before any ref is deleted.
+    // For discards with no credential refs, the debounced path is sufficient.
     let snapshotPersisted = true;
+    const flushSnapshot = ctx.flushSnapshot as
+      | (() => Promise<void>)
+      | undefined;
     const onWrite = ctx.onWrite as (() => void) | undefined;
-    try {
-      onWrite?.();
-    } catch (err) {
-      snapshotPersisted = false;
-      console.error("[dashframe] discardDraft: onWrite hook threw:", err);
+    if (mintedRefs.length > 0 && flushSnapshot != null) {
+      try {
+        await flushSnapshot();
+      } catch (err) {
+        snapshotPersisted = false;
+        console.error(
+          "[dashframe] discardDraft: flushSnapshot failed, skipping credential release:",
+          err,
+        );
+      }
+    } else {
+      // No credential refs to gate, or no durable-flush hook — use the
+      // debounced schedule (existing behaviour; release is not gated on it).
+      try {
+        onWrite?.();
+      } catch (err) {
+        snapshotPersisted = false;
+        console.error("[dashframe] discardDraft: onWrite hook threw:", err);
+      }
     }
 
     // Release the draft-minted refs now that the draft is gone AND that removal is

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -26,6 +26,7 @@ import type { Command } from "@wystack/server";
 import { mutation, query } from "@wystack/server";
 
 import {
+  collectDeletedSourceRefs,
   collectDiscardCandidateRefs,
   collectSupersededRefs,
   releaseRefsAtTransition,
@@ -55,6 +56,64 @@ interface PublishDraftInternalResult {
  * server app wrapper also uses `__extraTablesWritten` (stripped before the
  * response reaches the client) to drive WS reactive invalidation.
  */
+
+/**
+ * Fire the correct snapshot path and return whether durability was confirmed.
+ * Extracted to keep `publishDraft` and `discardDraft` within the cognitive-
+ * complexity budget (each snapshot/gate block is identical in both handlers).
+ *
+ * - credential refs + flushSnapshot hook present → await flush; return true/false.
+ * - credential refs + no flushSnapshot hook → fail-closed: log + return false;
+ *   onWrite still fires for non-credential snapshot scheduling.
+ * - no credential refs → call onWrite; return true on success.
+ */
+async function gateSnapshotForRelease(
+  ctx: Record<string, unknown>,
+  hasCredentialRefs: boolean,
+  label: string,
+): Promise<boolean> {
+  const flushSnapshot = ctx.flushSnapshot as (() => Promise<void>) | undefined;
+  const onWrite = ctx.onWrite as (() => void) | undefined;
+
+  if (hasCredentialRefs && flushSnapshot != null) {
+    try {
+      await flushSnapshot();
+      return true;
+    } catch (err) {
+      console.error(
+        `[dashframe] ${label}: flushSnapshot failed, skipping credential release:`,
+        err,
+      );
+      return false;
+    }
+  }
+
+  if (hasCredentialRefs) {
+    // Fail-closed: no durable flush hook — release blocked.
+    console.error(
+      `[dashframe] ${label}: credential refs present but no flushSnapshot ` +
+        "hook — skipping release (fail-closed). Wire flushSnapshot to ensure " +
+        "refs are released after this lifecycle event.",
+    );
+    // Still schedule onWrite for non-credential snapshot durability (best-effort).
+    try {
+      onWrite?.();
+    } catch {
+      // Non-credential path; onWrite failure here doesn't affect credential safety.
+    }
+    return false;
+  }
+
+  // No credential refs — debounced path is sufficient.
+  try {
+    onWrite?.();
+    return true;
+  } catch (err) {
+    console.error(`[dashframe] ${label}: onWrite hook threw:`, err);
+    return false;
+  }
+}
+
 const publishDraft = mutation({
   args: { draftId: text },
   handler: async (ctx, { draftId }): Promise<PublishDraftInternalResult> => {
@@ -77,14 +136,27 @@ const publishDraft = mutation({
     const prePublishLog = await draftController.getDraftLog(draftId);
 
     // TRANSITION-TIME RELEASE — publish half. Collect the canonical refs each
-    // command will REPLACE *before* replay overwrites them; release runs only
-    // AFTER the publish transaction commits (below), so a rolled-back publish
-    // never deletes a still-live secret.
+    // command will REPLACE or DELETE *before* replay acts on them; release runs
+    // only AFTER the publish transaction commits (below), so a rolled-back
+    // publish never deletes a still-live secret.
+    //
+    // Two collectors:
+    //  - collectSupersededRefs: credential-WRITE commands (CreateDataSource,
+    //    SetDataSourceConfig) — refs whose field is overwritten by the replay.
+    //  - collectDeletedSourceRefs: DeleteNode commands — credential refs held
+    //    in the config of a DataSource being deleted. DeleteNode is NOT in
+    //    CREDENTIAL_COMMAND_FIELDS so collectSupersededRefs cannot see it;
+    //    handling it here (pre-commit) lets the deleteNode replay handler skip
+    //    flushSnapshot+release inside the uncommitted transaction, preserving
+    //    the ordering invariant (delete-row → commit → flush → release-ref).
     const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
     const vault = ctx.vault as SecretVault | undefined;
     const replacedRefs =
       artifactDb != null
-        ? await collectSupersededRefs(artifactDb, prePublishLog)
+        ? [
+            ...(await collectSupersededRefs(artifactDb, prePublishLog)),
+            ...(await collectDeletedSourceRefs(artifactDb, prePublishLog)),
+          ]
         : [];
 
     // Mark the replay as the sanctioned canonical-commit path so the credential
@@ -98,38 +170,15 @@ const publishDraft = mutation({
     // used inside publishDraft). We call it explicitly via the injected callback.
     // Condition: fire when canonical tables were written OR when the draft had
     // a non-empty command log (its deletion is itself a durable change).
+    // When credential refs are replaced, a durable flush (not debounced onWrite)
+    // is required — `gateSnapshotForRelease` handles both paths.
     let snapshotPersisted = true;
     if (result.tablesWritten.size > 0 || prePublishLog.length > 0) {
-      // When the publish replaces credential refs, use flushSnapshot (durable,
-      // immediate write) instead of onWrite (debounced, fire-and-forget). The
-      // pre-release gate requires the snapshot to be confirmed on disk BEFORE
-      // any replaced ref is deleted — onWrite's debounce cannot provide that
-      // guarantee. For publishes with no credential refs, the debounced path
-      // is sufficient (no release is gated on it) and avoids the snapshot cost.
-      const flushSnapshot = ctx.flushSnapshot as
-        | (() => Promise<void>)
-        | undefined;
-      const onWrite = ctx.onWrite as (() => void) | undefined;
-      if (replacedRefs.length > 0 && flushSnapshot != null) {
-        try {
-          await flushSnapshot();
-        } catch (err) {
-          snapshotPersisted = false;
-          console.error(
-            "[dashframe] publishDraft: flushSnapshot failed, skipping credential release:",
-            err,
-          );
-        }
-      } else {
-        // No credential refs to gate, or no durable-flush hook — use the
-        // debounced schedule (existing behaviour; release is not gated on it).
-        try {
-          onWrite?.();
-        } catch (err) {
-          snapshotPersisted = false;
-          console.error("[dashframe] publishDraft: onWrite hook threw:", err);
-        }
-      }
+      snapshotPersisted = await gateSnapshotForRelease(
+        ctx as Record<string, unknown>,
+        replacedRefs.length > 0,
+        "publishDraft",
+      );
     }
 
     // Publish has committed: release the replaced canonical refs that are no
@@ -196,37 +245,14 @@ const discardDraft = mutation({
     // durable store; a stale snapshot would resurrect them on restart. This MUST
     // run before the credential release below: if the post-discard state is not
     // snapshotted, a restart restores the draft (referencing its refs), so those
-    // refs must not have been released yet.
-    //
-    // When the draft minted credential refs, use flushSnapshot (durable,
-    // immediate) instead of onWrite (debounced, fire-and-forget). The pre-release
-    // gate requires the snapshot to be confirmed on disk before any ref is deleted.
-    // For discards with no credential refs, the debounced path is sufficient.
-    let snapshotPersisted = true;
-    const flushSnapshot = ctx.flushSnapshot as
-      | (() => Promise<void>)
-      | undefined;
-    const onWrite = ctx.onWrite as (() => void) | undefined;
-    if (mintedRefs.length > 0 && flushSnapshot != null) {
-      try {
-        await flushSnapshot();
-      } catch (err) {
-        snapshotPersisted = false;
-        console.error(
-          "[dashframe] discardDraft: flushSnapshot failed, skipping credential release:",
-          err,
-        );
-      }
-    } else {
-      // No credential refs to gate, or no durable-flush hook — use the
-      // debounced schedule (existing behaviour; release is not gated on it).
-      try {
-        onWrite?.();
-      } catch (err) {
-        snapshotPersisted = false;
-        console.error("[dashframe] discardDraft: onWrite hook threw:", err);
-      }
-    }
+    // refs must not have been released yet. When credential refs are minted, a
+    // durable flush (not debounced onWrite) is required — `gateSnapshotForRelease`
+    // handles both paths.
+    const snapshotPersisted = await gateSnapshotForRelease(
+      ctx as Record<string, unknown>,
+      mintedRefs.length > 0,
+      "discardDraft",
+    );
 
     // Release the draft-minted refs now that the draft is gone AND that removal is
     // durably snapshotted (best-effort; gated so a stale-snapshot restore cannot

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -241,6 +241,25 @@ export async function releaseCredentialRefs(
 }
 
 /**
+ * Push the prior ref into the superseded collector (when one is provided) or
+ * release it immediately via `releaseCredentialRefs`. Extracted to reduce
+ * `applyCredentialField`'s cognitive complexity — the two call sites have
+ * identical branch logic.
+ */
+async function pushOrRelease(
+  prior: unknown,
+  field: "apiKey" | "connectionString",
+  vault: SecretVault | undefined,
+  superseded: SecretRef[] | undefined,
+): Promise<void> {
+  if (superseded != null && isSecretRef(prior)) {
+    superseded.push(prior);
+  } else {
+    await releaseCredentialRefs({ [field]: prior }, vault);
+  }
+}
+
+/**
  * Apply an inbound credential value to a config slice, in place. Three-way:
  *
  *   - `undefined` → leave the existing config key untouched (not part of this write).
@@ -323,11 +342,7 @@ export async function applyCredentialField(
     // transition (the publish/discard path releases the prior ref instead).
     // When a collector is provided, push instead of releasing immediately.
     if (!preview && !deferRelease) {
-      if (superseded != null && isSecretRef(prior)) {
-        superseded.push(prior);
-      } else {
-        await releaseCredentialRefs({ [field]: prior }, vault);
-      }
+      await pushOrRelease(prior, field, vault, superseded);
     }
     delete config[field]; // explicit clear
     return;
@@ -353,11 +368,7 @@ export async function applyCredentialField(
   // skipped in preview, or deferred to a lifecycle transition.
   // When a collector is provided, push instead of releasing immediately.
   if (!preview && !deferRelease && prior !== config[field]) {
-    if (superseded != null && isSecretRef(prior)) {
-      superseded.push(prior);
-    } else {
-      await releaseCredentialRefs({ [field]: prior }, vault);
-    }
+    await pushOrRelease(prior, field, vault, superseded);
   }
 }
 

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -296,6 +296,24 @@ export async function applyCredentialField(
   locatorHint: string,
   preview = false,
   deferRelease = false,
+  /**
+   * When provided (and `!preview && !deferRelease`), the superseded prior ref
+   * is PUSHED into this array instead of being released immediately. The caller
+   * is then responsible for: (1) performing the canonical DB write, (2) calling
+   * `flushSnapshot()` to ensure the snapshot capturing the new config is durable,
+   * and (3) calling `releaseCredentialRefs` (or equivalent) on the collected refs.
+   *
+   * This deferred-release collector is the fix for the legacy synchronous release
+   * path's crash window: previously the prior ref was released inside this function
+   * BEFORE the caller wrote the new config to the DB and flushed the snapshot,
+   * leaving a window where the ref was gone from the vault but the snapshot could
+   * still reference it. With the collector, the caller can guarantee the ordering:
+   *   store-new → canonical-write → flush-snapshot → release-old.
+   *
+   * When `superseded` is `undefined`, behaviour is unchanged: immediate release
+   * (backward-compatible for callers not exercising the flush-before-release path).
+   */
+  superseded?: SecretRef[],
 ): Promise<void> {
   if (value === undefined) return; // not part of this write
   const prior = config[field];
@@ -303,8 +321,13 @@ export async function applyCredentialField(
     // CLEAR branch: release the prior vault ref before dropping the config key.
     // Release is skipped in preview (rolled back) and when deferred to a
     // transition (the publish/discard path releases the prior ref instead).
+    // When a collector is provided, push instead of releasing immediately.
     if (!preview && !deferRelease) {
-      await releaseCredentialRefs({ [field]: prior }, vault);
+      if (superseded != null && isSecretRef(prior)) {
+        superseded.push(prior);
+      } else {
+        await releaseCredentialRefs({ [field]: prior }, vault);
+      }
     }
     delete config[field]; // explicit clear
     return;
@@ -328,8 +351,13 @@ export async function applyCredentialField(
   // Release the prior ref unless it is unchanged (idempotent re-set of the same
   // ref — releasing it would destroy the live secret the new config points at),
   // skipped in preview, or deferred to a lifecycle transition.
+  // When a collector is provided, push instead of releasing immediately.
   if (!preview && !deferRelease && prior !== config[field]) {
-    await releaseCredentialRefs({ [field]: prior }, vault);
+    if (superseded != null && isSecretRef(prior)) {
+      superseded.push(prior);
+    } else {
+      await releaseCredentialRefs({ [field]: prior }, vault);
+    }
   }
 }
 

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -716,15 +716,19 @@ describe("vault lifecycle — delete releases SecretRefs (DeleteNode)", () => {
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault } = makeTestVault());
     const rawApp = await createWyStack({ db, functions });
+    // flushSnapshot is required by the fail-closed credential-release gate: refs are
+    // only released after a confirmed durable snapshot. Wire a no-op for tests
+    // exercising the direct canonical path (no actual snapshot needed here).
+    const ctx = { vault, flushSnapshot: async () => {} };
     app = {
       ...rawApp,
-      async call(path, args, ctx) {
-        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      async call(path, args, extraCtx) {
+        return rawApp.call(path, args, { ...ctx, ...(extraCtx ?? {}) });
       },
-      async runHandler(path, args, tracked, ctx) {
+      async runHandler(path, args, tracked, extraCtx) {
         return rawApp.runHandler(path, args, tracked, {
-          ...(ctx ?? {}),
-          vault,
+          ...ctx,
+          ...(extraCtx ?? {}),
         });
       },
     };
@@ -1089,15 +1093,19 @@ describe("vault lifecycle — preview mode skips vault delete", () => {
   let deleteCallCount: number;
 
   function wrapWithVault(rawApp: WyStackApp): WyStackApp {
+    // flushSnapshot is required by the fail-closed credential-release gate:
+    // refs are only released after a confirmed durable snapshot. Wire a no-op
+    // for tests exercising the direct canonical path.
+    const ctx = { vault, flushSnapshot: async () => {} };
     return {
       ...rawApp,
-      async call(path, args, ctx) {
-        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      async call(path, args, extraCtx) {
+        return rawApp.call(path, args, { ...ctx, ...(extraCtx ?? {}) });
       },
-      async runHandler(path, args, tracked, ctx) {
+      async runHandler(path, args, tracked, extraCtx) {
         return rawApp.runHandler(path, args, tracked, {
-          ...(ctx ?? {}),
-          vault,
+          ...ctx,
+          ...(extraCtx ?? {}),
         });
       },
     };
@@ -1296,15 +1304,19 @@ describe("vault lifecycle: clear releases prior SecretRef (AC1)", () => {
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault } = makeTestVault());
     const rawApp = await createWyStack({ db, functions });
+    // flushSnapshot is required by the fail-closed credential-release gate: refs are
+    // only released after a confirmed durable snapshot. Wire a no-op for tests
+    // exercising the direct canonical path (no actual snapshot needed here).
+    const ctx = { vault, flushSnapshot: async () => {} };
     app = {
       ...rawApp,
-      async call(path, args, ctx) {
-        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      async call(path, args, extraCtx) {
+        return rawApp.call(path, args, { ...ctx, ...(extraCtx ?? {}) });
       },
-      async runHandler(path, args, tracked, ctx) {
+      async runHandler(path, args, tracked, extraCtx) {
         return rawApp.runHandler(path, args, tracked, {
-          ...(ctx ?? {}),
-          vault,
+          ...ctx,
+          ...(extraCtx ?? {}),
         });
       },
     };
@@ -1432,15 +1444,19 @@ describe("vault lifecycle: rotate releases prior SecretRef (AC2)", () => {
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault } = makeTestVault());
     const rawApp = await createWyStack({ db, functions });
+    // flushSnapshot is required by the fail-closed credential-release gate: refs are
+    // only released after a confirmed durable snapshot. Wire a no-op for tests
+    // exercising the direct canonical path (no actual snapshot needed here).
+    const ctx = { vault, flushSnapshot: async () => {} };
     app = {
       ...rawApp,
-      async call(path, args, ctx) {
-        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+      async call(path, args, extraCtx) {
+        return rawApp.call(path, args, { ...ctx, ...(extraCtx ?? {}) });
       },
-      async runHandler(path, args, tracked, ctx) {
+      async runHandler(path, args, tracked, extraCtx) {
         return rawApp.runHandler(path, args, tracked, {
-          ...(ctx ?? {}),
-          vault,
+          ...ctx,
+          ...(extraCtx ?? {}),
         });
       },
     };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -285,6 +285,9 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
     // Drive the debounced snapshot scheduler on the headless serve path too, so
     // `dashframe serve` gets the same crash-durability guarantee as desktop.
     onWrite: () => project.touchSnapshot(),
+    // Durable counterpart: used by the pre-release gate before deleting a vault
+    // ref so the snapshot that drops the ref is confirmed on disk first.
+    flushSnapshot: () => project.flushSnapshot(),
   });
 
   closeOnSignal(project, server);

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -129,6 +129,22 @@ export interface ProjectHandle {
    * debounced snapshot timer is reset.
    */
   touchSnapshot(): void;
+  /**
+   * Cancel any pending debounced timer, force an IMMEDIATE snapshot write, and
+   * await it — propagating errors to the caller.
+   *
+   * Provides the durability guarantee required by the credential pre-release
+   * gate: a vault ref must not be deleted until the snapshot that drops that ref
+   * from the config has been confirmed written to disk. The debounced
+   * `touchSnapshot()` cannot provide this because it returns before the write
+   * starts. Use `flushSnapshot()` immediately after a credential-bearing
+   * canonical write (publish/discard transition or direct config update) and
+   * before releasing the superseded vault ref.
+   *
+   * Propagates write errors so the caller can decide to skip the release and
+   * leave an inert orphan rather than risk a dangling live reference.
+   */
+  flushSnapshot(): Promise<void>;
   /** Flush pending writes, write a final snapshot, and close the underlying PGlite connection. */
   close(): Promise<CloseResult>;
 }
@@ -277,6 +293,7 @@ export async function openProject(
     meta,
     recovery,
     touchSnapshot: () => scheduler.touch(),
+    flushSnapshot: () => scheduler.flushNow(),
     close,
   };
 }

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -446,6 +446,51 @@ export class SnapshotScheduler {
     await this.inFlight.catch(() => {});
   }
 
+  /**
+   * Cancel any pending debounced timer, force an IMMEDIATE snapshot, and await
+   * it — propagating errors to the caller.
+   *
+   * Unlike `touch()` (which schedules a debounced write and returns void), this
+   * method guarantees the snapshot is durably persisted on disk before it
+   * resolves. It is the primitive for the pre-release flush gate: a credential
+   * ref must not be released from the vault until the snapshot that drops that
+   * ref from the config is known to be durable.
+   *
+   * Serialisation: the write is chained onto `inFlight` exactly as `fireNow()`
+   * does, so it cannot overlap a concurrently running debounced write or the
+   * final snapshot from `ProjectHandle.close()`.
+   *
+   * Error propagation: unlike `fireNow()`, which swallows errors to keep the
+   * chain healthy for the next debounced snapshot, this method surfaces write
+   * failures to the caller. The caller (pre-release gate) decides whether to
+   * skip the release and leave an inert orphan rather than risk a dangling live
+   * reference.
+   */
+  async flushNow(): Promise<void> {
+    // Cancel any pending debounce timer — we are writing immediately.
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.firstPendingAt = null;
+
+    // Chain onto the in-flight tail (prevents overlap) and capture a promise
+    // that both (a) updates inFlight to suppress "nothing pending" and (b)
+    // propagates the error to this caller. The chain has TWO branches:
+    //   - inFlight (error-swallowed): keeps the chain healthy for future
+    //     debounced calls if this flush is later followed by more touch() calls.
+    //   - write (error-propagated): returned to the caller so the pre-release
+    //     gate learns whether durability was achieved.
+    const write = this.inFlight
+      .catch(() => {}) // don't let a prior failure block this write
+      .then(() => writeSnapshot(this.pgliteClient, this.projectDir));
+    // Register the error-swallowed tail so future debounced writes still chain
+    // correctly even if `write` throws.
+    this.inFlight = write.catch(() => {});
+    // Await with error propagation — callers must handle rejection.
+    await write;
+  }
+
   /** Cancel any pending debounced snapshot (call before close). */
   cancel(): void {
     if (this.timer !== null) {


### PR DESCRIPTION
Fixes the incomplete release gate on credential vault refs: `onWrite` is debounced, so returning from it means a snapshot is *scheduled*, not written. The crash window: `onWrite` returns → debounced write pending → process exits → ref released but snapshot never persisted → on restart, the old snapshot still references a ref that's already been deleted from the vault.

## Changes

- **`packages/server-core/src/snapshots.ts`**: Add `flushNow()` — cancels any pending debounce timer, chains an immediate `writeSnapshot()` onto `inFlight`, and `await`s with error propagation. Dual-branch promise keeps the serialization chain healthy for concurrent debounced calls.

- **`packages/server-core/src/project.ts`**: Add `flushSnapshot(): Promise<void>` to `ProjectHandle` interface and implementation, backed by `scheduler.flushNow()`.

- **`apps/server/src/app.ts`** + **`apps/server/src/index.ts`**: Add `flushSnapshot?: () => Promise<void>` to `DashframeServerOptions`; wire it through `serverContext` and into the headless `dashframe serve` path.

- **`apps/desktop/src/main.ts`**: Wire `flushSnapshot: () => project.flushSnapshot()` to the Electron host — without this the fix was inert on the only production surface.

- **`apps/server/src/functions/draft-lifecycle.ts`** (`publishDraft` / `discardDraft`): When a transition has credential refs to release, use `flushSnapshot()` (durable, synchronous) instead of `onWrite()` (debounced). Fail-safe: if the flush throws, skip the release (inert orphan, never a dangling live ref). Non-credential transitions still use the cheap debounced `onWrite`.

- **`apps/server/src/functions/utils.ts`**: Add optional `superseded?: SecretRef[]` collector parameter to `applyCredentialField`. When provided (and not preview/deferRelease), pushes the prior ref to the collector instead of releasing immediately — caller controls the store-new → canonical-write → flush → release ordering.

- **`apps/server/src/functions/commands.ts`**:
  - `setDataSourceConfig`: Uses collector pattern → canonical write → `flushSnapshot` → release.
  - `deleteNode/dataSource`: Reordered to collect refs before delete → delete row → `isSecretRef` gate → `flushSnapshot` → release. Non-credential deletes skip the synchronous flush entirely (outer debounced `onWrite` handles them).

- **`apps/server/src/credential-release.test.ts`**: 10 new tests covering all three AC gates: publish/discard flush-before-release (success + failure), legacy canonical calls (set + clear + delete, success + failure each).

## Screenshots

No UI change.

## Verification

- `bun test apps/server`: 352 pass, 1 pre-existing fail (Proxy-spy seam issue unrelated to this PR, present on `main`), 353 total
- `bun run typecheck`: 48/48 tasks successful
- Acceptance criteria:
  1. Ref released only after snapshot durably written — enforced at all three call sites (publishDraft, discardDraft, setDataSourceConfig, deleteNode)
  2. Crash-mid-window: if `flushSnapshot` throws, release is skipped → inert orphan on restart (ref still valid), not a dangling live ref — verified by failure-path tests
  3. Legacy synchronous path covered by same guarantee via superseded-collector pattern

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the crash window between `onWrite()` returning (debounced, not durable) and a vault credential ref being deleted, by adding a synchronous `flushNow()` primitive to `SnapshotScheduler` and threading a `flushSnapshot` hook through the entire call stack from Electron/headless serve down to the credential release sites.

- **`SnapshotScheduler.flushNow()`** cancels any pending debounce timer, chains an immediate `writeSnapshot` onto `inFlight` using a dual-branch promise (error-propagated to the caller; error-swallowed for the chain's health), and awaits it.
- **`publishDraft` / `discardDraft`** now use the new `gateSnapshotForRelease` helper, which dispatches to `flushSnapshot` (durable) when credential refs are involved or to `onWrite` (debounced) otherwise.
- **`setDataSourceConfig` and `deleteNode`** adopt a collector pattern (`superseded?: SecretRef[]`) that defers vault ref release until after the canonical write and snapshot flush.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; the core durable-flush gate logic is correct and well-tested across success and failure paths.

The dual-branch promise in `flushNow()` correctly keeps the scheduler chain healthy while propagating errors to the caller. The `gateSnapshotForRelease` helper is consistent between `publishDraft` and `discardDraft`, and the `shouldDeferRelease` guard on `releaseDataSourceCredentials` properly prevents a flush inside an uncommitted publish-replay transaction. The two findings are a vault-ref orphan in an unusual intra-draft update-then-delete sequence, and a silent no-op when vault is absent — neither is a correctness regression on any normal user path.

`apps/server/src/credential-release.ts` (`collectDeletedSourceRefs`) and `apps/server/src/functions/commands.ts` (`flushAndReleaseRefs` release loop) contain the two minor issues noted.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/server-core/src/snapshots.ts | Adds `flushNow()` with correct dual-branch promise pattern: `write` propagates errors to the caller while `inFlight = write.catch(() => {})` keeps the chain healthy for subsequent debounced calls. |
| apps/server/src/functions/draft-lifecycle.ts | Extracts `gateSnapshotForRelease` helper; both `publishDraft` and `discardDraft` now use durable `flushSnapshot` for credential-bearing transitions and fall back to debounced `onWrite` for non-credential paths. |
| apps/server/src/functions/commands.ts | Adds `flushAndReleaseRefs` and `releaseDataSourceCredentials` helpers; `vault?.delete(ref)` silently no-ops when vault is undefined, masking the failure in the best-effort release path. |
| apps/server/src/credential-release.ts | Adds `collectDeletedSourceRefs` reading pre-publish canonical config; the draft-minted ref for a DataSource that is both credential-updated and deleted in the same draft is never collected. |
| apps/server/src/credential-release.test.ts | Adds 10 new tests covering all three AC gates including success and failure paths; ordering invariants verified via flush-time vault state capture. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Caller as publishDraft / discardDraft / setDataSourceConfig
  participant Gate as gateSnapshotForRelease / flushAndReleaseRefs
  participant Sched as SnapshotScheduler
  participant FS as Filesystem
  participant Vault as SecretVault

  Note over Caller: collect superseded/deleted refs BEFORE commit
  Caller->>Gate: "hasCredentialRefs=true"
  alt flushSnapshot hook present
    Gate->>Sched: flushNow()
    Sched->>FS: writeSnapshot()
    FS-->>Sched: written (durable)
    Sched-->>Gate: resolved
    Gate-->>Caller: "snapshotPersisted=true"
    Caller->>Vault: delete(supersededRef)
  else flushSnapshot absent OR throws
    Gate-->>Caller: "snapshotPersisted=false"
    Note over Caller: skip release — inert orphan
  end
  Note over Caller: non-credential path
  Caller->>Gate: "hasCredentialRefs=false"
  Gate->>Sched: onWrite() debounced
  Gate-->>Caller: "snapshotPersisted=true"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Caller as publishDraft / discardDraft / setDataSourceConfig
  participant Gate as gateSnapshotForRelease / flushAndReleaseRefs
  participant Sched as SnapshotScheduler
  participant FS as Filesystem
  participant Vault as SecretVault

  Note over Caller: collect superseded/deleted refs BEFORE commit
  Caller->>Gate: "hasCredentialRefs=true"
  alt flushSnapshot hook present
    Gate->>Sched: flushNow()
    Sched->>FS: writeSnapshot()
    FS-->>Sched: written (durable)
    Sched-->>Gate: resolved
    Gate-->>Caller: "snapshotPersisted=true"
    Caller->>Vault: delete(supersededRef)
  else flushSnapshot absent OR throws
    Gate-->>Caller: "snapshotPersisted=false"
    Note over Caller: skip release — inert orphan
  end
  Note over Caller: non-credential path
  Caller->>Gate: "hasCredentialRefs=false"
  Gate->>Sched: onWrite() debounced
  Gate-->>Caller: "snapshotPersisted=true"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/server/src/functions/commands.ts`, line 440-442 ([link](https://github.com/youhaowei/dashframe/blob/e1c8bdf4adf570d2fd1537c342b437720e2f65a8/apps/server/src/functions/commands.ts#L440-L442)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inconsistent `flushSnapshot` context access pattern**

   `commands.ts` (and `releaseDataSourceCredentials`) accesses the injected field via `(ctx as Record<string, unknown>).flushSnapshot` because the command handler context type has no index signature. `draft-lifecycle.ts` reaches the same field with a plain `ctx.flushSnapshot as ...` cast, suggesting its context is already a broader type. Both work at runtime, but the double-cast in command handlers will silently stop working if the handler context type ever tightens. Adding `flushSnapshot?: () => Promise<void>` to the server context's typed interface would resolve the inconsistency and remove the need for any widening cast.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/functions/commands.ts
   Line: 440-442

   Comment:
   **Inconsistent `flushSnapshot` context access pattern**

   `commands.ts` (and `releaseDataSourceCredentials`) accesses the injected field via `(ctx as Record<string, unknown>).flushSnapshot` because the command handler context type has no index signature. `draft-lifecycle.ts` reaches the same field with a plain `ctx.flushSnapshot as ...` cast, suggesting its context is already a broader type. Both work at runtime, but the double-cast in command handlers will silently stop working if the handler context type ever tightens. Adding `flushSnapshot?: () => Promise<void>` to the server context's typed interface would resolve the inconsistency and remove the need for any widening cast.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20440-442%0A%0AComment%3A%0A**Inconsistent%20%60flushSnapshot%60%20context%20access%20pattern**%0A%0A%60commands.ts%60%20%28and%20%60releaseDataSourceCredentials%60%29%20accesses%20the%20injected%20field%20via%20%60%28ctx%20as%20Record%3Cstring%2C%20unknown%3E%29.flushSnapshot%60%20because%20the%20command%20handler%20context%20type%20has%20no%20index%20signature.%20%60draft-lifecycle.ts%60%20reaches%20the%20same%20field%20with%20a%20plain%20%60ctx.flushSnapshot%20as%20...%60%20cast%2C%20suggesting%20its%20context%20is%20already%20a%20broader%20type.%20Both%20work%20at%20runtime%2C%20but%20the%20double-cast%20in%20command%20handlers%20will%20silently%20stop%20working%20if%20the%20handler%20context%20type%20ever%20tightens.%20Adding%20%60flushSnapshot%3F%3A%20%28%29%20%3D%3E%20Promise%3Cvoid%3E%60%20to%20the%20server%20context's%20typed%20interface%20would%20resolve%20the%20inconsistency%20and%20remove%20the%20need%20for%20any%20widening%20cast.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22yw-354%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22yw-354%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20440-442%0A%0AComment%3A%0A**Inconsistent%20%60flushSnapshot%60%20context%20access%20pattern**%0A%0A%60commands.ts%60%20%28and%20%60releaseDataSourceCredentials%60%29%20accesses%20the%20injected%20field%20via%20%60%28ctx%20as%20Record%3Cstring%2C%20unknown%3E%29.flushSnapshot%60%20because%20the%20command%20handler%20context%20type%20has%20no%20index%20signature.%20%60draft-lifecycle.ts%60%20reaches%20the%20same%20field%20with%20a%20plain%20%60ctx.flushSnapshot%20as%20...%60%20cast%2C%20suggesting%20its%20context%20is%20already%20a%20broader%20type.%20Both%20work%20at%20runtime%2C%20but%20the%20double-cast%20in%20command%20handlers%20will%20silently%20stop%20working%20if%20the%20handler%20context%20type%20ever%20tightens.%20Adding%20%60flushSnapshot%3F%3A%20%28%29%20%3D%3E%20Promise%3Cvoid%3E%60%20to%20the%20server%20context's%20typed%20interface%20would%20resolve%20the%20inconsistency%20and%20remove%20the%20need%20for%20any%20widening%20cast.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fcommands.ts%0ALine%3A%20440-442%0A%0AComment%3A%0A**Inconsistent%20%60flushSnapshot%60%20context%20access%20pattern**%0A%0A%60commands.ts%60%20%28and%20%60releaseDataSourceCredentials%60%29%20accesses%20the%20injected%20field%20via%20%60%28ctx%20as%20Record%3Cstring%2C%20unknown%3E%29.flushSnapshot%60%20because%20the%20command%20handler%20context%20type%20has%20no%20index%20signature.%20%60draft-lifecycle.ts%60%20reaches%20the%20same%20field%20with%20a%20plain%20%60ctx.flushSnapshot%20as%20...%60%20cast%2C%20suggesting%20its%20context%20is%20already%20a%20broader%20type.%20Both%20work%20at%20runtime%2C%20but%20the%20double-cast%20in%20command%20handlers%20will%20silently%20stop%20working%20if%20the%20handler%20context%20type%20ever%20tightens.%20Adding%20%60flushSnapshot%3F%3A%20%28%29%20%3D%3E%20Promise%3Cvoid%3E%60%20to%20the%20server%20context's%20typed%20interface%20would%20resolve%20the%20inconsistency%20and%20remove%20the%20need%20for%20any%20widening%20cast.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(server): close crash-window holes in..."](https://github.com/youhaowei/dashframe/commit/0c26a3fad092b12f7b476bd70ad6a6e05932b597) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40373138)</sub>

<!-- /greptile_comment -->