### PR TITLE
[YW-356] test(server): isolation test — no-flushSnapshot + onWrite-succeeds gate block for credential refs

### DIFF
--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -1145,6 +1145,78 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
     }
   });
 
+  // AC#2 isolation — no-flushSnapshot + onWrite-succeeds pin (YW-356): when
+  // credential refs are present but NO flushSnapshot hook is wired, a resolving
+  // debounced onWrite MUST NOT satisfy the release gate.
+  // "onWrite returned" != "durably persisted" — a future refactor that lets a
+  // successful onWrite satisfy the gate would silently re-open the
+  // crash-window for credentials (process exits between onWrite return and the
+  // debounced write; old snapshot is restored; ref already released → dangling).
+  it("publishDraft blocks credential release when flushSnapshot absent but onWrite succeeds", async () => {
+    const onWriteCalls: number[] = [];
+    const noHook = await makeHarness({
+      onWrite: () => onWriteCalls.push(Date.now()), // onWrite present and resolves
+      // flushSnapshot intentionally absent — the gate must block release here
+    });
+    try {
+      const { id, ref: oldRef } = await seedCanonicalSource(
+        noHook,
+        "original-key",
+      );
+      // Release candidate is live before publish — the gate has something to block.
+      expect(await noHook.vault.has(oldRef)).toBe(true);
+
+      const draftId = await noHook.controller.openDraft();
+      await noHook.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+      ]);
+      await noHook.app.call("publishDraft", { draftId });
+
+      // onWrite was invoked (proves the gate ran, not an early error — the
+      // fail-closed branch calls onWrite for non-credential snapshot scheduling
+      // before returning false). Combined with the vault assertion below, this
+      // pins the no-flushSnapshot credential branch of the gate.
+      expect(onWriteCalls).toHaveLength(1);
+      // Credential ref NOT released — gate blocks because durability is unproven.
+      expect(await noHook.vault.has(oldRef)).toBe(true);
+    } finally {
+      await noHook.db.$client.close();
+      rmSync(noHook.dir, { recursive: true, force: true });
+    }
+  });
+
+  // AC#2 isolation — discard twin (YW-356): same invariant holds for discardDraft.
+  it("discardDraft blocks credential release when flushSnapshot absent but onWrite succeeds", async () => {
+    const onWriteCalls: number[] = [];
+    const noHook = await makeHarness({
+      onWrite: () => onWriteCalls.push(Date.now()), // onWrite present and resolves
+      // flushSnapshot intentionally absent
+    });
+    try {
+      const { id } = await seedCanonicalSource(noHook, "canonical-key");
+      const draftId = await noHook.controller.openDraft();
+      await noHook.controller.appendToDraft(draftId, [
+        cmd("SetDataSourceConfig", { id, apiKey: "draft-key" }),
+      ]);
+      // capture-before-log minted a ref in the log — read it to assert it survives.
+      const logArgs = await firstLogArgs(noHook, draftId);
+      const mintedRef = logArgs.apiKey as SecretRef;
+      expect(isSecretRef(mintedRef)).toBe(true);
+      // Release candidate is live before discard — the gate has something to block.
+      expect(await noHook.vault.has(mintedRef)).toBe(true);
+
+      await noHook.app.call("discardDraft", { draftId });
+
+      // onWrite was invoked (proves we reached the fail-closed branch, not an early error).
+      expect(onWriteCalls).toHaveLength(1);
+      // Minted credential ref NOT released — gate blocks because durability is unproven.
+      expect(await noHook.vault.has(mintedRef)).toBe(true);
+    } finally {
+      await noHook.db.$client.close();
+      rmSync(noHook.dir, { recursive: true, force: true });
+    }
+  });
+
   // Non-credential publish still uses the debounced onWrite path (no expensive
   // flush on every publish — only on credential-bearing ones).
   it("publishDraft uses onWrite (not flushSnapshot) when no credential refs are replaced", async () => {

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -1145,7 +1145,7 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
     }
   });
 
-  // AC#2 isolation — no-flushSnapshot + onWrite-succeeds pin (YW-356): when
+  // AC#2 isolation — no-flushSnapshot + onWrite-succeeds pin: when
   // credential refs are present but NO flushSnapshot hook is wired, a resolving
   // debounced onWrite MUST NOT satisfy the release gate.
   // "onWrite returned" != "durably persisted" — a future refactor that lets a
@@ -1185,7 +1185,7 @@ describe("pre-release flush gate (flushSnapshot — transition-time path)", () =
     }
   });
 
-  // AC#2 isolation — discard twin (YW-356): same invariant holds for discardDraft.
+  // AC#2 isolation — discard twin: same invariant holds for discardDraft.
   it("discardDraft blocks credential release when flushSnapshot absent but onWrite succeeds", async () => {
     const onWriteCalls: number[] = [];
     const noHook = await makeHarness({


### PR DESCRIPTION
## Summary

- Adds two targeted isolation tests to `apps/server/src/credential-release.test.ts` that pin the regression vector from YW-354: **credential refs present + no `flushSnapshot` hook + `onWrite` (debounced touch) succeeds → ref MUST NOT be released**.
- The tests exercise the fail-closed branch of `gateSnapshotForRelease` in `draft-lifecycle.ts` — the branch where `onWrite` is called for non-credential snapshot scheduling but returns `false` (gate blocked).
- QA mutation-tested: flipping the gate to `return true` in that branch flips both tests from pass to fail (39 pass / 4 fail), confirming they catch the named regression.

## What the tests cover

| Test | Lifecycle | What it proves |
|---|---|---|
| `publishDraft blocks credential release when flushSnapshot absent but onWrite succeeds` | `publishDraft` | Superseded canonical ref survives publish when gate has no flushSnapshot hook, even if onWrite resolves |
| `discardDraft blocks credential release when flushSnapshot absent but onWrite succeeds` | `discardDraft` | Draft-minted ref survives discard under same condition |

Each test asserts both:
1. `onWriteCalls.toHaveLength(1)` — the gate ran (not an early error) and called onWrite as expected before returning false
2. `vault.has(ref) === true` — the credential ref was NOT released

## Pattern

Mirrors the sibling gate tests in the `pre-release flush gate (flushSnapshot — transition-time path)` describe block (the "flushSnapshot succeeds → release" and "flushSnapshot fails → skip release" pairs). Setup is byte-for-byte the same; only the harness options (`onWrite: present, flushSnapshot: absent`) and the final assertion (`toBe(true)` instead of `toBe(false)`) differ.

## Screenshots

No UI change — `apps/server` test-only.

Tracked internally as YW-356.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds two focused isolation tests to `credential-release.test.ts` that pin the regression vector where credential refs must NOT be released when no `flushSnapshot` hook is present, even if `onWrite` resolves successfully. The tests cover both the `publishDraft` and `discardDraft` lifecycle paths.

- Each test wires an `onWrite` stub (but no `flushSnapshot`) via `makeHarness`, then asserts that `onWriteCalls.toHaveLength(1)` (the gate ran) AND that `vault.has(ref)` remains `true` (release was blocked).
- The pattern mirrors the existing sibling tests in the `pre-release flush gate` describe block, differing only in harness options and final assertion polarity.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only addition with no production code changes; teardown is handled correctly via finally blocks and all assertions match the described invariant.

Both new tests follow the established harness pattern, correctly isolate the no-flushSnapshot branch, and their onWriteCalls.toHaveLength(1) + vault.has assertions together pin the exact regression without interfering with existing test setup paths (seedCanonicalSource calls addDataSource which does not trigger onWrite).

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/credential-release.test.ts | Adds two isolation tests (publishDraft + discardDraft) to the existing pre-release flush gate describe block; setup, teardown, and assertion patterns are consistent with existing sibling tests; no ticket ID violations or logic errors found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant App as noHook.app (publishDraft / discardDraft)
    participant Gate as gateSnapshotForRelease
    participant onWrite as onWrite stub
    participant Vault

    Test->>App: "call("publishDraft" | "discardDraft", ...)"
    App->>Gate: check credential refs + hooks
    Gate->>Gate: flushSnapshot absent?
    Note over Gate: No flushSnapshot → fail-closed branch
    Gate->>onWrite: onWrite() — non-credential snapshot scheduling
    onWrite-->>Gate: returns (resolves)
    Gate-->>App: return false (gate blocked)
    App-->>Test: resolve (no release)

    Test->>Vault: has(oldRef / mintedRef)
    Vault-->>Test: true (ref NOT released ✓)
    Test->>Test: onWriteCalls.toHaveLength(1) ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant App as noHook.app (publishDraft / discardDraft)
    participant Gate as gateSnapshotForRelease
    participant onWrite as onWrite stub
    participant Vault

    Test->>App: "call("publishDraft" | "discardDraft", ...)"
    App->>Gate: check credential refs + hooks
    Gate->>Gate: flushSnapshot absent?
    Note over Gate: No flushSnapshot → fail-closed branch
    Gate->>onWrite: onWrite() — non-credential snapshot scheduling
    onWrite-->>Gate: returns (resolves)
    Gate-->>App: return false (gate blocked)
    App-->>Test: resolve (no release)

    Test->>Vault: has(oldRef / mintedRef)
    Vault-->>Test: true (ref NOT released ✓)
    Test->>Test: onWriteCalls.toHaveLength(1) ✓
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove ticket refs from test co..."](https://github.com/youhaowei/dashframe/commit/4b218183ad6b1ee3039fe7bf7235e587fc7dd0e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40385878)</sub>

<!-- /greptile_comment -->