### PR TITLE
[codex] Add shared Clawpatch wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "clawpatch": "scripts/clawpatch.sh",
     "clawpatch:map": "scripts/clawpatch.sh map --source heuristic --json",
     "clawpatch:review": "scripts/clawpatch.sh review --since origin/main --json --no-input",
+    "clawpatch:review:branch": "scripts/clawpatch-review-branch.sh",
     "version": "changeset version && node scripts/annotate-web-changelog.mjs",
     "release": "changeset publish"
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "changeset": "changeset",
     "changeset:ai": "node scripts/ai-changeset.mjs",
     "changeset:status": "changeset status",
+    "clawpatch": "scripts/clawpatch.sh",
+    "clawpatch:map": "scripts/clawpatch.sh map --source heuristic --json",
+    "clawpatch:review": "scripts/clawpatch.sh review --since origin/main --json --no-input",
     "version": "changeset version && node scripts/annotate-web-changelog.mjs",
     "release": "changeset publish"
   },

--- a/scripts/clawpatch-review-branch.sh
+++ b/scripts/clawpatch-review-branch.sh
@@ -26,4 +26,4 @@ worktree="$("$repo_root/scripts/ensure-worktree.sh" "$branch")"
 cd "$worktree"
 
 "$worktree/scripts/clawpatch.sh" map --source heuristic --json
-exec "$worktree/scripts/clawpatch.sh" review --since origin/main --json --no-input "${extra_args[@]}"
+exec "$worktree/scripts/clawpatch.sh" review --since origin/main --json --no-input "${extra_args[@]:-}"

--- a/scripts/clawpatch-review-branch.sh
+++ b/scripts/clawpatch-review-branch.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Map and review a feature branch from an isolated worktree with shared Clawpatch state.
+#
+# Usage:
+#   scripts/clawpatch-review-branch.sh <branch> [-- extra review flags]
+#
+# Example:
+#   bun run clawpatch:review:branch -- codex/YW-134-perception-assembler
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+branch="${1:?usage: clawpatch-review-branch.sh <branch> [-- extra review flags]}"
+shift
+
+extra_args=()
+if [[ "${1:-}" == "--" ]]; then
+  shift
+  extra_args=("$@")
+fi
+
+worktree="$("$repo_root/scripts/ensure-worktree.sh" "$branch")"
+cd "$worktree"
+
+"$worktree/scripts/clawpatch.sh" map --source heuristic --json
+exec "$worktree/scripts/clawpatch.sh" review --since origin/main --json --no-input "${extra_args[@]}"

--- a/scripts/clawpatch-review-branch.sh
+++ b/scripts/clawpatch-review-branch.sh
@@ -13,7 +13,11 @@ branch="${1:?usage: clawpatch-review-branch.sh <branch> [-- extra review flags]}
 shift
 
 extra_args=()
-if [[ "${1:-}" == "--" ]]; then
+if [[ $# -gt 0 ]]; then
+  if [[ "${1:-}" != "--" ]]; then
+    echo "usage: clawpatch-review-branch.sh <branch> [-- extra review flags]" >&2
+    exit 1
+  fi
   shift
   extra_args=("$@")
 fi

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -10,7 +10,9 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
-git_dir=$(git rev-parse --git-common-dir); main_root=$(dirname "$git_dir"); project_name=$(basename "$main_root")
+git_dir=$(git rev-parse --path-format=absolute --git-common-dir)
+main_root=$(dirname "$git_dir")
+project_name=$(basename "$main_root")
 
 # Parse explicit --state-dir (or -s) from caller args before any default/pre-flight init
 state_dir_from_arg=""

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 git_dir=$(git rev-parse --path-format=absolute --git-common-dir)
 main_root=$(dirname "$git_dir")
-project_name=$(basename "$main_root")
+project_name="$(basename "$main_root")-$(printf '%s' "$git_dir" | cksum | cut -d' ' -f1)"
 
 # Parse explicit --state-dir (or -s) from caller args before any default/pre-flight init
 state_dir_from_arg=""

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -10,9 +10,27 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
-project_name="$(basename "$repo_root")"
+git_dir=$(git rev-parse --git-common-dir); main_root=$(dirname "$git_dir"); project_name=$(basename "$main_root")
 
-if [[ -n "${CLAWPATCH_STATE_DIR:-}" ]]; then
+# Parse explicit --state-dir (or -s) from caller args before any default/pre-flight init
+state_dir_from_arg=""
+parse_args=("$@")
+while [[ ${#parse_args[@]} -gt 0 ]]; do
+  arg="${parse_args[0]}"
+  parse_args=("${parse_args[@]:1}")
+  if [[ "$arg" == "--state-dir" && ${#parse_args[@]} -gt 0 ]]; then
+    state_dir_from_arg="${parse_args[0]}"; break
+  elif [[ "$arg" == --state-dir=* ]]; then
+    state_dir_from_arg="${arg#*=}"; break
+  elif [[ "$arg" == "-s" && ${#parse_args[@]} -gt 0 ]]; then
+    state_dir_from_arg="${parse_args[0]}"; break
+  elif [[ "$arg" == -s=* ]]; then
+    state_dir_from_arg="${arg#*=}"; break
+  fi
+done
+if [[ -n "$state_dir_from_arg" ]]; then
+  state_dir="$state_dir_from_arg"
+elif [[ -n "${CLAWPATCH_STATE_DIR:-}" ]]; then
   state_dir="$CLAWPATCH_STATE_DIR"
 elif [[ -n "${XDG_STATE_HOME:-}" ]]; then
   preferred_state_dir="${XDG_STATE_HOME}/clawpatch/$project_name"

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Repo-local Clawpatch wrapper: shared state outside any single worktree.
+#
+# Reliable workflow (from repo root):
+#   bun run clawpatch:review:branch -- <branch>     # map + review in worktree
+#   CLAWPATCH_STATE_DIR=~/.local/state/clawpatch/dashframe bun run clawpatch:map
+#   cd <worktree> && bun run clawpatch:review
+#
+# State dir: CLAWPATCH_STATE_DIR → XDG_STATE_HOME → ~/.local/state → /tmp fallback.
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
@@ -6,14 +14,22 @@ project_name="$(basename "$repo_root")"
 
 if [[ -n "${CLAWPATCH_STATE_DIR:-}" ]]; then
   state_dir="$CLAWPATCH_STATE_DIR"
-else
-  user_state_home="${XDG_STATE_HOME:-"$HOME/.local/state"}"
-  preferred_state_dir="$user_state_home/clawpatch/$project_name"
+elif [[ -n "${XDG_STATE_HOME:-}" ]]; then
+  preferred_state_dir="${XDG_STATE_HOME}/clawpatch/$project_name"
   if mkdir -p "$preferred_state_dir" 2>/dev/null; then
     state_dir="$preferred_state_dir"
   else
     state_dir="${TMPDIR:-/tmp}/clawpatch-state/$project_name"
   fi
+elif [[ -n "${HOME:-}" ]]; then
+  preferred_state_dir="${HOME}/.local/state/clawpatch/$project_name"
+  if mkdir -p "$preferred_state_dir" 2>/dev/null; then
+    state_dir="$preferred_state_dir"
+  else
+    state_dir="${TMPDIR:-/tmp}/clawpatch-state/$project_name"
+  fi
+else
+  state_dir="${TMPDIR:-/tmp}/clawpatch-state/$project_name"
 fi
 
 mkdir -p "$state_dir"
@@ -34,7 +50,7 @@ if [[ "$1" == "review" ]]; then
   shift
   has_jobs=false
   for arg in "$@"; do
-    if [[ "$arg" == "--jobs" || "$arg" == --jobs=* ]]; then
+    if [[ "$arg" == "--jobs" || "$arg" == --jobs=* || "$arg" == "-j" ]]; then
       has_jobs=true
       break
     fi

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+project_name="$(basename "$repo_root")"
+
+if [[ -n "${CLAWPATCH_STATE_DIR:-}" ]]; then
+  state_dir="$CLAWPATCH_STATE_DIR"
+else
+  user_state_home="${XDG_STATE_HOME:-"$HOME/.local/state"}"
+  preferred_state_dir="$user_state_home/clawpatch/$project_name"
+  if mkdir -p "$preferred_state_dir" 2>/dev/null; then
+    state_dir="$preferred_state_dir"
+  else
+    state_dir="${TMPDIR:-/tmp}/clawpatch-state/$project_name"
+  fi
+fi
+
+mkdir -p "$state_dir"
+
+if [[ ! -f "$state_dir/project.json" && -f "$repo_root/.clawpatch/project.json" ]]; then
+  cp -R "$repo_root/.clawpatch/." "$state_dir/"
+fi
+
+if [[ ! -f "$state_dir/project.json" ]]; then
+  clawpatch --state-dir "$state_dir" init --json >/dev/null
+fi
+
+if [[ $# -eq 0 ]]; then
+  set -- status --json
+fi
+
+if [[ "$1" == "review" ]]; then
+  shift
+  has_jobs=false
+  for arg in "$@"; do
+    if [[ "$arg" == "--jobs" || "$arg" == --jobs=* ]]; then
+      has_jobs=true
+      break
+    fi
+  done
+
+  if [[ "$has_jobs" == false ]]; then
+    set -- review --jobs 1 "$@"
+  else
+    set -- review "$@"
+  fi
+fi
+
+clawpatch --state-dir "$state_dir" "$@"


### PR DESCRIPTION
## Summary
- add a repo-local Clawpatch wrapper that keeps state outside any single worktree
- add package scripts for status/map/review workflows
- default review runs to --jobs 1 unless the caller opts into a different jobs setting

## Verification
- bash -n scripts/clawpatch.sh
- CLAWPATCH_STATE_DIR=/tmp/dashframe-clawpatch-pr-state bun run clawpatch -- status --json

## Notes
- This is tooling-only. It does not include the PR #197 assistant read-layer changes.
- The wrapper uses CLAWPATCH_STATE_DIR when set, otherwise XDG_STATE_HOME/~/.local/state, with a /tmp fallback for sandboxed environments.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a repo-local Clawpatch wrapper (`scripts/clawpatch.sh`) that resolves a shared state directory outside any single worktree, along with a branch-review helper (`scripts/clawpatch-review-branch.sh`) and four `bun run clawpatch*` shortcuts in `package.json`.

- `clawpatch.sh` resolves the state dir via a priority chain (explicit arg → `CLAWPATCH_STATE_DIR` → `XDG_STATE_HOME` → `HOME` → `/tmp`), seeds it from `.clawpatch/` on first run, and defaults `review` to `--jobs 1` unless the caller supplies a jobs flag.
- `clawpatch-review-branch.sh` delegates to `ensure-worktree.sh` to set up an isolated worktree, runs `map`, then `exec`s `review` with optional extra flags forwarded via `extra_args`.
- Previously flagged issues (the `$HOME` unbound variable under `set -u` and the missing `-j` short-form detection) are both addressed in this revision.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for Linux/CI users; the default case of clawpatch-review-branch.sh (no extra flags) still aborts on macOS where bash 3.2 is the system default.

The core wrapper logic in clawpatch.sh is solid and the previously flagged bugs are fixed. However, clawpatch-review-branch.sh line 29 still uses "${extra_args[@]:-}" on a declared-but-empty array under set -u, which aborts with unbound variable on bash 3.2 (macOS system default). Any developer running bun run clawpatch:review:branch -- <branch> without extra flags on a Mac will hit this immediately.

scripts/clawpatch-review-branch.sh — the empty-array expansion on the final exec line fails on macOS default bash
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/clawpatch.sh | New wrapper script resolving shared state dir across worktrees; state-dir priority chain, arg-parsing loop, and --jobs 1 defaulting all look correct. Previously flagged issues (HOME unbound var, -j detection) are addressed. |
| scripts/clawpatch-review-branch.sh | New helper that sets up a worktree, maps, then reviews; the empty-array expansion "${extra_args[@]:-}" on line 29 still triggers unbound variable on macOS (bash 3.2, the default) when no extra flags are passed. |
| package.json | Four new bun script entries added for clawpatch workflows; straightforward and consistent with existing script naming conventions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun run clawpatch*] --> B{which script?}

    B --> |clawpatch| C[clawpatch.sh]
    B --> |clawpatch:map| C
    B --> |clawpatch:review| C
    B --> |clawpatch:review:branch| D[clawpatch-review-branch.sh]

    D --> D1[ensure-worktree.sh branch]
    D1 --> D2[cd worktree]
    D2 --> D3[clawpatch.sh map --source heuristic --json]
    D3 --> D4[exec clawpatch.sh review --since origin/main ...]

    C --> E{resolve state_dir}
    E --> |--state-dir arg| F[use arg value]
    E --> |CLAWPATCH_STATE_DIR| G[use env var]
    E --> |XDG_STATE_HOME| H[XDG_STATE_HOME/clawpatch/project]
    E --> |HOME set| I[HOME/.local/state/clawpatch/project]
    E --> |else| J[TMPDIR /tmp/clawpatch-state/project]

    F & G & H & I & J --> K[mkdir -p state_dir]
    K --> L{seed state}
    L --> |.clawpatch/project.json exists| M[cp -R .clawpatch/ to state_dir]
    L --> |else| N{init needed?}
    M --> N
    N --> |no project.json| O[clawpatch init]
    N --> |exists| P{command?}
    O --> P

    P --> |none| Q[set -- status --json]
    P --> |review| R{--jobs present?}
    Q --> S[clawpatch --state-dir state_dir args]
    R --> |no| T[prepend --jobs 1]
    R --> |yes| U[pass through]
    T & U --> S
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[bun run clawpatch*] --> B{which script?}

    B --> |clawpatch| C[clawpatch.sh]
    B --> |clawpatch:map| C
    B --> |clawpatch:review| C
    B --> |clawpatch:review:branch| D[clawpatch-review-branch.sh]

    D --> D1[ensure-worktree.sh branch]
    D1 --> D2[cd worktree]
    D2 --> D3[clawpatch.sh map --source heuristic --json]
    D3 --> D4[exec clawpatch.sh review --since origin/main ...]

    C --> E{resolve state_dir}
    E --> |--state-dir arg| F[use arg value]
    E --> |CLAWPATCH_STATE_DIR| G[use env var]
    E --> |XDG_STATE_HOME| H[XDG_STATE_HOME/clawpatch/project]
    E --> |HOME set| I[HOME/.local/state/clawpatch/project]
    E --> |else| J[TMPDIR /tmp/clawpatch-state/project]

    F & G & H & I & J --> K[mkdir -p state_dir]
    K --> L{seed state}
    L --> |.clawpatch/project.json exists| M[cp -R .clawpatch/ to state_dir]
    L --> |else| N{init needed?}
    M --> N
    N --> |no project.json| O[clawpatch init]
    N --> |exists| P{command?}
    O --> P

    P --> |none| Q[set -- status --json]
    P --> |review| R{--jobs present?}
    Q --> S[clawpatch --state-dir state_dir args]
    R --> |no| T[prepend --jobs 1]
    R --> |yes| U[pass through]
    T & U --> S
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(clawpatch): safe empty array expansi..."](https://github.com/youhaowei/dashframe/commit/dade9065a712dd42aeaa6dd3076fa0dca3b85b47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40614840)</sub>

<!-- /greptile_comment -->