### PR TITLE
fix(drafts): collect discard credential-release refs inside the discard transaction

### DIFF
--- a/apps/server/src/credential-release.ts
+++ b/apps/server/src/credential-release.ts
@@ -54,11 +54,11 @@ import {
 
 /**
  * Read-only slice of `ArtifactDb` for the pre-transition collectors: they
- * COLLECT release candidates, never mutate — and on the publish path they run
- * on a transaction-bound raw handle that does NOT support `.transaction()` at
- * runtime. The narrowed type turns both misuses into compile errors and lets
- * the collectors accept `DraftController`'s `beforeReplay` tx (`LogReader`,
- * the structurally identical slice) without a cast.
+ * COLLECT release candidates, never mutate. The narrowed type makes mutation
+ * unrepresentable at compile time — least authority by construction,
+ * regardless of what the runtime handle supports — and lets the collectors
+ * accept `DraftController`'s hook tx (`LogReader`, the structurally identical
+ * slice) without a cast.
  */
 export type ArtifactReader = Pick<ArtifactDb, "select">;
 

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -352,6 +352,55 @@ describe("DraftController (persisted draft overlay)", () => {
     expect(hookCalled).toBe(false);
   });
 
+  it("a throw in beforeReplay aborts the publish transaction — nothing lands on canonical, log survives intact", async () => {
+    // Sibling of the discard-side "a throw in beforeDiscard aborts..." test
+    // below: pins the publish half's identical guarantee. The hook runs INSIDE
+    // the publish transaction, after the drift guard passes and the log is
+    // reloaded, but BEFORE applyCommands/deleteLog/sweepShadows run — a throw
+    // here must roll back the whole transaction, not just skip the write.
+    const { tableId } = await seedTable(controller);
+    const before = await canonicalInsights();
+
+    const draftId = await controller.openDraft();
+    const insightId = id();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "Throwaway src" }),
+      cmd("CreateInsight", {
+        id: insightId,
+        name: "Throwaway",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(1);
+
+    await expect(
+      controller.publishDraft(
+        draftId,
+        {},
+        {
+          beforeReplay: () => {
+            throw new Error("collection failed");
+          },
+        },
+      ),
+    ).rejects.toThrow(/collection failed/);
+
+    // Nothing replayed to canonical.
+    const after = await canonicalInsights();
+    expect(after).toHaveLength(before.length);
+    expect(after.find((r) => r.id === insightId)).toBeUndefined();
+    // The draft survives intact: both shadow tables AND the command log are
+    // untouched, so a retry (without the failing hook) can still publish it.
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(1);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(2);
+  });
+
   /** Seed a DataSource + DataTable on CANONICAL (the draft's base). */
   async function seedTable(
     target: ReturnType<typeof createDraftController>,
@@ -523,6 +572,80 @@ describe("DraftController (persisted draft overlay)", () => {
       (r) => r.draftId === draftId,
     );
     expect(logRows).toHaveLength(0);
+  });
+
+  it("beforeDiscard observes the AUTHORITATIVE reloaded log, not a stale pre-read (TOCTOU regression)", async () => {
+    // Mirrors the publish-side "beforeReplay observes the AUTHORITATIVE
+    // reloaded log" test above. A host that reads the draft log BEFORE
+    // calling discardDraft (e.g. to decide which credential-vault refs to
+    // release) races a command appended between that read and the discard
+    // transaction's own reload. `beforeDiscard` exists so the host instead
+    // reasons about the log INSIDE the transaction, after it is reloaded —
+    // this pins that it really does see the append, not whatever the caller
+    // read earlier.
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S1" }),
+    );
+
+    // Simulate a caller's stale pre-read (what draft-lifecycle.ts used to do
+    // via `draftController.getDraftLog(draftId)` before this fix).
+    const stalePreRead = await controller.getDraftLog(draftId);
+    expect(stalePreRead).toHaveLength(1);
+
+    // A second command lands after the stale read but before discard — the
+    // drift race this hook must be immune to.
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "S2" }),
+    );
+
+    let observedLogLength: number | undefined;
+    await controller.discardDraft(draftId, {
+      beforeDiscard: (log) => {
+        observedLogLength = log.length;
+      },
+    });
+
+    // The hook saw the AUTHORITATIVE 2-command log, not the stale 1-command
+    // pre-read — proving collection cannot run against stale state.
+    expect(observedLogLength).toBe(2);
+    expect(observedLogLength).not.toBe(stalePreRead.length);
+  });
+
+  it("a throw in beforeDiscard aborts the discard transaction — log + shadow rows survive intact", async () => {
+    const { tableId } = await seedTable(controller);
+    const draftId = await controller.openDraft();
+    await appendCmds(
+      draftId,
+      cmd("CreateDataSource", { id: id(), type: "csv", name: "Throwaway src" }),
+      cmd("CreateInsight", {
+        id: id(),
+        name: "Throwaway",
+        source: { sourceType: "dataTable", sourceId: tableId },
+      }),
+    );
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(1);
+
+    await expect(
+      controller.discardDraft(draftId, {
+        beforeDiscard: () => {
+          throw new Error("collection failed");
+        },
+      }),
+    ).rejects.toThrow(/collection failed/);
+
+    // The aborted discard rolls back atomically — the draft survives intact
+    // across BOTH shadow tables AND the command log, exactly like an aborted
+    // publish (see the `expectedCommandCount` rollback tests above).
+    expect(await draftInsightRows(draftId)).toHaveLength(1);
+    expect(await draftDataSourceRows(draftId)).toHaveLength(1);
+    const logRows = (await db.select().from(draftCommandLog)).filter(
+      (r) => r.draftId === draftId,
+    );
+    expect(logRows).toHaveLength(2);
   });
 
   it("does NOT draft when no draftId is in context — the seam writes straight to canonical", async () => {

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -91,11 +91,10 @@ const DRAFT_SHADOW_TABLES = [
 
 /**
  * The DB-handle surface the teardown helpers (`deleteLog`/`sweepShadows`) need:
- * just `.delete()`. Narrowing to this (rather than the full `ArtifactDb`) keeps
- * the publish path's `tx.raw` cast honest — a transaction-bound raw handle does
- * NOT expose `.transaction()`, so widening to `ArtifactDb` would advertise a
- * method that fails at runtime. With this type, any future helper that reaches for
- * `.transaction()` is a compile error, not a latent footgun.
+ * just `.delete()`. Narrowing to this (rather than the full `ArtifactDb`) is
+ * least authority by construction: any future helper that reaches for
+ * `.transaction()` or another surface it wasn't granted is a compile error,
+ * regardless of what the runtime handle happens to support.
  */
 type DeleteExecutor = Pick<ArtifactDb, "delete">;
 export type LogReader = Pick<ArtifactDb, "select">;
@@ -211,9 +210,9 @@ export interface DiscardDraftOptions {
    * publish side.
    *
    * Typed as `LogReader` — the same narrowed slice `readLog` uses — so the
-   * hook COLLECTS, never mutates: a transaction-bound handle does NOT support
-   * `.transaction()` at runtime, so widening the type to `ArtifactDb` would
-   * advertise a method that fails.
+   * contract "the hook COLLECTS, never mutates" is enforced at compile time:
+   * mutation and nested-transaction calls are unrepresentable through the
+   * narrowed type, regardless of what the runtime handle supports.
    */
   beforeDiscard?: (log: Command[], tx: LogReader) => Promise<void> | void;
 }
@@ -266,10 +265,10 @@ export interface PublishDraftOptions {
    * invokes collection — nothing here observes a log that won't actually
    * replay. A throw here aborts the publish transaction like any other guard.
    *
-   * Typed as `LogReader` — the same narrowed slice `readLog` uses — so both
-   * misuses are compile errors rather than latent runtime failures: the hook
-   * COLLECTS, never mutates, and a transaction-bound `tx.raw` does NOT
-   * support `.transaction()` at runtime.
+   * Typed as `LogReader` — the same narrowed slice `readLog` uses — so the
+   * contract "the hook COLLECTS, never mutates" is enforced at compile time:
+   * mutation and nested-transaction calls are unrepresentable through the
+   * narrowed type, regardless of what the runtime handle supports.
    */
   beforeReplay?: (log: Command[], tx: LogReader) => Promise<void> | void;
 }

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -172,11 +172,50 @@ export interface DraftController {
   /**
    * Discard = drop the draft's deltas: delete every `<table>__draft` row and
    * every `draft_command_log` row for this draftId. Canonical is untouched.
-   * Pure DELETE-by-draftId; no wystack call needed.
+   * Runs in ONE transaction (log reload, optional `beforeDiscard` hook, log
+   * delete, shadow sweep) — mirrors `publishDraft`'s outer-tx seam so a host
+   * can collect pre-teardown state (e.g. credential-release refs) against the
+   * AUTHORITATIVE reloaded log rather than a pre-transaction read. See
+   * `DiscardDraftOptions.beforeDiscard`.
    */
-  discardDraft(draftId: string): Promise<void>;
+  discardDraft(draftId: string, options?: DiscardDraftOptions): Promise<void>;
   /** Read-only peek at a draft's persisted (compacted) command log. */
   getDraftLog(draftId: string): Promise<Command[]>;
+}
+
+/**
+ * Per-call guards for `discardDraft`.
+ */
+export interface DiscardDraftOptions {
+  /**
+   * Pre-teardown hook, invoked INSIDE the discard transaction — after the log
+   * is reloaded via `readLog(draftId, tx)`, before the log delete + shadow
+   * sweep run.
+   *
+   * Mirrors `PublishDraftOptions.beforeReplay`: exists so a host can collect
+   * state the teardown is about to remove (DashFrame's credential-release
+   * refs — which vault refs the draft's log/shadow hold) against the
+   * AUTHORITATIVE reloaded log, never a pre-transaction read. A command
+   * appended between an outer `getDraftLog` call and `discardDraft` would
+   * make that pre-read stale — the same TOCTOU the publish half's
+   * `beforeReplay` closes (see its doc comment). Collection here observes
+   * exactly the log/shadow rows that are about to be dropped.
+   *
+   * Runs BEFORE the log delete and shadow sweep, so `dataSourcesDraft` (and
+   * the other five shadow tables) still hold this draft's rows when the hook
+   * fires — collectors that read the shadow (e.g. an inherited-only
+   * credential ref not present in the log) see them.
+   *
+   * A throw here aborts the discard transaction — the log and shadow rows
+   * survive intact, same abort semantics as a `beforeReplay` throw on the
+   * publish side.
+   *
+   * Typed as `LogReader` — the same narrowed slice `readLog` uses — so the
+   * hook COLLECTS, never mutates: a transaction-bound handle does NOT support
+   * `.transaction()` at runtime, so widening the type to `ArtifactDb` would
+   * advertise a method that fails.
+   */
+  beforeDiscard?: (log: Command[], tx: LogReader) => Promise<void> | void;
 }
 
 /**
@@ -343,8 +382,11 @@ export function createDraftController(
    * the OUTER transaction's handle (`tx.raw`) so the log delete commits ATOMICALLY
    * with the canonical replay — this is the load-bearing step that closes the
    * crash window (a process death between replay-commit and log-delete is no
-   * longer possible; both land in one commit or both roll back). Other callers
-   * (discard) pass the autocommit `db` handle. Defaults to `db`.
+   * longer possible; both land in one commit or both roll back). The discard
+   * path (`dropDraft`) similarly passes its own transaction's handle, so the log
+   * delete commits atomically with the shadow sweep and any `beforeDiscard`
+   * hook. Defaults to `db` (autocommit) for a direct call outside either
+   * lifecycle path.
    */
   async function deleteLog(
     draftId: string,
@@ -357,12 +399,17 @@ export function createDraftController(
 
   /**
    * Sweep a draft's `<table>__draft` shadow rows across the closed set. `exec` is
-   * the Drizzle handle the DELETEs run against — the publish path passes the outer
-   * transaction's `tx.raw` so the sweep commits ATOMICALLY with the canonical
-   * replay + log delete (defaults to the autocommit `db` for discard).
+   * the Drizzle handle the DELETEs run against — BOTH callers now pass their
+   * outer transaction's handle (publish: `tx.raw`; discard: `dropDraft`'s own
+   * `db.transaction` callback) so the sweep commits ATOMICALLY with the rest of
+   * that transaction (defaults to the autocommit `db` only for a direct call
+   * outside either lifecycle path, e.g. tests).
    *
    * A sweep failure HARD-FAILS (propagates). Both callers want this:
-   *   - discard — the whole draft must be fully gone; a partial sweep must surface.
+   *   - discard — the sweep runs inside `dropDraft`'s tx, so a failure rolls
+   *     back the whole discard (log delete + any `beforeDiscard` effects
+   *     included) and leaves the draft intact for a clean retry, rather than a
+   *     partially-torn-down draft.
    *   - publish — the sweep runs inside the outer tx, so a failure must roll back
    *     the whole publish (canonical replay + log delete included) and leave the
    *     draft intact for a clean retry, never canonical-committed with a half-swept
@@ -381,13 +428,41 @@ export function createDraftController(
   }
 
   /**
-   * Delete every log row + shadow row for a draft. Log-FIRST + hard-fail on any
-   * step: used by discard, where the whole draft must be removed atomically-ish
-   * (a failure should surface so the caller knows the draft is not fully gone).
+   * Delete every log row + shadow row for a draft, inside ONE transaction, with
+   * an optional pre-teardown hook run against the reloaded log.
+   *
+   * ATOMIC (mirrors `publishDraft`'s outer-tx seam): the log reload, the
+   * `beforeDiscard` hook, the log delete, and the shadow sweep all share one
+   * commit boundary. A `beforeDiscard` throw rolls back the whole discard —
+   * the log and shadow rows survive intact for a clean retry — rather than
+   * leaving a partially-torn-down draft. `tx` here is `db.transaction`'s own
+   * callback handle — already the native Drizzle handle (no `.raw` unwrap
+   * needed, unlike the `DrizzleTracker.transaction` the publish path uses);
+   * passing it to `readLog`/`deleteLog`/`sweepShadows` routes all four steps
+   * through the same pre-teardown snapshot and commit boundary, closing the
+   * same TOCTOU class `PublishDraftOptions.beforeReplay` closes on the
+   * publish side (a pre-transaction `getDraftLog` read can miss a
+   * command appended between that read and discard; reloading inside the tx
+   * cannot).
    */
-  async function dropDraft(draftId: string): Promise<void> {
-    await deleteLog(draftId);
-    await sweepShadows(draftId);
+  async function dropDraft(
+    draftId: string,
+    options: DiscardDraftOptions = {},
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      // `db.transaction`'s callback handle is ALREADY the plain Drizzle
+      // handle (unlike `DrizzleTracker.transaction`, whose callback wraps it
+      // behind `.raw` — see `writeLog` above for the same pattern). It
+      // structurally satisfies both `LogReader` and `DeleteExecutor`.
+      const log = await readLog(draftId, tx);
+      // Pre-teardown hook: runs on the AUTHORITATIVE reloaded log, BEFORE the
+      // log delete and shadow sweep remove the rows it might read (e.g. the
+      // `dataSourcesDraft` shadow config for an inherited-only ref). See
+      // `DiscardDraftOptions.beforeDiscard` for why this must live here.
+      await options.beforeDiscard?.(log, tx);
+      await deleteLog(draftId, tx);
+      await sweepShadows(draftId, tx);
+    });
   }
 
   return {
@@ -561,8 +636,8 @@ export function createDraftController(
       return result;
     },
 
-    async discardDraft(draftId) {
-      await dropDraft(draftId);
+    async discardDraft(draftId, options = {}) {
+      await dropDraft(draftId, options);
     },
 
     async getDraftLog(draftId) {

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -353,6 +353,65 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     expect(await vault.has(oldRef)).toBe(false);
   });
 
+  it("discard releases the ref minted by a command appended right before discard, via the real HTTP path", async () => {
+    // Discard-side mirror of the publish test above: pins that a credential
+    // ref minted by a command appended to the draft's log is still collected
+    // and released when the draft is discarded through the RPC — the case an
+    // OUTER pre-read (the old `collectDiscardCandidateRefs(artifactDb,
+    // draftId, await draftController.getDraftLog(draftId))` taken before
+    // `discardDraft` opened its transaction) could miss if the append landed
+    // between that pre-read and the discard call.
+    //
+    // As with the publish test, this does not reproduce the intra-discard
+    // race itself (the append below happens before `discardDraft` is
+    // invoked, so both an outer pre-read and the in-transaction reload would
+    // observe it here) — the regression guard for the ordering itself lives
+    // in draft-controller.test.ts ("beforeDiscard observes the AUTHORITATIVE
+    // reloaded log, not a stale pre-read"). This test instead pins the
+    // end-to-end outcome: the ref a late-appended command mints is not
+    // orphaned by discard.
+    const vault = makeTestVault();
+    project = await openProject({ dir: join(root, "proj") });
+    const db = project.db as ArtifactDb;
+
+    const seedApp = await buildDashframeApp({ db, vault });
+    const seedController = createDraftController(seedApp, db, {
+      captureCredentials: (c) => captureCommandCredentials(c, vault, db),
+    });
+
+    // Open the draft the RPC will discard.
+    const draftId = await seedController.openDraft();
+
+    server = await createDashframeServer({
+      db: project.db,
+      vault,
+      flushSnapshot: async () => {},
+    });
+
+    // Append a fresh credentialed CreateDataSource right before discard — the
+    // capture-before-log seam mints a real vault ref for it.
+    const sourceId = crypto.randomUUID();
+    await seedController.appendToDraft(draftId, [
+      cmd("CreateDataSource", {
+        id: sourceId,
+        type: "notion",
+        name: "Draft source",
+        apiKey: "fresh-key",
+      }),
+    ]);
+    const draftLog = await seedController.getDraftLog(draftId);
+    const mintedRef = (draftLog[0]!.args as Record<string, unknown>)
+      .apiKey as SecretRef;
+    expect(await vault.has(mintedRef)).toBe(true);
+
+    await postOk<void>(server.url, "discardDraft", { draftId });
+
+    // Collection (via `beforeDiscard`) sees the appended CreateDataSource
+    // against the authoritative in-tx log, so the draft-minted ref is
+    // released after discard commits — never left as an inert vault orphan.
+    expect(await vault.has(mintedRef)).toBe(false);
+  });
+
   // -------------------------------------------------------------------------
   // getDraftLog: compacted command log
   // -------------------------------------------------------------------------

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -259,22 +259,33 @@ const discardDraft = mutation({
       );
     }
 
-    // TRANSITION-TIME RELEASE — discard half. Read the draft-minted credential
-    // refs from its log BEFORE the discard drops the log + shadow; release them
-    // AFTER the draft is gone (best-effort), gated so a ref another open draft
-    // still references is never deleted.
+    // TRANSITION-TIME RELEASE — discard half. Collect the draft-minted
+    // credential refs from its log + shadow config; release them AFTER the
+    // draft is gone (best-effort), gated so a ref another open draft still
+    // references is never deleted.
+    //
+    // TOCTOU: collection must read the AUTHORITATIVE durable log/shadow — the
+    // ones `discardDraft` actually drops — not a pre-transaction read, which a
+    // command appended between an outer `getDraftLog` read and discard would
+    // make stale (an orphaned ref never collected). `beforeDiscard` runs
+    // INSIDE the discard transaction, after the log is reloaded and BEFORE the
+    // log delete + shadow sweep remove the rows collection reads (mirrors the
+    // publish half's `beforeReplay` — see its handler above and
+    // `DiscardDraftOptions.beforeDiscard`'s doc comment for the full
+    // rationale). `collectDiscardCandidateRefs` reads the `dataSourcesDraft`
+    // shadow for this draftId; those rows still exist at hook time because the
+    // hook runs strictly before teardown.
     const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
     const vault = ctx.vault as SecretVault | undefined;
-    const mintedRefs =
-      artifactDb != null
-        ? await collectDiscardCandidateRefs(
-            artifactDb,
-            draftId,
-            await draftController.getDraftLog(draftId),
-          )
-        : [];
+    let mintedRefs: SecretRef[] = [];
 
-    await draftController.discardDraft(draftId);
+    await draftController.discardDraft(draftId, {
+      beforeDiscard: async (log, tx) => {
+        if (artifactDb != null) {
+          mintedRefs = await collectDiscardCandidateRefs(tx, draftId, log);
+        }
+      },
+    });
 
     // Trigger snapshot persistence after discard — the shadow rows live in the
     // durable store; a stale snapshot would resurrect them on restart. This MUST


### PR DESCRIPTION
Discard-path symmetry for credential-release ref collection: `discardDraft` now collects the refs it's about to release **inside** its own transaction, against the authoritatively reloaded log — mirroring what the publish path (`PublishDraftOptions.beforeReplay`) already does.

## Changes

- **`apps/server/src/draft-controller.ts`**: add `DiscardDraftOptions.beforeDiscard?: (log, tx) => Promise<void> | void`, invoked inside `discardDraft`'s transaction after the log is reloaded (`readLog(draftId, tx)`) and before the log delete + shadow sweep run. Rewrote the internal `dropDraft` to be transactional (`db.transaction(async (tx) => { ... })`) so the hook, log delete, and shadow sweep are one atomic unit.
- **`apps/server/src/functions/draft-lifecycle.ts`**: the `discardDraft` RPC handler now collects credential refs via `collectDiscardCandidateRefs` from inside `beforeDiscard`, instead of via a pre-transaction `getDraftLog` read taken before `discardDraft` was called. Everything downstream (`gateSnapshotForRelease`, the snapshot-gated `releaseRefsAtTransition` call) is unchanged.
- **Tests**: three new regression tests, plus one publish-side sibling hardening test.

## Why

The old discard handler did:

```ts
const mintedRefs = await collectDiscardCandidateRefs(artifactDb, draftId, await draftController.getDraftLog(draftId));
await draftController.discardDraft(draftId);
```

The `getDraftLog` read happens **before** `discardDraft` opens its own transaction. A command appended to the draft between that pre-read and the discard call is invisible to collection — collection can only *shrink* the release set relative to what's actually torn down, never grow it. The result is a silently orphaned vault ref (inert, but never released) — never a use-after-release, since the omission only removes work, it never adds a ref that isn't real.

The publish path already closed the identical gap via `PublishDraftOptions.beforeReplay`, invoked inside the publish transaction on the reloaded log. This PR gives discard the same shape.

## Invariants preserved (for reviewers)

- **Ordering is unchanged and still linear**: collect (in-tx, pre-teardown) → transaction commits → `gateSnapshotForRelease` flush → `releaseRefsAtTransition` (best-effort, gated so a ref still referenced by canonical or another open draft is never deleted). None of this downstream sequencing moved.
- **Abort ⇒ nothing released, draft survives.** If `beforeDiscard` throws (or the log delete / shadow sweep fails), `db.transaction` rolls back the whole unit — the command log and all six `<table>__draft` shadow rows survive intact — and `discardDraft` rejects. Because the RPC handler `await`s `discardDraft` before it ever reaches `gateSnapshotForRelease`/`releaseRefsAtTransition`, an abort means release code never runs. `mintedRefs` having been *set* by the hook before a later, unrelated failure is harmless: nothing downstream fires without a successful commit.
- **Shadow rows are still readable at hook time.** `beforeDiscard` runs strictly before `deleteLog`/`sweepShadows`, so `collectDiscardCandidateRefs`'s read of the `dataSourcesDraft` shadow (needed for inherited-only refs not present in the log) sees this draft's rows — same as the old autocommit-timed read, just now consistent with the log reload instead of racing it.
- **No credential values are read, printed, or logged anywhere in this change** — only vault refs (opaque identifiers), exactly as the pre-existing code did.
- **Bonus, not just symmetry**: wrapping discard in a transaction also removes a pre-existing partial-teardown hazard. Previously `deleteLog` autocommitted before `sweepShadows` ran; if the sweep failed, the log was gone but shadow rows were orphaned with no release. That interleaving is now impossible.
- **No nesting risk**: `discardDraft` is only ever called from the RPC handler (not from inside an already-open transaction), confirmed via a repo-wide grep of production callers.
- **RPC signature unchanged** (`{draftId}`) — only the internal `DraftController.discardDraft(draftId, options?)` gained an optional second parameter, so `packages/app-data`'s client-side callers are unaffected.

## New tests

- `draft-controller.test.ts` — `"beforeDiscard observes the AUTHORITATIVE reloaded log, not a stale pre-read (TOCTOU regression)"`: a command appended after an outer pre-read but before `discardDraft` is seen by the hook (2 commands observed, not the stale pre-read's 1).
- `draft-controller.test.ts` — `"a throw in beforeDiscard aborts the discard transaction — log + shadow rows survive intact"`: hook throws, `discardDraft` rejects, both shadow tables and the command log are untouched.
- `draft-controller.test.ts` — `"a throw in beforeReplay aborts the publish transaction — nothing lands on canonical, log survives intact"`: publish-side sibling hardening test. The existing `beforeReplay` tests covered "sees the authoritative log" and "never runs when the drift guard aborts first," but not the hook itself throwing after guards pass — a distinct path (hook runs inside the tx, after guards, before `applyCommands`/`deleteLog`/`sweepShadows`). Confirms canonical is untouched and the draft (shadow rows + log) survives for a clean retry.
- `functions/draft-lifecycle.test.ts` — `"discard releases the ref minted by a command appended right before discard, via the real HTTP path"`: end-to-end mirror of the existing publish credential test, over the real RPC path, pinning that a ref minted by a command appended to the draft's log is collected and released on discard.

## Screenshots

No UI change.

## Verification

- `bun run typecheck` — clean (`apps/server`)
- `bun run lint` — clean (`apps/server`)
- `bunx prettier --check` — clean on all touched files
- `bunx vitest run src/draft-controller.test.ts src/functions/draft-lifecycle.test.ts src/credential-release.test.ts` — 79/79 passed
- Full `apps/server` suite (384+ tests) run clean prior to the final commit, to rule out collateral regressions
- Graph-wide build (`@dashframe/app-data`, `@dashframe/assistant`) confirmed green — RPC signature change is additive-only
- Repo-wide grep confirmed the RPC handler is the only production caller of `discardDraft`, ruling out transaction-nesting risk

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a TOCTOU gap in the discard path for credential-release ref collection: `discardDraft` now reloads the command log inside its own transaction and exposes a `beforeDiscard` hook — mirroring the publish path's `beforeReplay` seam — so collection always reads the authoritative log and shadow rows rather than a potentially stale pre-transaction `getDraftLog` call.

- **`draft-controller.ts`**: added `DiscardDraftOptions.beforeDiscard`, and rewrote `dropDraft` to wrap log-reload + hook + log-delete + shadow-sweep in a single `db.transaction`, eliminating both the TOCTOU window and the pre-existing partial-teardown hazard where `deleteLog` could autocommit before `sweepShadows` ran.
- **`draft-lifecycle.ts`**: moved `collectDiscardCandidateRefs` from a pre-`discardDraft` `getDraftLog` call into the new `beforeDiscard` hook, so collection reads the same snapshot the transaction tears down; snapshot gating and release sequencing are unchanged.
- **Tests**: three new `draft-controller` regression tests (TOCTOU, rollback-on-throw for discard, rollback-on-throw for publish) and one end-to-end `draft-lifecycle` RPC test pinning credential ref release for a late-appended command.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-scoped atomicity fix with no behaviour change on any path that was already working correctly.

The discard transaction now groups log-reload, hook, log-delete, and shadow-sweep into a single commit boundary, matching what the publish path has always done. Abort semantics are correct: a `beforeDiscard` throw rolls back the whole unit and the release path is never reached. Tests cover TOCTOU, rollback-on-throw, and full release round-trip.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-controller.ts | Added `DiscardDraftOptions` interface and `beforeDiscard` hook; rewrote `dropDraft` to wrap log-reload + hook + log-delete + shadow-sweep in one `db.transaction` — mirrors the `publishDraft` outer-tx seam. TypeScript narrowing (`LogReader`/`DeleteExecutor`) prevents mutation or nested-transaction calls through the hook handle. |
| apps/server/src/functions/draft-lifecycle.ts | Moved `collectDiscardCandidateRefs` from a pre-transaction `getDraftLog` call into a `beforeDiscard` hook, so collection reads the authoritative transaction-reloaded log and shadow rows rather than a potentially stale outer read. Ordering of snapshot and release is unchanged. |
| apps/server/src/credential-release.ts | Comment-only change: updated `ArtifactReader` doc to drop the now-inaccurate note about transaction-bound handles not supporting `.transaction()` at runtime, replacing it with the more precise 'least authority by construction' framing. |
| apps/server/src/draft-controller.test.ts | Three new regression tests: TOCTOU regression (hook sees authoritative 2-command log vs stale 1-command pre-read), rollback on `beforeDiscard` throw (log + both shadow tables survive intact), and publish-side sibling (`beforeReplay` throw leaves canonical untouched and draft retryable). |
| apps/server/src/functions/draft-lifecycle.test.ts | End-to-end RPC test: credential ref minted by a `CreateDataSource` appended right before discard is collected (via `beforeDiscard`) and released after the discard transaction commits — pins the full round-trip, not just the controller contract. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant RPC as discardDraft RPC
    participant DC as DraftController
    participant DB as db.transaction
    participant CR as credential-release

    RPC->>DC: "discardDraft(draftId, { beforeDiscard })"
    DC->>DB: BEGIN TRANSACTION
    DB->>DB: readLog(draftId, tx)
    DB->>CR: beforeDiscard(log, tx)
    CR->>DB: collectDiscardCandidateRefs(tx, draftId, log)
    Note over CR,DB: reads dataSourcesDraft shadow (still present)
    CR-->>RPC: "mintedRefs = [...]"
    DB->>DB: deleteLog(draftId, tx)
    DB->>DB: sweepShadows(draftId, tx)
    DB->>DB: COMMIT
    DC-->>RPC: discardDraft resolves
    RPC->>RPC: "gateSnapshotForRelease(mintedRefs.length > 0)"
    RPC->>CR: releaseRefsAtTransition(artifactDb, vault, mintedRefs, draftId)
    Note over RPC,CR: best-effort, post-commit, gated on snapshot persistence
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant RPC as discardDraft RPC
    participant DC as DraftController
    participant DB as db.transaction
    participant CR as credential-release

    RPC->>DC: "discardDraft(draftId, { beforeDiscard })"
    DC->>DB: BEGIN TRANSACTION
    DB->>DB: readLog(draftId, tx)
    DB->>CR: beforeDiscard(log, tx)
    CR->>DB: collectDiscardCandidateRefs(tx, draftId, log)
    Note over CR,DB: reads dataSourcesDraft shadow (still present)
    CR-->>RPC: "mintedRefs = [...]"
    DB->>DB: deleteLog(draftId, tx)
    DB->>DB: sweepShadows(draftId, tx)
    DB->>DB: COMMIT
    DC-->>RPC: discardDraft resolves
    RPC->>RPC: "gateSnapshotForRelease(mintedRefs.length > 0)"
    RPC->>CR: releaseRefsAtTransition(artifactDb, vault, mintedRefs, draftId)
    Note over RPC,CR: best-effort, post-commit, gated on snapshot persistence
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(drafts): correct the rationale on h..."](https://github.com/youhaowei/dashframe/commit/f26b098aa1ca77e336cb5166cead69651d70c068) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41368212)</sub>

<!-- /greptile_comment -->