### PR TITLE
Collect publish credential-release refs inside the publish transaction

### DIFF
--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -670,7 +670,7 @@ describe("credential write path — capture-before-log + transition release", ()
     // though collection observed the superseded ref, a rolled-back transaction
     // still releases nothing.
     /* eslint-disable @typescript-eslint/no-explicit-any -- structural fault injector over the tracked-tx seam, mirrors draft-controller.test.ts GH#157 */
-    let failTeardown = true;
+    const failTeardown = true;
     const realCreateTracked = h.app.createTracked.bind(h.app);
     (h.app as any).createTracked = () => {
       const t = realCreateTracked();

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -670,7 +670,6 @@ describe("credential write path — capture-before-log + transition release", ()
     // though collection observed the superseded ref, a rolled-back transaction
     // still releases nothing.
     /* eslint-disable @typescript-eslint/no-explicit-any -- structural fault injector over the tracked-tx seam, mirrors draft-controller.test.ts GH#157 */
-    const failTeardown = true;
     const realCreateTracked = h.app.createTracked.bind(h.app);
     (h.app as any).createTracked = () => {
       const t = realCreateTracked();
@@ -679,7 +678,7 @@ describe("credential write path — capture-before-log + transition release", ()
         realTx(async (tx) => {
           const realDelete = tx.raw.delete.bind(tx.raw);
           tx.raw.delete = (table: any) => {
-            if (table === draftCommandLog && failTeardown) {
+            if (table === draftCommandLog) {
               throw new Error("injected teardown failure");
             }
             return realDelete(table);
@@ -690,16 +689,20 @@ describe("credential write path — capture-before-log + transition release", ()
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */
 
-    await expect(h.app.call("publishDraft", { draftId })).rejects.toThrow(
-      "injected teardown failure",
-    );
+    try {
+      await expect(h.app.call("publishDraft", { draftId })).rejects.toThrow(
+        "injected teardown failure",
+      );
 
-    // The whole publish transaction rolled back — canonical still holds the
-    // OLD ref, and NEITHER ref was released (release only runs after
-    // `publishDraft` resolves, and it never resolved).
-    expect((await readConfig(h, id))!.apiKey).toBe(oldRef);
-    expect(await h.vault.has(oldRef)).toBe(true);
-    expect(await h.vault.has(mintedRef)).toBe(true);
+      // The whole publish transaction rolled back — canonical still holds the
+      // OLD ref, and NEITHER ref was released (release only runs after
+      // `publishDraft` resolves, and it never resolved).
+      expect((await readConfig(h, id))!.apiKey).toBe(oldRef);
+      expect(await h.vault.has(oldRef)).toBe(true);
+      expect(await h.vault.has(mintedRef)).toBe(true);
+    } finally {
+      (h.app as any).createTracked = realCreateTracked;
+    }
   });
 
   // 9 — provenance: an agent-context create is auditably distinct.

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -644,6 +644,64 @@ describe("credential write path — capture-before-log + transition release", ()
     expect((await readConfig(h, id))!.apiKey).toBe(canonicalRef);
   });
 
+  // TOCTOU regression: a publish that FAILS DURING REPLAY (after
+  // collection has already run inside the transaction via `beforeReplay`) must
+  // release nothing. Unlike the duplicate-PK CreateDataSource rollback above
+  // (which `collectSupersededRefs` never sees, since CreateDataSource is not a
+  // credential-superseding command), this forces the failure on a draft that
+  // DOES supersede a live credential ref — the exact case the ref-release list
+  // is computed for — so the assertion is meaningful rather than vacuous.
+  it("releases nothing when a credential-superseding publish fails mid-transaction", async () => {
+    const { id, ref: oldRef } = await seedCanonicalSource(h, "orig-key");
+
+    const draftId = await h.controller.openDraft();
+    await h.controller.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id, apiKey: "rotated-key" }),
+    ]);
+    const args = await firstLogArgs(h, draftId);
+    const mintedRef = args.apiKey as SecretRef;
+
+    // Fault-inject a failure INSIDE the publish transaction, after replay would
+    // have run (mirrors the GH #157 fault injector in draft-controller.test.ts):
+    // patch the tx-bound raw handle's `delete` to throw when it targets
+    // `draftCommandLog` — the teardown step that runs immediately after replay,
+    // inside the same commit boundary. `beforeReplay` (and therefore
+    // `collectSupersededRefs`) has ALREADY run by this point — proving that even
+    // though collection observed the superseded ref, a rolled-back transaction
+    // still releases nothing.
+    /* eslint-disable @typescript-eslint/no-explicit-any -- structural fault injector over the tracked-tx seam, mirrors draft-controller.test.ts GH#157 */
+    let failTeardown = true;
+    const realCreateTracked = h.app.createTracked.bind(h.app);
+    (h.app as any).createTracked = () => {
+      const t = realCreateTracked();
+      const realTx = t.transaction.bind(t);
+      t.transaction = ((fn: any, opts: any) =>
+        realTx(async (tx) => {
+          const realDelete = tx.raw.delete.bind(tx.raw);
+          tx.raw.delete = (table: any) => {
+            if (table === draftCommandLog && failTeardown) {
+              throw new Error("injected teardown failure");
+            }
+            return realDelete(table);
+          };
+          return fn(tx);
+        }, opts)) as any;
+      return t;
+    };
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    await expect(h.app.call("publishDraft", { draftId })).rejects.toThrow(
+      "injected teardown failure",
+    );
+
+    // The whole publish transaction rolled back — canonical still holds the
+    // OLD ref, and NEITHER ref was released (release only runs after
+    // `publishDraft` resolves, and it never resolved).
+    expect((await readConfig(h, id))!.apiKey).toBe(oldRef);
+    expect(await h.vault.has(oldRef)).toBe(true);
+    expect(await h.vault.has(mintedRef)).toBe(true);
+  });
+
   // 9 — provenance: an agent-context create is auditably distinct.
   it("stamps agent provenance when the create runs in an agent context", async () => {
     const id = crypto.randomUUID();

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -701,6 +701,7 @@ describe("credential write path — capture-before-log + transition release", ()
       expect(await h.vault.has(oldRef)).toBe(true);
       expect(await h.vault.has(mintedRef)).toBe(true);
     } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- undo the structural fault injector patched above
       (h.app as any).createTracked = realCreateTracked;
     }
   });

--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -52,6 +52,16 @@ import {
   type DataSourceConfig,
 } from "./functions/utils";
 
+/**
+ * Read-only slice of `ArtifactDb` for the pre-transition collectors: they
+ * COLLECT release candidates, never mutate — and on the publish path they run
+ * on a transaction-bound raw handle that does NOT support `.transaction()` at
+ * runtime. The narrowed type turns both misuses into compile errors and lets
+ * the collectors accept `DraftController`'s `beforeReplay` tx (`LogReader`,
+ * the structurally identical slice) without a cast.
+ */
+export type ArtifactReader = Pick<ArtifactDb, "select">;
+
 // ---------------------------------------------------------------------------
 // Seam 1 — capture-before-log
 // ---------------------------------------------------------------------------
@@ -371,7 +381,7 @@ function credentialCommandId(cmd: Command): string | undefined {
  * Reads must run BEFORE the discard drops the log + shadow.
  */
 export async function collectDiscardCandidateRefs(
-  db: ArtifactDb,
+  db: ArtifactReader,
   draftId: string,
   log: Command[],
 ): Promise<SecretRef[]> {
@@ -399,7 +409,7 @@ export async function collectDiscardCandidateRefs(
  * Reads committed canonical state via the raw artifact db, BEFORE replay.
  */
 export async function collectSupersededRefs(
-  db: ArtifactDb,
+  db: ArtifactReader,
   log: Command[],
 ): Promise<SecretRef[]> {
   const simulated = await seedSimulatedConfigs(db, log);
@@ -433,7 +443,7 @@ export async function collectSupersededRefs(
  * Reads committed canonical state via the raw artifact db, BEFORE replay.
  */
 export async function collectDeletedSourceRefs(
-  db: ArtifactDb,
+  db: ArtifactReader,
   log: Command[],
 ): Promise<SecretRef[]> {
   const refs: SecretRef[] = [];
@@ -452,7 +462,7 @@ export async function collectDeletedSourceRefs(
 
 /** Seed each touched source's simulated field→ref map from pre-publish canonical. */
 async function seedSimulatedConfigs(
-  db: ArtifactDb,
+  db: ArtifactReader,
   log: Command[],
 ): Promise<Map<string, SimulatedConfig>> {
   const simulated = new Map<string, SimulatedConfig>();

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -121,6 +121,79 @@ describe("DraftController (persisted draft overlay)", () => {
     expect(await controller.getDraftLog(draftId)).toHaveLength(0);
   });
 
+  it("beforeReplay observes the AUTHORITATIVE reloaded log, not a stale pre-read (TOCTOU regression)", async () => {
+    // A host that reads the draft log BEFORE calling publishDraft (e.g.
+    // to decide which credential-vault refs a publish will supersede) races a
+    // command appended between that read and the publish transaction's own
+    // reload. `beforeReplay` exists so the host instead reasons about the log
+    // INSIDE the transaction, after it is reloaded — this pins that it really
+    // does see the append, not whatever the caller read earlier.
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S1" }),
+    );
+
+    // Simulate a caller's stale pre-read (what draft-lifecycle.ts used to do
+    // via `draftController.getDraftLog(draftId)` before this fix).
+    const stalePreRead = await controller.getDraftLog(draftId);
+    expect(stalePreRead).toHaveLength(1);
+
+    // A second command lands after the stale read but before publish — the
+    // drift race this hook must be immune to.
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S2" }),
+    );
+
+    let observedLogLength: number | undefined;
+    await controller.publishDraft(
+      draftId,
+      {},
+      {
+        beforeReplay: (log) => {
+          observedLogLength = log.length;
+        },
+      },
+    );
+
+    // The hook saw the AUTHORITATIVE 2-command log, not the stale 1-command
+    // pre-read — proving collection cannot run against stale state.
+    expect(observedLogLength).toBe(2);
+    expect(observedLogLength).not.toBe(stalePreRead.length);
+  });
+
+  it("beforeReplay never runs when expectedCommandCount aborts the publish", async () => {
+    // The hook must run AFTER the drift guard, not before — an aborted publish
+    // (draft changed since review) must never invoke collection over a log that
+    // is not actually about to replay.
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S1" }),
+    );
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S2" }),
+    );
+
+    let hookCalled = false;
+    await expect(
+      controller.publishDraft(
+        draftId,
+        {},
+        {
+          expectedCommandCount: 1,
+          beforeReplay: () => {
+            hookCalled = true;
+          },
+        },
+      ),
+    ).rejects.toThrow(/changed since review/);
+
+    expect(hookCalled).toBe(false);
+  });
+
   /** Seed a DataSource + DataTable on CANONICAL (the draft's base). */
   async function seedTable(
     target: ReturnType<typeof createDraftController>,

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -189,6 +189,34 @@ export interface PublishDraftOptions {
    * a pre-transaction read cannot provide this guarantee.
    */
   expectedCommandCount?: number;
+  /**
+   * Pre-replay hook, invoked INSIDE the publish transaction — after the
+   * `expectedCommandCount` and late-bound/`validatePublishLog` guards pass,
+   * before `applyCommands` replays the log onto canonical.
+   *
+   * Exists so a host can collect state the replay is about to overwrite (e.g.
+   * DashFrame's credential-release refs: which vault refs the replay's writes
+   * SUPERSEDE) against the AUTHORITATIVE reloaded log and the pre-replay
+   * canonical rows — never a pre-transaction read, which a command appended
+   * between review and publish would make stale (the TOCTOU this hook closes).
+   * `tx` is the transaction's native handle (same `ArtifactDb` shape queries
+   * elsewhere use) — reads through it see the same pre-replay snapshot the
+   * replay itself is about to act on.
+   *
+   * Runs AFTER both guards so an aborted publish (drift or late-bound) never
+   * invokes collection — nothing here observes a log that won't actually
+   * replay. A throw here aborts the publish transaction like any other guard.
+   *
+   * Typed as the full `ArtifactDb` rather than a narrowed `Pick<>` (unlike
+   * `LogReader`/`DeleteExecutor` below) because the collectors this hook is
+   * built for (`collectSupersededRefs`/`collectDeletedSourceRefs` in
+   * `credential-release.ts`) are themselves typed `db: ArtifactDb` and are
+   * shared with non-tx-bound call sites; narrowing here would force a cast at
+   * every call. As with those helpers, `tx.raw` inside a transaction does
+   * NOT actually support `.transaction()` at runtime — a `beforeReplay`
+   * implementation must not call it.
+   */
+  beforeReplay?: (log: Command[], tx: ArtifactDb) => Promise<void> | void;
 }
 
 /**
@@ -463,6 +491,11 @@ export function createDraftController(
         }
         assertPublishLogHasNoLateBound(log);
         validatePublishLog?.(log);
+        // Pre-replay hook: runs on the AUTHORITATIVE reloaded log, after both
+        // guards above, before replay mutates canonical rows. See
+        // `PublishDraftOptions.beforeReplay` for why this must live here and
+        // not before the transaction opens.
+        await options.beforeReplay?.(log, tx.raw as ArtifactDb);
         const committed = (await applyCommands(app, log, {
           mode: "commit",
           context: publishContext,

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -97,7 +97,7 @@ const DRAFT_SHADOW_TABLES = [
  * `.transaction()` is a compile error, not a latent footgun.
  */
 type DeleteExecutor = Pick<ArtifactDb, "delete">;
-type LogReader = Pick<ArtifactDb, "select">;
+export type LogReader = Pick<ArtifactDb, "select">;
 
 /** A persisted log row mapped back to the `DraftCommand` shape replay consumes. */
 function rowToDraftCommand(row: {
@@ -207,16 +207,12 @@ export interface PublishDraftOptions {
    * invokes collection — nothing here observes a log that won't actually
    * replay. A throw here aborts the publish transaction like any other guard.
    *
-   * Typed as the full `ArtifactDb` rather than a narrowed `Pick<>` (unlike
-   * `LogReader`/`DeleteExecutor` below) because the collectors this hook is
-   * built for (`collectSupersededRefs`/`collectDeletedSourceRefs` in
-   * `credential-release.ts`) are themselves typed `db: ArtifactDb` and are
-   * shared with non-tx-bound call sites; narrowing here would force a cast at
-   * every call. As with those helpers, `tx.raw` inside a transaction does
-   * NOT actually support `.transaction()` at runtime — a `beforeReplay`
-   * implementation must not call it.
+   * Typed as `LogReader` — the same narrowed slice `readLog` uses — so both
+   * misuses are compile errors rather than latent runtime failures: the hook
+   * COLLECTS, never mutates, and a transaction-bound `tx.raw` does NOT
+   * support `.transaction()` at runtime.
    */
-  beforeReplay?: (log: Command[], tx: ArtifactDb) => Promise<void> | void;
+  beforeReplay?: (log: Command[], tx: LogReader) => Promise<void> | void;
 }
 
 /**
@@ -495,7 +491,7 @@ export function createDraftController(
         // guards above, before replay mutates canonical rows. See
         // `PublishDraftOptions.beforeReplay` for why this must live here and
         // not before the transaction opens.
-        await options.beforeReplay?.(log, tx.raw as ArtifactDb);
+        await options.beforeReplay?.(log, tx.raw as LogReader);
         const committed = (await applyCommands(app, log, {
           mode: "commit",
           context: publishContext,

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -33,9 +33,18 @@ import { join } from "node:path";
 
 import {
   openProject,
+  schema,
   type ArtifactDb,
   type ProjectHandle,
 } from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+  type SecretRef,
+} from "@wystack/secret-vault";
+import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -44,7 +53,18 @@ import {
   createDraftController,
   type DashframeServer,
 } from "../app";
+import { captureCommandCredentials } from "../credential-release";
 import { cmd } from "./commands";
+
+const { dataSources } = schema;
+
+function makeTestVault(): SecretVault {
+  const backend = new TestBackend();
+  const registry = new SecretRegistry();
+  registry.register("test", backend, { fallback: true });
+  registry.setClassDefault("connector-key", "test");
+  return new SecretVault(registry, new InMemoryMappingStore());
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -256,6 +276,81 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
       draftId,
     });
     expect(log.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // TOCTOU guard: credential-release refs must reflect the AUTHORITATIVE log
+  // -------------------------------------------------------------------------
+
+  it("publish releases the ref superseded by a command appended after a draft is opened, via the real HTTP path", async () => {
+    // End-to-end (HTTP + real vault) coverage of the release flow: a
+    // credential-superseding command appended to a draft is picked up and its
+    // superseded ref released when the draft is published through the RPC.
+    //
+    // This does NOT reproduce the intra-publish TOCTOU race itself — the
+    // append below happens before `publishDraft` is invoked, so both the old
+    // (pre-transaction) and new (in-transaction) read would observe it here.
+    // The race the fix closes is a command landing BETWEEN a pre-transaction
+    // read and the transaction's own reload inside a single publish call; that
+    // window no longer exists by construction (collection now runs strictly
+    // inside the transaction, against the reloaded log — see
+    // `PublishDraftOptions.beforeReplay`), and there is no pre-transaction read
+    // left to race against, so a live repro isn't constructible at this layer.
+    // The regression guard for that ordering lives in draft-controller.test.ts
+    // ("beforeReplay observes the AUTHORITATIVE reloaded log, not a stale
+    // pre-read"), which asserts the hook sees a command appended after an
+    // intermediate `getDraftLog` read within the same publish flow.
+    const vault = makeTestVault();
+    project = await openProject({ dir: join(root, "proj") });
+    const db = project.db as ArtifactDb;
+
+    // Seed a canonical, credentialed DataSource via a real controller (so the
+    // capture-before-log seam mints a real vault ref, not plaintext).
+    const seedApp = await buildDashframeApp({ db, vault });
+    const seedController = createDraftController(seedApp, db, {
+      captureCredentials: (c) => captureCommandCredentials(c, vault, db),
+    });
+    const sourceId = crypto.randomUUID();
+    const baseDraft = await seedController.openDraft();
+    await seedController.appendToDraft(baseDraft, [
+      cmd("CreateDataSource", {
+        id: sourceId,
+        type: "notion",
+        name: "Base",
+        apiKey: "orig-key",
+      }),
+    ]);
+    await seedController.publishDraft(baseDraft);
+    const canonicalRows = await db
+      .select()
+      .from(dataSources)
+      .where(eq(dataSources.id, sourceId));
+    const oldRef = (canonicalRows[0]!.config as Record<string, unknown>)
+      .apiKey as SecretRef;
+    expect(await vault.has(oldRef)).toBe(true);
+
+    // Open the draft the RPC will publish, then append a credential-superseding
+    // command to it.
+    const draftId = await seedController.openDraft();
+
+    server = await createDashframeServer({
+      db: project.db,
+      vault,
+      flushSnapshot: async () => {},
+    });
+
+    await seedController.appendToDraft(draftId, [
+      cmd("SetDataSourceConfig", { id: sourceId, apiKey: "rotated-key" }),
+    ]);
+
+    await postOk<{ tablesWritten: string[] }>(server.url, "publishDraft", {
+      draftId,
+    });
+
+    // Collection (via `beforeReplay`) sees the appended SetDataSourceConfig
+    // against the authoritative in-tx log, so the superseded ref is released
+    // after publish commits.
+    expect(await vault.has(oldRef)).toBe(false);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -21,7 +21,7 @@
  */
 import type { ArtifactDb } from "@dashframe/server-core";
 import { text } from "@wystack/db";
-import type { SecretVault } from "@wystack/secret-vault";
+import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import type { Command } from "@wystack/server";
 import { mutation, query } from "@wystack/server";
 
@@ -128,20 +128,10 @@ const publishDraft = mutation({
       );
     }
 
-    // Pre-read the log length before publishing so we can determine whether
-    // any durable rows were deleted, even when all commands are no-ops.
-    // `publishDraft` unconditionally deletes the command log + shadow rows for
-    // any non-empty draft (inside one atomic tx), so a draft with no-op
-    // commands (e.g. GetOrCreateDataSource for an existing source) produces
-    // `tablesWritten = {}` but still modifies durable storage. Without this
-    // check, `onWrite` would be skipped and the deletion goes un-snapshotted,
-    // leaving a resurrection window across server restarts.
-    const prePublishLog = await draftController.getDraftLog(draftId);
-
     // Parse the reviewed count here; ENFORCEMENT happens inside the publish
     // transaction (see DraftController.publishDraft's expectedCommandCount
     // guard) against the reloaded durable log — a command appended between
-    // this read and the replay aborts the publish atomically rather than
+    // this parse and the replay aborts the publish atomically rather than
     // bypassing a pre-transaction check.
     let expected: number | undefined;
     if (expectedCommandCount !== undefined) {
@@ -165,22 +155,41 @@ const publishDraft = mutation({
     //    handling it here (pre-commit) lets the deleteNode replay handler skip
     //    flushSnapshot+release inside the uncommitted transaction, preserving
     //    the ordering invariant (delete-row → commit → flush → release-ref).
+    //
+    // TOCTOU: both collectors must read the AUTHORITATIVE durable log — the one
+    // `publishDraft` actually replays — not a pre-transaction read, which a
+    // command appended between review and publish would make stale (a still-live
+    // ref released, or a due release missed). `beforeReplay` runs INSIDE the
+    // publish transaction, after the reloaded log passes the
+    // expectedCommandCount + late-bound guards and BEFORE replay mutates the
+    // canonical rows the collectors read — so `log` here is always the log that
+    // is about to replay, and `tx` sees the pre-replay canonical state.
     const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
     const vault = ctx.vault as SecretVault | undefined;
-    const replacedRefs =
-      artifactDb != null
-        ? [
-            ...(await collectSupersededRefs(artifactDb, prePublishLog)),
-            ...(await collectDeletedSourceRefs(artifactDb, prePublishLog)),
-          ]
-        : [];
+    let replacedRefs: SecretRef[] = [];
+    // Log length at the authoritative pre-replay read, for the snapshot-trigger
+    // condition below — replaces the old pre-transaction `prePublishLog.length`.
+    // Set unconditionally (not gated on `artifactDb`) so the no-op-commands
+    // snapshot trigger still fires even without an artifactDb wired in.
+    let publishLogLength = 0;
 
     // Mark the replay as the sanctioned canonical-commit path so the credential
     // command handlers' direct-call guard accepts it (release is handled here).
     const result = await draftController.publishDraft(
       draftId,
       { [PUBLISH_REPLAY_CONTEXT_KEY]: true },
-      { expectedCommandCount: expected },
+      {
+        expectedCommandCount: expected,
+        beforeReplay: async (log, tx) => {
+          publishLogLength = log.length;
+          if (artifactDb != null) {
+            replacedRefs = [
+              ...(await collectSupersededRefs(tx, log)),
+              ...(await collectDeletedSourceRefs(tx, log)),
+            ];
+          }
+        },
+      },
     );
 
     // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does
@@ -191,7 +200,7 @@ const publishDraft = mutation({
     // When credential refs are replaced, a durable flush (not debounced onWrite)
     // is required — `gateSnapshotForRelease` handles both paths.
     let snapshotPersisted = true;
-    if (result.tablesWritten.size > 0 || prePublishLog.length > 0) {
+    if (result.tablesWritten.size > 0 || publishLogLength > 0) {
       snapshotPersisted = await gateSnapshotForRelease(
         ctx as Record<string, unknown>,
         replacedRefs.length > 0,


### PR DESCRIPTION
Closes a TOCTOU in the draft-publish credential-release path: the ref-release list was computed from a `getDraftLog` read taken **before** the publish transaction opened, so a command appended between that read and the transaction's own reload was invisible to collection — a still-live secret-vault ref could be released, or a due release missed.

**This is a credential-seam change and should get independent security review before merge**, not just the automated gate — it touches the code path that decides which secret-vault refs get destroyed after a publish.

## Changes

- `DraftController.publishDraft` (`apps/server/src/draft-controller.ts`) gains an optional `beforeReplay(log, tx)` hook, invoked strictly *inside* the publish transaction — after the `expectedCommandCount` drift guard and the late-bound/`validatePublishLog` guards pass, and before `applyCommands` replays the log onto canonical. The hook sees the authoritative reloaded log and a transaction-scoped db handle reflecting pre-replay canonical state.
- `draft-lifecycle.ts`'s `publishDraft` handler now computes `replacedRefs` (via `collectSupersededRefs` / `collectDeletedSourceRefs`) inside that hook instead of from a pre-transaction `getDraftLog` call. The pre-transaction read is removed entirely — one authoritative read, taken at the right time.
- No change to replay semantics, the `expectedCommandCount` guard, `assertPublishLogHasNoLateBound`, or release ordering (collect pre-replay in-tx → publish commits → snapshot gate → release after commit). A failed publish (transaction rollback) still releases nothing.
- `discardDraft`'s handler is unchanged. It also collects refs (`collectDiscardCandidateRefs`) ahead of its delete, which is structurally similar to the bug fixed here — but that path was not analyzed for a symmetric TOCTOU window as part of this ticket. Out of scope here; flagging for separate follow-up if warranted.

## Screenshots

No UI change.

## Verification

- `apps/server/src/draft-controller.test.ts` — two new unit tests: `beforeReplay` observes the authoritative reloaded log rather than an earlier stale read (appends a command after an intermediate `getDraftLog` call within the same publish flow, asserts the hook sees it); `beforeReplay` never runs when `expectedCommandCount` aborts the publish.
- `apps/server/src/credential-release.test.ts` — new fault-injection test: a credential-superseding publish (`SetDataSourceConfig`, which `collectSupersededRefs` actually tracks, unlike the existing `CreateDataSource` duplicate-PK rollback test) is forced to fail mid-transaction after `beforeReplay` has already run; asserts neither the old nor the newly-minted ref is released and canonical still holds the old ref.
- `apps/server/src/functions/draft-lifecycle.test.ts` — new end-to-end HTTP + real-vault test confirming a credential-superseding command appended to a draft has its superseded ref released when the draft is published through the RPC. Note: this does not reproduce the intra-publish race itself (the append happens before the RPC call, so both old and new code would observe it) — the race is closed structurally (the pre-transaction read no longer exists) and pinned by the `draft-controller.test.ts` unit above; a live repro isn't constructible at the HTTP layer since there is no longer a pre-transaction read left to race against.
- Whole dependency-graph typecheck clean (`bun run build:wystack` then `npx turbo typecheck --filter=@dashframe/server --filter=@dashframe/server^...`).
- Full `apps/server` suite: 368/368 passing (`vitest run`) — locally. **Note:** CI's "Lint, Type Check & Format" job runs `turbo check` (typecheck + lint) but not the test suite; test verification here is local-only, not independently re-run by CI.
- `prettier --check` clean on touched files; `bun run check:ticket-refs` clean.
- Ran `wystack-agent-kit:code-review` locally (opus-tier, security+correctness focus) — one MUST (a test comment overclaiming what it verified) fixed by re-scoping that test's docstring and assertions to what it actually proves; one SUGGEST (whether `beforeReplay`'s tx param should be narrowed like the file's existing `LogReader`/`DeleteExecutor` `Pick<>` aliases) addressed with a documented rationale rather than narrowing, since the shared `credential-release.ts` collectors it feeds are typed `ArtifactDb` across multiple non-tx-bound call sites.
- CI initially failed on `@dashframe/server#lint` (`prefer-const` on an unreassigned fault-injection flag in the new `credential-release.test.ts` test); fixed in a follow-up commit.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a TOCTOU in the draft-publish credential-release path: the list of secret-vault refs to release after a publish was previously built from a `getDraftLog` read taken *before* the publish transaction opened, so a command appended in that window could cause a live ref to be released prematurely or a due release to be missed. The fix introduces a `beforeReplay` hook on `PublishDraftOptions` that runs *inside* the publish transaction—after both guards pass, before `applyCommands` replays the log—so collection always operates on the authoritative reloaded log and pre-replay canonical rows.

- **`draft-controller.ts`** gains the optional `beforeReplay?(log, tx: LogReader)` hook, invoked strictly inside the publish transaction after both guards and before replay.
- **`draft-lifecycle.ts`** removes the pre-transaction `getDraftLog` call entirely; collectors now run inside `beforeReplay`, with `publishLogLength` captured there to drive the post-publish snapshot trigger.
- **`credential-release.ts`** narrows collector signatures from `ArtifactDb` to `ArtifactReader = Pick<ArtifactDb, \"select\">`, enforcing read-only access at compile time.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The fix is structurally sound — the pre-transaction log read is fully removed and collection now runs exclusively inside the publish transaction against the authoritative reloaded log. The credential-release ordering invariant is preserved.

The TOCTOU window is closed by construction: there is no pre-transaction read left to race against. The hook is positioned correctly after both guards, before applyCommands mutates canonical rows. Type narrowing turns key misuse patterns into compile errors, and test coverage spans authoritative log observation, drift-guard suppression, mid-transaction failure releasing nothing, and full HTTP end-to-end release confirmation.

No files require special attention. The discardDraft parallel path is explicitly acknowledged as out of scope for a separate follow-up.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-controller.ts | Adds the beforeReplay hook to PublishDraftOptions; hook is positioned correctly after both guards and before applyCommands, inside the atomic transaction. LogReader is exported for consumer reuse. |
| apps/server/src/functions/draft-lifecycle.ts | Pre-transaction getDraftLog read removed; collection moved into beforeReplay. publishLogLength captured inside the hook and used correctly for the snapshot trigger. |
| apps/server/src/credential-release.ts | Introduces ArtifactReader and narrows four collector signatures to it; change is purely additive/restrictive and does not alter runtime semantics. |
| apps/server/src/draft-controller.test.ts | Two new unit tests pin that beforeReplay sees the authoritative log and never fires when the drift guard aborts. |
| apps/server/src/credential-release.test.ts | Fault-injection test exercises a credential-superseding publish that fails mid-transaction; asserts neither ref is released. Cleanup restored in a finally block. |
| apps/server/src/functions/draft-lifecycle.test.ts | End-to-end HTTP test verifies a credential-superseding command's superseded ref is released on publish. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client RPC
    participant DL as draft-lifecycle publishDraft
    participant DC as DraftController
    participant TX as DB Transaction
    participant CR as credential-release collectors
    participant V as SecretVault
    C->>DL: publishDraft
    DL->>DC: publishDraft with beforeReplay hook
    DC->>TX: open transaction
    TX->>TX: readLog authoritative reload
    TX->>TX: expectedCommandCount guard
    TX->>TX: assertPublishLogHasNoLateBound
    TX->>DL: beforeReplay(log, tx)
    DL->>CR: collectSupersededRefs
    CR-->>DL: refs
    DL->>CR: collectDeletedSourceRefs
    CR-->>DL: refs
    TX->>TX: applyCommands replay
    TX->>TX: deleteLog + sweepShadows
    TX-->>DC: commit
    DC-->>DL: result
    DL->>DL: gateSnapshotForRelease
    DL->>V: releaseRefsAtTransition
    DL-->>C: tablesWritten
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client RPC
    participant DL as draft-lifecycle publishDraft
    participant DC as DraftController
    participant TX as DB Transaction
    participant CR as credential-release collectors
    participant V as SecretVault
    C->>DL: publishDraft
    DL->>DC: publishDraft with beforeReplay hook
    DC->>TX: open transaction
    TX->>TX: readLog authoritative reload
    TX->>TX: expectedCommandCount guard
    TX->>TX: assertPublishLogHasNoLateBound
    TX->>DL: beforeReplay(log, tx)
    DL->>CR: collectSupersededRefs
    CR-->>DL: refs
    DL->>CR: collectDeletedSourceRefs
    CR-->>DL: refs
    TX->>TX: applyCommands replay
    TX->>TX: deleteLog + sweepShadows
    TX-->>DC: commit
    DC-->>DL: result
    DL->>DL: gateSnapshotForRelease
    DL->>V: releaseRefsAtTransition
    DL-->>C: tablesWritten
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(server): eslint suppression for faul..."](https://github.com/youhaowei/dashframe/commit/0b27185f5f5e9a0ab866ac2d5d2c2dd6f59635df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41341353)</sub>

<!-- /greptile_comment -->