### PR TITLE
fix(drafts): publish drift guard compares a content signature, not just command count

### DIFF
--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -24,6 +24,7 @@ import {
   schema,
 } from "@dashframe/server-core";
 import type { Command } from "@wystack/server";
+import { eq } from "drizzle-orm";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -35,6 +36,7 @@ import {
   createFallThroughDraftDb,
   withDraftSeam,
 } from "./app";
+import { computeLogSignature } from "./draft-log-signature";
 import { cmd } from "./functions/commands";
 
 const { insights, dataSources, projectMeta } = schema;
@@ -119,6 +121,162 @@ describe("DraftController (persisted draft overlay)", () => {
     // A count matching the reloaded log publishes normally.
     await controller.publishDraft(draftId, {}, { expectedCommandCount: 2 });
     expect(await controller.getDraftLog(draftId)).toHaveLength(0);
+  });
+
+  it("publishes when expectedLogSignature matches the unchanged reloaded log", async () => {
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S1" }),
+    );
+
+    const reviewedLog = await controller.getDraftLog(draftId);
+    const signature = computeLogSignature(reviewedLog);
+
+    await controller.publishDraft(
+      draftId,
+      {},
+      { expectedLogSignature: signature },
+    );
+    expect(await controller.getDraftLog(draftId)).toHaveLength(0);
+  });
+
+  /**
+   * Seed the same "reviewer saw one create, then a same-key delete+recreate
+   * compacts to a DIFFERENT surviving command at the SAME length" scenario in
+   * a fresh draft. `compactionKey`/`kind` are lifecycle-internal fields the
+   * `cmd()` vocabulary never sets, so this seeds raw `draft_command_log` rows
+   * directly (same technique as the late-bound test above) rather than
+   * relying on real command handlers to mint them.
+   *
+   * Returns the reviewer's signature/count and confirms the reload really is
+   * same-length-different-content — the blind spot this guard closes.
+   */
+  async function seedSameLengthContentDrift() {
+    const draftId = await controller.openDraft();
+    const keptId = id();
+    await db.insert(draftCommandLog).values({
+      draftId,
+      seq: 0,
+      path: "createDataSource",
+      args: { id: keptId, type: "csv", name: "Reviewed" },
+      compactionKey: `createDataSource:${keptId}`,
+      kind: "create",
+    });
+
+    const reviewedLog = await controller.getDraftLog(draftId);
+    expect(reviewedLog).toHaveLength(1);
+    const reviewedSignature = computeLogSignature(reviewedLog);
+
+    // After review: the REVIEWED row is deleted (cancelling its own create —
+    // compacts to nothing for that key) while an unrelated create backfills
+    // the count — net length is still 1, but the surviving command is NOT
+    // what was reviewed.
+    const swapId = id();
+    await db.insert(draftCommandLog).values([
+      {
+        draftId,
+        seq: 1,
+        path: "deleteNode",
+        args: { id: keptId },
+        compactionKey: `createDataSource:${keptId}`,
+        kind: "delete",
+      },
+      {
+        draftId,
+        seq: 2,
+        path: "createDataSource",
+        args: { id: swapId, type: "csv", name: "Swapped in" },
+      },
+    ]);
+
+    const rawRows = await db
+      .select()
+      .from(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    // Sanity: 3 raw rows on disk, but the create+delete pair (same key as the
+    // reviewed row) cancels — the controller's own compaction on the NEXT
+    // append would collapse this; here we assert the read-time state
+    // directly reflects what publish will see when it reloads (readLog does
+    // not itself compact — `writeLog` does, on append). Simulate the
+    // post-compaction reload by appending an effect-free batch, which
+    // re-runs `compactLog` over the full log.
+    expect(rawRows).toHaveLength(3);
+    await controller.appendToDraft(draftId, []);
+
+    const driftedLog = await controller.getDraftLog(draftId);
+    // Count-only guard would NOT catch this: same length as reviewed.
+    expect(driftedLog).toHaveLength(reviewedLog.length);
+    expect(computeLogSignature(driftedLog)).not.toBe(reviewedSignature);
+
+    return { draftId, reviewedCount: reviewedLog.length, reviewedSignature };
+  }
+
+  it("expectedCommandCount alone does NOT catch same-length content drift (the blind spot)", async () => {
+    const { draftId, reviewedCount } = await seedSameLengthContentDrift();
+
+    // The count-only guard sees the drifted log's length matches what the
+    // reviewer saw, so it wrongly lets a content-drifted publish through.
+    await expect(
+      controller.publishDraft(
+        draftId,
+        {},
+        { expectedCommandCount: reviewedCount },
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects same-length content drift that expectedCommandCount alone would miss", async () => {
+    const { draftId, reviewedCount, reviewedSignature } =
+      await seedSameLengthContentDrift();
+
+    // The SAME drifted log, this time guarded by the content signature: it
+    // must reject even though the count still matches what the reviewer saw.
+    await expect(
+      controller.publishDraft(
+        draftId,
+        {},
+        {
+          expectedCommandCount: reviewedCount,
+          expectedLogSignature: reviewedSignature,
+        },
+      ),
+    ).rejects.toThrow(/changed since review/);
+    // The aborted publish rolls back atomically — the draft survives intact.
+    expect(await controller.getDraftLog(draftId)).toHaveLength(reviewedCount);
+  });
+
+  it("rejects publish when expectedLogSignature does not match the reloaded log, even with a correct count", async () => {
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S1" }),
+    );
+    const reviewedLog = await controller.getDraftLog(draftId);
+    const staleSignature = computeLogSignature(reviewedLog);
+
+    // Draft changes after review, but the count happens to still match (a
+    // command is replaced rather than added) — content drift the signature
+    // must catch even when expectedCommandCount is not passed at all.
+    await db
+      .delete(draftCommandLog)
+      .where(eq(draftCommandLog.draftId, draftId));
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S2 (drifted)" }),
+    );
+    const driftedLog = await controller.getDraftLog(draftId);
+    expect(driftedLog).toHaveLength(reviewedLog.length);
+
+    await expect(
+      controller.publishDraft(
+        draftId,
+        {},
+        { expectedLogSignature: staleSignature },
+      ),
+    ).rejects.toThrow(/changed since review/);
+    // The aborted publish rolls back atomically — the draft survives intact.
+    expect(await controller.getDraftLog(draftId)).toHaveLength(1);
   });
 
   it("beforeReplay observes the AUTHORITATIVE reloaded log, not a stale pre-read (TOCTOU regression)", async () => {

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -510,13 +510,17 @@ export function createDraftController(
           options.expectedCommandCount !== undefined &&
           log.length !== options.expectedCommandCount
         ) {
-          throw new Error("publishDraft: draft changed since review");
+          throw new Error(
+            "publishDraft: draft changed since review (count mismatch)",
+          );
         }
         if (
           options.expectedLogSignature !== undefined &&
           computeLogSignature(log) !== options.expectedLogSignature
         ) {
-          throw new Error("publishDraft: draft changed since review");
+          throw new Error(
+            "publishDraft: draft changed since review (content drift)",
+          );
         }
         assertPublishLogHasNoLateBound(log);
         validatePublishLog?.(log);

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -70,6 +70,7 @@ import {
 import { eq } from "drizzle-orm";
 
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
+import { computeLogSignature } from "./draft-log-signature";
 
 /**
  * The closed set of `<table>__draft` shadows a draft can touch. Discard
@@ -183,12 +184,31 @@ export interface DraftController {
  */
 export interface PublishDraftOptions {
   /**
-   * Review-drift guard: the command-log length the reviewer saw. Enforced
-   * INSIDE the publish transaction against the reloaded durable log, so a
-   * command appended between review and publish aborts the replay atomically —
-   * a pre-transaction read cannot provide this guarantee.
+   * Review-drift guard, cheap fast-path: the command-log length the reviewer
+   * saw. Enforced INSIDE the publish transaction against the reloaded durable
+   * log, so a command appended between review and publish aborts the replay
+   * atomically — a pre-transaction read cannot provide this guarantee.
+   *
+   * COUNT ALONE IS NOT SUFFICIENT: `compactLog` can DROP earlier log
+   * positions (a create cancelled by a later delete collapses to nothing), so
+   * a concurrent append that triggers compaction can leave the length
+   * unchanged while the content differs from what the reviewer saw. Kept
+   * alongside `expectedLogSignature` as a cheap, distinct-evidence check
+   * (a count mismatch and a signature mismatch are different failure modes
+   * worth telling apart when debugging), not folded into it.
    */
   expectedCommandCount?: number;
+  /**
+   * Review-drift guard, content check: the SHA-256 hex signature (see
+   * `computeLogSignature`) of the command log the reviewer saw, over
+   * `[{path, args}]` in replay order. Enforced INSIDE the publish transaction
+   * against the reloaded durable log, same placement and atomicity guarantee
+   * as `expectedCommandCount`. Closes the gap the count-only guard misses:
+   * same-length, different-content drift caused by compaction (see the
+   * `expectedCommandCount` doc above) slips a count check but changes the
+   * signature.
+   */
+  expectedLogSignature?: string;
   /**
    * Pre-replay hook, invoked INSIDE the publish transaction — after the
    * `expectedCommandCount` and late-bound/`validatePublishLog` guards pass,
@@ -476,12 +496,25 @@ export function createDraftController(
       // routes their DELETEs through the same commit boundary as the replay.
       const result = await app.createTracked().transaction(async (tx) => {
         const log = await readLog(draftId, tx.raw as LogReader);
-        // Review-drift guard first: this log read shares the replay's commit
+        // Review-drift guards first: this log read shares the replay's commit
         // boundary, so a mismatch here means the draft REALLY changed since the
-        // reviewed count was taken — abort before content validation.
+        // reviewed state was taken — abort before content validation.
+        //
+        // Count is the cheap fast-path; signature is the content check that
+        // catches same-length drift the count alone misses (see
+        // `PublishDraftOptions` docs for why compaction makes this possible).
+        // Both checks read the SAME reloaded log, so their evidence is always
+        // consistent with each other — never a case where count passes,
+        // signature fails, but on a log that's already been mutated further.
         if (
           options.expectedCommandCount !== undefined &&
           log.length !== options.expectedCommandCount
+        ) {
+          throw new Error("publishDraft: draft changed since review");
+        }
+        if (
+          options.expectedLogSignature !== undefined &&
+          computeLogSignature(log) !== options.expectedLogSignature
         ) {
           throw new Error("publishDraft: draft changed since review");
         }

--- a/apps/server/src/draft-log-signature.test.ts
+++ b/apps/server/src/draft-log-signature.test.ts
@@ -81,6 +81,32 @@ describe("computeLogSignature", () => {
     expect(computeLogSignature(a)).toBe(computeLogSignature(b));
   });
 
+  it("is sensitive to a differing __proto__-named argument key (prototype-pollution regression)", () => {
+    // args is attacker-influenced JSON parsed from `jsonb` storage. A key
+    // literally named `__proto__` assigned via bracket notation on a normal
+    // object invokes the legacy prototype SETTER rather than creating an
+    // enumerable own property, so a naive canonicalizer would silently drop
+    // it — a drifted log differing only in this field would wrongly hash the
+    // same as the reviewed one. Parse from JSON (not an object literal) so
+    // the key is genuinely an own `__proto__` property, matching how
+    // `readLog` reconstructs args from stored jsonb.
+    const a: Command[] = [
+      {
+        path: "createDataSource",
+        args: JSON.parse('{"__proto__": {"evil": true}, "id": "1"}') as unknown,
+      },
+    ];
+    const b: Command[] = [
+      {
+        path: "createDataSource",
+        args: JSON.parse(
+          '{"__proto__": {"evil": false}, "id": "1"}',
+        ) as unknown,
+      },
+    ];
+    expect(computeLogSignature(a)).not.toBe(computeLogSignature(b));
+  });
+
   it("returns the empty-log signature for an empty log, distinct from any non-empty log", () => {
     expect(computeLogSignature([])).toBe(computeLogSignature([]));
     expect(computeLogSignature([])).not.toBe(

--- a/apps/server/src/draft-log-signature.test.ts
+++ b/apps/server/src/draft-log-signature.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `computeLogSignature` — the drift guard's content check.
+ *
+ * The only property that matters here is DETERMINISM: the same logical log
+ * must always produce the same signature, and a logically different log must
+ * produce a different one. `draft_command_log.args` is `jsonb`, which does
+ * not preserve object key insertion order across a write/read round trip, so
+ * key-order independence is the load-bearing contract — not an edge case.
+ */
+import type { Command } from "@wystack/server";
+import { describe, expect, it } from "vitest";
+
+import { computeLogSignature } from "./draft-log-signature";
+
+describe("computeLogSignature", () => {
+  it("is independent of object key insertion order in args", () => {
+    const a: Command[] = [
+      { path: "createDataSource", args: { id: "1", type: "csv", name: "S" } },
+    ];
+    const b: Command[] = [
+      { path: "createDataSource", args: { name: "S", id: "1", type: "csv" } },
+    ];
+    expect(computeLogSignature(a)).toBe(computeLogSignature(b));
+  });
+
+  it("is independent of key order in nested objects", () => {
+    const a: Command[] = [
+      {
+        path: "setDataSourceConfig",
+        args: { id: "1", config: { host: "h", port: 5432 } },
+      },
+    ];
+    const b: Command[] = [
+      {
+        path: "setDataSourceConfig",
+        args: { config: { port: 5432, host: "h" }, id: "1" },
+      },
+    ];
+    expect(computeLogSignature(a)).toBe(computeLogSignature(b));
+  });
+
+  it("is sensitive to array order (position is semantic, unlike object keys)", () => {
+    const a: Command[] = [{ path: "reorder", args: { ids: ["1", "2"] } }];
+    const b: Command[] = [{ path: "reorder", args: { ids: ["2", "1"] } }];
+    expect(computeLogSignature(a)).not.toBe(computeLogSignature(b));
+  });
+
+  it("is sensitive to command order (replay order matters)", () => {
+    const a: Command[] = [
+      { path: "createDataSource", args: { id: "1" } },
+      { path: "createDataSource", args: { id: "2" } },
+    ];
+    const b: Command[] = [
+      { path: "createDataSource", args: { id: "2" } },
+      { path: "createDataSource", args: { id: "1" } },
+    ];
+    expect(computeLogSignature(a)).not.toBe(computeLogSignature(b));
+  });
+
+  it("is sensitive to a changed argument value", () => {
+    const a: Command[] = [
+      { path: "createDataSource", args: { id: "1", name: "Original" } },
+    ];
+    const b: Command[] = [
+      { path: "createDataSource", args: { id: "1", name: "Renamed" } },
+    ];
+    expect(computeLogSignature(a)).not.toBe(computeLogSignature(b));
+  });
+
+  it("ignores id/compactionKey/kind — only path+args determine publish's effect", () => {
+    const a: Command[] = [{ path: "createDataSource", args: { id: "1" } }];
+    const b = [
+      {
+        path: "createDataSource",
+        args: { id: "1" },
+        id: "corr-1",
+        compactionKey: "createDataSource:1",
+        kind: "create" as const,
+      },
+    ];
+    expect(computeLogSignature(a)).toBe(computeLogSignature(b));
+  });
+
+  it("returns the empty-log signature for an empty log, distinct from any non-empty log", () => {
+    expect(computeLogSignature([])).toBe(computeLogSignature([]));
+    expect(computeLogSignature([])).not.toBe(
+      computeLogSignature([{ path: "noop", args: {} }]),
+    );
+  });
+});

--- a/apps/server/src/draft-log-signature.ts
+++ b/apps/server/src/draft-log-signature.ts
@@ -29,18 +29,28 @@ import { createHash } from "node:crypto";
  * identically regardless of key insertion order (which `jsonb` does not
  * preserve). Arrays keep their order — position is semantic there, unlike
  * object keys.
+ *
+ * Built via `Object.fromEntries`, NOT `out[key] = ...` assignment: command
+ * args are attacker-influenced JSON, and a key literally named `__proto__`
+ * assigned with bracket notation invokes the legacy prototype SETTER instead
+ * of creating an enumerable own property — the field would silently vanish
+ * from `JSON.stringify`, making a log that differs only in a `__proto__`
+ * argument value hash identically to one that doesn't (the signature's whole
+ * job is to catch content differences). `Object.fromEntries` defines each
+ * entry as a genuine own property, so `__proto__` round-trips like any other
+ * key.
  */
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(canonicalize);
   }
   if (value !== null && typeof value === "object") {
-    const sortedKeys = Object.keys(value as Record<string, unknown>).sort();
-    const out: Record<string, unknown> = {};
-    for (const key of sortedKeys) {
-      out[key] = canonicalize((value as Record<string, unknown>)[key]);
-    }
-    return out;
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, canonicalize(record[key])]),
+    );
   }
   return value;
 }

--- a/apps/server/src/draft-log-signature.ts
+++ b/apps/server/src/draft-log-signature.ts
@@ -1,0 +1,66 @@
+/**
+ * Content signature of a draft's command log — the review-drift guard's
+ * second, stronger check (alongside `expectedCommandCount`).
+ *
+ * WHY a count alone is not enough: `compactLog` (see `@wystack/server`) can
+ * DROP earlier log positions — a create cancelled by a later delete collapses
+ * to nothing, so the surviving list can shrink while a DIFFERENT command that
+ * landed after the reviewer's read fills the gap. A concurrent append that
+ * triggers this kind of compaction can leave `log.length` unchanged from what
+ * the reviewer saw while the actual content differs. Same-count content drift
+ * slips a count-only guard. A content signature closes that gap: it is
+ * sensitive to which commands survived, not just how many.
+ *
+ * DETERMINISM is the whole point of this file. The signature must be
+ * byte-for-byte identical for an unchanged log whether it is computed at
+ * review time (`draftPublishReview`) or recomputed inside the publish
+ * transaction (`DraftController.publishDraft`) — both call sites import THIS
+ * function, so there is exactly one serializer to keep in sync, never two.
+ * `draft_command_log.args` is stored as `jsonb`, which does not preserve
+ * object key insertion order across a write/read round trip, so `args` is
+ * serialized with keys sorted (recursively, arrays keep their order) rather
+ * than relying on JSON.stringify's insertion-order behavior.
+ */
+import type { Command } from "@wystack/server";
+import { createHash } from "node:crypto";
+
+/**
+ * Recursively sort object keys so structurally-equal values serialize
+ * identically regardless of key insertion order (which `jsonb` does not
+ * preserve). Arrays keep their order — position is semantic there, unlike
+ * object keys.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === "object") {
+    const sortedKeys = Object.keys(value as Record<string, unknown>).sort();
+    const out: Record<string, unknown> = {};
+    for (const key of sortedKeys) {
+      out[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Compute a deterministic content signature over a command log in replay
+ * order. Only `path` and `args` participate — the fields that determine what
+ * publish actually DOES. `id`/`compactionKey`/`kind` are replay bookkeeping,
+ * not content the reviewer evaluated, and including them would make the
+ * signature sensitive to compaction-internal metadata rather than to the
+ * commands' user-visible effect.
+ *
+ * Returns a SHA-256 hex digest — an opaque string the client ferries back
+ * verbatim (RPC args are text; hex round-trips without escaping concerns).
+ */
+export function computeLogSignature(log: Command[]): string {
+  const canonical = log.map((command) => ({
+    path: command.path,
+    args: canonicalize(command.args ?? null),
+  }));
+  const serialized = JSON.stringify(canonical);
+  return createHash("sha256").update(serialized).digest("hex");
+}

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -115,10 +115,14 @@ async function gateSnapshotForRelease(
 }
 
 const publishDraft = mutation({
-  args: { draftId: text, expectedCommandCount: text.optional() },
+  args: {
+    draftId: text,
+    expectedCommandCount: text.optional(),
+    expectedLogSignature: text.optional(),
+  },
   handler: async (
     ctx,
-    { draftId, expectedCommandCount },
+    { draftId, expectedCommandCount, expectedLogSignature },
   ): Promise<PublishDraftInternalResult> => {
     const draftController = ctx.draftController as DraftController | undefined;
     if (!draftController) {
@@ -129,10 +133,13 @@ const publishDraft = mutation({
     }
 
     // Parse the reviewed count here; ENFORCEMENT happens inside the publish
-    // transaction (see DraftController.publishDraft's expectedCommandCount
-    // guard) against the reloaded durable log — a command appended between
-    // this parse and the replay aborts the publish atomically rather than
-    // bypassing a pre-transaction check.
+    // transaction (see DraftController.publishDraft's expectedCommandCount +
+    // expectedLogSignature guards) against the reloaded durable log — a
+    // command appended between this parse and the replay aborts the publish
+    // atomically rather than bypassing a pre-transaction check.
+    //
+    // `expectedLogSignature` is already a hex string (RPC args are text), so
+    // it is forwarded verbatim — no parse step, unlike the count.
     let expected: number | undefined;
     if (expectedCommandCount !== undefined) {
       expected = Number.parseInt(expectedCommandCount, 10);
@@ -180,6 +187,7 @@ const publishDraft = mutation({
       { [PUBLISH_REPLAY_CONTEXT_KEY]: true },
       {
         expectedCommandCount: expected,
+        expectedLogSignature,
         beforeReplay: async (log, tx) => {
           publishLogLength = log.length;
           if (artifactDb != null) {

--- a/apps/server/src/functions/drafts.test.ts
+++ b/apps/server/src/functions/drafts.test.ts
@@ -88,6 +88,7 @@ describe("draft publish functions", () => {
           args?: unknown;
         }>;
         commandCount: number;
+        logSignature: string;
         diff: { directNodes: Array<{ nodeId: string }> };
       };
     }>(
@@ -108,15 +109,62 @@ describe("draft publish functions", () => {
     });
     expect(review.data.commands[0]).not.toHaveProperty("args");
     expect(review.data.commandCount).toBe(1);
+    expect(review.data.logSignature).toMatch(/^[0-9a-f]{64}$/);
     expect(review.data.diff.directNodes[0]?.nodeId).toBe(sourceId);
 
     await postJson(`${server.url}/api/publishDraft`, {
       draftId,
       expectedCommandCount: "1",
+      expectedLogSignature: review.data.logSignature,
     });
     expect(onWriteCalls).toHaveLength(1);
     const rows = await db.select().from(dataSources);
     expect(rows.find((row) => row.id === sourceId)?.name).toBe("Draft source");
+    expect(await draftController.getDraftLog(draftId)).toHaveLength(0);
+  });
+
+  it("rejects publish when expectedLogSignature does not match what draftPublishReview returned (end-to-end)", async () => {
+    const draftController = await controller();
+    const draftId = await draftController.openDraft();
+    await draftController.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id: crypto.randomUUID(),
+        type: "csv",
+        name: "Draft source",
+      }),
+    ]);
+
+    server = await createDashframeServer({ db });
+
+    const review = await getJson<{ data: DraftPublishReview }>(
+      `${server.url}/api/draftPublishReview?args=${encodeURIComponent(
+        JSON.stringify({ draftId }),
+      )}`,
+    );
+    expect(review.data.logSignature).toMatch(/^[0-9a-f]{64}$/);
+
+    // A signature that does not match the reviewed (and still-current) log —
+    // the same failure mode a stale client would trigger after a real drift.
+    const res = await fetch(`${server.url}/api/publishDraft`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        draftId,
+        expectedLogSignature: "0".repeat(64),
+      }),
+    });
+    expect(res.status).toBe(500);
+
+    // Rejected publish leaves the draft intact for a clean retry.
+    expect(await draftController.getDraftLog(draftId)).toHaveLength(1);
+
+    // The review-produced signature, passed back verbatim, publishes cleanly
+    // — proving review-time compute and publish-time recompute agree
+    // byte-for-byte for an unchanged log.
+    await postJson(`${server.url}/api/publishDraft`, {
+      draftId,
+      expectedLogSignature: review.data.logSignature,
+    });
     expect(await draftController.getDraftLog(draftId)).toHaveLength(0);
   });
 

--- a/apps/server/src/functions/drafts.ts
+++ b/apps/server/src/functions/drafts.ts
@@ -6,6 +6,7 @@ import { query } from "@wystack/server";
 
 import { createDraftController } from "../draft-controller";
 import { findLateBound, type LateBoundOperandRef } from "../draft-late-bound";
+import { computeLogSignature } from "../draft-log-signature";
 import { buildPreviewDiff } from "./preview-diff";
 
 export { findLateBound };
@@ -16,6 +17,17 @@ export interface DraftPublishReview {
   commands: DraftCommandSummary[];
   /** Length of the durable log at review time — publish may pass this back to detect drift. */
   commandCount: number;
+  /**
+   * Content signature (see `computeLogSignature`) of the durable log at
+   * review time — publish passes this back as `expectedLogSignature` so the
+   * server can detect same-length content drift that `commandCount` alone
+   * cannot see (compaction can drop earlier positions while a different
+   * command backfills the count). Computed HERE, over the same `commands`
+   * this response returns, and recomputed inside the publish transaction
+   * over the reloaded log with the SAME function — one serializer, so an
+   * unchanged log is guaranteed to signature-match byte for byte.
+   */
+  logSignature: string;
   diff: PreviewDiff;
   lateBound: LateBoundOperandRef[];
   publishBlocked: boolean;
@@ -84,6 +96,7 @@ const draftPublishReview = query({
       draftId,
       commands: summarizeCommands(commands, lateBound),
       commandCount: commands.length,
+      logSignature: computeLogSignature(commands),
       diff,
       lateBound,
       publishBlocked: lateBound.length > 0 || diff.error !== undefined,

--- a/packages/app-data/src/draft-lifecycle.ts
+++ b/packages/app-data/src/draft-lifecycle.ts
@@ -20,7 +20,7 @@ import { loose } from "./wystack-args";
  */
 export async function publishDraft(
   draftId: string,
-  options?: { expectedCommandCount?: number },
+  options?: { expectedCommandCount?: number; expectedLogSignature?: string },
 ): Promise<{ tablesWritten: string[] }> {
   return getWyStackClient().mutate(
     api.publishDraft,
@@ -30,6 +30,7 @@ export async function publishDraft(
         options?.expectedCommandCount !== undefined
           ? String(options.expectedCommandCount)
           : undefined,
+      expectedLogSignature: options?.expectedLogSignature,
     }),
   );
 }

--- a/packages/app-data/src/drafts.ts
+++ b/packages/app-data/src/drafts.ts
@@ -28,7 +28,7 @@ export function useDraftPublishReview(
 export interface DraftMutations {
   publish: (
     draftId: string,
-    options?: { expectedCommandCount?: number },
+    options?: { expectedCommandCount?: number; expectedLogSignature?: string },
   ) => Promise<void>;
   discard: (draftId: string) => Promise<void>;
 }
@@ -41,7 +41,10 @@ export function useDraftMutations(): DraftMutations {
     () => ({
       publish: async (
         draftId: string,
-        options?: { expectedCommandCount?: number },
+        options?: {
+          expectedCommandCount?: number;
+          expectedLogSignature?: string;
+        },
       ): Promise<void> => {
         await publishMutation.mutateAsync(
           loose({
@@ -50,6 +53,7 @@ export function useDraftMutations(): DraftMutations {
               options?.expectedCommandCount !== undefined
                 ? String(options.expectedCommandCount)
                 : undefined,
+            expectedLogSignature: options?.expectedLogSignature,
           }),
         );
       },

--- a/packages/app/src/app/drafts/[draftId]/publish/page.tsx
+++ b/packages/app/src/app/drafts/[draftId]/publish/page.tsx
@@ -78,7 +78,10 @@ export default function DraftPublishPage({ draftId }: DraftPublishPageProps) {
     if (!review || review.publishBlocked) return;
     setBusy("publish");
     try {
-      await publish(draftId, { expectedCommandCount: review.commandCount });
+      await publish(draftId, {
+        expectedCommandCount: review.commandCount,
+        expectedLogSignature: review.logSignature,
+      });
       if (useAssistantStore.getState().pendingDraftId === draftId) {
         setPendingDraft(null);
       }

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -40,6 +40,7 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
   const [diff, setDiff] = useState<PreviewDiff | null>(null);
   const [publishBlocked, setPublishBlocked] = useState(true);
   const [commandCount, setCommandCount] = useState<number | null>(null);
+  const [logSignature, setLogSignature] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -62,6 +63,7 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
       }
       setPublishBlocked(review.publishBlocked);
       setCommandCount(review.commandCount);
+      setLogSignature(review.logSignature);
       setDiff(review.diff);
       setDialogOpen(true);
       if (review.lateBound.length > 0) {
@@ -98,6 +100,9 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
         ...(commandCount !== null
           ? { expectedCommandCount: commandCount }
           : {}),
+        ...(logSignature !== null
+          ? { expectedLogSignature: logSignature }
+          : {}),
       });
       toast.success("Draft published.");
       setDialogOpen(false);
@@ -108,7 +113,14 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
         description: draftLifecycleErrorDescription(err),
       });
     }
-  }, [commandCount, draftId, openFullReview, publishBlocked, setPendingDraft]);
+  }, [
+    commandCount,
+    draftId,
+    logSignature,
+    openFullReview,
+    publishBlocked,
+    setPendingDraft,
+  ]);
 
   const handleDiscard = useCallback(async () => {
     try {


### PR DESCRIPTION
## Changes

- Add a deterministic SHA-256 content signature over a draft's compacted command log (`draft-log-signature.ts`), used as a second review-drift check alongside the existing `expectedCommandCount` guard.
- `DraftController.publishDraft` accepts an optional `expectedLogSignature` in `PublishDraftOptions`, enforced inside the publish transaction against the reloaded durable log (same placement/atomicity as the count guard). Kept the count check as a cheap, distinct-evidence fast path rather than folding it into the signature.
- `publishDraft` RPC (`draft-lifecycle.ts`) accepts and forwards `expectedLogSignature` (already hex text — no parsing needed).
- `draftPublishReview` (`drafts.ts`) computes and returns `logSignature` alongside the existing `commandCount`.
- Client: both review surfaces — the full publish review page and the assistant sidebar `DraftReviewPanel` — now capture `logSignature` from the review response and pass it back on publish.

### The gap this closes

The count-only guard compared `log.length !== expectedCommandCount`. `compactLog` can DROP earlier log positions (a create cancelled by a later delete collapses to nothing), so a concurrent append that triggers compaction can leave the log length unchanged from what the reviewer saw while the actual surviving content differs — same-count content drift slipped the guard undetected.

### Signature design and determinism

- Computed **server-side** in `draftPublishReview`, not client-side: the client only ever receives redacted command summaries (`{path, hasArgs, lateBoundCount}`), never raw `args`, so it has no way to compute a content signature itself. The client instead receives the server-computed `logSignature` and ferries it back verbatim as an opaque hex string.
- Hashes `[{path, args}]` in replay order — only the fields that determine what publish actually does. `id`/`compactionKey`/`kind` are replay bookkeeping, deliberately excluded so the signature reflects the commands' user-visible effect, not compaction internals.
- `draft_command_log.args` is stored as `jsonb`, which does not preserve object key insertion order across a write/read round trip. `args` is canonicalized (object keys sorted recursively; array order preserved, since position is semantic there) before `JSON.stringify` + SHA-256, so structurally-equal args always hash identically regardless of storage round-trip.
- **One serializer, one call site pattern**: both `draftPublishReview` (review time) and `DraftController.publishDraft` (publish time, inside the transaction, over the reloaded log) import the same `computeLogSignature` function. There is no second implementation to drift out of sync — an unchanged log is guaranteed to signature-match byte for byte by construction.

## Screenshots

No UI change (passing an extra RPC argument, no visible UI difference).

## Verification

- `apps/server/src/draft-log-signature.test.ts` (new) — unit tests pin determinism: key-order independence (object and nested), array-order sensitivity, command-order sensitivity, value-change sensitivity, exclusion of `id`/`compactionKey`/`kind`, empty-log handling.
- `apps/server/src/draft-controller.test.ts` — added:
  - `publishes when expectedLogSignature matches the unchanged reloaded log`
  - `expectedCommandCount alone does NOT catch same-length content drift (the blind spot)` — proves the pre-existing guard's gap using a seeded create+delete-same-key+create-new compaction scenario (raw `draft_command_log` rows, since the real `cmd()` vocabulary never sets `compactionKey`/`kind`).
  - `rejects same-length content drift that expectedCommandCount alone would miss` — the same seeded scenario, now guarded by `expectedLogSignature`, correctly rejects.
  - `rejects publish when expectedLogSignature does not match the reloaded log, even with a correct count`
- `apps/server/src/functions/drafts.test.ts` — extended the existing end-to-end review→publish test to assert `logSignature` shape and round-trip it through the real `publishDraft` RPC; added `rejects publish when expectedLogSignature does not match what draftPublishReview returned (end-to-end)` covering both the negative case (wrong signature → 500, draft survives) and the positive case (review-produced signature → publishes cleanly).
- Ran the full server test suite locally: 380/380 passing. Lint clean on `apps/server`, `packages/app-data`, `packages/app`.
- Typecheck: pre-existing environment issue (dual `drizzle-orm` resolution between the root workspace and the `libs/wystack` git submodule's independent lockfile — confirmed present on `main` before this change, identical error count with and without this diff) prevents a clean `tsc` run repo-wide; not something this diff introduces or is in scope to fix. No draft-related typecheck errors appear in the diff.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a blind spot in the draft publish drift guard: the existing `expectedCommandCount` check could be fooled by compaction, which can drop cancelled commands and let a different command backfill the count at the same length. It introduces a deterministic SHA-256 content signature (`computeLogSignature`) over `[{path, args}]` in replay order, computed server-side at review time and recomputed inside the publish transaction for comparison.

- **`draft-log-signature.ts`** (new): single-function canonicalizer that sorts object keys recursively (preserving array order), uses `Object.fromEntries` to handle `__proto__` keys correctly, and SHA-256 hashes the result. Comprehensive unit tests pin all determinism properties including the prototype-pollution edge case.
- **`DraftController.publishDraft`** / **`draftPublishReview`**: `expectedLogSignature` is enforced inside the same transaction as the count guard (both read the same reloaded log), and `draftPublishReview` returns `logSignature` for the client to ferry back verbatim.
- **Client surfaces** (`publish/page.tsx`, `DraftReviewPanel`): capture `logSignature` from the review response and pass it back on publish; no UI changes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All guard checks run inside the publish transaction against the reloaded log, the canonicalizer is well-tested, and no existing behaviour is broken.

The change is narrowly scoped — a new server-side hash function plus plumbing to thread an opaque hex string from review to publish. The implementation is correct: same function at both call sites, canonicalization handles JSONB key-order and prototype-pollution edge cases, both guards read the same reloaded log atomically, and the test suite covers the blind spot it closes as well as all determinism properties. The only finding is a stale phrase in a JSDoc comment.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-log-signature.ts | New file implementing SHA-256 content signature for the drift guard. `canonicalize` correctly uses `Object.fromEntries` (not bracket assignment) to handle `__proto__` keys, and sorts keys recursively while preserving array order. Unit-tested for determinism, key-order independence, and prototype-pollution edge cases. |
| apps/server/src/draft-controller.ts | Adds `expectedLogSignature` field to `PublishDraftOptions` and enforces it inside the publish transaction immediately after the count check. Both guards read the same reloaded log, have distinct error messages, and run before `beforeReplay`. Minor: the `beforeReplay` JSDoc first sentence omits `expectedLogSignature` from the guard enumeration. |
| apps/server/src/functions/drafts.ts | Adds `logSignature: computeLogSignature(commands)` to the `DraftPublishReview` response. Signature is computed over the full (unsummarized) `commands` array — correct, since `summarizeCommands` strips `args` before the response leaves the server. |
| apps/server/src/functions/draft-lifecycle.ts | Adds `expectedLogSignature` as an optional text RPC argument and forwards it verbatim to `publishDraft`. Correctly notes no parse step is needed (unlike the count, which is serialized to string for the RPC layer). |
| packages/app/src/components/assistant/DraftReviewPanel.tsx | Adds `logSignature` state, sets it from `review.logSignature` on successful review, and spreads it into the publish options when non-null. Correctly added to the `useCallback` dependency array. |
| apps/server/src/draft-log-signature.test.ts | Comprehensive unit tests pinning all determinism properties: key-order independence (flat and nested), array-order sensitivity, command-order sensitivity, value-change sensitivity, `id`/`compactionKey`/`kind` exclusion, empty-log, and the `__proto__` prototype-pollution edge case. |
| apps/server/src/draft-controller.test.ts | Adds four tests: happy-path signature match, proof-of-blind-spot (count guard alone passes on same-length drift), signature rejects same-length drift, and signature rejects with correct count. The `seedSameLengthContentDrift` helper correctly seeds raw rows and triggers compaction via an empty append. |
| apps/server/src/functions/drafts.test.ts | Extends the end-to-end review→publish test to verify the `logSignature` hex format and round-trip, and adds a rejection test proving a wrong signature returns 500 while leaving the draft intact. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Server as Server (RPC)
    participant Controller as DraftController
    participant DB as draft_command_log

    Client->>Server: "draftPublishReview({ draftId })"
    Server->>DB: getDraftLog(draftId)
    DB-->>Server: commands[]
    Server->>Server: computeLogSignature(commands)
    Server-->>Client: "{ commandCount, logSignature, commands (redacted), diff }"

    Note over Client: Stores commandCount + logSignature in state

    Client->>Server: "publishDraft({ draftId, expectedCommandCount, expectedLogSignature })"
    Server->>Controller: publishDraft(draftId, options)

    rect rgb(230, 240, 255)
        Note over Controller,DB: Inside single transaction
        Controller->>DB: readLog(draftId, tx)
        DB-->>Controller: log[] (reloaded)
        Controller->>Controller: "log.length !== expectedCommandCount?"
        Note over Controller: throws (count mismatch)
        Controller->>Controller: "computeLogSignature(log) !== expectedLogSignature?"
        Note over Controller: throws (content drift)
        Controller->>Controller: assertPublishLogHasNoLateBound(log)
        Controller->>Controller: beforeReplay hook
        Controller->>DB: applyCommands (replay)
        Controller->>DB: deleteLog + sweepShadows
    end

    Controller-->>Server: CommitResult
    Server-->>Client: "{ tablesWritten }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Server as Server (RPC)
    participant Controller as DraftController
    participant DB as draft_command_log

    Client->>Server: "draftPublishReview({ draftId })"
    Server->>DB: getDraftLog(draftId)
    DB-->>Server: commands[]
    Server->>Server: computeLogSignature(commands)
    Server-->>Client: "{ commandCount, logSignature, commands (redacted), diff }"

    Note over Client: Stores commandCount + logSignature in state

    Client->>Server: "publishDraft({ draftId, expectedCommandCount, expectedLogSignature })"
    Server->>Controller: publishDraft(draftId, options)

    rect rgb(230, 240, 255)
        Note over Controller,DB: Inside single transaction
        Controller->>DB: readLog(draftId, tx)
        DB-->>Controller: log[] (reloaded)
        Controller->>Controller: "log.length !== expectedCommandCount?"
        Note over Controller: throws (count mismatch)
        Controller->>Controller: "computeLogSignature(log) !== expectedLogSignature?"
        Note over Controller: throws (content drift)
        Controller->>Controller: assertPublishLogHasNoLateBound(log)
        Controller->>Controller: beforeReplay hook
        Controller->>DB: applyCommands (replay)
        Controller->>DB: deleteLog + sweepShadows
    end

    Controller-->>Server: CommitResult
    Server-->>Client: "{ tablesWritten }"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(drafts): address review feedback on ..."](https://github.com/youhaowei/dashframe/commit/4ce4cb83deb4a6756746b680c09dfc45c6caa3bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41355264)</sub>

<!-- /greptile_comment -->