### PR TITLE
Document provider measurement CLI bedrock preconditions

### DIFF
--- a/packages/assistant/README.md
+++ b/packages/assistant/README.md
@@ -1,0 +1,70 @@
+# @dashframe/assistant
+
+Agentic report harness substrate: OAuth credential lifecycle (Claude Code
+keychain token), the typed tool-layer helper, the privacy-aware READ layer,
+the `applyCommand` mutation tool, and the provider measurement harness
+documented below.
+
+## Provider measurement CLI
+
+`src/provider-measurement.cli.ts` runs a one-shot streaming measurement
+against each configured provider (latency, time-to-first-token, stop reason,
+usage) and prints the results as JSON. Run it from `packages/assistant`:
+
+```bash
+bun run measure:providers
+```
+
+It exits non-zero if any provider run did not complete successfully
+(`result.ok === false`), so it's safe to use as a smoke check.
+
+### Anthropic credential resolution
+
+Before measuring, the CLI calls `ensureAnthropicCredential()`
+(`src/provider-credential.ts`), which resolves a credential in this order:
+
+1. If `ANTHROPIC_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is already set in the
+   environment, it's used as-is — explicit config always wins.
+2. Otherwise, it reads a live OAuth token from the macOS keychain (the same
+   token Claude Code uses) and sets it as `ANTHROPIC_OAUTH_TOKEN` for the
+   run.
+3. If neither is available (no env var, no keychain entry, non-macOS host,
+   expired token with a dead refresh), it prints a fixed hint to stderr and
+   leaves the environment untouched — the run then fails downstream with a
+   "no credentials" style error from pi-ai.
+
+### Bedrock preconditions (not live-validated)
+
+The `amazon-bedrock` leg reads `AWS_REGION` / `AWS_PROFILE` directly from
+`process.env` (see `measureProviderRuns` in `src/provider-measurement.ts`) and
+passes them through to the provider run. Unlike the Anthropic leg, there is
+**no resolver or keychain fallback** — you must have AWS credentials already
+configured before running the CLI, e.g.:
+
+- `AWS_PROFILE` pointing at a profile in `~/.aws/config` /
+  `~/.aws/credentials` (including one backed by AWS SSO), and
+- `AWS_REGION` set to a region where the target Bedrock model is available.
+
+This leg has not yet been exercised successfully in CI or locally — every
+attempt so far has failed with "Could not load credentials from any
+providers." Credential-resolution parity with the Anthropic leg (keychain or
+another non-env fallback) is future scope, not implemented today.
+
+### Prompt override
+
+Set `DASHFRAME_PROVIDER_MEASUREMENT_PROMPT` to replace the default
+measurement prompt sent to every provider in the run:
+
+```bash
+DASHFRAME_PROVIDER_MEASUREMENT_PROMPT="Say hello in one word." bun run measure:providers
+```
+
+When unset, `measureProviderRuns` falls back to a built-in default prompt
+that asks for a single concise JSON object.
+
+### Model overrides
+
+`DASHFRAME_ANTHROPIC_MODEL` and `DASHFRAME_BEDROCK_MODEL` override the model
+ID used for each provider's run (see `measureProviderRuns`). When unset, the
+CLI picks the first model from a built-in default list that's registered in
+pi-ai for that provider.

--- a/packages/assistant/src/provider-measurement.cli.ts
+++ b/packages/assistant/src/provider-measurement.cli.ts
@@ -1,6 +1,11 @@
 import { ensureAnthropicCredential } from "./provider-credential.js";
 import { measureProviderRuns } from "./provider-measurement.js";
 
+/**
+ * Optional override for the measurement prompt sent to every provider run.
+ * Falls back to `measureProviderRuns`'s built-in default prompt when unset.
+ * See packages/assistant/README.md for usage.
+ */
 const prompt = process.env.DASHFRAME_PROVIDER_MEASUREMENT_PROMPT;
 
 await ensureAnthropicCredential();


### PR DESCRIPTION
Documents two gaps in the provider-measurement CLI that had no written record:

## Changes

- Add `packages/assistant/README.md` with a "Provider measurement CLI" section covering: how to run it (`bun run measure:providers`), Anthropic credential resolution order (env-wins, then macOS keychain fallback via `ensureAnthropicCredential()`, then a fixed stderr hint), bedrock preconditions (`AWS_PROFILE`/`AWS_REGION` read straight from `process.env`, no resolver/keychain fallback, and the leg has not yet run successfully live), and the `DASHFRAME_PROVIDER_MEASUREMENT_PROMPT` / model-override env vars.
- Add a doc comment at the `DASHFRAME_PROVIDER_MEASUREMENT_PROMPT` read site in `provider-measurement.cli.ts` pointing at the README.

No behavior change — documentation only.

## Screenshots

No UI change.

## Verification

- `bunx prettier --write` on both changed files (no diff — already formatted)
- `bun run check:ticket-refs` — passes
- Every claim in the README cross-checked against `provider-measurement.ts`, `provider-measurement.cli.ts`, `provider-credential.ts`, and `provider-measurement.test.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR adds `packages/assistant/README.md` describing the provider-measurement CLI — covering Anthropic credential resolution order, Bedrock preconditions, and the `DASHFRAME_PROVIDER_MEASUREMENT_PROMPT` / model-override environment variables — and adds a JSDoc comment at the `DASHFRAME_PROVIDER_MEASUREMENT_PROMPT` read site pointing at that README.

- All factual claims in the README were verified against the source (`provider-measurement.ts`, `provider-measurement.cli.ts`, `provider-credential.ts`): credential resolution steps, Bedrock `AWS_REGION`/`AWS_PROFILE` env pass-through, model fallback logic, and the `process.exitCode = 1` smoke-check behaviour are accurately described.
- No behaviour changes are introduced.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no logic modifications; all README claims verified against the implementation.

Every factual claim in the new README was cross-checked against the source files and is accurate. The single JSDoc comment added to the CLI file is a forward pointer with no functional impact. Nothing here can regress runtime behaviour.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/README.md | New README documenting the provider-measurement CLI; all factual claims verified against the source implementation — credential resolution order, Bedrock env-var handling, prompt/model overrides, and exit-code behaviour are accurate. |
| packages/assistant/src/provider-measurement.cli.ts | Adds a JSDoc comment above the DASHFRAME_PROVIDER_MEASUREMENT_PROMPT read site pointing at the new README; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as provider-measurement.cli.ts
    participant Cred as ensureAnthropicCredential()<br/>(provider-credential.ts)
    participant KC as macOS Keychain<br/>(getOAuthToken)
    participant Meas as measureProviderRuns()<br/>(provider-measurement.ts)
    participant PiAi as pi-ai (streamSimple)

    CLI->>Cred: ensureAnthropicCredential()
    alt ANTHROPIC_OAUTH_TOKEN or ANTHROPIC_API_KEY already set
        Cred-->>CLI: return (no-op)
    else keychain fallback
        Cred->>KC: getOAuthToken()
        KC-->>Cred: OAuth token
        Cred->>Cred: set process.env.ANTHROPIC_OAUTH_TOKEN
        Cred-->>CLI: return
    else keychain fails / non-macOS
        Cred->>CLI: log fixed hint to stderr
        Cred-->>CLI: return (env untouched)
    end

    CLI->>Meas: "measureProviderRuns({ prompt })"
    par Anthropic leg
        Meas->>PiAi: streamSimple(anthropic model, context)
        PiAi-->>Meas: AssistantMessageEventStream
    and Bedrock leg
        Note over Meas: Reads AWS_REGION/AWS_PROFILE<br/>from process.env — no resolver fallback
        Meas->>PiAi: "streamSimple(bedrock model, context, { env: { AWS_REGION, AWS_PROFILE } })"
        PiAi-->>Meas: AssistantMessageEventStream (or error)
    end
    Meas-->>CLI: ProviderMeasurementResult[]

    CLI->>CLI: console.log(JSON)
    alt "any result.ok === false"
        CLI->>CLI: "process.exitCode = 1"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as provider-measurement.cli.ts
    participant Cred as ensureAnthropicCredential()<br/>(provider-credential.ts)
    participant KC as macOS Keychain<br/>(getOAuthToken)
    participant Meas as measureProviderRuns()<br/>(provider-measurement.ts)
    participant PiAi as pi-ai (streamSimple)

    CLI->>Cred: ensureAnthropicCredential()
    alt ANTHROPIC_OAUTH_TOKEN or ANTHROPIC_API_KEY already set
        Cred-->>CLI: return (no-op)
    else keychain fallback
        Cred->>KC: getOAuthToken()
        KC-->>Cred: OAuth token
        Cred->>Cred: set process.env.ANTHROPIC_OAUTH_TOKEN
        Cred-->>CLI: return
    else keychain fails / non-macOS
        Cred->>CLI: log fixed hint to stderr
        Cred-->>CLI: return (env untouched)
    end

    CLI->>Meas: "measureProviderRuns({ prompt })"
    par Anthropic leg
        Meas->>PiAi: streamSimple(anthropic model, context)
        PiAi-->>Meas: AssistantMessageEventStream
    and Bedrock leg
        Note over Meas: Reads AWS_REGION/AWS_PROFILE<br/>from process.env — no resolver fallback
        Meas->>PiAi: "streamSimple(bedrock model, context, { env: { AWS_REGION, AWS_PROFILE } })"
        PiAi-->>Meas: AssistantMessageEventStream (or error)
    end
    Meas-->>CLI: ProviderMeasurementResult[]

    CLI->>CLI: console.log(JSON)
    alt "any result.ok === false"
        CLI->>CLI: "process.exitCode = 1"
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(assistant): document provider measu..."](https://github.com/youhaowei/dashframe/commit/7604f744e432702abdf68d10c36632dd6761c278) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41335949)</sub>

<!-- /greptile_comment -->