### PR TITLE
Refresh publish review page after publish failure

### DIFF
--- a/packages/app/src/app/drafts/[draftId]/publish/page.tsx
+++ b/packages/app/src/app/drafts/[draftId]/publish/page.tsx
@@ -88,6 +88,11 @@ export default function DraftPublishPage({ draftId }: DraftPublishPageProps) {
       toast.error("Failed to publish draft", {
         description: draftLifecycleErrorDescription(error),
       });
+      // The failure may mean the draft changed since this review loaded (or
+      // otherwise reflects stale state) — reload the review so the page
+      // shows the current draft instead of sitting stale behind a toast
+      // that fades.
+      void refetch();
     } finally {
       setBusy(null);
     }


### PR DESCRIPTION
Refreshes the draft publish review page after any publish failure, so the review reflects current draft state instead of staying stale behind a toast that fades.

## Changes

- `handlePublish`'s catch block now calls `refetch()` unconditionally on any publish failure (not just the drift-guard error), reloading the review data. The existing failure toast is unchanged.

## Screenshots

### ready-to-publish
![ready-to-publish](https://github.com/youhaowei/DashFrame/releases/download/pr-207-screenshots/01-publish-ready-before-drift.png)

### publish-failure-toast-with-refreshed-review
![publish-failure-toast-with-refreshed-review](https://github.com/youhaowei/DashFrame/releases/download/pr-207-screenshots/02-publish-drift-toast-in-context-light.png)

### toast-closeup
![toast-closeup](https://github.com/youhaowei/DashFrame/releases/download/pr-207-screenshots/02a-toast-closeup.png)

### refreshed-review-light
![refreshed-review-light](https://github.com/youhaowei/DashFrame/releases/download/pr-207-screenshots/03-publish-refreshed-after-drift-light.png)

### refreshed-review-dark
![refreshed-review-dark](https://github.com/youhaowei/DashFrame/releases/download/pr-207-screenshots/04-publish-refreshed-after-drift-dark.png)

_Screenshots via pr-screenshots (prerelease `pr-207-screenshots`, not in git)._
## Verification

- Full-graph `bun run check` (typecheck, lint, 364 tests across all packages) — all green, no regressions.
- Local review: dispatched an independent `code-reviewer` subagent (opus) against the diff — verdict MERGE READINESS: YES, zero MUST findings.
- Manual runtime verification via a scripted Playwright harness (server + Vite dev server + headless Chromium, not committed): seeded a draft with 1 command, loaded the publish review, appended a 2nd command directly through the draft controller (simulating a second context/tab), then clicked Publish in the real running app. Confirmed the server rejects with the drift-guard error (`HTTP 500`, body `{"error":"publishDraft: draft changed since review"}`), the failure toast renders, and — this is the fix under test — the review page reloads to show the current 2-command draft state instead of the stale 1-command view.
- **Adjacent finding, out of scope for this fix:** the toast currently shows the generic "Please try again." instead of the drift-specific copy in `user-facing-errors.ts` (`draftLifecycleErrorDescription`'s `.includes("changed since review")` check). Root cause: the WyStack RPC client (`libs/wystack/packages/client/src/client.ts`) throws `Error("HTTP ${status}")` on any non-2xx response without reading the JSON error body, so the server's specific message never reaches the client's error-classification logic. This is a pre-existing bug in the `libs/wystack` submodule, unrelated to the refetch fix in this PR (the refetch runs unconditionally in the catch block regardless of the error message). Flagged separately for a submodule-side fix.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an unconditional `void refetch()` call in `handlePublish`'s catch block so the publish-review page always shows the current draft state after any publish failure, rather than leaving a stale view behind the fading error toast.

- The fix is one line: `void refetch()` after `toast.error(...)` in the catch block, with the existing `finally { setBusy(null) }` unchanged.
- `void` is used correctly to fire-and-forget the Promise without suppressing React Query's internal error handling; the `isError` / `isLoading` flags on the hook will reflect the refetch outcome in the UI automatically.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single targeted line with no risk to the happy path.

The change touches only the error path: one fire-and-forget refetch() call after the failure toast. The happy path (successful publish → navigate away) is completely unaffected. void refetch() correctly discards the Promise, React Query handles any refetch-level errors internally, and setBusy(null) in finally still runs immediately as before. No custom-rule violations were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/app/drafts/[draftId]/publish/page.tsx | Adds `void refetch()` in the publish catch block so the review panel reloads fresh draft state after any publish failure; logic, ordering, and Promise handling are all correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DraftPublishPage
    participant Server
    participant useDraftPublishReview

    User->>DraftPublishPage: clicks Publish
    DraftPublishPage->>DraftPublishPage: setBusy("publish")
    DraftPublishPage->>Server: "publish(draftId, {expectedCommandCount})"
    Server-->>DraftPublishPage: throws (e.g. drift-guard error)
    DraftPublishPage->>DraftPublishPage: toast.error("Failed to publish draft")
    DraftPublishPage->>useDraftPublishReview: void refetch()  [NEW]
    DraftPublishPage->>DraftPublishPage: setBusy(null) [finally]
    useDraftPublishReview-->>DraftPublishPage: fresh review data
    DraftPublishPage->>User: UI shows updated draft state
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DraftPublishPage
    participant Server
    participant useDraftPublishReview

    User->>DraftPublishPage: clicks Publish
    DraftPublishPage->>DraftPublishPage: setBusy("publish")
    DraftPublishPage->>Server: "publish(draftId, {expectedCommandCount})"
    Server-->>DraftPublishPage: throws (e.g. drift-guard error)
    DraftPublishPage->>DraftPublishPage: toast.error("Failed to publish draft")
    DraftPublishPage->>useDraftPublishReview: void refetch()  [NEW]
    DraftPublishPage->>DraftPublishPage: setBusy(null) [finally]
    useDraftPublishReview-->>DraftPublishPage: fresh review data
    DraftPublishPage->>User: UI shows updated draft state
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into charixandra/yw-..."](https://github.com/youhaowei/dashframe/commit/4b92912ff695a3b8e680b793943b306ecb66148e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41337536)</sub>

<!-- /greptile_comment -->