### PR TITLE
[codex] Add assistant recovery loop guard

### DIFF
--- a/packages/assistant/src/apply-command-tool.ts
+++ b/packages/assistant/src/apply-command-tool.ts
@@ -283,6 +283,8 @@ export interface CreateApplyCommandToolOptions {
   context?: Record<string, unknown>;
   /** Called after a successful append; used by the run to lazy-surface drafts. */
   onSuccess?: () => Promise<void> | void;
+  /** Return false to refuse new mutations for this run before host.append. */
+  shouldExecute?: () => boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -329,6 +331,13 @@ export function createApplyCommandTool(options: CreateApplyCommandToolOptions) {
     }),
 
     async execute(_toolCallId, params) {
+      if (options.shouldExecute?.() === false) {
+        throw new Error(
+          "applyCommand: the assistant run has stopped after repeated command failures; " +
+            "further draft mutations are blocked for this run.",
+        );
+      }
+
       const { type, args } = params;
 
       // SECURITY GATE: enforce the draft-safe allow-list BEFORE calling

--- a/packages/assistant/src/assistant-run.test.ts
+++ b/packages/assistant/src/assistant-run.test.ts
@@ -74,6 +74,16 @@ function call(
   return { type: "toolCall", id, name, arguments: args };
 }
 
+function createDashboardCall(
+  id: string,
+  args: Record<string, unknown>,
+): ToolCall {
+  return call(id, "applyCommand", {
+    type: "CreateDashboard",
+    args,
+  });
+}
+
 function scriptedStream(messages: AssistantMessage[]): StreamFn {
   let index = 0;
   return () => {
@@ -204,9 +214,9 @@ describe("createAssistantRun", () => {
       streamFn: scriptedStream([
         assistantMessage(
           [
-            call("create-dashboard", "applyCommand", {
-              type: "CreateDashboard",
-              args: { id: "dashboard-1", name: "Executive" },
+            createDashboardCall("create-dashboard", {
+              id: "dashboard-1",
+              name: "Executive",
             }),
             call("rename-dashboard", "applyCommand", {
               type: "RenameNode",
@@ -252,9 +262,9 @@ describe("createAssistantRun", () => {
         ),
         assistantMessage(
           [
-            call("fixed-command", "applyCommand", {
-              type: "CreateDashboard",
-              args: { id: "dashboard-1", name: "Recovered" },
+            createDashboardCall("fixed-command", {
+              id: "dashboard-1",
+              name: "Recovered",
             }),
           ],
           "toolUse",
@@ -287,28 +297,19 @@ describe("createAssistantRun", () => {
     const stream = scriptedStream([
       assistantMessage(
         [
-          call("bad-1", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-1", name: "Bad 1" },
-          }),
+          createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-2", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-2", name: "Bad 2" },
-          }),
+          createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-3", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-3", name: "Bad 3" },
-          }),
+          createDashboardCall("bad-3", { id: "bad-3", name: "Bad 3" }),
         ],
         "toolUse",
       ),
@@ -332,6 +333,87 @@ describe("createAssistantRun", () => {
     expect(streamCalls).toBe(3);
     expect(result.messages.at(-1)?.role).toBe("toolResult");
     expect(host.appends).toEqual([]);
+    expect(host.discarded).toEqual([]);
+  });
+
+  it("counts applyCommand validation failures toward the configured cap", async () => {
+    const host = makeHost();
+    let streamCalls = 0;
+    const stream = scriptedStream([
+      assistantMessage(
+        [
+          call("missing-args", "applyCommand", {
+            type: "CreateDashboard",
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("missing-type", "applyCommand", {
+            args: { id: "bad-2", name: "Bad 2" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [{ type: "text", text: "Should not be requested." }],
+        "stop",
+      ),
+    ]);
+
+    const result = await createAssistantRun(host, {
+      model,
+      prompt: "Keep emitting malformed applyCommand args.",
+      maxConsecutiveFailures: 2,
+      streamFn: (...args) => {
+        streamCalls += 1;
+        return stream(...args);
+      },
+    });
+
+    expect(result.terminationReason).toBe("failureCap");
+    expect(streamCalls).toBe(2);
+    expect(result.messages.at(-1)?.role).toBe("toolResult");
+    expect(host.appends).toEqual([]);
+    expect(host.discarded).toEqual([]);
+  });
+
+  it("refuses later applyCommand executions in the same turn after the guard trips", async () => {
+    const host = makeHost();
+    failAppendForCommandIds(host, ["bad-1"]);
+    const events: AgentEvent[] = [];
+
+    const result = await createAssistantRun(host, {
+      model,
+      prompt: "Try two mutations at once.",
+      maxConsecutiveFailures: 1,
+      streamFn: scriptedStream([
+        assistantMessage(
+          [
+            createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
+            createDashboardCall("good", { id: "good", name: "Should Block" }),
+          ],
+          "toolUse",
+        ),
+        assistantMessage(
+          [{ type: "text", text: "Should not be requested." }],
+          "stop",
+        ),
+      ]),
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    const toolEnds = events.filter(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(result.terminationReason).toBe("failureCap");
+    expect(toolEnds.map((event) => event.isError)).toEqual([true, true]);
+    expect(host.appends).toEqual([]);
+    expect(host.discarded).toEqual([]);
   });
 
   it("terminates on repeated failing applyCommand fingerprints before the cap", async () => {
@@ -341,27 +423,21 @@ describe("createAssistantRun", () => {
     const stream = scriptedStream([
       assistantMessage(
         [
-          call("bad-a", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "repeat", name: "Repeated" },
-          }),
+          createDashboardCall("bad-a", { id: "repeat", name: "Repeated" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-b", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "other", name: "Other" },
-          }),
+          createDashboardCall("bad-b", { id: "other", name: "Other" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-a-again", "applyCommand", {
-            type: "CreateDashboard",
-            args: { name: "Repeated", id: "repeat" },
+          createDashboardCall("bad-a-again", {
+            name: "Repeated",
+            id: "repeat",
           }),
         ],
         "toolUse",
@@ -385,6 +461,7 @@ describe("createAssistantRun", () => {
     expect(result.terminationReason).toBe("oscillation");
     expect(streamCalls).toBe(3);
     expect(host.appends).toEqual([]);
+    expect(host.discarded).toEqual([]);
   });
 
   it("resets the failure counter after a successful applyCommand", async () => {
@@ -393,28 +470,19 @@ describe("createAssistantRun", () => {
     const stream = scriptedStream([
       assistantMessage(
         [
-          call("bad-1", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-1", name: "Bad 1" },
-          }),
+          createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("good", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "good", name: "Recovered" },
-          }),
+          createDashboardCall("good", { id: "good", name: "Recovered" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-2", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-2", name: "Bad 2" },
-          }),
+          createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" }),
         ],
         "toolUse",
       ),
@@ -442,28 +510,19 @@ describe("createAssistantRun", () => {
     const stream = scriptedStream([
       assistantMessage(
         [
-          call("good", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "good", name: "Keep Me" },
-          }),
+          createDashboardCall("good", { id: "good", name: "Keep Me" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-1", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-1", name: "Bad 1" },
-          }),
+          createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
         ],
         "toolUse",
       ),
       assistantMessage(
         [
-          call("bad-2", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "bad-2", name: "Bad 2" },
-          }),
+          createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" }),
         ],
         "toolUse",
       ),
@@ -500,9 +559,9 @@ describe("createAssistantRun", () => {
       streamFn: scriptedStream([
         assistantMessage(
           [
-            call("create-dashboard", "applyCommand", {
-              type: "CreateDashboard",
-              args: { id: "dashboard-1", name: "Executive" },
+            createDashboardCall("create-dashboard", {
+              id: "dashboard-1",
+              name: "Executive",
             }),
           ],
           "toolUse",
@@ -545,6 +604,7 @@ describe("createAssistantRun", () => {
     expect(last?.role === "assistant" ? last.stopReason : undefined).toBe(
       "error",
     );
+    expect(result.terminationReason).toBe("error");
     expect(result.firstMutationObserved).toBe(false);
     expect(host.discarded).toEqual([]);
 
@@ -560,9 +620,9 @@ describe("createAssistantRun", () => {
     const mutationStream = scriptedStream([
       assistantMessage(
         [
-          call("create-dashboard", "applyCommand", {
-            type: "CreateDashboard",
-            args: { id: "dashboard-1", name: "Executive" },
+          createDashboardCall("create-dashboard", {
+            id: "dashboard-1",
+            name: "Executive",
           }),
         ],
         "toolUse",
@@ -588,6 +648,7 @@ describe("createAssistantRun", () => {
     expect(last?.role === "assistant" ? last.stopReason : undefined).toBe(
       "error",
     );
+    expect(result.terminationReason).toBe("error");
     expect(firstMutations).toEqual(["draft-run"]);
     expect(host.appends).toHaveLength(1);
     expect(host.discarded).toEqual([]);
@@ -611,6 +672,7 @@ describe("createAssistantRun", () => {
 
     expect(streamCalls).toBe(0);
     expect(host.appends).toEqual([]);
+    expect(result.terminationReason).toBe("aborted");
     expect(result.firstMutationObserved).toBe(false);
     expect(host.discarded).toEqual(["draft-run"]);
   });
@@ -624,9 +686,9 @@ describe("createAssistantRun", () => {
       streamFn: scriptedStream([
         assistantMessage(
           [
-            call("create-dashboard", "applyCommand", {
-              type: "CreateDashboard",
-              args: { id: "dashboard-1", name: "Discard Me" },
+            createDashboardCall("create-dashboard", {
+              id: "dashboard-1",
+              name: "Discard Me",
             }),
           ],
           "toolUse",

--- a/packages/assistant/src/assistant-run.test.ts
+++ b/packages/assistant/src/assistant-run.test.ts
@@ -149,6 +149,25 @@ function makeHost(): AssistantHost & {
   };
 }
 
+function failAppendForCommandIds(
+  host: ReturnType<typeof makeHost>,
+  ids: string[],
+) {
+  const failingIds = new Set(ids);
+  const append = host.append.bind(host);
+  host.append = async (draftId, batch) => {
+    const args = batch[0]?.args;
+    const id =
+      args !== null && typeof args === "object"
+        ? (args as { id?: unknown }).id
+        : undefined;
+    if (typeof id === "string" && failingIds.has(id)) {
+      throw new Error(`invalid command: ${id}`);
+    }
+    return append(draftId, batch);
+  };
+}
+
 describe("createAssistantRun", () => {
   it("eager-mints a draft but lazy-surfaces only after first successful mutation", async () => {
     const host = makeHost();
@@ -259,6 +278,216 @@ describe("createAssistantRun", () => {
     expect(host.appends.map((append) => append.batch[0]?.path)).toEqual([
       "CreateDashboardPath",
     ]);
+  });
+
+  it("terminates after the configured consecutive applyCommand failure cap", async () => {
+    const host = makeHost();
+    failAppendForCommandIds(host, ["bad-1", "bad-2", "bad-3"]);
+    let streamCalls = 0;
+    const stream = scriptedStream([
+      assistantMessage(
+        [
+          call("bad-1", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-1", name: "Bad 1" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-2", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-2", name: "Bad 2" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-3", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-3", name: "Bad 3" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [{ type: "text", text: "Should not be requested." }],
+        "stop",
+      ),
+    ]);
+
+    const result = await createAssistantRun(host, {
+      model,
+      prompt: "Keep trying unsafe drafts.",
+      maxConsecutiveFailures: 3,
+      streamFn: (...args) => {
+        streamCalls += 1;
+        return stream(...args);
+      },
+    });
+
+    expect(result.terminationReason).toBe("failureCap");
+    expect(streamCalls).toBe(3);
+    expect(result.messages.at(-1)?.role).toBe("toolResult");
+    expect(host.appends).toEqual([]);
+  });
+
+  it("terminates on repeated failing applyCommand fingerprints before the cap", async () => {
+    const host = makeHost();
+    failAppendForCommandIds(host, ["repeat", "other"]);
+    let streamCalls = 0;
+    const stream = scriptedStream([
+      assistantMessage(
+        [
+          call("bad-a", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "repeat", name: "Repeated" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-b", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "other", name: "Other" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-a-again", "applyCommand", {
+            type: "CreateDashboard",
+            args: { name: "Repeated", id: "repeat" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [{ type: "text", text: "Should not be requested." }],
+        "stop",
+      ),
+    ]);
+
+    const result = await createAssistantRun(host, {
+      model,
+      prompt: "Oscillate.",
+      maxConsecutiveFailures: 5,
+      streamFn: (...args) => {
+        streamCalls += 1;
+        return stream(...args);
+      },
+    });
+
+    expect(result.terminationReason).toBe("oscillation");
+    expect(streamCalls).toBe(3);
+    expect(host.appends).toEqual([]);
+  });
+
+  it("resets the failure counter after a successful applyCommand", async () => {
+    const host = makeHost();
+    failAppendForCommandIds(host, ["bad-1", "bad-2"]);
+    const stream = scriptedStream([
+      assistantMessage(
+        [
+          call("bad-1", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-1", name: "Bad 1" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("good", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "good", name: "Recovered" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-2", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-2", name: "Bad 2" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage([{ type: "text", text: "Stopped normally." }], "stop"),
+    ]);
+
+    const result = await createAssistantRun(host, {
+      model,
+      prompt: "Recover once, then fail again.",
+      maxConsecutiveFailures: 2,
+      streamFn: stream,
+    });
+
+    expect(result.terminationReason).toBe("completed");
+    expect(result.messages.at(-1)?.role).toBe("assistant");
+    expect(host.appends.map((append) => append.batch[0]?.path)).toEqual([
+      "CreateDashboardPath",
+    ]);
+  });
+
+  it("keeps a guard-terminated draft after a prior successful mutation", async () => {
+    const host = makeHost();
+    const firstMutations: string[] = [];
+    failAppendForCommandIds(host, ["bad-1", "bad-2"]);
+    const stream = scriptedStream([
+      assistantMessage(
+        [
+          call("good", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "good", name: "Keep Me" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-1", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-1", name: "Bad 1" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [
+          call("bad-2", "applyCommand", {
+            type: "CreateDashboard",
+            args: { id: "bad-2", name: "Bad 2" },
+          }),
+        ],
+        "toolUse",
+      ),
+      assistantMessage(
+        [{ type: "text", text: "Should not be requested." }],
+        "stop",
+      ),
+    ]);
+
+    const result = await createAssistantRun(host, {
+      model,
+      prompt: "Mutate, then get stuck.",
+      maxConsecutiveFailures: 2,
+      streamFn: stream,
+      onFirstMutation: ({ draftId }) => {
+        firstMutations.push(draftId);
+      },
+    });
+
+    expect(result.terminationReason).toBe("failureCap");
+    expect(result.firstMutationObserved).toBe(true);
+    expect(firstMutations).toEqual(["draft-run"]);
+    expect(host.appends).toHaveLength(1);
+    expect(host.discarded).toEqual([]);
   });
 
   it("isolates onFirstMutation observer failures from tool success", async () => {

--- a/packages/assistant/src/assistant-run.test.ts
+++ b/packages/assistant/src/assistant-run.test.ts
@@ -296,21 +296,15 @@ describe("createAssistantRun", () => {
     let streamCalls = 0;
     const stream = scriptedStream([
       assistantMessage(
-        [
-          createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
-        ],
+        [createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" }),
-        ],
+        [createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("bad-3", { id: "bad-3", name: "Bad 3" }),
-        ],
+        [createDashboardCall("bad-3", { id: "bad-3", name: "Bad 3" })],
         "toolUse",
       ),
       assistantMessage(
@@ -422,15 +416,11 @@ describe("createAssistantRun", () => {
     let streamCalls = 0;
     const stream = scriptedStream([
       assistantMessage(
-        [
-          createDashboardCall("bad-a", { id: "repeat", name: "Repeated" }),
-        ],
+        [createDashboardCall("bad-a", { id: "repeat", name: "Repeated" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("bad-b", { id: "other", name: "Other" }),
-        ],
+        [createDashboardCall("bad-b", { id: "other", name: "Other" })],
         "toolUse",
       ),
       assistantMessage(
@@ -469,21 +459,15 @@ describe("createAssistantRun", () => {
     failAppendForCommandIds(host, ["bad-1", "bad-2"]);
     const stream = scriptedStream([
       assistantMessage(
-        [
-          createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
-        ],
+        [createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("good", { id: "good", name: "Recovered" }),
-        ],
+        [createDashboardCall("good", { id: "good", name: "Recovered" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" }),
-        ],
+        [createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" })],
         "toolUse",
       ),
       assistantMessage([{ type: "text", text: "Stopped normally." }], "stop"),
@@ -509,21 +493,15 @@ describe("createAssistantRun", () => {
     failAppendForCommandIds(host, ["bad-1", "bad-2"]);
     const stream = scriptedStream([
       assistantMessage(
-        [
-          createDashboardCall("good", { id: "good", name: "Keep Me" }),
-        ],
+        [createDashboardCall("good", { id: "good", name: "Keep Me" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" }),
-        ],
+        [createDashboardCall("bad-1", { id: "bad-1", name: "Bad 1" })],
         "toolUse",
       ),
       assistantMessage(
-        [
-          createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" }),
-        ],
+        [createDashboardCall("bad-2", { id: "bad-2", name: "Bad 2" })],
         "toolUse",
       ),
       assistantMessage(

--- a/packages/assistant/src/assistant-run.ts
+++ b/packages/assistant/src/assistant-run.ts
@@ -37,6 +37,8 @@ export interface CreateAssistantRunOptions {
 
 export type AssistantRunTerminationReason =
   | "completed"
+  | "aborted"
+  | "error"
   | "failureCap"
   | "oscillation";
 
@@ -132,41 +134,56 @@ function normalizeMaxConsecutiveFailures(value: number | undefined): number {
 function createRecoveryGuard(maxConsecutiveFailures: number) {
   let consecutiveFailures = 0;
   const failedFingerprints = new Set<string>();
+  const finalizedToolCallIds = new Set<string>();
   let terminationReason: AssistantRunTerminationReason = "completed";
 
   return {
     get terminationReason() {
       return terminationReason;
     },
-    afterToolCall(options: {
+    get shouldBlockApplyCommand() {
+      return terminationReason !== "completed";
+    },
+    observeApplyCommandResult(options: {
       toolCall: AgentToolCall;
       args: unknown;
       isError: boolean;
+      source: "afterToolCall" | "messageEnd";
     }) {
+      if (options.toolCall.name !== "applyCommand") {
+        return terminationReason;
+      }
       if (
-        options.toolCall.name !== "applyCommand" ||
-        terminationReason !== "completed"
+        options.source === "messageEnd" &&
+        finalizedToolCallIds.delete(options.toolCall.id)
       ) {
-        return;
+        return terminationReason;
+      }
+      if (options.source === "afterToolCall") {
+        finalizedToolCallIds.add(options.toolCall.id);
+      }
+      if (terminationReason !== "completed") {
+        return terminationReason;
       }
 
       if (!options.isError) {
         consecutiveFailures = 0;
         failedFingerprints.clear();
-        return;
+        return terminationReason;
       }
 
       consecutiveFailures += 1;
       const fingerprint = fingerprintApplyCommand(options.args);
       if (failedFingerprints.has(fingerprint)) {
         terminationReason = "oscillation";
-        return;
+        return terminationReason;
       }
       failedFingerprints.add(fingerprint);
 
       if (consecutiveFailures >= maxConsecutiveFailures) {
         terminationReason = "failureCap";
       }
+      return terminationReason;
     },
   };
 }
@@ -245,6 +262,7 @@ function createTools(options: {
   draftId: string;
   context?: Record<string, unknown>;
   markFirstMutation: () => Promise<void>;
+  shouldExecuteApplyCommand: () => boolean;
 }): AgentTool[] {
   const readTools = Object.values(
     createReadTools(options.host.reader(options.draftId)),
@@ -254,6 +272,7 @@ function createTools(options: {
     draftId: options.draftId,
     context: options.context,
     onSuccess: options.markFirstMutation,
+    shouldExecute: options.shouldExecuteApplyCommand,
   });
   return [...readTools, applyCommand];
 }
@@ -265,6 +284,8 @@ export async function createAssistantRun(
   const draftId = await host.open();
   let firstMutationObserved = false;
   const messages: AgentMessage[] = [];
+  const applyCommandCalls = new Map<string, AgentToolCall>();
+  let runTerminationReason: AssistantRunTerminationReason | undefined;
   const recoveryGuard = createRecoveryGuard(
     normalizeMaxConsecutiveFailures(options.maxConsecutiveFailures),
   );
@@ -286,11 +307,56 @@ export async function createAssistantRun(
     draftId,
     context: options.context,
     markFirstMutation,
+    // pi's afterToolCall terminate hint is evaluated only after the current
+    // tool batch, so a same-turn second applyCommand may still be prepared.
+    // Refusing inside the tool blocks further draft mutations for this run;
+    // other non-mutating or invalid tool results may still finish the turn.
+    shouldExecuteApplyCommand: () => !recoveryGuard.shouldBlockApplyCommand,
   });
 
   async function emit(event: AgentEvent) {
+    if (
+      event.type === "tool_execution_start" &&
+      event.toolName === "applyCommand"
+    ) {
+      applyCommandCalls.set(event.toolCallId, {
+        type: "toolCall",
+        id: event.toolCallId,
+        name: event.toolName,
+        arguments: event.args,
+      });
+    }
     if (event.type === "message_end") {
       messages.push(event.message);
+      if (
+        event.message.role === "assistant" &&
+        event.message.stopReason === "aborted"
+      ) {
+        runTerminationReason ??= "aborted";
+      } else if (
+        event.message.role === "assistant" &&
+        event.message.stopReason === "error"
+      ) {
+        runTerminationReason ??= "error";
+      } else if (
+        event.message.role === "toolResult" &&
+        event.message.toolName === "applyCommand"
+      ) {
+        const toolCall =
+          applyCommandCalls.get(event.message.toolCallId) ??
+          ({
+            type: "toolCall",
+            id: event.message.toolCallId,
+            name: event.message.toolName,
+            arguments: {},
+          } satisfies AgentToolCall);
+        recoveryGuard.observeApplyCommandResult({
+          toolCall,
+          args: toolCall.arguments,
+          isError: event.message.isError,
+          source: "messageEnd",
+        });
+      }
     }
     await options.onEvent?.(event);
   }
@@ -298,6 +364,7 @@ export async function createAssistantRun(
   if (options.signal?.aborted) {
     // Cancelled before the run started: nothing to prompt; clean up the
     // just-minted sandbox if it never surfaced.
+    runTerminationReason = "aborted";
     await discardIfUnsurfaced({
       host,
       draftId,
@@ -323,8 +390,13 @@ export async function createAssistantRun(
               getApiKey: options.getApiKey,
               toolExecution: "sequential",
               afterToolCall: async ({ toolCall, args, isError }) => {
-                recoveryGuard.afterToolCall({ toolCall, args, isError });
-                return undefined;
+                const reason = recoveryGuard.observeApplyCommandResult({
+                  toolCall,
+                  args,
+                  isError,
+                  source: "afterToolCall",
+                });
+                return reason === "completed" ? undefined : { terminate: true };
               },
               shouldStopAfterTurn: () =>
                 recoveryGuard.terminationReason !== "completed",
@@ -334,6 +406,8 @@ export async function createAssistantRun(
             options.streamFn,
           );
         } catch (error) {
+          runTerminationReason =
+            options.signal?.aborted === true ? "aborted" : "error";
           await emitFailure({
             message: createFailureMessage({
               model: options.model,
@@ -351,7 +425,7 @@ export async function createAssistantRun(
     draftId,
     messages,
     firstMutationObserved,
-    terminationReason: recoveryGuard.terminationReason,
+    terminationReason: runTerminationReason ?? recoveryGuard.terminationReason,
     discard: () => host.discard(draftId),
   };
 }

--- a/packages/assistant/src/assistant-run.ts
+++ b/packages/assistant/src/assistant-run.ts
@@ -1,11 +1,18 @@
 import {
-  Agent,
+  runAgentLoop,
   type AgentEvent,
   type AgentMessage,
   type AgentTool,
+  type AgentToolCall,
   type StreamFn,
 } from "@earendil-works/pi-agent-core";
-import type { Api, Message, Model } from "@earendil-works/pi-ai";
+import type {
+  Api,
+  AssistantMessage,
+  Message,
+  Model,
+} from "@earendil-works/pi-ai";
+import { createHash } from "node:crypto";
 
 import { createApplyCommandTool } from "./apply-command-tool.js";
 import type { AssistantHost } from "./assistant-host.js";
@@ -25,19 +32,43 @@ export interface CreateAssistantRunOptions {
   signal?: AbortSignal;
   onEvent?: (event: AgentEvent) => Promise<void> | void;
   onFirstMutation?: (event: { draftId: string }) => Promise<void> | void;
+  maxConsecutiveFailures?: number;
 }
+
+export type AssistantRunTerminationReason =
+  | "completed"
+  | "failureCap"
+  | "oscillation";
 
 export interface AssistantRunResult {
   draftId: string;
   messages: AgentMessage[];
   firstMutationObserved: boolean;
+  terminationReason: AssistantRunTerminationReason;
   discard(): Promise<void>;
 }
+
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 5;
 
 const DEFAULT_SYSTEM_PROMPT =
   "You are the DashFrame authoring assistant. Use the provided read tools to " +
   "understand the project graph and applyCommand for all mutations. Write only " +
   "to the draft sandbox; publishing is a human action.";
+
+const EMPTY_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+} as const;
 
 function passThroughMessages(messages: AgentMessage[]): Message[] {
   return messages.flatMap((message) => {
@@ -50,6 +81,94 @@ function passThroughMessages(messages: AgentMessage[]): Message[] {
     }
     return [];
   });
+}
+
+function normalizePrompt(prompt: AssistantRunPrompt): AgentMessage[] {
+  if (typeof prompt === "string") {
+    return [
+      {
+        role: "user",
+        content: [{ type: "text", text: prompt }],
+        timestamp: Date.now(),
+      },
+    ];
+  }
+  if (Array.isArray(prompt)) return prompt;
+  return [prompt];
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, canonicalize(record[key])]),
+    );
+  }
+  return value;
+}
+
+function fingerprintApplyCommand(args: unknown): string {
+  const params = args as { type?: unknown; args?: unknown };
+  const batch = [
+    {
+      type: params.type ?? null,
+      args: canonicalize(params.args ?? null),
+    },
+  ];
+  return createHash("sha256").update(JSON.stringify(batch)).digest("hex");
+}
+
+function normalizeMaxConsecutiveFailures(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_MAX_CONSECUTIVE_FAILURES;
+  if (!Number.isFinite(value)) return DEFAULT_MAX_CONSECUTIVE_FAILURES;
+  return Math.max(1, Math.floor(value));
+}
+
+function createRecoveryGuard(maxConsecutiveFailures: number) {
+  let consecutiveFailures = 0;
+  const failedFingerprints = new Set<string>();
+  let terminationReason: AssistantRunTerminationReason = "completed";
+
+  return {
+    get terminationReason() {
+      return terminationReason;
+    },
+    afterToolCall(options: {
+      toolCall: AgentToolCall;
+      args: unknown;
+      isError: boolean;
+    }) {
+      if (
+        options.toolCall.name !== "applyCommand" ||
+        terminationReason !== "completed"
+      ) {
+        return;
+      }
+
+      if (!options.isError) {
+        consecutiveFailures = 0;
+        failedFingerprints.clear();
+        return;
+      }
+
+      consecutiveFailures += 1;
+      const fingerprint = fingerprintApplyCommand(options.args);
+      if (failedFingerprints.has(fingerprint)) {
+        terminationReason = "oscillation";
+        return;
+      }
+      failedFingerprints.add(fingerprint);
+
+      if (consecutiveFailures >= maxConsecutiveFailures) {
+        terminationReason = "failureCap";
+      }
+    },
+  };
 }
 
 async function discardIfUnsurfaced(options: {
@@ -69,23 +188,14 @@ async function discardIfUnsurfaced(options: {
   }
 }
 
-function promptAgent(agent: Agent, prompt: AssistantRunPrompt): Promise<void> {
-  // The calls look identical, but agent.prompt is overloaded on (string) vs
-  // (AgentMessage | AgentMessage[]) — the typeof narrowing is what lets each
-  // call match one overload.
-  if (typeof prompt === "string") return agent.prompt(prompt);
-  return agent.prompt(prompt);
-}
-
 async function promptWithDraftCleanup(options: {
-  agent: Agent;
-  prompt: AssistantRunPrompt;
+  run: () => Promise<void>;
   host: AssistantHost;
   draftId: string;
   wasSurfaced: () => boolean;
 }): Promise<void> {
   try {
-    await promptAgent(options.agent, options.prompt);
+    await options.run();
   } catch (error) {
     // pi resolves provider failures into stopReason:"error" messages, so a
     // rejection here is exceptional (setup/internal). It must still not
@@ -93,6 +203,41 @@ async function promptWithDraftCleanup(options: {
     await discardIfUnsurfaced(options);
     throw error;
   }
+}
+
+function createFailureMessage(options: {
+  model: Model<Api>;
+  error: unknown;
+  aborted: boolean;
+}): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "" }],
+    api: options.model.api,
+    provider: options.model.provider,
+    model: options.model.id,
+    usage: EMPTY_USAGE,
+    stopReason: options.aborted ? "aborted" : "error",
+    errorMessage:
+      options.error instanceof Error
+        ? options.error.message
+        : String(options.error),
+    timestamp: Date.now(),
+  };
+}
+
+async function emitFailure(options: {
+  message: AssistantMessage;
+  emit: (event: AgentEvent) => Promise<void>;
+}): Promise<void> {
+  await options.emit({ type: "message_start", message: options.message });
+  await options.emit({ type: "message_end", message: options.message });
+  await options.emit({
+    type: "turn_end",
+    message: options.message,
+    toolResults: [],
+  });
+  await options.emit({ type: "agent_end", messages: [options.message] });
 }
 
 function createTools(options: {
@@ -119,6 +264,10 @@ export async function createAssistantRun(
 ): Promise<AssistantRunResult> {
   const draftId = await host.open();
   let firstMutationObserved = false;
+  const messages: AgentMessage[] = [];
+  const recoveryGuard = createRecoveryGuard(
+    normalizeMaxConsecutiveFailures(options.maxConsecutiveFailures),
+  );
 
   async function markFirstMutation() {
     if (firstMutationObserved) return;
@@ -132,61 +281,77 @@ export async function createAssistantRun(
     }
   }
 
-  const agent = new Agent({
-    initialState: {
-      model: options.model,
-      systemPrompt: options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
-      tools: createTools({
-        host,
-        draftId,
-        context: options.context,
-        markFirstMutation,
-      }),
-    },
-    convertToLlm: passThroughMessages,
-    streamFn: options.streamFn,
-    getApiKey: options.getApiKey,
-    toolExecution: "sequential",
+  const tools = createTools({
+    host,
+    draftId,
+    context: options.context,
+    markFirstMutation,
   });
 
-  if (options.onEvent !== undefined) {
-    agent.subscribe((event) => options.onEvent?.(event));
+  async function emit(event: AgentEvent) {
+    if (event.type === "message_end") {
+      messages.push(event.message);
+    }
+    await options.onEvent?.(event);
   }
 
-  let onAbort: (() => void) | undefined;
-  if (options.signal !== undefined && !options.signal.aborted) {
-    onAbort = () => agent.abort();
-    options.signal.addEventListener("abort", onAbort, { once: true });
-  }
-
-  try {
-    if (options.signal?.aborted) {
-      // Cancelled before the run started: nothing to prompt; clean up the
-      // just-minted sandbox if it never surfaced.
-      await discardIfUnsurfaced({
-        host,
-        draftId,
-        wasSurfaced: () => firstMutationObserved,
-      });
-    } else {
-      await promptWithDraftCleanup({
-        agent,
-        prompt: options.prompt,
-        host,
-        draftId,
-        wasSurfaced: () => firstMutationObserved,
-      });
-    }
-  } finally {
-    if (onAbort !== undefined && options.signal !== undefined) {
-      options.signal.removeEventListener("abort", onAbort);
-    }
+  if (options.signal?.aborted) {
+    // Cancelled before the run started: nothing to prompt; clean up the
+    // just-minted sandbox if it never surfaced.
+    await discardIfUnsurfaced({
+      host,
+      draftId,
+      wasSurfaced: () => firstMutationObserved,
+    });
+  } else {
+    await promptWithDraftCleanup({
+      host,
+      draftId,
+      wasSurfaced: () => firstMutationObserved,
+      run: async () => {
+        try {
+          await runAgentLoop(
+            normalizePrompt(options.prompt),
+            {
+              systemPrompt: options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
+              messages: [],
+              tools,
+            },
+            {
+              model: options.model,
+              convertToLlm: passThroughMessages,
+              getApiKey: options.getApiKey,
+              toolExecution: "sequential",
+              afterToolCall: async ({ toolCall, args, isError }) => {
+                recoveryGuard.afterToolCall({ toolCall, args, isError });
+                return undefined;
+              },
+              shouldStopAfterTurn: () =>
+                recoveryGuard.terminationReason !== "completed",
+            },
+            emit,
+            options.signal,
+            options.streamFn,
+          );
+        } catch (error) {
+          await emitFailure({
+            message: createFailureMessage({
+              model: options.model,
+              error,
+              aborted: options.signal?.aborted === true,
+            }),
+            emit,
+          });
+        }
+      },
+    });
   }
 
   return {
     draftId,
-    messages: agent.state.messages,
+    messages,
     firstMutationObserved,
+    terminationReason: recoveryGuard.terminationReason,
     discard: () => host.discard(draftId),
   };
 }

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -45,6 +45,7 @@ export {
 export {
   createAssistantRun,
   type AssistantRunResult,
+  type AssistantRunTerminationReason,
   type CreateAssistantRunOptions,
 } from "./assistant-run.js";
 


### PR DESCRIPTION
## Summary

- Add a configurable consecutive applyCommand failure cap to assistant runs.
- Detect repeated failing applyCommand fingerprints with stable canonical hashing and stop on oscillation.
- Return an additive `terminationReason` on assistant run results.

## Verification

- `bun test packages/assistant/src/assistant-run.test.ts`
- `bun run check`
- `bun run --filter @dashframe/assistant check`
- `bun run clawpatch:review` returned `no features touched by diff`

## Screenshots

No UI change

Tracked internally as <issue id="dbd8f2b7-d058-4ee5-8d65-a42cbdadacf1" href="https://linear.app/youhaowei/issue/YW-135/pi-agent-recovery-loop-emitvalidateretry-with-oscillation-guard">YW-135</issue>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a configurable recovery-loop guard to `createAssistantRun` that terminates an agent run when `applyCommand` fails too many times consecutively or oscillates between the same failing command fingerprints. It also migrates from the `Agent` class to `runAgentLoop` and exposes a new `terminationReason` field on `AssistantRunResult`.

- **Recovery guard** (`createRecoveryGuard`): tracks consecutive failures and a set of SHA-256 fingerprints of failed commands; returns `\"failureCap\"` or `\"oscillation\"` on termination. A `shouldExecute` gate in `createApplyCommandTool` blocks further draft mutations once the guard trips, even for tool calls in the same LLM turn.
- **Deduplication** (`finalizedToolCallIds`): prevents the `afterToolCall` hook and the `message_end` event from counting the same tool call twice toward the failure counter. Both paths canonicalize args with sorted-key JSON hashing so `{ id, name }` and `{ name, id }` produce the same fingerprint.
- **New tests**: six new scenarios cover the cap, validation failures, same-turn blocking, oscillation, counter reset after success, and draft retention after partial success; three existing tests gain `terminationReason` assertions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the guard is additive and defaults to 5 consecutive failures, leaving normal runs unaffected.

The core guard logic, deduplication mechanism, and shouldExecute gate are all exercised by the new tests. No mutations to existing host or draft lifecycle paths; the terminationReason field is purely additive to the result shape.

packages/assistant/src/assistant-run.ts warrants a second read — the finalizedToolCallIds deduplication between afterToolCall and messageEnd is subtle and relies on an ordering invariant from runAgentLoop.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/assistant/src/assistant-run.ts | Major refactor from Agent class to runAgentLoop; adds createRecoveryGuard with consecutive-failure counting, oscillation detection, deduplication logic, and terminationReason propagation. Logic is sound but complex. |
| packages/assistant/src/apply-command-tool.ts | Adds optional shouldExecute gate that throws before host.append when the guard has tripped; uses strict === false so an absent callback still allows execution. |
| packages/assistant/src/assistant-run.test.ts | Adds six targeted tests covering failure cap, validation failures, same-turn blocking, oscillation detection, failure counter reset, and draft-keep-after-partial-success; also asserts terminationReason on three existing tests. |
| packages/assistant/src/index.ts | Trivially re-exports the new AssistantRunTerminationReason type. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant createAssistantRun
    participant runAgentLoop
    participant applyCommandTool
    participant recoveryGuard

    Caller->>createAssistantRun: createAssistantRun(host, options)
    createAssistantRun->>runAgentLoop: run with afterToolCall + shouldStopAfterTurn hooks

    loop Each LLM turn
        runAgentLoop->>applyCommandTool: execute(toolCallId, params)
        applyCommandTool->>recoveryGuard: shouldBlockApplyCommand?
        alt guard tripped
            applyCommandTool-->>runAgentLoop: throw Error (blocked)
        else guard clear
            applyCommandTool->>applyCommandTool: host.append(draftId, batch)
        end
        runAgentLoop->>recoveryGuard: "afterToolCall({toolCall, args, isError})"
        recoveryGuard->>recoveryGuard: track consecutive failures and fingerprints
        alt failure cap reached
            recoveryGuard-->>runAgentLoop: "terminationReason=failureCap, terminate true"
        else oscillation detected
            recoveryGuard-->>runAgentLoop: "terminationReason=oscillation, terminate true"
        else success
            recoveryGuard->>recoveryGuard: reset consecutiveFailures + failedFingerprints
            recoveryGuard-->>runAgentLoop: "terminationReason=completed"
        end
        runAgentLoop->>createAssistantRun: emit(message_end)
        runAgentLoop->>runAgentLoop: shouldStopAfterTurn() check
    end

    runAgentLoop-->>createAssistantRun: resolve
    createAssistantRun-->>Caller: AssistantRunResult with terminationReason
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant createAssistantRun
    participant runAgentLoop
    participant applyCommandTool
    participant recoveryGuard

    Caller->>createAssistantRun: createAssistantRun(host, options)
    createAssistantRun->>runAgentLoop: run with afterToolCall + shouldStopAfterTurn hooks

    loop Each LLM turn
        runAgentLoop->>applyCommandTool: execute(toolCallId, params)
        applyCommandTool->>recoveryGuard: shouldBlockApplyCommand?
        alt guard tripped
            applyCommandTool-->>runAgentLoop: throw Error (blocked)
        else guard clear
            applyCommandTool->>applyCommandTool: host.append(draftId, batch)
        end
        runAgentLoop->>recoveryGuard: "afterToolCall({toolCall, args, isError})"
        recoveryGuard->>recoveryGuard: track consecutive failures and fingerprints
        alt failure cap reached
            recoveryGuard-->>runAgentLoop: "terminationReason=failureCap, terminate true"
        else oscillation detected
            recoveryGuard-->>runAgentLoop: "terminationReason=oscillation, terminate true"
        else success
            recoveryGuard->>recoveryGuard: reset consecutiveFailures + failedFingerprints
            recoveryGuard-->>runAgentLoop: "terminationReason=completed"
        end
        runAgentLoop->>createAssistantRun: emit(message_end)
        runAgentLoop->>runAgentLoop: shouldStopAfterTurn() check
    end

    runAgentLoop-->>createAssistantRun: resolve
    createAssistantRun-->>Caller: AssistantRunResult with terminationReason
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Format assistant recovery guard tests"](https://github.com/youhaowei/dashframe/commit/dfa000d3892ea9480713cb4cbbb92f215e00b7a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41840026)</sub>

<!-- /greptile_comment -->