### PR TITLE
Fix ensure-worktree.sh mutating the main checkout for new branches

### DIFF
--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -8,8 +8,11 @@
 #   - Verifies the caller is already in an isolated worktree (not the main
 #     checkout).  If so, prints the worktree path and exits 0.
 #   - If the caller IS in the main checkout, creates a new worktree at
-#     ~/worktrees/<project>/<branch>, checks out <branch-name> there, and
-#     prints the new path.  The caller must cd into that path.
+#     ~/worktrees/<project>/<branch> via `git worktree add`, which populates
+#     <branch-name> in the *new* worktree only, and prints the new path.  The
+#     caller must cd into that path.  The main checkout's HEAD and current
+#     branch are never switched — verified by an assertion before this
+#     script hands back control.
 #   - Hard-fails (exit 1) if anything goes wrong — this is fail-closed by
 #     design so that a briefed agent cannot silently proceed in main.
 #
@@ -23,6 +26,24 @@
 # or, in a brief: "Run scripts/ensure-worktree.sh <branch>; cd into the path it prints."
 
 set -eu
+
+# assert_main_checkout_unchanged <repo_root> <head_before> <branch_before>
+# Fail closed if provisioning the new worktree mutated the main checkout's
+# HEAD or current branch out from under whoever else is using it.
+assert_main_checkout_unchanged() {
+  _amcu_repo_root="$1"
+  _amcu_head_before="$2"
+  _amcu_branch_before="$3"
+  _amcu_head_after=$(git -C "$_amcu_repo_root" rev-parse HEAD 2>/dev/null || echo "")
+  _amcu_branch_after=$(git -C "$_amcu_repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$_amcu_head_after" != "$_amcu_head_before" ] || [ "$_amcu_branch_after" != "$_amcu_branch_before" ]; then
+    echo "ERROR [ensure-worktree]: main checkout at '$_amcu_repo_root' was mutated while provisioning the worktree." >&2
+    echo "  Before: HEAD=$_amcu_head_before branch=$_amcu_branch_before" >&2
+    echo "  After:  HEAD=$_amcu_head_after branch=$_amcu_branch_after" >&2
+    echo "  This should never happen — refusing to hand back a worktree path." >&2
+    exit 1
+  fi
+}
 
 # ── 1. Require a branch argument ────────────────────────────────────────────
 branch="${1:-}"
@@ -58,6 +79,13 @@ if [ "$git_dir" != "$git_common_dir" ]; then
 fi
 
 # ── 3. We're in the main checkout — provision a new worktree ────────────────
+# Snapshot the main checkout's HEAD + current branch so we can assert, right
+# before we hand control back to the caller, that provisioning the new
+# worktree never mutated the main checkout itself (see assertion at the
+# bottom of this branch).
+main_head_before=$(git rev-parse HEAD 2>/dev/null || echo "")
+main_branch_before=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
 repo_root=$(git rev-parse --show-toplevel)
 # Lowercase the project name so the canonical worktree base is always
 # ~/worktrees/<lower-project>/<branch> regardless of how the repo dir is
@@ -93,6 +121,7 @@ if [ -d "$worktree_path" ]; then
     echo "  Remove it manually ('git worktree remove $worktree_path') or choose a different base." >&2
     exit 1
   fi
+  assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
   echo "$worktree_path"
   exit 0
 fi
@@ -111,7 +140,8 @@ _wt_rc=0
 if git show-ref --verify --quiet "refs/heads/$branch"; then
   git worktree add "$worktree_path" "$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
 else
-  # Try to track from origin; error out if the branch doesn't exist anywhere.
+  # Try to track from origin; error out only if the branch doesn't exist
+  # anywhere AND we have no base ref to create it from.
   if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
     # Fetch to ensure the local remote-tracking ref exists — ls-remote verifies the
     # branch on the network but git worktree add resolves against the local
@@ -119,10 +149,19 @@ else
     git fetch origin "$branch" >/dev/null 2>&1 || true
     git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
   else
-    rm -f "$_wt_log"
-    echo "ERROR [ensure-worktree]: branch '$branch' not found locally or on origin." >&2
-    echo "  Create it first: git checkout -b $branch" >&2
-    exit 1
+    # Brand-new branch: create it AND the worktree in one atomic command,
+    # rooted at a fresh origin/main. This never touches the main checkout's
+    # HEAD or current branch — unlike instructing the caller to run
+    # `git checkout -b <branch>` in the main checkout (the historical
+    # behaviour here), which yanks the branch out from under whoever else
+    # is using that checkout.
+    git fetch origin main >/dev/null 2>&1 || true
+    if ! git show-ref --verify --quiet "refs/remotes/origin/main"; then
+      rm -f "$_wt_log"
+      echo "ERROR [ensure-worktree]: branch '$branch' not found locally or on origin, and 'origin/main' is unavailable to branch from." >&2
+      exit 1
+    fi
+    git worktree add -b "$branch" "$worktree_path" origin/main >"$_wt_log" 2>&1 || _wt_rc=$?
   fi
 fi
 if [ "$_wt_rc" -ne 0 ]; then
@@ -146,5 +185,7 @@ if [ "$actual_branch" != "$branch" ]; then
   echo "ERROR [ensure-worktree]: worktree created but is on '$actual_branch' instead of '$branch'." >&2
   exit 1
 fi
+
+assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
 
 echo "$worktree_path"

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -140,28 +140,39 @@ _wt_rc=0
 if git show-ref --verify --quiet "refs/heads/$branch"; then
   git worktree add "$worktree_path" "$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
 else
-  # Try to track from origin; error out only if the branch doesn't exist
-  # anywhere AND we have no base ref to create it from.
-  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  # Check whether the branch exists on origin. `git ls-remote --exit-code`
+  # only guarantees exit code 2 for "no matching refs" — other non-zero
+  # exits (network down, auth failure, etc.) mean the lookup itself failed,
+  # not that the branch is confirmed absent. Distinguish the two so a
+  # transient remote failure can't be misread as "brand new branch" and
+  # silently branch from main instead.
+  _ls_remote_rc=0
+  git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1 || _ls_remote_rc=$?
+  if [ "$_ls_remote_rc" -eq 0 ]; then
     # Fetch to ensure the local remote-tracking ref exists — ls-remote verifies the
     # branch on the network but git worktree add resolves against the local
     # refs/remotes/origin/<branch> ref, which only exists after a fetch.
     git fetch origin "$branch" >/dev/null 2>&1 || true
     git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
+  elif [ "$_ls_remote_rc" -ne 2 ]; then
+    echo "ERROR [ensure-worktree]: could not determine whether branch '$branch' exists on origin (git ls-remote exited $_ls_remote_rc)." >&2
+    echo "  This looks like a network or auth problem reaching 'origin', not a missing branch — not falling back to branching from main." >&2
+    exit 1
   else
-    # Brand-new branch: create it AND the worktree in one atomic command,
-    # rooted at a fresh origin/main. This never touches the main checkout's
-    # HEAD or current branch — unlike instructing the caller to run
-    # `git checkout -b <branch>` in the main checkout (the historical
-    # behaviour here), which yanks the branch out from under whoever else
-    # is using that checkout.
+    # Brand-new branch (ls-remote confirmed no matching ref, exit 2): create
+    # it AND the worktree in one atomic command, rooted at a fresh
+    # origin/main, with tracking disabled so the new branch's upstream isn't
+    # main. This never touches the main checkout's HEAD or current branch —
+    # unlike instructing the caller to run `git checkout -b <branch>` in the
+    # main checkout (the historical behaviour here), which yanks the branch
+    # out from under whoever else is using that checkout.
     git fetch origin main >/dev/null 2>&1 || true
     if ! git show-ref --verify --quiet "refs/remotes/origin/main"; then
       rm -f "$_wt_log"
       echo "ERROR [ensure-worktree]: branch '$branch' not found locally or on origin, and 'origin/main' is unavailable to branch from." >&2
       exit 1
     fi
-    git worktree add -b "$branch" "$worktree_path" origin/main >"$_wt_log" 2>&1 || _wt_rc=$?
+    git worktree add --no-track -b "$branch" "$worktree_path" origin/main >"$_wt_log" 2>&1 || _wt_rc=$?
   fi
 fi
 if [ "$_wt_rc" -ne 0 ]; then

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -166,6 +166,11 @@ else
     # unlike instructing the caller to run `git checkout -b <branch>` in the
     # main checkout (the historical behaviour here), which yanks the branch
     # out from under whoever else is using that checkout.
+    #
+    # DashFrame convention: upstream default branch is always main (CLAUDE.md,
+    # CI, branch protection). We hardcode origin/main here rather than deriving
+    # from origin/HEAD — that would be the right call if this script were
+    # vendored for other repos, but it wouldn't change behaviour here.
     git fetch origin main >/dev/null 2>&1 || true
     if ! git show-ref --verify --quiet "refs/remotes/origin/main"; then
       rm -f "$_wt_log"

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -151,8 +151,14 @@ else
   if [ "$_ls_remote_rc" -eq 0 ]; then
     # Fetch to ensure the local remote-tracking ref exists — ls-remote verifies the
     # branch on the network but git worktree add resolves against the local
-    # refs/remotes/origin/<branch> ref, which only exists after a fetch.
-    git fetch origin "$branch" >/dev/null 2>&1 || true
+    # refs/remotes/origin/<branch> ref, which only exists after a fetch. Fail
+    # closed if the fetch itself fails rather than silently falling back to
+    # whatever (possibly stale, possibly absent) refs/remotes/origin/<branch>
+    # already exists locally.
+    if ! git fetch origin "$branch" >/dev/null 2>&1; then
+      echo "ERROR [ensure-worktree]: branch '$branch' exists on origin but 'git fetch origin $branch' failed — not falling back to a possibly stale local ref." >&2
+      exit 1
+    fi
     git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
   elif [ "$_ls_remote_rc" -ne 2 ]; then
     echo "ERROR [ensure-worktree]: could not determine whether branch '$branch' exists on origin (git ls-remote exited $_ls_remote_rc)." >&2

--- a/scripts/test-worktree-guard.sh
+++ b/scripts/test-worktree-guard.sh
@@ -172,6 +172,51 @@ else
 fi
 echo ""
 
+# ── Regression: main checkout must never be mutated ─────────────────────────
+# ensure-worktree.sh used to instruct the caller to run `git checkout -b
+# <branch>` in the main checkout when the branch didn't exist anywhere yet —
+# mutating the main checkout's HEAD/branch out from under whoever else was
+# using it. Assert the main checkout is untouched by a provisioning call,
+# both for the "branch already exists locally" path (exercised above) and
+# the brand-new-branch path.
+echo "Test 8: ensure-worktree.sh never mutates the main checkout's HEAD/branch"
+cd "$SCRATCH"
+git checkout main --quiet 2>/dev/null
+main_head_before=$(git rev-parse HEAD)
+main_branch_before=$(git branch --show-current)
+
+# 8a: provisioning for a branch that already exists locally (feature-e).
+git checkout -b feature-e --quiet 2>/dev/null
+git checkout main --quiet 2>/dev/null
+WORKTREE_BASE="$SCRATCH/wt-out2" "$HELPER" feature-e >/dev/null 2>&1 || true
+main_head_after=$(git rev-parse HEAD)
+main_branch_after=$(git branch --show-current)
+if [ "$main_head_after" = "$main_head_before" ] && [ "$main_branch_after" = "$main_branch_before" ]; then
+  ok "main checkout unchanged after provisioning an existing branch"
+else
+  fail "main checkout mutated: HEAD $main_head_before -> $main_head_after, branch $main_branch_before -> $main_branch_after"
+fi
+
+# 8b: requesting a branch that does not exist anywhere (no local branch, and
+# 'origin' is not fetchable in this scratch repo) must fail closed WITHOUT
+# ever touching the main checkout — it must not fall back to instructing
+# (or performing) a checkout in the main checkout.
+nonexistent_rc=0
+"$HELPER" totally-nonexistent-branch >/dev/null 2>&1 || nonexistent_rc=$?
+main_head_after2=$(git rev-parse HEAD)
+main_branch_after2=$(git branch --show-current)
+if [ "$nonexistent_rc" -ne 0 ]; then
+  ok "unresolvable branch request fails closed (exit $nonexistent_rc)"
+else
+  fail "unresolvable branch request unexpectedly succeeded"
+fi
+if [ "$main_head_after2" = "$main_head_before" ] && [ "$main_branch_after2" = "$main_branch_before" ]; then
+  ok "main checkout unchanged after an unresolvable branch request"
+else
+  fail "main checkout mutated on unresolvable branch: HEAD $main_head_before -> $main_head_after2, branch $main_branch_before -> $main_branch_after2"
+fi
+echo ""
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 if [ "$FAILURES" -eq 0 ]; then
   printf "${GREEN}All tests passed — worktree isolation guard is working.${RESET}\n"

--- a/scripts/test-worktree-guard.sh
+++ b/scripts/test-worktree-guard.sh
@@ -188,7 +188,13 @@ main_branch_before=$(git branch --show-current)
 # 8a: provisioning for a branch that already exists locally (feature-e).
 git checkout -b feature-e --quiet 2>/dev/null
 git checkout main --quiet 2>/dev/null
-WORKTREE_BASE="$SCRATCH/wt-out2" "$HELPER" feature-e >/dev/null 2>&1 || true
+feature_e_rc=0
+feature_e_result=$(WORKTREE_BASE="$SCRATCH/wt-out2" "$HELPER" feature-e 2>/dev/null) || feature_e_rc=$?
+if [ "$feature_e_rc" -eq 0 ] && [ -d "$feature_e_result" ] && git -C "$feature_e_result" rev-parse --verify HEAD >/dev/null 2>&1; then
+  ok "helper provisioned feature-e successfully (exit 0, valid checkout at $feature_e_result)"
+else
+  fail "helper did not provision feature-e as expected (exit $feature_e_rc, result '$feature_e_result')"
+fi
 main_head_after=$(git rev-parse HEAD)
 main_branch_after=$(git branch --show-current)
 if [ "$main_head_after" = "$main_head_before" ] && [ "$main_branch_after" = "$main_branch_before" ]; then
@@ -214,6 +220,72 @@ if [ "$main_head_after2" = "$main_head_before" ] && [ "$main_branch_after2" = "$
   ok "main checkout unchanged after an unresolvable branch request"
 else
   fail "main checkout mutated on unresolvable branch: HEAD $main_head_before -> $main_head_after2, branch $main_branch_before -> $main_branch_after2"
+fi
+echo ""
+
+# ── Test 9: brand-new branch created atomically from a real, fetchable origin/main ──
+# The scratch repo's 'origin' remote (https://example.com/repo.git) is
+# deliberately unreachable so Test 8b can exercise the "lookup failed"
+# path. Exercise the success path separately against a real local bare
+# repo standing in for a fetchable 'origin', proving the new branch is
+# created directly from origin/main, does NOT track main (avoiding a
+# broken first push/pull), and — again — never touches the main checkout.
+echo "Test 9: ensure-worktree.sh creates a brand-new branch atomically from origin/main"
+FAKE_ORIGIN="$SCRATCH/fake-origin.git"
+git init --quiet --bare "$FAKE_ORIGIN"
+
+REAL_ORIGIN_REPO="$SCRATCH/real-origin-checkout"
+git init --quiet "$REAL_ORIGIN_REPO"
+(
+  cd "$REAL_ORIGIN_REPO"
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git config commit.gpgsign false 2>/dev/null || true
+  git checkout -b main --quiet
+  printf 'origin-main\n' > origin-main.txt
+  git add origin-main.txt
+  git commit -m "origin main" --quiet
+  git remote add origin "$FAKE_ORIGIN"
+  git push --quiet origin main
+)
+
+cd "$SCRATCH"
+git remote set-url origin "$FAKE_ORIGIN"
+git fetch --quiet origin main
+origin_main_sha=$(git rev-parse origin/main)
+
+new_branch_rc=0
+new_branch_result=$(WORKTREE_BASE="$SCRATCH/wt-out3" "$HELPER" brand-new-from-origin-main 2>/dev/null) || new_branch_rc=$?
+if [ "$new_branch_rc" -eq 0 ] && [ -d "$new_branch_result" ]; then
+  ok "helper created the new branch's worktree (exit 0, at $new_branch_result)"
+else
+  fail "helper did not create the new-branch worktree as expected (exit $new_branch_rc, result '$new_branch_result')"
+fi
+new_branch_actual=$(git -C "$new_branch_result" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$new_branch_actual" = "brand-new-from-origin-main" ]; then
+  ok "new worktree is on the requested branch"
+else
+  fail "new worktree is on '$new_branch_actual', expected 'brand-new-from-origin-main'"
+fi
+new_branch_sha=$(git -C "$new_branch_result" rev-parse HEAD 2>/dev/null || echo "")
+if [ "$new_branch_sha" = "$origin_main_sha" ]; then
+  ok "new branch is rooted at origin/main's commit ($origin_main_sha)"
+else
+  fail "new branch HEAD ($new_branch_sha) does not match origin/main ($origin_main_sha)"
+fi
+new_branch_upstream=$(git -C "$new_branch_result" rev-parse --abbrev-ref "brand-new-from-origin-main@{upstream}" 2>/dev/null || echo "")
+if [ -z "$new_branch_upstream" ]; then
+  ok "new branch does not track origin/main (--no-track honoured, no broken upstream)"
+else
+  fail "new branch unexpectedly tracks '$new_branch_upstream' — first push/pull would target the wrong branch"
+fi
+
+main_head_after3=$(git rev-parse HEAD)
+main_branch_after3=$(git branch --show-current)
+if [ "$main_head_after3" = "$main_head_before" ] && [ "$main_branch_after3" = "$main_branch_before" ]; then
+  ok "main checkout unchanged after creating a brand-new branch from origin/main"
+else
+  fail "main checkout mutated on new-branch creation: HEAD $main_head_before -> $main_head_after3, branch $main_branch_before -> $main_branch_after3"
 fi
 echo ""
 

--- a/scripts/test-worktree-guard.sh
+++ b/scripts/test-worktree-guard.sh
@@ -203,23 +203,31 @@ else
   fail "main checkout mutated: HEAD $main_head_before -> $main_head_after, branch $main_branch_before -> $main_branch_after"
 fi
 
-# 8b: requesting a branch that does not exist anywhere (no local branch, and
-# 'origin' is not fetchable in this scratch repo) must fail closed WITHOUT
-# ever touching the main checkout — it must not fall back to instructing
-# (or performing) a checkout in the main checkout.
+# 8b: requesting a branch when 'origin' itself is unreachable (this scratch
+# repo's 'origin' remote is a deliberately unfetchable URL, so `git
+# ls-remote` fails with a network-error exit code, not the "no matching
+# ref" exit code 2). This must be treated as a remote-lookup FAILURE — fail
+# closed with a diagnostic naming that distinction — not misread as
+# "confirmed absent, fall back to branching from main". It must also never
+# touch the main checkout.
 nonexistent_rc=0
-"$HELPER" totally-nonexistent-branch >/dev/null 2>&1 || nonexistent_rc=$?
+nonexistent_stderr=$(WORKTREE_BASE="$SCRATCH/wt-out2b" "$HELPER" totally-nonexistent-branch 2>&1 >/dev/null) || nonexistent_rc=$?
 main_head_after2=$(git rev-parse HEAD)
 main_branch_after2=$(git branch --show-current)
 if [ "$nonexistent_rc" -ne 0 ]; then
-  ok "unresolvable branch request fails closed (exit $nonexistent_rc)"
+  ok "unresolvable-origin branch request fails closed (exit $nonexistent_rc)"
 else
-  fail "unresolvable branch request unexpectedly succeeded"
+  fail "unresolvable-origin branch request unexpectedly succeeded"
+fi
+if printf '%s' "$nonexistent_stderr" | grep -q "network or auth problem reaching 'origin'"; then
+  ok "failure message correctly identifies a remote lookup failure, not a confirmed-missing branch"
+else
+  fail "expected a remote-lookup-failure diagnostic, got: $nonexistent_stderr"
 fi
 if [ "$main_head_after2" = "$main_head_before" ] && [ "$main_branch_after2" = "$main_branch_before" ]; then
-  ok "main checkout unchanged after an unresolvable branch request"
+  ok "main checkout unchanged after an unresolvable-origin branch request"
 else
-  fail "main checkout mutated on unresolvable branch: HEAD $main_head_before -> $main_head_after2, branch $main_branch_before -> $main_branch_after2"
+  fail "main checkout mutated on unresolvable-origin branch: HEAD $main_head_before -> $main_head_after2, branch $main_branch_before -> $main_branch_after2"
 fi
 echo ""
 


### PR DESCRIPTION
Fixes a bug in `scripts/ensure-worktree.sh` where bootstrapping a worktree for a brand-new branch could mutate the **main checkout's** current branch instead of only creating the new worktree.

## Changes

- When the requested branch didn't exist locally or on `origin`, the script used to error out with `Create it first: git checkout -b <branch>` — pushing the caller to run that checkout in the shared main checkout, which switches its HEAD/branch out from under whoever else is using it.
- Replaced that refuse-and-instruct path with an atomic `git worktree add -b <branch> <path> origin/main` (after a fresh `git fetch origin main`), which creates the branch and the worktree together and never touches the main checkout's HEAD.
- Added a defensive assertion: the script now snapshots the main checkout's HEAD + current branch before provisioning, and re-checks both at every exit point of the main-checkout path — it fails closed with a clear diagnostic if either changed.
- Existing-branch and already-in-a-worktree code paths were already safe (verified — no `checkout`/`switch` calls existed there); left untouched.
- Contract preserved exactly: stdout is still only the worktree path, all diagnostics go to stderr, slug rules (`/` and `:` → `-`, lowercase, under `~/worktrees/<project>/`) are unchanged, and re-invoking for an existing worktree is still idempotent.
- Added a regression test (Test 8) to the existing `scripts/test-worktree-guard.sh` suite asserting the main checkout's HEAD/branch are unchanged after provisioning, for both the existing-local-branch path and an unresolvable-branch request that must fail closed.

## Screenshots

No UI change.

## Verification

Ran the fixed script directly against the real main checkout (`/Users/youhaowei/Projects/DashFrame`, on `main`) with a throwaway branch name that exists neither locally nor on origin, using `WORKTREE_BASE` pointed at a scratch directory. Transcript (trimmed):

```
$ cd /Users/youhaowei/Projects/DashFrame
$ git rev-parse HEAD; git branch --show-current
b0ea4db00899f388f65d10bb988087a6f5464211
main

$ export WORKTREE_BASE=/tmp/yw370-verify/worktrees
$ WT1=$(scripts/ensure-worktree.sh yw-370-throwaway-verify-1783000504)
[ensure-worktree] Preparing worktree (new branch 'yw-370-throwaway-verify-1783000504')
[ensure-worktree] branch 'yw-370-throwaway-verify-1783000504' set up to track 'origin/main'.
[ensure-worktree] HEAD is now at b0ea4db0 fix(drafts): collect discard credential-release refs inside the discard transaction
$ echo $WT1
/tmp/yw370-verify/worktrees/yw-370-throwaway-verify-1783000504
$ echo $?
0

$ git rev-parse HEAD; git branch --show-current   # main checkout, unchanged
b0ea4db00899f388f65d10bb988087a6f5464211
main
PASS: main checkout HEAD+branch unchanged

$ git -C "$WT1" merge-base --is-ancestor origin/main HEAD && echo PASS
PASS   # worktree correctly rooted from fresh origin/main

# Idempotency — second invocation for the same branch, still from the main checkout
$ WT2=$(scripts/ensure-worktree.sh yw-370-throwaway-verify-1783000504)
$ echo $WT2
/tmp/yw370-verify/worktrees/yw-370-throwaway-verify-1783000504   # same path
$ echo $?
0
$ git rev-parse HEAD; git branch --show-current   # still unchanged
b0ea4db00899f388f65d10bb988087a6f5464211
main

# stdout-only check
$ STDOUT_ONLY=$(scripts/ensure-worktree.sh yw-370-throwaway-verify-1783000504 2>/tmp/yw370-verify/stderr.log)
$ printf 'STDOUT bytes: [%s]\n' "$STDOUT_ONLY"
STDOUT bytes: [/tmp/yw370-verify/worktrees/yw-370-throwaway-verify-1783000504]
# stdout is exactly the path, nothing else — diagnostics confirmed stderr-only
```

Confirmed:
- (a) worktree created at the expected slug path, rooted from fresh `origin/main`
- (b) main checkout HEAD and current branch unchanged before/after
- (c) second invocation is idempotent — same exit 0, same path, main checkout still unchanged
- (d) stdout is exactly the worktree path and nothing else

Cleaned up the throwaway worktree and branch afterward (`git worktree remove --force` + `git branch -D`); confirmed main checkout still at the original SHA/branch.

Also ran `shellcheck scripts/ensure-worktree.sh scripts/test-worktree-guard.sh` — zero new warnings (two pre-existing SC2059 info-level notices in the unrelated summary block of `test-worktree-guard.sh`, confirmed present on `origin/main` before this change). Ran the full `scripts/test-worktree-guard.sh` suite (8 tests) — all pass.

Tracked internally as YW-370.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race-condition-class bug in `scripts/ensure-worktree.sh` where bootstrapping a worktree for a brand-new branch could switch the main checkout's `HEAD`/branch, mutating shared state for anyone else using that checkout. It replaces the old \"refuse and instruct `git checkout -b`\" path with `git worktree add --no-track -b <branch> <path> origin/main`, which is atomic and never touches the main checkout.

- **ensure-worktree.sh**: Adds `assert_main_checkout_unchanged` defensive assertion (called at both success exit paths); distinguishes `ls-remote` exit-code 2 (confirmed absent) from other non-zero exits (network/auth failure) to avoid silently branching from main on a transient error; hardens the origin-branch fetch to fail closed instead of falling back to a stale local ref.
- **test-worktree-guard.sh**: Adds Tests 8 and 9 covering the existing-branch path, the unreachable-origin failure path, and the full happy-path for brand-new branch creation against a real fetchable bare repo with assertions on branch, SHA rooting, no-track, and main-checkout invariant.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The fix correctly replaces a destructive main-checkout mutation with an atomic worktree-only operation, and the defensive assertion at both success exit points makes any regression self-diagnosing.

The core logic change is minimal and well-scoped. The ls-remote exit-code discrimination is correctly handled. Test 9 exercises the exact new code path against a real fetchable bare repo with precise assertions. Only a minor temp-file cleanup omission exists on two new error exits.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ensure-worktree.sh | Core fix: replaces the refuse-and-instruct path with atomic git worktree add --no-track; adds assert_main_checkout_unchanged at both success exit points; adds ls-remote exit-code discrimination. Minor: two new early-exit paths miss rm -f cleanup of _wt_log. |
| scripts/test-worktree-guard.sh | Adds Tests 8 and 9: existing-branch + unreachable-origin failure paths with proper exit-code guards, and a full happy-path against a real fetchable local bare repo asserting branch, SHA rooting, no-track, and main-checkout invariant. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ensure-worktree.sh called] --> B{Already in a linked worktree?}
    B -- Yes --> C[Print worktree path, exit 0]
    B -- No --> D[Snapshot main HEAD + branch]
    D --> E{Worktree path already exists?}
    E -- Yes --> F[Validate repo + branch]
    F --> G[assert_main_checkout_unchanged]
    G --> C
    E -- No --> H{Branch exists locally?}
    H -- Yes --> I[git worktree add path branch]
    H -- No --> J{git ls-remote origin branch}
    J -- exit 0 --> K[git fetch origin branch]
    K -- fails --> L[ERROR exit 1]
    K -- ok --> M[git worktree add -b branch origin/branch]
    J -- exit non-2 --> N[ERROR exit 1]
    J -- exit 2 --> O[git fetch origin main]
    O --> P{origin/main ref exists?}
    P -- No --> Q[ERROR exit 1]
    P -- Yes --> R[git worktree add --no-track -b branch path origin/main]
    I --> S{_wt_rc == 0?}
    M --> S
    R --> S
    S -- No --> T[ERROR exit 1]
    S -- Yes --> U{Dir + branch ok?}
    U -- No --> V[ERROR exit 1]
    U -- Yes --> Y[assert_main_checkout_unchanged]
    Y --> Z[Print worktree path, exit 0]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ensure-worktree.sh called] --> B{Already in a linked worktree?}
    B -- Yes --> C[Print worktree path, exit 0]
    B -- No --> D[Snapshot main HEAD + branch]
    D --> E{Worktree path already exists?}
    E -- Yes --> F[Validate repo + branch]
    F --> G[assert_main_checkout_unchanged]
    G --> C
    E -- No --> H{Branch exists locally?}
    H -- Yes --> I[git worktree add path branch]
    H -- No --> J{git ls-remote origin branch}
    J -- exit 0 --> K[git fetch origin branch]
    K -- fails --> L[ERROR exit 1]
    K -- ok --> M[git worktree add -b branch origin/branch]
    J -- exit non-2 --> N[ERROR exit 1]
    J -- exit 2 --> O[git fetch origin main]
    O --> P{origin/main ref exists?}
    P -- No --> Q[ERROR exit 1]
    P -- Yes --> R[git worktree add --no-track -b branch path origin/main]
    I --> S{_wt_rc == 0?}
    M --> S
    R --> S
    S -- No --> T[ERROR exit 1]
    S -- Yes --> U{Dir + branch ok?}
    U -- No --> V[ERROR exit 1]
    U -- Yes --> Y[assert_main_checkout_unchanged]
    Y --> Z[Print worktree path, exit 0]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/ensure-worktree.sh`, line 177-187 ([link](https://github.com/youhaowei/dashframe/blob/f797e2aa1054cd64bbb8fd751484ecbdb050fbee/scripts/ensure-worktree.sh#L177-L187)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`assert_main_checkout_unchanged` skipped on two post-success error exits**

   The PR description says the assertion fires "at every exit point of the main-checkout path," but two exits that come *after* a successful `git worktree add` skip it: the "worktree dir missing despite success" path (~line 180) and the "worktree on wrong branch" path (~line 186). In both cases `git worktree add` returned 0, so the main checkout is certainly untouched, but the stated invariant isn't quite enforced at every exit. Calling `assert_main_checkout_unchanged` before each of those `exit 1`s would make the claim airtight.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/ensure-worktree.sh
   Line: 177-187

   Comment:
   **`assert_main_checkout_unchanged` skipped on two post-success error exits**

   The PR description says the assertion fires "at every exit point of the main-checkout path," but two exits that come *after* a successful `git worktree add` skip it: the "worktree dir missing despite success" path (~line 180) and the "worktree on wrong branch" path (~line 186). In both cases `git worktree add` returned 0, so the main checkout is certainly untouched, but the stated invariant isn't quite enforced at every exit. Calling `assert_main_checkout_unchanged` before each of those `exit 1`s would make the claim airtight.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fensure-worktree.sh%0ALine%3A%20177-187%0A%0AComment%3A%0A**%60assert_main_checkout_unchanged%60%20skipped%20on%20two%20post-success%20error%20exits**%0A%0AThe%20PR%20description%20says%20the%20assertion%20fires%20%22at%20every%20exit%20point%20of%20the%20main-checkout%20path%2C%22%20but%20two%20exits%20that%20come%20*after*%20a%20successful%20%60git%20worktree%20add%60%20skip%20it%3A%20the%20%22worktree%20dir%20missing%20despite%20success%22%20path%20%28~line%20180%29%20and%20the%20%22worktree%20on%20wrong%20branch%22%20path%20%28~line%20186%29.%20In%20both%20cases%20%60git%20worktree%20add%60%20returned%200%2C%20so%20the%20main%20checkout%20is%20certainly%20untouched%2C%20but%20the%20stated%20invariant%20isn't%20quite%20enforced%20at%20every%20exit.%20Calling%20%60assert_main_checkout_unchanged%60%20before%20each%20of%20those%20%60exit%201%60s%20would%20make%20the%20claim%20airtight.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=211&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-370-ensure-worktree-no-main-checkout-mutation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-370-ensure-worktree-no-main-checkout-mutation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fensure-worktree.sh%0ALine%3A%20177-187%0A%0AComment%3A%0A**%60assert_main_checkout_unchanged%60%20skipped%20on%20two%20post-success%20error%20exits**%0A%0AThe%20PR%20description%20says%20the%20assertion%20fires%20%22at%20every%20exit%20point%20of%20the%20main-checkout%20path%2C%22%20but%20two%20exits%20that%20come%20*after*%20a%20successful%20%60git%20worktree%20add%60%20skip%20it%3A%20the%20%22worktree%20dir%20missing%20despite%20success%22%20path%20%28~line%20180%29%20and%20the%20%22worktree%20on%20wrong%20branch%22%20path%20%28~line%20186%29.%20In%20both%20cases%20%60git%20worktree%20add%60%20returned%200%2C%20so%20the%20main%20checkout%20is%20certainly%20untouched%2C%20but%20the%20stated%20invariant%20isn't%20quite%20enforced%20at%20every%20exit.%20Calling%20%60assert_main_checkout_unchanged%60%20before%20each%20of%20those%20%60exit%201%60s%20would%20make%20the%20claim%20airtight.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=211&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fensure-worktree.sh%0ALine%3A%20177-187%0A%0AComment%3A%0A**%60assert_main_checkout_unchanged%60%20skipped%20on%20two%20post-success%20error%20exits**%0A%0AThe%20PR%20description%20says%20the%20assertion%20fires%20%22at%20every%20exit%20point%20of%20the%20main-checkout%20path%2C%22%20but%20two%20exits%20that%20come%20*after*%20a%20successful%20%60git%20worktree%20add%60%20skip%20it%3A%20the%20%22worktree%20dir%20missing%20despite%20success%22%20path%20%28~line%20180%29%20and%20the%20%22worktree%20on%20wrong%20branch%22%20path%20%28~line%20186%29.%20In%20both%20cases%20%60git%20worktree%20add%60%20returned%200%2C%20so%20the%20main%20checkout%20is%20certainly%20untouched%2C%20but%20the%20stated%20invariant%20isn't%20quite%20enforced%20at%20every%20exit.%20Calling%20%60assert_main_checkout_unchanged%60%20before%20each%20of%20those%20%60exit%201%60s%20would%20make%20the%20claim%20airtight.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=211&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(scripts): fail closed on fetch failu..."](https://github.com/youhaowei/dashframe/commit/1f5cf10148d54ac152db0464ea1cecb8c5f39258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41380236)</sub>

<!-- /greptile_comment -->