### PR TITLE
Wire keychain credential resolution into provider measurement CLI

### DIFF
--- a/packages/assistant/src/oauth/token-provider.ts
+++ b/packages/assistant/src/oauth/token-provider.ts
@@ -15,6 +15,15 @@ export class OAuthTokenExpiredError extends Error {
   }
 }
 
+/**
+ * `readKeychain` and `fetchRefresh` must be stable function references (a
+ * module-level function, a memoized closure, etc.) — NOT an inline closure
+ * created fresh per call. `getOAuthToken`'s `CredentialState` cache is
+ * WeakMap-keyed on these two functions (see `credentialStatesByReader`
+ * below); a new closure each call is a new WeakMap key, so every call misses
+ * the cache and loses both the in-memory refresh-token rotation tracking and
+ * the single-flight in-flight-refresh dedup.
+ */
 export interface TokenProviderOptions {
   /**
    * Injectable keychain reader for testing.

--- a/packages/assistant/src/provider-credential.test.ts
+++ b/packages/assistant/src/provider-credential.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ensureAnthropicCredential } from "./provider-credential";
+
+describe("ensureAnthropicCredential", () => {
+  it("leaves the environment untouched when ANTHROPIC_OAUTH_TOKEN is already set", async () => {
+    const env = { ANTHROPIC_OAUTH_TOKEN: "existing-oauth-token" };
+    const getToken = vi.fn();
+
+    await ensureAnthropicCredential({ env, getToken });
+
+    expect(getToken).not.toHaveBeenCalled();
+    expect(env.ANTHROPIC_OAUTH_TOKEN).toBe("existing-oauth-token");
+  });
+
+  it("leaves the environment untouched when ANTHROPIC_API_KEY is already set", async () => {
+    const env: Record<string, string | undefined> = {
+      ANTHROPIC_API_KEY: "existing-api-key",
+    };
+    const getToken = vi.fn();
+
+    await ensureAnthropicCredential({ env, getToken });
+
+    expect(getToken).not.toHaveBeenCalled();
+    expect(env.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  it("resolves and sets ANTHROPIC_OAUTH_TOKEN from the injected token source when neither env var is set", async () => {
+    const env: Record<string, string | undefined> = {};
+    const getToken = vi.fn(async () => "resolved-token-from-keychain");
+
+    await ensureAnthropicCredential({ env, getToken });
+
+    expect(getToken).toHaveBeenCalledOnce();
+    expect(env.ANTHROPIC_OAUTH_TOKEN).toBe("resolved-token-from-keychain");
+  });
+
+  it("treats a blank-string env value as unset and still resolves via the token source", async () => {
+    const env: Record<string, string | undefined> = {
+      ANTHROPIC_OAUTH_TOKEN: "   ",
+      ANTHROPIC_API_KEY: "",
+    };
+    const getToken = vi.fn(async () => "resolved-token");
+
+    await ensureAnthropicCredential({ env, getToken });
+
+    expect(getToken).toHaveBeenCalledOnce();
+    expect(env.ANTHROPIC_OAUTH_TOKEN).toBe("resolved-token");
+  });
+
+  it("prints a fixed, secret-free hint and leaves env unset when the token source fails", async () => {
+    const env: Record<string, string | undefined> = {};
+    const getToken = vi.fn(async () => {
+      throw new Error("keychain says: sk-ant-oat-should-never-appear");
+    });
+    const log = vi.fn();
+
+    await ensureAnthropicCredential({ env, getToken, log });
+
+    expect(env.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+    expect(log).toHaveBeenCalledOnce();
+    const [message] = log.mock.calls[0]!;
+    expect(message).not.toContain("sk-ant-oat-should-never-appear");
+    expect(message).toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/packages/assistant/src/provider-credential.ts
+++ b/packages/assistant/src/provider-credential.ts
@@ -1,0 +1,58 @@
+import { getOAuthToken } from "./oauth/index.js";
+
+/**
+ * User-facing hint printed when no Anthropic credential is available from
+ * either the environment or the keychain. Fixed copy — never interpolates
+ * the underlying error, which may otherwise echo credential-adjacent detail.
+ */
+const NO_CREDENTIAL_HINT =
+  "[assistant] no Anthropic credential: set ANTHROPIC_API_KEY or log in to Claude Code";
+
+export interface EnsureAnthropicCredentialOptions {
+  /** Defaults to `process.env`. Mutated in place when the keychain fallback fires. */
+  env?: Record<string, string | undefined>;
+  /** Defaults to the real `getOAuthToken` (macOS keychain read + refresh). */
+  getToken?: () => Promise<string>;
+  /** Defaults to a stderr writer. Receives only the fixed hint string, never secret material. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Ensures `env.ANTHROPIC_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) is set before
+ * a provider-measurement run so pi-ai's `streamSimple` can resolve an
+ * Anthropic credential.
+ *
+ * Resolution order:
+ * 1. If `ANTHROPIC_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is already set
+ *    (non-empty) in `env` → do nothing. Explicit config always wins over the
+ *    implicit keychain fallback.
+ * 2. Otherwise, resolve a live token via `getToken()` (the package's own
+ *    macOS-keychain-backed OAuth provider) and set it as
+ *    `env.ANTHROPIC_OAUTH_TOKEN`.
+ * 3. If the keychain resolution fails (no entry, expired + dead refresh,
+ *    non-macOS host, etc.), print a fixed user-facing hint — never the
+ *    underlying error — and leave `env` untouched so the caller's downstream
+ *    "No API key for provider" failure surfaces normally.
+ *
+ * Security invariant: the resolved token is only ever assigned into `env`,
+ * never logged, printed, or returned to the caller.
+ */
+export async function ensureAnthropicCredential(
+  options: EnsureAnthropicCredentialOptions = {},
+): Promise<void> {
+  const env = options.env ?? process.env;
+  const getToken = options.getToken ?? getOAuthToken;
+  const log =
+    options.log ?? ((message: string) => process.stderr.write(`${message}\n`));
+
+  if (env.ANTHROPIC_OAUTH_TOKEN?.trim() || env.ANTHROPIC_API_KEY?.trim()) {
+    return;
+  }
+
+  try {
+    const token = await getToken();
+    env.ANTHROPIC_OAUTH_TOKEN = token;
+  } catch {
+    log(NO_CREDENTIAL_HINT);
+  }
+}

--- a/packages/assistant/src/provider-credential.ts
+++ b/packages/assistant/src/provider-credential.ts
@@ -9,7 +9,13 @@ const NO_CREDENTIAL_HINT =
   "[assistant] no Anthropic credential: set ANTHROPIC_API_KEY or log in to Claude Code";
 
 export interface EnsureAnthropicCredentialOptions {
-  /** Defaults to `process.env`. Mutated in place when the keychain fallback fires. */
+  /**
+   * Defaults to `process.env`. Mutated in place when the keychain fallback
+   * fires — acceptable ONLY for a one-shot CLI that exits after the run.
+   * Calling this from a long-lived host (Electron main, server) would leave
+   * the token resident in global `process.env` for the process lifetime;
+   * such a caller must pass a scoped `env` instead.
+   */
   env?: Record<string, string | undefined>;
   /** Defaults to the real `getOAuthToken` (macOS keychain read + refresh). */
   getToken?: () => Promise<string>;

--- a/packages/assistant/src/provider-measurement.cli.ts
+++ b/packages/assistant/src/provider-measurement.cli.ts
@@ -1,6 +1,9 @@
+import { ensureAnthropicCredential } from "./provider-credential.js";
 import { measureProviderRuns } from "./provider-measurement.js";
 
 const prompt = process.env.DASHFRAME_PROVIDER_MEASUREMENT_PROMPT;
+
+await ensureAnthropicCredential();
 
 const results = await measureProviderRuns({ prompt });
 console.log(JSON.stringify({ results }, null, 2));


### PR DESCRIPTION
## Changes

- Add `ensureAnthropicCredential()` (`packages/assistant/src/provider-credential.ts`): if neither `ANTHROPIC_OAUTH_TOKEN` nor `ANTHROPIC_API_KEY` is set (non-blank) in the environment, resolves a live token via the package's own `getOAuthToken()` (macOS keychain read + refresh) and sets `process.env.ANTHROPIC_OAUTH_TOKEN` in-process before the measurement run. Explicit env vars always win over the implicit keychain fallback. On keychain-miss, prints a fixed, secret-free hint (`no Anthropic credential: set ANTHROPIC_API_KEY or log in to Claude Code`) instead of letting the CLI surface a bare "No API key for provider" failure.
- Wire the resolver into `provider-measurement.cli.ts` ahead of `measureProviderRuns()`.
- Add a JSDoc note on `TokenProviderOptions` (oauth module) documenting that `readKeychain` / `fetchRefresh` must be stable function references — `getOAuthToken`'s `CredentialState` cache is WeakMap-keyed on them, so an inline closure re-created per call loses single-flight dedup and refresh-token rotation tracking. Doc-only, non-blocking SUGGEST carried over from the #198 review.
- Test `ensureAnthropicCredential`'s load-bearing contract: env-var-wins (both `ANTHROPIC_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`), keychain-fallback resolution, and the secret-free-hint-on-failure invariant. The token source (`getToken`) and `env` are injected as plain parameters — an honest seam, no keychain mocking thicket.

Note: `ensureAnthropicCredential` treats a whitespace-only env value as unset (`.trim()` check) and falls through to the keychain in that case — a deliberate, safer reading of "is set" than a literal presence check, since a blank string isn't a usable credential.

## Screenshots

No UI change.

## Verification

Ran the live measurement from a clean worktree with no `ANTHROPIC_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` in the shell (so the keychain path was actually exercised, not env-shortcut):

```
cd packages/assistant && bun run measure:providers
```

**anthropic-direct** (via keychain-resolved OAuth token) — succeeded:

| metric | value |
|---|---|
| ok | true |
| model | claude-haiku-4-5 |
| durationMs | 1935 |
| timeToFirstTokenMs | 1171 |
| textDeltaCount | 6 |
| stopReason | stop |
| usage.input / output / total tokens | 65 / 85 / 150 |
| estimated cost | $0.00049 |

**bedrock** — failed as expected (AWS credentials not configured in this environment; out of scope for this ticket):

```
error: "Could not load credentials from any providers"
```

The credential value itself was never printed, logged, or written anywhere — it only ever lives in `process.env.ANTHROPIC_OAUTH_TOKEN` in-process for the duration of the CLI run.

Local gate (all green): `bun run typecheck`, `bun run lint`, `bun run test` (124 tests) in `packages/assistant`; `bun run format:check` and `node scripts/check-no-ticket-refs.mjs` at repo root. Two-axis code review (Standards + Spec sub-agents) run locally — no blocking findings.

## Security review note

Independent credential-seam review (opus) assessed the injected-token change against the stdout/CI error path: measurement failures flow through `failedMeasurement` → `errorMessage(error)` → `console.log(JSON.stringify(...))`, but pi-ai builds anthropic error messages from the response body/SSE/status only — never the outbound `Authorization`/`x-api-key` header where the token lives. The failure hint in `provider-credential.ts` is a fixed constant and the caught error object is discarded, so the secret-free property is provable by reading. Verdict: SHIP.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires a keychain-backed credential resolver (`ensureAnthropicCredential`) into the provider-measurement CLI, so the measurement can run without requiring manually-exported env vars when a Claude Code OAuth session exists in the macOS keychain. A documentation note is added to `TokenProviderOptions` to warn about the WeakMap-keyed cache requiring stable function references.

- **`provider-credential.ts`**: New `ensureAnthropicCredential` helper that short-circuits if `ANTHROPIC_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is already set, otherwise attempts to resolve a live token via `getOAuthToken()`, mutating `process.env` in-place only for the CLI use case; swallows the raw error to keep credential-adjacent details off stderr.
- **`provider-credential.test.ts`**: Five cases covering env-var-wins paths (both keys), keychain fallback, whitespace-only env var treated as unset, and the secret-free error hint invariant — with injected `env`/`getToken`/`log` seams for clean, keychain-free tests.
- **`provider-measurement.cli.ts` / `oauth/token-provider.ts`**: Single-line wiring and doc-only JSDoc addition respectively.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change adds a credential resolution layer that is additive and correctly scoped to the one-shot CLI context; it cannot affect other call sites.

The new ensureAnthropicCredential function is well-contained: it short-circuits on any existing env var, only mutates process.env inside a one-shot CLI, swallows the raw error to prevent credential leakage, and is tested with honest injected seams. The token-provider.ts change is doc-only. No existing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/src/provider-credential.ts | New helper that resolves Anthropic credentials with explicit env-var priority, keychain fallback, and secret-free error handling; well-documented with clear security invariants. |
| packages/assistant/src/provider-credential.test.ts | Five-case test suite using injected seams; covers both env-var-wins paths, keychain resolution, whitespace-only guard, and the secret-free hint invariant — thorough for the load-bearing contract. |
| packages/assistant/src/provider-measurement.cli.ts | Single-line wiring of ensureAnthropicCredential ahead of measureProviderRuns; straightforward and correct. |
| packages/assistant/src/oauth/token-provider.ts | Doc-only addition: JSDoc warning on TokenProviderOptions explaining the WeakMap-keyed cache requirement for stable function references; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as provider-measurement.cli.ts
    participant EC as ensureAnthropicCredential
    participant Env as process.env
    participant KC as getOAuthToken (keychain)
    participant MP as measureProviderRuns

    CLI->>EC: ensureAnthropicCredential()
    EC->>Env: read ANTHROPIC_OAUTH_TOKEN / ANTHROPIC_API_KEY
    alt env var already set (non-blank)
        EC-->>CLI: return (no-op)
    else env var missing or blank
        EC->>KC: getOAuthToken()
        alt keychain resolves
            KC-->>EC: token (sk-ant-oat…)
            EC->>Env: "ANTHROPIC_OAUTH_TOKEN = token"
            EC-->>CLI: return
        else keychain fails
            KC-->>EC: throws (any error)
            EC->>CLI: log fixed hint to stderr (no error details)
            EC-->>CLI: return (env unchanged)
        end
    end
    CLI->>MP: "measureProviderRuns({ prompt })"
    MP->>Env: read ANTHROPIC_OAUTH_TOKEN / ANTHROPIC_API_KEY
    MP-->>CLI: results[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as provider-measurement.cli.ts
    participant EC as ensureAnthropicCredential
    participant Env as process.env
    participant KC as getOAuthToken (keychain)
    participant MP as measureProviderRuns

    CLI->>EC: ensureAnthropicCredential()
    EC->>Env: read ANTHROPIC_OAUTH_TOKEN / ANTHROPIC_API_KEY
    alt env var already set (non-blank)
        EC-->>CLI: return (no-op)
    else env var missing or blank
        EC->>KC: getOAuthToken()
        alt keychain resolves
            KC-->>EC: token (sk-ant-oat…)
            EC->>Env: "ANTHROPIC_OAUTH_TOKEN = token"
            EC-->>CLI: return
        else keychain fails
            KC-->>EC: throws (any error)
            EC->>CLI: log fixed hint to stderr (no error details)
            EC-->>CLI: return (env unchanged)
        end
    end
    CLI->>MP: "measureProviderRuns({ prompt })"
    MP->>Env: read ANTHROPIC_OAUTH_TOKEN / ANTHROPIC_API_KEY
    MP-->>CLI: results[]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(assistant): flag env mutation in cr..."](https://github.com/youhaowei/dashframe/commit/5ebea52b90c40962666dc6131186c4aaff0b1f99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41315950)</sub>

<!-- /greptile_comment -->