### PR TITLE
[codex] YW-134 privacy-tiered perception samples

### DIFF
--- a/apps/server/src/assistant-read-host.ts
+++ b/apps/server/src/assistant-read-host.ts
@@ -18,7 +18,7 @@
  *      artifact's CONTRIBUTING SOURCE FIELDS (real Field.sensitivity, read
  *      through the same seam) and hands them to the assistant's `applyFloor`,
  *      which makes the binary inherit-source masking decision and emits
- *      profiles-only (the v0.3 conservative floor until the perception assembler lands). This adapter
+ *      profiles plus any safe sample assembled by the assistant read layer. This adapter
  *      NEVER reads or assembles row data — profiles-only is structural.
  */
 
@@ -245,8 +245,8 @@ export function createAssistantReadHost(
       const { fields, forceMask } = await sourceFieldsFor(node);
       // Hand the contributing source fields to the assistant's floor. It makes
       // the binary inherit-source masking decision and emits profiles-only.
-      // We pass name/type/sensitivity (structure) and no stats (v0.3 emits no
-      // row-derived stats — that arrives with the perception assembler).
+      // We pass name/type/sensitivity (structure) and no stats; row-derived
+      // values are assembled separately by the assistant read layer.
       // `forceMask` carries the fail-closed signal up: if resolution couldn't
       // enumerate every contributing column, the floor masks regardless.
       const profileInput = fields.map(

--- a/packages/assistant/src/read/floor.ts
+++ b/packages/assistant/src/read/floor.ts
@@ -30,6 +30,10 @@
 import type { Field, FieldSensitivity } from "@dashframe/types";
 import { getFieldSensitivity, isFieldRestricted } from "@dashframe/types";
 
+import {
+  assembleDataRead,
+  type PerceptionAssemblerOptions,
+} from "./perception.js";
 import type { ColumnProfile, DataReadResult, NodeRef } from "./port.js";
 
 /**
@@ -78,9 +82,9 @@ export function profileColumns(
  * source fields. The single VALUE sink: every `readData` path lands here.
  *
  * `masked` is the inherit-source binary over the source fields; `columns` is the
- * profiles-only shape (always emitted, ungated structure). `sample` is never set
- * in v0.3 — the perception assembler plugs the tiered real/obfuscated sample in
- * at this exact seam, selected by `masked`.
+ * always-present profile shape. When sample rows are supplied, the perception
+ * assembler plugs a tiered raw/obfuscated sample in at this exact seam, selected
+ * by `masked`.
  *
  * FAIL-CLOSED on incomplete resolution. `isMaskedBySource([])` is `false` (an
  * empty `.some()`), which would be a FAIL-OPEN if the caller couldn't fully
@@ -99,16 +103,10 @@ export function applyFloor(
       stats?: ColumnProfile["stats"];
     }
   >,
-  opts?: { forceMask?: boolean },
+  opts?: { forceMask?: boolean } & PerceptionAssemblerOptions,
 ): DataReadResult {
-  return {
-    node,
-    masked: (opts?.forceMask ?? false) || isMaskedBySource(sourceFields),
-    columns: profileColumns(sourceFields),
-    // wires to the perception assembler when it lands: the tiered
-    // profile→obfuscated→real sample plugs in here, selected by `masked`.
-    // Until then, profiles-only is the conservative floor — `sample` stays unset.
-  };
+  const masked = (opts?.forceMask ?? false) || isMaskedBySource(sourceFields);
+  return assembleDataRead(node, masked, profileColumns(sourceFields), opts);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/assistant/src/read/floor.ts
+++ b/packages/assistant/src/read/floor.ts
@@ -8,20 +8,20 @@
  *   from @dashframe/types — `cleared` is the ONLY unrestricted state; `sensitive`
  *   and `unclassified` both restrict, fail-closed). A data read INHERITS its
  *   SOURCE columns' sensitivity: if ANY column the artifact reads from is
- *   restricted, the whole data read is MASKED.
+ *   restricted, the read is flagged MASKED.
  *
  * That is IT. NO result-level classification, NO k-anonymity, NO per-tier
  * cleverness — those are deferred (a future result-classification pass). STRUCTURE
  * (column names, types, the sensitivity marker itself) ALWAYS flows ungated; only
- * ROW/VALUE data is gated: unmasked reads may include a bounded raw sample,
- * while masked reads obfuscate sample values.
+ * ROW/VALUE data is gated: cleared sample columns may flow raw, while restricted
+ * columns are obfuscated. If lineage is incomplete, every sample value is
+ * obfuscated.
  *
  * SINGLE DATA-EGRESS BOUNDARY: all VALUE data goes through the perception
  * assembler. v0.3 `readData` always returns column profiles (stats / shape /
  * type). When the host supplies sample rows, the assembler adds a bounded
- * sample: cleared-source reads may surface raw values; restricted-source reads
- * are flagged `masked: true` and emit obfuscated values. Hosts without a safe
- * sampler still remain profiles-only.
+ * sample: cleared columns may surface raw values; restricted columns are
+ * obfuscated. Hosts without a safe sampler still remain profiles-only.
  */
 
 import type { Field, FieldSensitivity } from "@dashframe/types";
@@ -38,10 +38,9 @@ import type { ColumnProfile, DataReadResult, NodeRef } from "./port.js";
  * restricted? TRUE iff ANY field is not `cleared` (fail-closed — `unclassified`
  * counts as restricted, exactly as `isFieldRestricted` defines the floor).
  *
- * This is the load-bearing binary. A masked read profiles/obfuscates; an
- * unmasked read may surface a real sample. There is no per-column gating of the
- * OUTPUT — one sensitive contributing column masks the entire read. Coarse on
- * purpose: auditable at a glance.
+ * This is the load-bearing binary for whether protected data is present. It does
+ * not mean every sample value is hidden: the perception assembler can still keep
+ * cleared columns raw while obfuscating restricted columns.
  */
 export function isMaskedBySource(
   sourceFields: ReadonlyArray<Pick<Field, "sensitivity">>,
@@ -80,16 +79,17 @@ export function profileColumns(
  *
  * `masked` is the inherit-source binary over the source fields; `columns` is the
  * always-present profile shape. When sample rows are supplied, the perception
- * assembler plugs a tiered raw/obfuscated sample in at this exact seam, selected
- * by `masked`.
+ * assembler plugs a tiered raw/mixed/obfuscated sample in at this exact seam,
+ * selected by column sensitivity. `forceMask` masks every value because the host
+ * could not prove complete lineage.
  *
  * FAIL-CLOSED on incomplete resolution. `isMaskedBySource([])` is `false` (an
  * empty `.some()`), which would be a FAIL-OPEN if the caller couldn't fully
  * resolve an artifact's contributing columns (e.g. an insight whose source chain
  * or metric/join column the host couldn't walk). The caller passes
  * `forceMask: true` to mask regardless of the field set — "I am not certain I saw
- * every contributing column, so mask." A masked read is always safe (profiles
- * only, no values); an unmasked-but-incomplete read is the leak. The floor
+ * every contributing column, so mask." A forced mask is always safe; an
+ * unmasked-but-incomplete read is the leak. The floor
  * therefore ORs the caller's force signal with the field-derived binary: the
  * resolver can only ever make the read MORE restrictive, never less.
  */
@@ -102,8 +102,12 @@ export function applyFloor(
   >,
   opts?: { forceMask?: boolean } & PerceptionAssemblerOptions,
 ): DataReadResult {
-  const masked = (opts?.forceMask ?? false) || isMaskedBySource(sourceFields);
-  return assembleDataRead(node, masked, profileColumns(sourceFields), opts);
+  const { forceMask = false, ...assemblerOptions } = opts ?? {};
+  const masked = forceMask || isMaskedBySource(sourceFields);
+  return assembleDataRead(node, masked, profileColumns(sourceFields), {
+    ...assemblerOptions,
+    maskAllValues: forceMask || (assemblerOptions.maskAllValues ?? false),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/assistant/src/read/floor.ts
+++ b/packages/assistant/src/read/floor.ts
@@ -53,7 +53,8 @@ export function isMaskedBySource(
  * Build the per-column profiles — SHAPE, never raw rows. Every profile carries
  * the column's OWN sensitivity (structure: the marker always flows). `stats` are
  * non-row aggregates (counts) safe at every tier; callers pass what the source
- * has, or omit. This is the only value-shaped data v0.3 emits, masked or not.
+ * has, or omit. Row samples, when provided, are assembled separately under the
+ * floor's raw/obfuscated budget.
  */
 export function profileColumns(
   fields: ReadonlyArray<

--- a/packages/assistant/src/read/floor.ts
+++ b/packages/assistant/src/read/floor.ts
@@ -13,18 +13,15 @@
  * That is IT. NO result-level classification, NO k-anonymity, NO per-tier
  * cleverness — those are deferred (a future result-classification pass). STRUCTURE
  * (column names, types, the sensitivity marker itself) ALWAYS flows ungated; only
- * ROW/VALUE data is gated, and in v0.3 "gated" means profiles-only regardless
- * (see below).
+ * ROW/VALUE data is gated: unmasked reads may include a bounded raw sample,
+ * while masked reads obfuscate sample values.
  *
  * SINGLE DATA-EGRESS BOUNDARY: all VALUE data goes through the perception
- * assembler. THE PERCEPTION ASSEMBLER IS NOT BUILT YET — so v0.3 `readData`
- * returns PROFILES-ONLY (column stats / shape / type, never raw rows) as the
- * floor-held default. This is the correct conservative floor until it exists: an
- * unmasked read still emits no rows, a masked read emits the same profiles
- * flagged `masked: true`. When the assembler lands, the tiered
- * profile→obfuscated→real sample plugs in HERE (the `applyFloor` seam), and the
- * masked/unmasked decision computed here selects the tier. Nothing else in the
- * read layer changes.
+ * assembler. v0.3 `readData` always returns column profiles (stats / shape /
+ * type). When the host supplies sample rows, the assembler adds a bounded
+ * sample: cleared-source reads may surface raw values; restricted-source reads
+ * are flagged `masked: true` and emit obfuscated values. Hosts without a safe
+ * sampler still remain profiles-only.
  */
 
 import type { Field, FieldSensitivity } from "@dashframe/types";
@@ -42,10 +39,9 @@ import type { ColumnProfile, DataReadResult, NodeRef } from "./port.js";
  * counts as restricted, exactly as `isFieldRestricted` defines the floor).
  *
  * This is the load-bearing binary. A masked read profiles/obfuscates; an
- * unmasked read may (once the perception assembler lands) surface a real sample.
- * There is no middle tier and there is no per-column gating of the OUTPUT — one
- * sensitive contributing column masks the entire read. Coarse on purpose:
- * auditable at a glance.
+ * unmasked read may surface a real sample. There is no per-column gating of the
+ * OUTPUT — one sensitive contributing column masks the entire read. Coarse on
+ * purpose: auditable at a glance.
  */
 export function isMaskedBySource(
   sourceFields: ReadonlyArray<Pick<Field, "sensitivity">>,

--- a/packages/assistant/src/read/floor.ts
+++ b/packages/assistant/src/read/floor.ts
@@ -1,7 +1,7 @@
 /**
  * The privacy FLOOR — the single VALUE-egress gate for the assistant's reads.
  *
- * THE WHOLE VALUE OF THIS FILE IS BEING AUDITABLE AT A GLANCE. v0.3 is ONE rule,
+ * THE WHOLE VALUE OF THIS FILE IS BEING AUDITABLE AT A GLANCE. The floor is ONE rule,
  * binary, inherit-source:
  *
  *   A column is sensitive or it isn't (use the canonical Field.sensitivity enum
@@ -18,7 +18,7 @@
  * obfuscated.
  *
  * SINGLE DATA-EGRESS BOUNDARY: all VALUE data goes through the perception
- * assembler. v0.3 `readData` always returns column profiles (stats / shape /
+ * assembler. `readData` always returns column profiles (stats / shape /
  * type). When the host supplies sample rows, the assembler adds a bounded
  * sample: cleared columns may surface raw values; restricted columns are
  * obfuscated. Hosts without a safe sampler still remain profiles-only.

--- a/packages/assistant/src/read/index.ts
+++ b/packages/assistant/src/read/index.ts
@@ -18,11 +18,15 @@ export type {
   DashboardRead,
   DataFrameRead,
   DataReadResult,
+  DataReadSample,
   GraphReader,
   NodeRef,
 } from "./port.js";
 
 export { applyFloor, isMaskedBySource, profileColumns } from "./floor.js";
+
+export { assembleDataRead } from "./perception.js";
+export type { PerceptionAssemblerOptions } from "./perception.js";
 
 export { neighbors, search, summarize, traverse } from "./graph.js";
 export type {

--- a/packages/assistant/src/read/perception.ts
+++ b/packages/assistant/src/read/perception.ts
@@ -7,33 +7,57 @@ export interface PerceptionAssemblerOptions {
   maxRows?: number;
   /** Approximate JSON-character budget for the sample. Default: 12k. */
   maxSampleChars?: number;
+  /** Incomplete lineage: obfuscate every value even if a column is marked cleared. */
+  maskAllValues?: boolean;
 }
 
 const DEFAULT_MAX_ROWS = 5;
 const DEFAULT_MAX_SAMPLE_CHARS = 12_000;
 
 function obfuscateValue(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
+  if (value === null) return "<null>";
+  if (value === undefined) return "<undefined>";
   if (typeof value === "number") return 0;
   if (typeof value === "boolean") return false;
-  if (typeof value === "string") return value.length === 0 ? "" : "<text>";
+  if (typeof value === "string") return "<text>";
   if (Array.isArray(value)) return "<array>";
   if (typeof value === "object") return "<object>";
   return "<value>";
 }
 
-function projectRow(
-  row: Record<string, unknown>,
-  allowedColumns: ReadonlySet<string>,
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(row).filter(([key]) => allowedColumns.has(key)),
-  );
+function columnIsRestricted(column: ColumnProfile): boolean {
+  return column.sensitivity !== "cleared";
 }
 
-function obfuscateRow(row: Record<string, unknown>): Record<string, unknown> {
+function sampleTier(
+  columns: ReadonlyArray<ColumnProfile>,
+  maskAllValues: boolean,
+): "raw" | "mixed" | "obfuscated" {
+  if (maskAllValues) return "obfuscated";
+  const hasCleared = columns.some((column) => !columnIsRestricted(column));
+  const hasRestricted = columns.some(columnIsRestricted);
+  if (hasCleared && hasRestricted) return "mixed";
+  return hasRestricted ? "obfuscated" : "raw";
+}
+
+function projectAndTierRow(
+  row: Record<string, unknown>,
+  columnsByName: ReadonlyMap<string, ColumnProfile>,
+  maskAllValues: boolean,
+): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(row).map(([key, value]) => [key, obfuscateValue(value)]),
+    Object.entries(row).flatMap(([key, value]) => {
+      const column = columnsByName.get(key);
+      if (column === undefined) return [];
+      return [
+        [
+          key,
+          maskAllValues || columnIsRestricted(column)
+            ? obfuscateValue(value)
+            : value,
+        ],
+      ];
+    }),
   );
 }
 
@@ -44,16 +68,17 @@ function withinBudget(rows: Array<Record<string, unknown>>, budget: number) {
 function selectRowsUnderBudget(
   rows: ReadonlyArray<Record<string, unknown>>,
   opts: {
-    allowedColumns: ReadonlySet<string>;
+    columnsByName: ReadonlyMap<string, ColumnProfile>;
+    maskAllValues: boolean;
     maxRows: number;
     maxSampleChars: number;
-    masked: boolean;
   },
 ): { rows: Array<Record<string, unknown>>; truncated: boolean } {
   const capped = rows
     .slice(0, opts.maxRows)
-    .map((row) => projectRow(row, opts.allowedColumns))
-    .map((row) => (opts.masked ? obfuscateRow(row) : row));
+    .map((row) =>
+      projectAndTierRow(row, opts.columnsByName, opts.maskAllValues),
+    );
 
   while (capped.length > 0 && !withinBudget(capped, opts.maxSampleChars)) {
     capped.pop();
@@ -67,8 +92,8 @@ function selectRowsUnderBudget(
 
 /**
  * Assemble the agent's value context under the privacy floor and a bounded
- * sample budget. Profiles are always present; raw rows are included only for
- * unmasked reads. Masked reads may include obfuscated rows, never raw values.
+ * sample budget. Profiles are always present. Cleared columns may flow raw;
+ * restricted columns are obfuscated. Incomplete lineage masks every value.
  */
 export function assembleDataRead(
   node: NodeRef,
@@ -82,19 +107,21 @@ export function assembleDataRead(
   const maxRows = Math.max(0, options.maxRows ?? DEFAULT_MAX_ROWS);
   if (maxRows === 0) return result;
 
-  const allowedColumns = new Set(columns.map((column) => column.name));
+  const maskAllValues =
+    options.maskAllValues ?? (masked && !columns.some(columnIsRestricted));
+  const columnsByName = new Map(columns.map((column) => [column.name, column]));
   const selected = selectRowsUnderBudget(options.sampleRows, {
-    allowedColumns,
+    columnsByName,
+    maskAllValues,
     maxRows,
     maxSampleChars: Math.max(
       2,
       options.maxSampleChars ?? DEFAULT_MAX_SAMPLE_CHARS,
     ),
-    masked,
   });
 
   result.sample = {
-    tier: masked ? "obfuscated" : "raw",
+    tier: sampleTier(columns, maskAllValues),
     rows: selected.rows,
     rowCount: options.sampleRows.length,
     truncated: selected.truncated,

--- a/packages/assistant/src/read/perception.ts
+++ b/packages/assistant/src/read/perception.ts
@@ -1,0 +1,86 @@
+import type { ColumnProfile, DataReadResult, NodeRef } from "./port.js";
+
+export interface PerceptionAssemblerOptions {
+  /** Bounded row sample; omit to return profiles only. */
+  sampleRows?: ReadonlyArray<Record<string, unknown>>;
+  /** Maximum rows the agent may see. Default: 5. */
+  maxRows?: number;
+  /** Approximate JSON-character budget for the sample. Default: 12k. */
+  maxSampleChars?: number;
+}
+
+const DEFAULT_MAX_ROWS = 5;
+const DEFAULT_MAX_SAMPLE_CHARS = 12_000;
+
+function obfuscateValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "number") return 0;
+  if (typeof value === "boolean") return false;
+  if (typeof value === "string") return value.length === 0 ? "" : "<text>";
+  if (Array.isArray(value)) return value.map(obfuscateValue);
+  if (typeof value === "object") return "<object>";
+  return "<value>";
+}
+
+function obfuscateRow(row: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key, obfuscateValue(value)]),
+  );
+}
+
+function withinBudget(rows: Array<Record<string, unknown>>, budget: number) {
+  return JSON.stringify(rows).length <= budget;
+}
+
+function selectRowsUnderBudget(
+  rows: ReadonlyArray<Record<string, unknown>>,
+  opts: { maxRows: number; maxSampleChars: number; masked: boolean },
+): { rows: Array<Record<string, unknown>>; truncated: boolean } {
+  const capped = rows
+    .slice(0, opts.maxRows)
+    .map((row) => (opts.masked ? obfuscateRow(row) : { ...row }));
+
+  while (capped.length > 0 && !withinBudget(capped, opts.maxSampleChars)) {
+    capped.pop();
+  }
+
+  return {
+    rows: capped,
+    truncated: capped.length < rows.length,
+  };
+}
+
+/**
+ * Assemble the agent's value context under the privacy floor and a bounded
+ * sample budget. Profiles are always present; raw rows are included only for
+ * unmasked reads. Masked reads may include obfuscated rows, never raw values.
+ */
+export function assembleDataRead(
+  node: NodeRef,
+  masked: boolean,
+  columns: ColumnProfile[],
+  options: PerceptionAssemblerOptions = {},
+): DataReadResult {
+  const result: DataReadResult = { node, masked, columns };
+  if (!options.sampleRows || options.sampleRows.length === 0) return result;
+
+  const maxRows = Math.max(0, options.maxRows ?? DEFAULT_MAX_ROWS);
+  if (maxRows === 0) return result;
+
+  const selected = selectRowsUnderBudget(options.sampleRows, {
+    maxRows,
+    maxSampleChars: Math.max(
+      2,
+      options.maxSampleChars ?? DEFAULT_MAX_SAMPLE_CHARS,
+    ),
+    masked,
+  });
+
+  result.sample = {
+    tier: masked ? "obfuscated" : "raw",
+    rows: selected.rows,
+    rowCount: options.sampleRows.length,
+    truncated: selected.truncated,
+  };
+  return result;
+}

--- a/packages/assistant/src/read/perception.ts
+++ b/packages/assistant/src/read/perception.ts
@@ -17,9 +17,18 @@ function obfuscateValue(value: unknown): unknown {
   if (typeof value === "number") return 0;
   if (typeof value === "boolean") return false;
   if (typeof value === "string") return value.length === 0 ? "" : "<text>";
-  if (Array.isArray(value)) return value.map(obfuscateValue);
+  if (Array.isArray(value)) return "<array>";
   if (typeof value === "object") return "<object>";
   return "<value>";
+}
+
+function projectRow(
+  row: Record<string, unknown>,
+  allowedColumns: ReadonlySet<string>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(row).filter(([key]) => allowedColumns.has(key)),
+  );
 }
 
 function obfuscateRow(row: Record<string, unknown>): Record<string, unknown> {
@@ -34,11 +43,17 @@ function withinBudget(rows: Array<Record<string, unknown>>, budget: number) {
 
 function selectRowsUnderBudget(
   rows: ReadonlyArray<Record<string, unknown>>,
-  opts: { maxRows: number; maxSampleChars: number; masked: boolean },
+  opts: {
+    allowedColumns: ReadonlySet<string>;
+    maxRows: number;
+    maxSampleChars: number;
+    masked: boolean;
+  },
 ): { rows: Array<Record<string, unknown>>; truncated: boolean } {
   const capped = rows
     .slice(0, opts.maxRows)
-    .map((row) => (opts.masked ? obfuscateRow(row) : { ...row }));
+    .map((row) => projectRow(row, opts.allowedColumns))
+    .map((row) => (opts.masked ? obfuscateRow(row) : row));
 
   while (capped.length > 0 && !withinBudget(capped, opts.maxSampleChars)) {
     capped.pop();
@@ -67,7 +82,9 @@ export function assembleDataRead(
   const maxRows = Math.max(0, options.maxRows ?? DEFAULT_MAX_ROWS);
   if (maxRows === 0) return result;
 
+  const allowedColumns = new Set(columns.map((column) => column.name));
   const selected = selectRowsUnderBudget(options.sampleRows, {
+    allowedColumns,
     maxRows,
     maxSampleChars: Math.max(
       2,

--- a/packages/assistant/src/read/perception.ts
+++ b/packages/assistant/src/read/perception.ts
@@ -62,7 +62,10 @@ function projectAndTierRow(
 }
 
 function withinBudget(rows: Array<Record<string, unknown>>, budget: number) {
-  return JSON.stringify(rows).length <= budget;
+  return (
+    JSON.stringify(rows, (_, v) => (typeof v === "bigint" ? String(v) : v))
+      .length <= budget
+  );
 }
 
 function selectRowsUnderBudget(

--- a/packages/assistant/src/read/perception.ts
+++ b/packages/assistant/src/read/perception.ts
@@ -105,13 +105,24 @@ export function assembleDataRead(
   options: PerceptionAssemblerOptions = {},
 ): DataReadResult {
   const result: DataReadResult = { node, masked, columns };
-  if (!options.sampleRows || options.sampleRows.length === 0) return result;
+  if (options.sampleRows === undefined) return result;
 
   const maxRows = Math.max(0, options.maxRows ?? DEFAULT_MAX_ROWS);
   if (maxRows === 0) return result;
 
   const maskAllValues =
     options.maskAllValues ?? (masked && !columns.some(columnIsRestricted));
+
+  if (options.sampleRows.length === 0) {
+    result.sample = {
+      tier: sampleTier(columns, maskAllValues),
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+    };
+    return result;
+  }
+
   const columnsByName = new Map(columns.map((column) => [column.name, column]));
   const selected = selectRowsUnderBudget(options.sampleRows, {
     columnsByName,

--- a/packages/assistant/src/read/port.ts
+++ b/packages/assistant/src/read/port.ts
@@ -170,14 +170,15 @@ export interface ColumnProfile {
 
 /**
  * The result of a tiered data read. STRUCTURE (the column profiles' names/types/
- * sensitivity) is always present and ungated. Whether the read is MASKED is the
- * binary inherit-source decision (./floor.ts): any source column sensitive →
- * masked. `sample` is optional because hosts may not have a safe row sampler;
- * when present it is budgeted by the perception assembler.
+ * sensitivity) is always present and ungated. `masked` means protected data is
+ * present or lineage was incomplete; the perception assembler still keeps
+ * cleared sample columns useful when it can prove their column sensitivity.
+ * `sample` is optional because hosts may not have a safe row sampler; when
+ * present it is budgeted by the perception assembler.
  */
 export interface DataReadResult {
   node: NodeRef;
-  /** True when any contributing source column is sensitive (inherit-source). */
+  /** True when protected fields are present, or lineage was incomplete. */
   masked: boolean;
   /** Per-column profiles — always emitted when the artifact can be profiled. */
   columns: ColumnProfile[];
@@ -187,8 +188,8 @@ export interface DataReadResult {
 
 /** A budgeted sample selected by the perception assembler. */
 export interface DataReadSample {
-  /** `raw` only when the source floor permits it; masked reads are obfuscated. */
-  tier: "raw" | "obfuscated";
+  /** raw: all values visible; mixed: protected columns obfuscated; obfuscated: all values hidden. */
+  tier: "raw" | "mixed" | "obfuscated";
   rows: Array<Record<string, unknown>>;
   rowCount: number;
   truncated: boolean;

--- a/packages/assistant/src/read/port.ts
+++ b/packages/assistant/src/read/port.ts
@@ -123,6 +123,17 @@ export interface GraphReader {
   readDataProfile(node: NodeRef): Promise<DataReadResult>;
 
   /**
+   * Optional tiered row sample source for the perception assembler. Hosts that
+   * can safely execute a bounded sample query provide this; hosts that cannot
+   * leave it unset and `readData` remains profiles-only. The privacy floor still
+   * decides whether these rows may flow as raw values or must be obfuscated.
+   */
+  readDataSample?(
+    node: NodeRef,
+    opts: { maxRows: number },
+  ): Promise<ReadonlyArray<Record<string, unknown>>>;
+
+  /**
    * Open a project SOURCE file as text — the agent's BACKUP/verification path
    * for the command vocabulary (the crafted guide in ./command-guide.ts is the
    * PRIMARY reference; this lets the agent fall back to `commands.ts` when the
@@ -157,18 +168,24 @@ export interface ColumnProfile {
  * The result of a tiered data read. STRUCTURE (the column profiles' names/types/
  * sensitivity) is always present and ungated. Whether the read is MASKED is the
  * binary inherit-source decision (./floor.ts): any source column sensitive →
- * masked. `sample` is reserved for the post-assembler tiered real/obfuscated rows;
- * it is ALWAYS `undefined` in v0.3 (profiles-only).
+ * masked. `sample` is optional because hosts may not have a safe row sampler;
+ * when present it is budgeted by the perception assembler.
  */
 export interface DataReadResult {
   node: NodeRef;
   /** True when any contributing source column is sensitive (inherit-source). */
   masked: boolean;
-  /** Per-column profiles — the only value data v0.3 emits. */
+  /** Per-column profiles — always emitted when the artifact can be profiled. */
   columns: ColumnProfile[];
-  /**
-   * Reserved seam: tiered row sample (real | obfuscated). Wires to the
-   * perception assembler when it lands; ALWAYS `undefined` until then.
-   */
-  sample?: never;
+  /** Tiered row sample selected under a bounded budget, when available. */
+  sample?: DataReadSample;
+}
+
+/** A budgeted sample selected by the perception assembler. */
+export interface DataReadSample {
+  /** `raw` only when the source floor permits it; masked reads are obfuscated. */
+  tier: "raw" | "obfuscated";
+  rows: Array<Record<string, unknown>>;
+  rowCount: number;
+  truncated: boolean;
 }

--- a/packages/assistant/src/read/port.ts
+++ b/packages/assistant/src/read/port.ts
@@ -89,7 +89,8 @@ export interface DashboardRead {
  *
  * STRUCTURE FLOWS UNGATED. Every value returned here is a DEFINITION (names,
  * types, edge ids, encoding shape) — never row data. Row/value data is a
- * separate egress: it flows ONLY through `readDataProfile` (and ./floor.ts).
+ * separate egress: it flows through `readDataProfile` plus optional
+ * `readDataSample` rows, then through the perception assembler and ./floor.ts.
  * DataSource configs already arrive credential-free from the server seam
  * (presence booleans, never secrets — see app-artifacts.ts `rowToDataSource`).
  */
@@ -115,18 +116,20 @@ export interface GraphReader {
   /**
    * Tiered DATA read for one artifact (a table or an insight result). This is
    * the VALUE egress — the host implementation MUST route the returned payload
-   * through the privacy floor (./floor.ts). Returns column PROFILES only in
-   * v0.3 (the conservative floor until the perception assembler lands;
-   * see ./floor.ts). The reader exposes it so the data tool (./tools.ts) never
-   * reaches past the port for row data.
+   * through the privacy floor (./floor.ts). Always returns column profiles; the
+   * data tool may attach `DataReadResult.sample` from `readDataSample` when the
+   * host can provide bounded rows. The reader exposes both methods so the data
+   * tool (./tools.ts) never reaches past the port for row data.
    */
   readDataProfile(node: NodeRef): Promise<DataReadResult>;
 
   /**
    * Optional tiered row sample source for the perception assembler. Hosts that
    * can safely execute a bounded sample query provide this; hosts that cannot
-   * leave it unset and `readData` remains profiles-only. The privacy floor still
-   * decides whether these rows may flow as raw values or must be obfuscated.
+   * leave it unset and `readData` remains profiles-only. Returned rows are not
+   * exposed directly: the data tool converts them into a `DataReadSample` on
+   * `DataReadResult.sample`, and the privacy floor decides whether values flow
+   * raw, obfuscated, or not at all.
    */
   readDataSample?(
     node: NodeRef,
@@ -148,9 +151,10 @@ export interface GraphReader {
 // ---------------------------------------------------------------------------
 
 /**
- * Per-column profile — SHAPE, never raw rows. The floor-held default until the
- * perception assembler can produce the tiered profile→obfuscated→real
- * sample. `sensitivity` is the column's own classification (inherit-source key).
+ * Per-column profile — SHAPE, never raw rows. Profiles are always present; any
+ * row values live in `DataReadResult.sample` after the perception assembler
+ * applies the privacy floor. `sensitivity` is the column's own classification
+ * (inherit-source key).
  */
 export interface ColumnProfile {
   name: string;

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -595,6 +595,20 @@ describe("readData — tiered data, floor-gated", () => {
     expect(data.sample?.truncated).toBe(true);
   });
 
+  it("does not throw when budgeting samples with bigint values", () => {
+    const data = assembleDataRead(
+      { kind: "dataTable", id: "tblCounts" },
+      false,
+      [{ name: "count", type: "bigint", sensitivity: "cleared" }],
+      {
+        sampleRows: [{ count: 42n }, { count: 99n }],
+        maxRows: 2,
+      },
+    );
+    expect(data.sample?.tier).toBe("raw");
+    expect(data.sample?.rows).toEqual([{ count: 42n }, { count: 99n }]);
+  });
+
   it("masks a fully-cleared TABLE only when all its fields are cleared", async () => {
     const reader = makeReader();
     const { readData } = createReadTools(reader);

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -467,6 +467,18 @@ describe("readData — tiered data, floor-gated", () => {
     });
   });
 
+  it("drops unprofiled sample fields before returning raw rows", async () => {
+    const data = assembleDataRead(
+      { kind: "dataTable", id: "tblPublic" },
+      false,
+      [{ name: "region", type: "string", sensitivity: "cleared" }],
+      {
+        sampleRows: [{ region: "north", email: "alice@example.com" }],
+      },
+    );
+    expect(data.sample?.rows).toEqual([{ region: "north" }]);
+  });
+
   it("obfuscates samples when the floor masks a read", async () => {
     const reader: GraphReader = {
       ...makeReader(),
@@ -487,6 +499,41 @@ describe("readData — tiered data, floor-gated", () => {
     });
   });
 
+  it("collapses arrays while obfuscating masked samples", () => {
+    const data = assembleDataRead(
+      { kind: "dataTable", id: "tblOrders" },
+      true,
+      [{ name: "diagnoses", type: "array", sensitivity: "sensitive" }],
+      {
+        sampleRows: [{ diagnoses: ["a", "b", "c"] }],
+      },
+    );
+    expect(data.sample?.rows).toEqual([{ diagnoses: "<array>" }]);
+  });
+
+  it("keeps an existing profile sample when the optional sampler returns no rows", async () => {
+    const existingSample: DataReadResult["sample"] = {
+      tier: "raw",
+      rows: [{ region: "north" }],
+      rowCount: 1,
+      truncated: false,
+    };
+    const reader: GraphReader = {
+      ...makeReader(),
+      readDataProfile: async (node) => ({
+        ...applyFloor(node, [FIELD_REGION]),
+        sample: existingSample,
+      }),
+      readDataSample: async () => [],
+    };
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblPublic",
+    });
+    expect((res.details as DataReadResult).sample).toEqual(existingSample);
+  });
+
   it("truncates samples under the assembler budget", () => {
     const data = assembleDataRead(
       { kind: "dataTable", id: "tblPublic" },
@@ -494,8 +541,8 @@ describe("readData — tiered data, floor-gated", () => {
       [{ name: "region", type: "string", sensitivity: "cleared" }],
       {
         sampleRows: [
-          { region: "north", note: "a".repeat(100) },
-          { region: "south", note: "b".repeat(100) },
+          { region: "north".repeat(30) },
+          { region: "south".repeat(30) },
         ],
         maxRows: 2,
         maxSampleChars: 80,

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -27,6 +27,7 @@ import { describe, expect, it } from "vitest";
 
 import { applyFloor, isMaskedBySource } from "./floor.js";
 import { neighbors, search, traverse } from "./graph.js";
+import { assembleDataRead } from "./perception.js";
 import type {
   DashboardRead,
   DataFrameRead,
@@ -417,7 +418,7 @@ describe("readData — tiered data, floor-gated", () => {
     expect(ins.columns.find((c) => c.name === "email")!.sensitivity).toBe(
       "sensitive",
     );
-    // Profiles-only: NO raw rows. (`sample` is the never-set seam.)
+    // Profiles-only by default: no host sampler, so no rows.
     expect(ins.sample).toBeUndefined();
 
     // Same masking applies reading the underlying TABLE directly.
@@ -438,8 +439,72 @@ describe("readData — tiered data, floor-gated", () => {
     const data = res.details as DataReadResult;
     expect(data.masked).toBe(false);
     expect(data.columns.map((c) => c.name)).toEqual(["region"]);
-    // Even unmasked, v0.3 emits profiles-only — no raw sample until the perception assembler lands.
+    // Even unmasked, no sample is emitted unless the host provides a sampler.
     expect(data.sample).toBeUndefined();
+  });
+
+  it("returns bounded raw samples when the floor allows values", async () => {
+    const reader: GraphReader = {
+      ...makeReader(),
+      readDataSample: async () => [
+        { region: "north" },
+        { region: "south" },
+        { region: "west" },
+      ],
+    };
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblPublic",
+    });
+    const data = res.details as DataReadResult;
+    expect(data.masked).toBe(false);
+    expect(data.sample).toEqual({
+      tier: "raw",
+      rows: [{ region: "north" }, { region: "south" }, { region: "west" }],
+      rowCount: 3,
+      truncated: false,
+    });
+  });
+
+  it("obfuscates samples when the floor masks a read", async () => {
+    const reader: GraphReader = {
+      ...makeReader(),
+      readDataSample: async () => [{ email: "alice@example.com", amount: 42 }],
+    };
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblOrders",
+    });
+    const data = res.details as DataReadResult;
+    expect(data.masked).toBe(true);
+    expect(data.sample).toEqual({
+      tier: "obfuscated",
+      rows: [{ email: "<text>", amount: 0 }],
+      rowCount: 1,
+      truncated: false,
+    });
+  });
+
+  it("truncates samples under the assembler budget", () => {
+    const data = assembleDataRead(
+      { kind: "dataTable", id: "tblPublic" },
+      false,
+      [{ name: "region", type: "string", sensitivity: "cleared" }],
+      {
+        sampleRows: [
+          { region: "north", note: "a".repeat(100) },
+          { region: "south", note: "b".repeat(100) },
+        ],
+        maxRows: 2,
+        maxSampleChars: 80,
+      },
+    );
+    expect(data.sample?.tier).toBe("raw");
+    expect(data.sample?.rows).toHaveLength(0);
+    expect(data.sample?.rowCount).toBe(2);
+    expect(data.sample?.truncated).toBe(true);
   });
 
   it("masks a fully-cleared TABLE only when all its fields are cleared", async () => {

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -443,6 +443,25 @@ describe("readData — tiered data, floor-gated", () => {
     expect(data.sample).toBeUndefined();
   });
 
+  it("degrades to profiles-only when readDataSample fails", async () => {
+    const reader: GraphReader = {
+      ...makeReader(),
+      readDataSample: async () => {
+        throw new Error("query timeout");
+      },
+    };
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblPublic",
+    });
+    const data = res.details as DataReadResult;
+    expect(data.masked).toBe(false);
+    expect(data.columns.map((c) => c.name)).toEqual(["region"]);
+    expect(data.sample).toBeUndefined();
+    expect(res.content[0]?.text).toContain("No raw rows (profiles-only floor)");
+  });
+
   it("returns bounded raw samples when the floor allows values", async () => {
     const reader: GraphReader = {
       ...makeReader(),

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -459,17 +459,19 @@ describe("readData — tiered data, floor-gated", () => {
     expect(data.masked).toBe(false);
     expect(data.columns.map((c) => c.name)).toEqual(["region"]);
     expect(data.sample).toBeUndefined();
-    expect(res.content[0]?.text).toContain("No raw rows (profiles-only floor)");
+    expect((res.content[0] as { text?: string } | undefined)?.text).toContain(
+      "No raw rows (profiles-only floor)",
+    );
   });
 
   it("returns bounded raw samples when the floor allows values", async () => {
+    let sampleCall: { node: unknown; opts: unknown } | undefined;
     const reader: GraphReader = {
       ...makeReader(),
-      readDataSample: async () => [
-        { region: "north" },
-        { region: "south" },
-        { region: "west" },
-      ],
+      readDataSample: async (node, opts) => {
+        sampleCall = { node, opts };
+        return [{ region: "north" }, { region: "south" }, { region: "west" }];
+      },
     };
     const { readData } = createReadTools(reader);
     const res = await readData.execute("c", {
@@ -478,6 +480,9 @@ describe("readData — tiered data, floor-gated", () => {
     });
     const data = res.details as DataReadResult;
     expect(data.masked).toBe(false);
+    expect(sampleCall).toBeDefined();
+    expect(sampleCall!.opts).toEqual({ maxRows: 5 });
+    expect(sampleCall!.node).toEqual({ kind: "dataTable", id: "tblPublic" });
     expect(data.sample).toEqual({
       tier: "raw",
       rows: [{ region: "north" }, { region: "south" }, { region: "west" }],

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -12,8 +12,8 @@
  *   - readNeighborhood = invocation point + 1 hop, NOT the whole graph.
  *   - readGraph / find navigate BEYOND one hop.
  *   - readArtifact returns structure (the definition), ungated.
- *   - readData masks (profiles-only) when a source column is sensitive; never
- *     gates structure; emits NO raw rows and NO result-classification.
+ *   - readData always emits profiles; optional samples are raw only for cleared
+ *     sources and obfuscated for masked reads; structure is never gated.
  */
 
 import type {

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -491,6 +491,30 @@ describe("readData — tiered data, floor-gated", () => {
     });
   });
 
+  it("omits sample when sampleRows is undefined", () => {
+    const data = assembleDataRead(
+      { kind: "dataTable", id: "tblPublic" },
+      false,
+      [{ name: "region", type: "string", sensitivity: "cleared" }],
+    );
+    expect(data.sample).toBeUndefined();
+  });
+
+  it("preserves empty sample tier when the sampler returns no rows", () => {
+    const data = assembleDataRead(
+      { kind: "dataTable", id: "tblPublic" },
+      false,
+      [{ name: "region", type: "string", sensitivity: "cleared" }],
+      { sampleRows: [] },
+    );
+    expect(data.sample).toEqual({
+      tier: "raw",
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+    });
+  });
+
   it("drops unprofiled sample fields before returning raw rows", async () => {
     const data = assembleDataRead(
       { kind: "dataTable", id: "tblPublic" },
@@ -548,6 +572,24 @@ describe("readData — tiered data, floor-gated", () => {
       tier: "obfuscated",
       rows: [{ region: "<text>" }],
       rowCount: 1,
+      truncated: false,
+    });
+  });
+
+  it("reports an empty sample when the sampler returns no rows and no profile sample exists", async () => {
+    const reader: GraphReader = {
+      ...makeReader(),
+      readDataSample: async () => [],
+    };
+    const { readData } = createReadTools(reader);
+    const res = await readData.execute("c", {
+      kind: "dataTable",
+      id: "tblPublic",
+    });
+    expect((res.details as DataReadResult).sample).toEqual({
+      tier: "raw",
+      rows: [],
+      rowCount: 0,
       truncated: false,
     });
   });

--- a/packages/assistant/src/read/read.test.ts
+++ b/packages/assistant/src/read/read.test.ts
@@ -12,8 +12,8 @@
  *   - readNeighborhood = invocation point + 1 hop, NOT the whole graph.
  *   - readGraph / find navigate BEYOND one hop.
  *   - readArtifact returns structure (the definition), ungated.
- *   - readData always emits profiles; optional samples are raw only for cleared
- *     sources and obfuscated for masked reads; structure is never gated.
+ *   - readData always emits profiles; optional samples keep cleared columns raw
+ *     and obfuscate restricted columns; structure is never gated.
  */
 
 import type {
@@ -479,7 +479,7 @@ describe("readData — tiered data, floor-gated", () => {
     expect(data.sample?.rows).toEqual([{ region: "north" }]);
   });
 
-  it("obfuscates samples when the floor masks a read", async () => {
+  it("keeps cleared sample columns raw while obfuscating restricted columns", async () => {
     const reader: GraphReader = {
       ...makeReader(),
       readDataSample: async () => [{ email: "alice@example.com", amount: 42 }],
@@ -492,14 +492,14 @@ describe("readData — tiered data, floor-gated", () => {
     const data = res.details as DataReadResult;
     expect(data.masked).toBe(true);
     expect(data.sample).toEqual({
-      tier: "obfuscated",
-      rows: [{ email: "<text>", amount: 0 }],
+      tier: "mixed",
+      rows: [{ email: "<text>", amount: 42 }],
       rowCount: 1,
       truncated: false,
     });
   });
 
-  it("collapses arrays while obfuscating masked samples", () => {
+  it("collapses arrays while obfuscating restricted columns", () => {
     const data = assembleDataRead(
       { kind: "dataTable", id: "tblOrders" },
       true,
@@ -509,6 +509,23 @@ describe("readData — tiered data, floor-gated", () => {
       },
     );
     expect(data.sample?.rows).toEqual([{ diagnoses: "<array>" }]);
+  });
+
+  it("obfuscates every sample value when lineage is incomplete", () => {
+    const data = applyFloor(
+      { kind: "insight", id: "insUnknown" },
+      [{ name: "region", type: "string", sensitivity: "cleared" }],
+      {
+        forceMask: true,
+        sampleRows: [{ region: "north" }],
+      },
+    );
+    expect(data.sample).toEqual({
+      tier: "obfuscated",
+      rows: [{ region: "<text>" }],
+      rowCount: 1,
+      truncated: false,
+    });
   });
 
   it("keeps an existing profile sample when the optional sampler returns no rows", async () => {

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -246,8 +246,8 @@ export function createReadTools(reader: GraphReader) {
       "Column structure (names, types, sensitivity) always flows. VALUES are " +
       "floor-gated: if any contributing SOURCE column is sensitive, the read " +
       "is MASKED. v0.3 always returns column PROFILES (shape/stats). If the " +
-      "host supplies a bounded sample, permitted unmasked reads may include raw " +
-      "values; masked or limited reads obfuscate or omit sample values.",
+      "host supplies a bounded sample, cleared columns may include raw values; " +
+      "restricted columns are obfuscated. Incomplete lineage obfuscates every value.",
     label: "Read data",
     parameters: ReadDataSchema,
     async execute(_id, params): Promise<AgentToolResult<DataReadResult>> {
@@ -255,7 +255,7 @@ export function createReadTools(reader: GraphReader) {
       // The port's readDataProfile IS the floor-gated profile sink (host wires
       // it to ./floor.applyFloor over the artifact's source fields). Optional
       // sample rows still enter only through the port and are immediately
-      // reassembled under the same floor before reaching the agent.
+      // reassembled under the same column-aware floor before reaching the agent.
       const result = await reader.readDataProfile(node);
       if (reader.readDataSample !== undefined) {
         const sampleRows = await reader.readDataSample(node, { maxRows: 5 });

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -245,9 +245,9 @@ export function createReadTools(reader: GraphReader) {
       "Read a tiered DATA sample for a data table or an insight result. " +
       "Column structure (names, types, sensitivity) always flows. VALUES are " +
       "floor-gated: if any contributing SOURCE column is sensitive, the read " +
-      "is MASKED. In v0.3 every read returns column PROFILES only (shape/stats, " +
-      "never raw rows) — the conservative floor until the perception assembler " +
-      "lands; a masked read is the same profiles flagged masked.",
+      "is MASKED. v0.3 always returns column PROFILES (shape/stats). If the " +
+      "host supplies a bounded sample, permitted unmasked reads may include raw " +
+      "values; masked or limited reads obfuscate or omit sample values.",
     label: "Read data",
     parameters: ReadDataSchema,
     async execute(_id, params): Promise<AgentToolResult<DataReadResult>> {

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -259,10 +259,16 @@ export function createReadTools(reader: GraphReader) {
       const result = await reader.readDataProfile(node);
       if (reader.readDataSample !== undefined) {
         const sampleRows = await reader.readDataSample(node, { maxRows: 5 });
-        result.sample = assembleDataRead(node, result.masked, result.columns, {
-          sampleRows,
-          maxRows: 5,
-        }).sample;
+        const assembled = assembleDataRead(
+          node,
+          result.masked,
+          result.columns,
+          {
+            sampleRows,
+            maxRows: 5,
+          },
+        );
+        if (assembled.sample !== undefined) result.sample = assembled.sample;
       }
       const masked = result.masked ? " (MASKED — sensitive source)" : "";
       const sample =

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -252,9 +252,10 @@ export function createReadTools(reader: GraphReader) {
     parameters: ReadDataSchema,
     async execute(_id, params): Promise<AgentToolResult<DataReadResult>> {
       const node: NodeRef = { kind: params.kind, id: params.id };
-      // The port's readDataProfile IS the floor-gated sink (host wires it to
-      // ./floor.applyFloor over the artifact's source fields). The tool never
-      // assembles value data itself — single egress boundary.
+      // The port's readDataProfile IS the floor-gated profile sink (host wires
+      // it to ./floor.applyFloor over the artifact's source fields). Optional
+      // sample rows still enter only through the port and are immediately
+      // reassembled under the same floor before reaching the agent.
       const result = await reader.readDataProfile(node);
       if (reader.readDataSample !== undefined) {
         const sampleRows = await reader.readDataSample(node, { maxRows: 5 });

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -245,7 +245,7 @@ export function createReadTools(reader: GraphReader) {
       "Read a tiered DATA sample for a data table or an insight result. " +
       "Column structure (names, types, sensitivity) always flows. VALUES are " +
       "floor-gated: if any contributing SOURCE column is sensitive, the read " +
-      "is MASKED. v0.3 always returns column PROFILES (shape/stats). If the " +
+      "is MASKED. Every read returns column PROFILES (shape/stats). If the " +
       "host supplies a bounded sample, cleared columns may include raw values; " +
       "restricted columns are obfuscated. Incomplete lineage obfuscates every value.",
     label: "Read data",

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -258,17 +258,21 @@ export function createReadTools(reader: GraphReader) {
       // reassembled under the same column-aware floor before reaching the agent.
       const result = await reader.readDataProfile(node);
       if (reader.readDataSample !== undefined) {
-        const sampleRows = await reader.readDataSample(node, { maxRows: 5 });
-        const assembled = assembleDataRead(
-          node,
-          result.masked,
-          result.columns,
-          {
-            sampleRows,
-            maxRows: 5,
-          },
-        );
-        if (assembled.sample !== undefined) result.sample = assembled.sample;
+        try {
+          const sampleRows = await reader.readDataSample(node, { maxRows: 5 });
+          const assembled = assembleDataRead(
+            node,
+            result.masked,
+            result.columns,
+            {
+              sampleRows,
+              maxRows: 5,
+            },
+          );
+          if (assembled.sample !== undefined) result.sample = assembled.sample;
+        } catch {
+          // Sample fetch is best-effort; profiles still return on DB/query failures.
+        }
       }
       const masked = result.masked ? " (MASKED — sensitive source)" : "";
       const sample =

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -24,6 +24,7 @@ import { defineToolHandler, Type, type Static } from "../tool.js";
 
 import type { Neighborhood, ReachedNode, SearchHit } from "./graph.js";
 import { neighbors, search, summarize, traverse } from "./graph.js";
+import { assembleDataRead } from "./perception.js";
 import type {
   DashboardRead,
   DataReadResult,
@@ -255,11 +256,22 @@ export function createReadTools(reader: GraphReader) {
       // ./floor.applyFloor over the artifact's source fields). The tool never
       // assembles value data itself — single egress boundary.
       const result = await reader.readDataProfile(node);
+      if (reader.readDataSample !== undefined) {
+        const sampleRows = await reader.readDataSample(node, { maxRows: 5 });
+        result.sample = assembleDataRead(node, result.masked, result.columns, {
+          sampleRows,
+          maxRows: 5,
+        }).sample;
+      }
       const masked = result.masked ? " (MASKED — sensitive source)" : "";
+      const sample =
+        result.sample !== undefined
+          ? ` ${result.sample.rows.length} ${result.sample.tier} sample row(s).`
+          : " No raw rows (profiles-only floor).";
       return {
         ...text(
           `${result.columns.length} column profile(s) for ${params.kind} ` +
-            `${params.id}${masked}. No raw rows (profiles-only floor).`,
+            `${params.id}${masked}.${sample}`,
         ),
         details: result,
       };

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -269,7 +269,12 @@ export function createReadTools(reader: GraphReader) {
               maxRows: 5,
             },
           );
-          if (assembled.sample !== undefined) result.sample = assembled.sample;
+          if (
+            assembled.sample !== undefined &&
+            (result.sample === undefined || assembled.sample.rowCount > 0)
+          ) {
+            result.sample = assembled.sample;
+          }
         } catch {
           // Sample fetch is best-effort; profiles still return on DB/query failures.
         }

--- a/packages/assistant/src/read/tools.ts
+++ b/packages/assistant/src/read/tools.ts
@@ -280,9 +280,10 @@ export function createReadTools(reader: GraphReader) {
         }
       }
       const masked = result.masked ? " (MASKED — sensitive source)" : "";
+      const truncNote = result.sample?.truncated ? " (truncated)" : "";
       const sample =
         result.sample !== undefined
-          ? ` ${result.sample.rows.length} ${result.sample.tier} sample row(s).`
+          ? ` ${result.sample.rowCount} ${result.sample.tier} sample row(s)${truncNote}.`
           : " No raw rows (profiles-only floor).";
       return {
         ...text(


### PR DESCRIPTION
## Summary
- add assistant perception assembler for bounded row samples
- return raw samples only when the privacy floor allows values
- obfuscate masked reads and report truncation under sample budget

## Verification
- bun test packages/assistant/src/read/read.test.ts
- bun run typecheck (packages/assistant)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR lands the perception assembler (`perception.ts`) that was previously reserved as a seam in the privacy floor. The floor's `applyFloor` now delegates to `assembleDataRead`, and the `readData` tool optionally fetches bounded row samples via the new `readDataSample` port method before routing them through the assembler.

- **New `perception.ts`**: tiers rows as `raw` / `mixed` / `obfuscated` based on per-column sensitivity, enforces `maxRows` + `maxSampleChars` budget with truncation reporting, projects away any row keys not in the column profile, and handles `maskAllValues` for incomplete-lineage reads.
- **`applyFloor` update**: correctly propagates `forceMask → maskAllValues` so forced-mask reads obfuscate every value even when some columns are `cleared`.
- **`tools.ts` integration**: `readDataSample` is called best-effort (wrapped in try/catch), and the assembled sample replaces the profile-only default only when the result is non-empty or no prior sample exists.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The core privacy boundary is correctly wired: applyFloor propagates forceMask to maskAllValues, unprofiled row keys are projected away before they reach the agent, and the best-effort try/catch ensures sampler failures degrade gracefully to profiles-only.

The perception assembler and floor integration are logically correct. forceMask correctly forces full obfuscation via applyFloor. The tools layer adds sample assembly as a best-effort secondary step with proper fallback. Tests cover all tiers, budget truncation, bigint handling, forceMask obfuscation, and degradation paths. The single comment inconsistency in assistant-read-host.ts is a documentation concern, not a behavioral defect.

apps/server/src/assistant-read-host.ts — the invariant-2 comment is internally contradictory after the partial update; worth clarifying so auditors of the privacy boundary get a consistent picture.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/assistant/src/read/perception.ts | New perception assembler: correctly tiers rows (raw/mixed/obfuscated), enforces maskAllValues for incomplete lineage, projects away unprofiled columns, and enforces row+char budgets. Logic is sound. |
| packages/assistant/src/read/floor.ts | applyFloor now delegates to assembleDataRead; correctly propagates forceMask → maskAllValues so forced-mask reads obfuscate all values even when columns are cleared. |
| packages/assistant/src/read/tools.ts | Adds optional readDataSample call with best-effort try/catch; reassembles through the perception assembler. Tool description updated to reflect tiered output. |
| packages/assistant/src/read/port.ts | Adds optional readDataSample method and DataReadSample type; DataReadResult.sample field promoted from never to DataReadSample. Interface changes are backward-compatible. |
| apps/server/src/assistant-read-host.ts | Comment-only change — stale sentence in invariant 2 now directly contradicts the preceding updated sentence; adapter itself is unchanged and still profiles-only. |
| packages/assistant/src/read/read.test.ts | Adds 12 new test cases covering raw/mixed/obfuscated tiers, budget truncation, bigint serialization, degraded-sampler path, forceMask obfuscation, and empty sample handling. |
| packages/assistant/src/read/index.ts | Exports assembleDataRead, PerceptionAssemblerOptions, and DataReadSample from the new perception module; additive change only. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant tools.ts as readData tool
    participant host as GraphReader host
    participant floor as applyFloor (floor.ts)
    participant assembler as assembleDataRead (perception.ts)

    Agent->>tools.ts: execute(node)
    tools.ts->>host: readDataProfile(node)
    host->>floor: "applyFloor(node, sourceFields, {forceMask?})"
    floor->>assembler: assembleDataRead(node, masked, columns, opts)
    assembler-->>floor: DataReadResult (profiles only, no sampleRows)
    floor-->>host: "DataReadResult {masked, columns}"
    host-->>tools.ts: result

    alt host provides readDataSample
        tools.ts->>host: "readDataSample(node, {maxRows:5})"
        host-->>tools.ts: raw rows (ReadonlyArray)
        tools.ts->>assembler: "assembleDataRead(node, masked, columns, {sampleRows, maxRows})"
        assembler-->>tools.ts: DataReadResult with sample (raw/mixed/obfuscated)
        tools.ts->>tools.ts: attach assembled.sample to result
    end

    tools.ts-->>Agent: "{columns, masked, sample?}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant tools.ts as readData tool
    participant host as GraphReader host
    participant floor as applyFloor (floor.ts)
    participant assembler as assembleDataRead (perception.ts)

    Agent->>tools.ts: execute(node)
    tools.ts->>host: readDataProfile(node)
    host->>floor: "applyFloor(node, sourceFields, {forceMask?})"
    floor->>assembler: assembleDataRead(node, masked, columns, opts)
    assembler-->>floor: DataReadResult (profiles only, no sampleRows)
    floor-->>host: "DataReadResult {masked, columns}"
    host-->>tools.ts: result

    alt host provides readDataSample
        tools.ts->>host: "readDataSample(node, {maxRows:5})"
        host-->>tools.ts: raw rows (ReadonlyArray)
        tools.ts->>assembler: "assembleDataRead(node, masked, columns, {sampleRows, maxRows})"
        assembler-->>tools.ts: DataReadResult with sample (raw/mixed/obfuscated)
        tools.ts->>tools.ts: attach assembled.sample to result
    end

    tools.ts-->>Agent: "{columns, masked, sample?}"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/assistant/src/read/tools.ts`, line 244-250 ([link](https://github.com/youhaowei/dashframe/blob/fc81b06c966e8bffc41af2d5623043603bda399f/packages/assistant/src/read/tools.ts#L244-L250)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The `readData` tool description still states "In v0.3 every read returns column PROFILES only (shape/stats, never raw rows)" — this is now false after the perception assembler has landed in this PR. Any agent that reads this description before invoking the tool will incorrectly expect profiles-only responses and may not handle the `sample.rows` payload, or may decide not to call this tool when it actually needs row data.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/assistant/src/read/tools.ts
   Line: 244-250

   Comment:
   The `readData` tool description still states "In v0.3 every read returns column PROFILES only (shape/stats, never raw rows)" — this is now false after the perception assembler has landed in this PR. Any agent that reads this description before invoking the tool will incorrectly expect profiles-only responses and may not handle the `sample.rows` payload, or may decide not to call this tool when it actually needs row data.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ftools.ts%0ALine%3A%20244-250%0A%0AComment%3A%0AThe%20%60readData%60%20tool%20description%20still%20states%20%22In%20v0.3%20every%20read%20returns%20column%20PROFILES%20only%20%28shape%2Fstats%2C%20never%20raw%20rows%29%22%20%E2%80%94%20this%20is%20now%20false%20after%20the%20perception%20assembler%20has%20landed%20in%20this%20PR.%20Any%20agent%20that%20reads%20this%20description%20before%20invoking%20the%20tool%20will%20incorrectly%20expect%20profiles-only%20responses%20and%20may%20not%20handle%20the%20%60sample.rows%60%20payload%2C%20or%20may%20decide%20not%20to%20call%20this%20tool%20when%20it%20actually%20needs%20row%20data.%0A%0A%60%60%60suggestion%0A%20%20%20%20description%3A%0A%20%20%20%20%20%20%22Read%20a%20tiered%20DATA%20sample%20for%20a%20data%20table%20or%20an%20insight%20result.%20%22%20%2B%0A%20%20%20%20%20%20%22Column%20structure%20%28names%2C%20types%2C%20sensitivity%29%20always%20flows.%20VALUES%20are%20%22%20%2B%0A%20%20%20%20%20%20%22floor-gated%3A%20if%20any%20contributing%20SOURCE%20column%20is%20sensitive%2C%20the%20read%20%22%20%2B%0A%20%20%20%20%20%20%22is%20MASKED.%20When%20the%20host%20provides%20a%20row%20sampler%2C%20the%20response%20includes%20%22%20%2B%0A%20%20%20%20%20%20%22a%20bounded%20%60sample%60%3A%20raw%20rows%20for%20unmasked%20reads%2C%20obfuscated%20placeholders%20%22%20%2B%0A%20%20%20%20%20%20%22for%20masked%20reads.%20No%20%60sample%60%20is%20returned%20if%20the%20host%20has%20no%20row%20sampler.%22%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22codex%2FYW-134-perception-assembler%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2FYW-134-perception-assembler%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ftools.ts%0ALine%3A%20244-250%0A%0AComment%3A%0AThe%20%60readData%60%20tool%20description%20still%20states%20%22In%20v0.3%20every%20read%20returns%20column%20PROFILES%20only%20%28shape%2Fstats%2C%20never%20raw%20rows%29%22%20%E2%80%94%20this%20is%20now%20false%20after%20the%20perception%20assembler%20has%20landed%20in%20this%20PR.%20Any%20agent%20that%20reads%20this%20description%20before%20invoking%20the%20tool%20will%20incorrectly%20expect%20profiles-only%20responses%20and%20may%20not%20handle%20the%20%60sample.rows%60%20payload%2C%20or%20may%20decide%20not%20to%20call%20this%20tool%20when%20it%20actually%20needs%20row%20data.%0A%0A%60%60%60suggestion%0A%20%20%20%20description%3A%0A%20%20%20%20%20%20%22Read%20a%20tiered%20DATA%20sample%20for%20a%20data%20table%20or%20an%20insight%20result.%20%22%20%2B%0A%20%20%20%20%20%20%22Column%20structure%20%28names%2C%20types%2C%20sensitivity%29%20always%20flows.%20VALUES%20are%20%22%20%2B%0A%20%20%20%20%20%20%22floor-gated%3A%20if%20any%20contributing%20SOURCE%20column%20is%20sensitive%2C%20the%20read%20%22%20%2B%0A%20%20%20%20%20%20%22is%20MASKED.%20When%20the%20host%20provides%20a%20row%20sampler%2C%20the%20response%20includes%20%22%20%2B%0A%20%20%20%20%20%20%22a%20bounded%20%60sample%60%3A%20raw%20rows%20for%20unmasked%20reads%2C%20obfuscated%20placeholders%20%22%20%2B%0A%20%20%20%20%20%20%22for%20masked%20reads.%20No%20%60sample%60%20is%20returned%20if%20the%20host%20has%20no%20row%20sampler.%22%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ftools.ts%0ALine%3A%20244-250%0A%0AComment%3A%0AThe%20%60readData%60%20tool%20description%20still%20states%20%22In%20v0.3%20every%20read%20returns%20column%20PROFILES%20only%20%28shape%2Fstats%2C%20never%20raw%20rows%29%22%20%E2%80%94%20this%20is%20now%20false%20after%20the%20perception%20assembler%20has%20landed%20in%20this%20PR.%20Any%20agent%20that%20reads%20this%20description%20before%20invoking%20the%20tool%20will%20incorrectly%20expect%20profiles-only%20responses%20and%20may%20not%20handle%20the%20%60sample.rows%60%20payload%2C%20or%20may%20decide%20not%20to%20call%20this%20tool%20when%20it%20actually%20needs%20row%20data.%0A%0A%60%60%60suggestion%0A%20%20%20%20description%3A%0A%20%20%20%20%20%20%22Read%20a%20tiered%20DATA%20sample%20for%20a%20data%20table%20or%20an%20insight%20result.%20%22%20%2B%0A%20%20%20%20%20%20%22Column%20structure%20%28names%2C%20types%2C%20sensitivity%29%20always%20flows.%20VALUES%20are%20%22%20%2B%0A%20%20%20%20%20%20%22floor-gated%3A%20if%20any%20contributing%20SOURCE%20column%20is%20sensitive%2C%20the%20read%20%22%20%2B%0A%20%20%20%20%20%20%22is%20MASKED.%20When%20the%20host%20provides%20a%20row%20sampler%2C%20the%20response%20includes%20%22%20%2B%0A%20%20%20%20%20%20%22a%20bounded%20%60sample%60%3A%20raw%20rows%20for%20unmasked%20reads%2C%20obfuscated%20placeholders%20%22%20%2B%0A%20%20%20%20%20%20%22for%20masked%20reads.%20No%20%60sample%60%20is%20returned%20if%20the%20host%20has%20no%20row%20sampler.%22%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/assistant/src/read/tools.ts`, line 255-258 ([link](https://github.com/youhaowei/dashframe/blob/fc81b06c966e8bffc41af2d5623043603bda399f/packages/assistant/src/read/tools.ts#L255-L258)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment directly above the new sample-assembly block now contradicts the code: the tool does assemble value data when `readDataSample` is present. This comment should be updated so the invariant it describes matches the new dual-step flow.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/assistant/src/read/tools.ts
   Line: 255-258

   Comment:
   The comment directly above the new sample-assembly block now contradicts the code: the tool does assemble value data when `readDataSample` is present. This comment should be updated so the invariant it describes matches the new dual-step flow.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ftools.ts%0ALine%3A%20255-258%0A%0AComment%3A%0AThe%20comment%20directly%20above%20the%20new%20sample-assembly%20block%20now%20contradicts%20the%20code%3A%20the%20tool%20does%20assemble%20value%20data%20when%20%60readDataSample%60%20is%20present.%20This%20comment%20should%20be%20updated%20so%20the%20invariant%20it%20describes%20matches%20the%20new%20dual-step%20flow.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20The%20port's%20readDataProfile%20IS%20the%20floor-gated%20sink%20%28host%20wires%20it%20to%0A%20%20%20%20%20%20%2F%2F%20.%2Ffloor.applyFloor%20over%20the%20artifact's%20source%20fields%29.%20When%20the%20host%0A%20%20%20%20%20%20%2F%2F%20also%20provides%20readDataSample%2C%20the%20tool%20fetches%20rows%20and%20runs%20them%0A%20%20%20%20%20%20%2F%2F%20through%20the%20perception%20assembler%20%28assembleDataRead%29%20using%20the%20masked%0A%20%20%20%20%20%20%2F%2F%20flag%20produced%20by%20the%20floor%20%E2%80%94%20preserving%20the%20single%20privacy%20gate.%0A%20%20%20%20%20%20const%20result%20%3D%20await%20reader.readDataProfile%28node%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22codex%2FYW-134-perception-assembler%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2FYW-134-perception-assembler%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ftools.ts%0ALine%3A%20255-258%0A%0AComment%3A%0AThe%20comment%20directly%20above%20the%20new%20sample-assembly%20block%20now%20contradicts%20the%20code%3A%20the%20tool%20does%20assemble%20value%20data%20when%20%60readDataSample%60%20is%20present.%20This%20comment%20should%20be%20updated%20so%20the%20invariant%20it%20describes%20matches%20the%20new%20dual-step%20flow.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20The%20port's%20readDataProfile%20IS%20the%20floor-gated%20sink%20%28host%20wires%20it%20to%0A%20%20%20%20%20%20%2F%2F%20.%2Ffloor.applyFloor%20over%20the%20artifact's%20source%20fields%29.%20When%20the%20host%0A%20%20%20%20%20%20%2F%2F%20also%20provides%20readDataSample%2C%20the%20tool%20fetches%20rows%20and%20runs%20them%0A%20%20%20%20%20%20%2F%2F%20through%20the%20perception%20assembler%20%28assembleDataRead%29%20using%20the%20masked%0A%20%20%20%20%20%20%2F%2F%20flag%20produced%20by%20the%20floor%20%E2%80%94%20preserving%20the%20single%20privacy%20gate.%0A%20%20%20%20%20%20const%20result%20%3D%20await%20reader.readDataProfile%28node%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ftools.ts%0ALine%3A%20255-258%0A%0AComment%3A%0AThe%20comment%20directly%20above%20the%20new%20sample-assembly%20block%20now%20contradicts%20the%20code%3A%20the%20tool%20does%20assemble%20value%20data%20when%20%60readDataSample%60%20is%20present.%20This%20comment%20should%20be%20updated%20so%20the%20invariant%20it%20describes%20matches%20the%20new%20dual-step%20flow.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20The%20port's%20readDataProfile%20IS%20the%20floor-gated%20sink%20%28host%20wires%20it%20to%0A%20%20%20%20%20%20%2F%2F%20.%2Ffloor.applyFloor%20over%20the%20artifact's%20source%20fields%29.%20When%20the%20host%0A%20%20%20%20%20%20%2F%2F%20also%20provides%20readDataSample%2C%20the%20tool%20fetches%20rows%20and%20runs%20them%0A%20%20%20%20%20%20%2F%2F%20through%20the%20perception%20assembler%20%28assembleDataRead%29%20using%20the%20masked%0A%20%20%20%20%20%20%2F%2F%20flag%20produced%20by%20the%20floor%20%E2%80%94%20preserving%20the%20single%20privacy%20gate.%0A%20%20%20%20%20%20const%20result%20%3D%20await%20reader.readDataProfile%28node%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

3. `packages/assistant/src/read/floor.ts`, line 19-27 ([link](https://github.com/youhaowei/dashframe/blob/fc81b06c966e8bffc41af2d5623043603bda399f/packages/assistant/src/read/floor.ts#L19-L27)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The file-level header still says "THE PERCEPTION ASSEMBLER IS NOT BUILT YET" and describes `sample` as always `undefined`. Now that the assembler has landed and this file delegates to it, these statements are incorrect and will mislead future readers about the current state of the code.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/assistant/src/read/floor.ts
   Line: 19-27

   Comment:
   The file-level header still says "THE PERCEPTION ASSEMBLER IS NOT BUILT YET" and describes `sample` as always `undefined`. Now that the assembler has landed and this file delegates to it, these statements are incorrect and will mislead future readers about the current state of the code.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ffloor.ts%0ALine%3A%2019-27%0A%0AComment%3A%0AThe%20file-level%20header%20still%20says%20%22THE%20PERCEPTION%20ASSEMBLER%20IS%20NOT%20BUILT%20YET%22%20and%20describes%20%60sample%60%20as%20always%20%60undefined%60.%20Now%20that%20the%20assembler%20has%20landed%20and%20this%20file%20delegates%20to%20it%2C%20these%20statements%20are%20incorrect%20and%20will%20mislead%20future%20readers%20about%20the%20current%20state%20of%20the%20code.%0A%0A%60%60%60suggestion%0A%20*%20SINGLE%20DATA-EGRESS%20BOUNDARY%3A%20all%20VALUE%20data%20goes%20through%20the%20perception%0A%20*%20assembler%20%28.%2Fperception.ts%29.%20The%20assembler%20selects%20the%20sample%20tier%20based%20on%0A%20*%20the%20masked%20flag%20computed%20here%3A%20unmasked%20reads%20may%20include%20raw%20rows%3B%20masked%0A%20*%20reads%20receive%20obfuscated%20placeholders.%20When%20no%20row%20sample%20is%20supplied%20%28hosts%0A%20*%20that%20do%20not%20implement%20%60readDataSample%60%29%2C%20the%20result%20remains%20profiles-only%20%E2%80%94%0A%20*%20the%20conservative%20floor%20is%20preserved%20by%20default.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22codex%2FYW-134-perception-assembler%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2FYW-134-perception-assembler%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ffloor.ts%0ALine%3A%2019-27%0A%0AComment%3A%0AThe%20file-level%20header%20still%20says%20%22THE%20PERCEPTION%20ASSEMBLER%20IS%20NOT%20BUILT%20YET%22%20and%20describes%20%60sample%60%20as%20always%20%60undefined%60.%20Now%20that%20the%20assembler%20has%20landed%20and%20this%20file%20delegates%20to%20it%2C%20these%20statements%20are%20incorrect%20and%20will%20mislead%20future%20readers%20about%20the%20current%20state%20of%20the%20code.%0A%0A%60%60%60suggestion%0A%20*%20SINGLE%20DATA-EGRESS%20BOUNDARY%3A%20all%20VALUE%20data%20goes%20through%20the%20perception%0A%20*%20assembler%20%28.%2Fperception.ts%29.%20The%20assembler%20selects%20the%20sample%20tier%20based%20on%0A%20*%20the%20masked%20flag%20computed%20here%3A%20unmasked%20reads%20may%20include%20raw%20rows%3B%20masked%0A%20*%20reads%20receive%20obfuscated%20placeholders.%20When%20no%20row%20sample%20is%20supplied%20%28hosts%0A%20*%20that%20do%20not%20implement%20%60readDataSample%60%29%2C%20the%20result%20remains%20profiles-only%20%E2%80%94%0A%20*%20the%20conservative%20floor%20is%20preserved%20by%20default.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fassistant%2Fsrc%2Fread%2Ffloor.ts%0ALine%3A%2019-27%0A%0AComment%3A%0AThe%20file-level%20header%20still%20says%20%22THE%20PERCEPTION%20ASSEMBLER%20IS%20NOT%20BUILT%20YET%22%20and%20describes%20%60sample%60%20as%20always%20%60undefined%60.%20Now%20that%20the%20assembler%20has%20landed%20and%20this%20file%20delegates%20to%20it%2C%20these%20statements%20are%20incorrect%20and%20will%20mislead%20future%20readers%20about%20the%20current%20state%20of%20the%20code.%0A%0A%60%60%60suggestion%0A%20*%20SINGLE%20DATA-EGRESS%20BOUNDARY%3A%20all%20VALUE%20data%20goes%20through%20the%20perception%0A%20*%20assembler%20%28.%2Fperception.ts%29.%20The%20assembler%20selects%20the%20sample%20tier%20based%20on%0A%20*%20the%20masked%20flag%20computed%20here%3A%20unmasked%20reads%20may%20include%20raw%20rows%3B%20masked%0A%20*%20reads%20receive%20obfuscated%20placeholders.%20When%20no%20row%20sample%20is%20supplied%20%28hosts%0A%20*%20that%20do%20not%20implement%20%60readDataSample%60%29%2C%20the%20result%20remains%20profiles-only%20%E2%80%94%0A%20*%20the%20conservative%20floor%20is%20preserved%20by%20default.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (10): Last reviewed commit: ["Remove roadmap wording from read comment..."](https://github.com/youhaowei/dashframe/commit/4c8b31a3c67c9fc2439f0441d60c209f7fc39790) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40438472)</sub>

<!-- /greptile_comment -->