### PR TITLE
Bump wystack: surface server error bodies on publish drift

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
     "@types/bun": "^1.2.0",
+    "@wystack/client": "workspace:*",
     "esbuild": "^0.28.0",
     "typescript": "5.7.2",
     "vitest": "^4.1.6"

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -330,7 +330,9 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
           // same drift branch `draft-controller.ts` uses for real content
           // drift, without needing a second controller to race the log.
           expectedCommandCount: "99",
-        } as never,
+        } as unknown as Parameters<
+          typeof client.mutate<typeof api.publishDraft>
+        >[1],
       );
     } catch (err) {
       caught = err as Error;

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -38,6 +38,11 @@ import {
   type ProjectHandle,
 } from "@dashframe/server-core";
 import {
+  createApi,
+  createClient,
+  type ApiFromFunctions,
+} from "@wystack/client";
+import {
   InMemoryMappingStore,
   SecretRegistry,
   SecretVault,
@@ -54,7 +59,11 @@ import {
   type DashframeServer,
 } from "../app";
 import { captureCommandCredentials } from "../credential-release";
+import type { Functions } from "../functions";
 import { cmd } from "./commands";
+
+/** Mirrors packages/app-data/src/api.ts's module-scope api object. */
+const api: ApiFromFunctions<Functions> = createApi<Functions>();
 
 const { dataSources } = schema;
 
@@ -276,6 +285,64 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
       draftId,
     });
     expect(log.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // RPC-boundary regression guard: the real @wystack/client must surface the
+  // server's drift message, not a generic `HTTP 500`.
+  //
+  // `@wystack/client`'s own test suite (packages/client/src/__tests__/
+  // client.test.ts) already proves the client forwards an arbitrary server
+  // error message against a synthetic handler; what that suite cannot prove
+  // is that DashFrame's ACTUAL drift error — the string draft-controller.ts
+  // throws — survives the round trip through DashFrame's real server. Before
+  // the client fix, it discarded the response body and threw a bare
+  // `Error("HTTP 500")`, so `draftLifecycleErrorDescription` (packages/app/
+  // src/components/preview-diff/user-facing-errors.ts) could never match
+  // `.includes("changed since review")` — the drift-specific toast copy was
+  // dead code. The other half of that contract (message → user-facing copy)
+  // is pinned by user-facing-errors.test.ts in packages/app; the two tests
+  // share the "changed since review" substring as their join point instead of
+  // a single cross-package test, since apps/server does not (and should not)
+  // depend on the packages/app UI layer.
+  // -------------------------------------------------------------------------
+
+  it("publishDraft's drift rejection survives the real @wystack/client RPC boundary with the drift message intact", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const draftId = await seedDraft(project.db as ArtifactDb);
+
+    server = await createDashframeServer({ db: project.db });
+
+    const client = createClient({ url: server.url });
+
+    let caught: Error | undefined;
+    try {
+      await client.mutate(
+        api.publishDraft,
+        // WyStack's InferArg discards a column's `.optional()` flag, so the
+        // generated arg type demands `expectedLogSignature` even though the
+        // handler treats it as optional (see packages/app-data/src/
+        // wystack-args.ts's `loose` helper, which documents and works around
+        // the same upstream gap for the app's own publishDraft caller).
+        {
+          draftId,
+          // A count that can never match the seeded log's length forces the
+          // same drift branch `draft-controller.ts` uses for real content
+          // drift, without needing a second controller to race the log.
+          expectedCommandCount: "99",
+        } as never,
+      );
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    // Pre-bump, this was `Error("HTTP 500")` — the server's actual message
+    // never reached the client. Post-bump, the client parses the `{ error }`
+    // JSON body @wystack/server always sends and throws with that message.
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught?.message).toContain("changed since review");
+    expect(caught?.message).not.toBe("HTTP 500");
+    expect((caught as Error & { status?: number })?.status).toBe(500);
   });
 
   // -------------------------------------------------------------------------

--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
         "@types/bun": "^1.2.0",
+        "@wystack/client": "workspace:*",
         "esbuild": "^0.28.0",
         "typescript": "5.7.2",
         "vitest": "^4.1.6",
@@ -281,6 +282,7 @@
         "@wystack/server": "workspace:*",
         "drizzle-orm": "^0.45.1",
         "happy-dom": "^20.10.1",
+        "hono": "^4.12.9",
         "react": "^19.0.0",
         "react-dom": "19.2.4",
         "typescript": "^5.8.3",


### PR DESCRIPTION
Bumps the `libs/wystack` submodule to pick up a wystack fix so DashFrame's draft-publish drift errors reach the UI's drift-specific copy instead of a generic fallback.

## Changes

- Bump `libs/wystack` submodule to `cbdc65b` ("Surface server error body on non-2xx RPC responses"). `@wystack/client`'s `query()`/`mutate()` previously threw `Error("HTTP ${status}")` on any non-2xx response, discarding the body. `@wystack/server` always responds `{ error: string }` on handler errors (`routes.ts`); the client now parses that JSON, falls back to raw text, then to `HTTP ${status}` if the body is empty, and attaches the status as an `Error.status` property.
- Rebuilt `libs/wystack` dist bottom-up (`bun run build:wystack`) before running the full repo check, per the stale-dist hazard for wystack-consuming packages.
- Added `apps/server/src/functions/draft-lifecycle.test.ts`: `publishDraft`'s drift rejection survives the real `@wystack/client` RPC boundary with the drift message intact — proves the *actual* DashFrame drift error (`draft-controller.ts`'s `"publishDraft: draft changed since review"`) now reaches the client unmangled, not just a synthetic message. `@wystack/client`'s own test suite already covers the generic client contract; this test covers the DashFrame-specific integration that mattered for the ticket.
- Added `@wystack/client` as a devDependency of `apps/server` (needed only for the new test's real client instantiation).

Why DashFrame cares: `draftLifecycleErrorDescription` (`packages/app/src/components/preview-diff/user-facing-errors.ts`) pattern-matches `.includes("changed since review")` on the caught error's message to show drift-specific publish-failure copy in the UI. Before this bump, that match could never fire — the message died at the RPC boundary as a bare `"HTTP 500"`, so users always saw the generic "Please try again." fallback even when the real cause was a stale review (the draft changed after they opened it).

Tracked internally as YW-367.

## Screenshots

No UI change — the copy shown was already implemented (`user-facing-errors.ts` / `user-facing-errors.test.ts`, already merged); this PR only fixes the transport bug that prevented the existing drift-specific copy from ever being reachable.

## Verification

- `bun run build:wystack` — wystack dist rebuilt bottom-up (8/8 packages), clean.
- `bun run check` (repo-wide, not package-scoped) — 83/83 tasks green, including `@dashframe/server`'s 386 tests (was 385 before this PR's new test).
- New test: `apps/server/src/functions/draft-lifecycle.test.ts` > "publishDraft's drift rejection survives the real @wystack/client RPC boundary with the drift message intact". It spins up a real `createDashframeServer`, seeds a real draft, and calls `publishDraft` through a real `createClient()` from `@wystack/client` (not raw `fetch`) with a mismatched `expectedCommandCount` — the same drift branch `draft-controller.ts` uses for content drift. Asserts the caught `Error.message` contains `"changed since review"` (not `"HTTP 500"`) and `Error.status === 500`.
- **Discrimination check**: temporarily reverted just `packages/client/src/client.ts` in the wystack submodule to its pre-fix state and re-ran the new test — it failed with `expected 'HTTP 500' to contain 'changed since review'`, confirming the test is not a false green. Restored the fix and re-ran; green again.
- The other half of the contract — that the `"changed since review"` substring maps to the drift-specific UI copy — is already pinned by the existing `packages/app/src/components/preview-diff/user-facing-errors.test.ts` (unchanged by this PR). The two tests join on that shared substring rather than a single cross-package test, since `apps/server` does not depend on the `packages/app` UI layer (and shouldn't start now for a test).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Bumps the `libs/wystack` submodule to `cbdc65b` so that `@wystack/client` now parses non-2xx response bodies instead of silently discarding them, letting DashFrame's drift-specific publish-failure copy in `user-facing-errors.ts` finally fire at runtime.

- **Submodule bump**: `@wystack/client`'s `query()`/`mutate()` previously threw `Error("HTTP ${status}")` on any non-2xx response; it now parses the `{ error }` JSON body `@wystack/server` always sends, attaches `Error.status`, and falls back through raw text then status-string only if the body is empty.
- **Regression test** (`apps/server/src/functions/draft-lifecycle.test.ts`): a new integration test spins up a real `DashframeServer`, seeds a real draft, and calls `publishDraft` through a real `createClient()` with a mismatched `expectedCommandCount`, asserting the caught error contains `"changed since review"` (not `"HTTP 500"`) and `Error.status === 500`. Server cleanup is handled by the existing `afterEach` guard.
- **devDependency**: `@wystack/client` is added to `apps/server` devDependencies only (test instantiation only; the server itself does not depend on the client at runtime).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a submodule bump plus a targeted integration test; no production runtime code in DashFrame itself is modified.

The only DashFrame-owned changes are a new devDependency and a new test. The submodule bump is narrowly scoped to client error-body parsing, and the new test includes a discrimination check (reverted-client fails, restored-client passes) that rules out a false green. Cleanup is handled by the existing afterEach, and the devDependency is correctly test-scoped.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/draft-lifecycle.test.ts | Adds a well-scoped integration test that validates the full RPC round-trip for drift rejection; server cleanup delegated to the existing afterEach guard, assertion set is tight and discriminating. |
| apps/server/package.json | Adds @wystack/client as a devDependency only, correctly scoped for test-only use; runtime dependency set is unchanged. |
| bun.lock | Lockfile reflects the new @wystack/client devDep and hono appearing as a transitive side-effect of the wystack submodule bump; expected generated output. |
| libs/wystack | Submodule pointer advanced from 521ddbc to cbdc65b to pick up the client error-body fix; no other submodule changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as draft-lifecycle.test.ts
    participant Client as @wystack/client
    participant Server as DashframeServer
    participant Controller as DraftController

    Test->>Server: "createDashframeServer({ db })"
    Test->>Client: "createClient({ url: server.url })"
    Test->>Client: "client.mutate(api.publishDraft, { expectedCommandCount: "99" })"
    Client->>Server: POST /api/publishDraft
    Server->>Controller: "publishDraft({ expectedCommandCount: "99" })"
    Controller-->>Server: throw Error("publishDraft: draft changed since review")
    Server-->>Client: "HTTP 500 { error: "publishDraft: draft changed since review" }"
    Note over Client: Pre-bump: threw Error("HTTP 500"), body discarded
    Note over Client: Post-bump: parses { error } JSON, attaches .status = 500
    Client-->>Test: "throw Error("draft changed since review") + .status=500"
    Test->>Test: assert message.includes("changed since review") ✓
    Test->>Test: "assert status === 500 ✓"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as draft-lifecycle.test.ts
    participant Client as @wystack/client
    participant Server as DashframeServer
    participant Controller as DraftController

    Test->>Server: "createDashframeServer({ db })"
    Test->>Client: "createClient({ url: server.url })"
    Test->>Client: "client.mutate(api.publishDraft, { expectedCommandCount: "99" })"
    Client->>Server: POST /api/publishDraft
    Server->>Controller: "publishDraft({ expectedCommandCount: "99" })"
    Controller-->>Server: throw Error("publishDraft: draft changed since review")
    Server-->>Client: "HTTP 500 { error: "publishDraft: draft changed since review" }"
    Note over Client: Pre-bump: threw Error("HTTP 500"), body discarded
    Note over Client: Post-bump: parses { error } JSON, attaches .status = 500
    Client-->>Test: "throw Error("draft changed since review") + .status=500"
    Test->>Test: assert message.includes("changed since review") ✓
    Test->>Test: "assert status === 500 ✓"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["address review: self-document the InferA..."](https://github.com/youhaowei/dashframe/commit/9f905813f585f9a40176ffc4301d164975a82ad1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41407044)</sub>

<!-- /greptile_comment -->