### PR TITLE
Make clawpatch review scripts reliable

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "changeset:status": "changeset status",
     "clawpatch": "scripts/clawpatch.sh",
     "clawpatch:map": "scripts/clawpatch.sh map --source heuristic --json",
-    "clawpatch:review": "scripts/clawpatch.sh review --since origin/main --json --no-input",
+    "clawpatch:review": "scripts/clawpatch.sh map --source heuristic --json && scripts/clawpatch.sh review --since origin/main --json --no-input",
     "clawpatch:review:branch": "scripts/clawpatch-review-branch.sh",
     "version": "changeset version && node scripts/annotate-web-changelog.mjs",
     "release": "changeset publish"

--- a/scripts/clawpatch-review-branch.sh
+++ b/scripts/clawpatch-review-branch.sh
@@ -23,6 +23,7 @@ if [[ $# -gt 0 ]]; then
 fi
 
 review_branch=""
+review_branch_created=false
 review_worktree=""
 review_worktree_parent=""
 
@@ -30,7 +31,7 @@ cleanup_review_worktree() {
   if [[ -n "$review_worktree" ]]; then
     git -C "$repo_root" worktree remove --force "$review_worktree" >/dev/null 2>&1 || true
   fi
-  if [[ -n "$review_branch" ]]; then
+  if [[ "$review_branch_created" == true && -n "$review_branch" ]]; then
     git -C "$repo_root" branch -D "$review_branch" >/dev/null 2>&1 || true
   fi
   if [[ -n "$review_worktree_parent" ]]; then
@@ -39,18 +40,20 @@ cleanup_review_worktree() {
 }
 trap cleanup_review_worktree EXIT
 
-is_bare_commit_sha() {
-  [[ "$1" =~ ^[0-9a-fA-F]{7,40}$ ]] && git -C "$repo_root" cat-file -e "$1^{commit}" 2>/dev/null
+looks_like_commit_sha() {
+  [[ "$1" =~ ^[0-9a-fA-F]{7,40}$ ]]
 }
 
 resolve_target_sha() {
   local ref="$1"
-  git -C "$repo_root" rev-parse --verify "${ref}^{commit}" 2>/dev/null && return 0
-  git -C "$repo_root" rev-parse --verify "origin/${ref}^{commit}" 2>/dev/null && return 0
-
+  # A fresh fetch is the only trustworthy source for a remote branch; an
+  # existing origin/<ref> tracking ref may be stale, so never use it without
+  # a successful fetch backing it.
   if git -C "$repo_root" fetch origin "$ref" >/dev/null 2>&1; then
     git -C "$repo_root" rev-parse --verify "FETCH_HEAD^{commit}" 2>/dev/null && return 0
   fi
+  # Local-only branches never exist on origin; a local head is authoritative.
+  git -C "$repo_root" rev-parse --verify "refs/heads/${ref}^{commit}" 2>/dev/null && return 0
 
   return 1
 }
@@ -88,16 +91,28 @@ create_review_worktree() {
 
   if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$review_branch"; then
     echo "ERROR [clawpatch-review-branch]: could not allocate a throwaway review branch for '$ref'." >&2
+    review_branch=""
     exit 1
   fi
 
   review_worktree_parent="$(mktemp -d "${TMPDIR:-/tmp}/clawpatch-review-${slug}.XXXXXX")"
   review_worktree="$review_worktree_parent/worktree"
   git -C "$repo_root" worktree add -b "$review_branch" "$review_worktree" "$sha" >/dev/null
+  review_branch_created=true
 }
 
 worktree=""
-if is_bare_commit_sha "$target"; then
+if looks_like_commit_sha "$target"; then
+  # A hex-shaped target is always treated as a commit, never handed to
+  # ensure-worktree.sh as a branch name (which would silently create a fresh
+  # branch off origin/main and review the wrong diff).
+  if ! git -C "$repo_root" cat-file -e "${target}^{commit}" 2>/dev/null; then
+    git -C "$repo_root" fetch origin "$target" >/dev/null 2>&1 || true
+  fi
+  if ! git -C "$repo_root" cat-file -e "${target}^{commit}" 2>/dev/null; then
+    echo "ERROR [clawpatch-review-branch]: '$target' looks like a commit SHA but cannot be resolved locally or fetched from origin." >&2
+    exit 1
+  fi
   target_sha="$(git -C "$repo_root" rev-parse --verify "${target}^{commit}")"
   create_review_worktree "$target" "$target_sha"
   worktree="$review_worktree"

--- a/scripts/clawpatch-review-branch.sh
+++ b/scripts/clawpatch-review-branch.sh
@@ -2,28 +2,129 @@
 # Map and review a feature branch from an isolated worktree with shared Clawpatch state.
 #
 # Usage:
-#   scripts/clawpatch-review-branch.sh <branch> [-- extra review flags]
+#   scripts/clawpatch-review-branch.sh <branch-or-sha> [-- extra review flags]
 #
 # Example:
-#   bun run clawpatch:review:branch -- codex/YW-134-perception-assembler
+#   bun run clawpatch:review:branch -- codex/example-feature
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-branch="${1:?usage: clawpatch-review-branch.sh <branch> [-- extra review flags]}"
+target="${1:?usage: clawpatch-review-branch.sh <branch-or-sha> [-- extra review flags]}"
 shift
 
 extra_args=()
 if [[ $# -gt 0 ]]; then
   if [[ "${1:-}" != "--" ]]; then
-    echo "usage: clawpatch-review-branch.sh <branch> [-- extra review flags]" >&2
+    echo "usage: clawpatch-review-branch.sh <branch-or-sha> [-- extra review flags]" >&2
     exit 1
   fi
   shift
   extra_args=("$@")
 fi
 
-worktree="$("$repo_root/scripts/ensure-worktree.sh" "$branch")"
+review_branch=""
+review_worktree=""
+review_worktree_parent=""
+
+cleanup_review_worktree() {
+  if [[ -n "$review_worktree" ]]; then
+    git -C "$repo_root" worktree remove --force "$review_worktree" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$review_branch" ]]; then
+    git -C "$repo_root" branch -D "$review_branch" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$review_worktree_parent" ]]; then
+    rm -rf "$review_worktree_parent"
+  fi
+}
+trap cleanup_review_worktree EXIT
+
+is_bare_commit_sha() {
+  [[ "$1" =~ ^[0-9a-fA-F]{7,40}$ ]] && git -C "$repo_root" cat-file -e "$1^{commit}" 2>/dev/null
+}
+
+resolve_target_sha() {
+  local ref="$1"
+  git -C "$repo_root" rev-parse --verify "${ref}^{commit}" 2>/dev/null && return 0
+  git -C "$repo_root" rev-parse --verify "origin/${ref}^{commit}" 2>/dev/null && return 0
+
+  if git -C "$repo_root" fetch origin "$ref" >/dev/null 2>&1; then
+    git -C "$repo_root" rev-parse --verify "FETCH_HEAD^{commit}" 2>/dev/null && return 0
+  fi
+
+  return 1
+}
+
+slugify_ref() {
+  local raw="$1"
+  local slug
+  slug="$(printf '%s' "$raw" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
+    | cut -c1-48)"
+  if [[ -z "$slug" ]]; then
+    slug="target"
+  fi
+  printf '%s' "$slug"
+}
+
+create_review_worktree() {
+  local ref="$1"
+  local sha="$2"
+  local slug short_sha suffix
+  slug="$(slugify_ref "$ref")"
+  short_sha="$(git -C "$repo_root" rev-parse --short "$sha")"
+
+  for attempt in {0..20}; do
+    suffix=""
+    if [[ "$attempt" -gt 0 ]]; then
+      suffix="-$attempt"
+    fi
+    review_branch="review/${slug}-${short_sha}${suffix}"
+    if ! git -C "$repo_root" show-ref --verify --quiet "refs/heads/$review_branch"; then
+      break
+    fi
+  done
+
+  if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$review_branch"; then
+    echo "ERROR [clawpatch-review-branch]: could not allocate a throwaway review branch for '$ref'." >&2
+    exit 1
+  fi
+
+  review_worktree_parent="$(mktemp -d "${TMPDIR:-/tmp}/clawpatch-review-${slug}.XXXXXX")"
+  review_worktree="$review_worktree_parent/worktree"
+  git -C "$repo_root" worktree add -b "$review_branch" "$review_worktree" "$sha" >/dev/null
+}
+
+worktree=""
+if is_bare_commit_sha "$target"; then
+  target_sha="$(git -C "$repo_root" rev-parse --verify "${target}^{commit}")"
+  create_review_worktree "$target" "$target_sha"
+  worktree="$review_worktree"
+else
+  ensure_log="$(mktemp)"
+  if worktree="$("$repo_root/scripts/ensure-worktree.sh" "$target" 2>"$ensure_log")"; then
+    cat "$ensure_log" >&2
+    rm -f "$ensure_log"
+  else
+    ensure_rc=$?
+    ensure_error="$(cat "$ensure_log")"
+    rm -f "$ensure_log"
+
+    if target_sha="$(resolve_target_sha "$target")"; then
+      if [[ -n "$ensure_error" ]]; then
+        printf '%s\n' "$ensure_error" | sed 's/^/[clawpatch-review-branch] ensure-worktree failed; using throwaway review branch: /' >&2
+      fi
+      create_review_worktree "$target" "$target_sha"
+      worktree="$review_worktree"
+    else
+      printf '%s\n' "$ensure_error" >&2
+      exit "$ensure_rc"
+    fi
+  fi
+fi
+
 cd "$worktree"
 
-"$worktree/scripts/clawpatch.sh" map --source heuristic --json
-exec "$worktree/scripts/clawpatch.sh" review --since origin/main --json --no-input "${extra_args[@]:-}"
+"$repo_root/scripts/clawpatch.sh" map --source heuristic --json
+"$repo_root/scripts/clawpatch.sh" review --since origin/main --json --no-input ${extra_args[@]+"${extra_args[@]}"}

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -83,4 +83,36 @@ if [[ "$1" == "review" ]]; then
   fi
 fi
 
+if [[ "${1:-}" == "review" ]]; then
+  since_base=""
+  previous_arg=""
+  for arg in "$@"; do
+    if [[ "$previous_arg" == "--since" ]]; then
+      since_base="$arg"
+      break
+    fi
+    if [[ "$arg" == --since=* ]]; then
+      since_base="${arg#--since=}"
+      break
+    fi
+    previous_arg="$arg"
+  done
+
+  set +e
+  review_output="$(clawpatch --state-dir "$state_dir" "$@" 2>&1)"
+  review_rc=$?
+  set -e
+  printf '%s\n' "$review_output"
+
+  if [[ "$review_rc" -eq 0 && -n "$since_base" ]] \
+    && printf '%s\n' "$review_output" | grep -Fq "no features touched by diff" \
+    && git diff --name-only "$since_base" -- | grep -q .; then
+    echo "ERROR [clawpatch]: stale map / unmapped files: review reported no features touched by diff, but git diff --name-only '$since_base' is non-empty." >&2
+    echo "ERROR [clawpatch]: run scripts/clawpatch.sh map --source heuristic and check whether changed files are mapped to features." >&2
+    exit 1
+  fi
+
+  exit "$review_rc"
+fi
+
 clawpatch --state-dir "$state_dir" "$@"

--- a/scripts/clawpatch.sh
+++ b/scripts/clawpatch.sh
@@ -98,18 +98,30 @@ if [[ "${1:-}" == "review" ]]; then
     previous_arg="$arg"
   done
 
+  review_stdout_file="$(mktemp)"
+  review_stderr_file="$(mktemp)"
   set +e
-  review_output="$(clawpatch --state-dir "$state_dir" "$@" 2>&1)"
+  clawpatch --state-dir "$state_dir" "$@" >"$review_stdout_file" 2>"$review_stderr_file"
   review_rc=$?
   set -e
-  printf '%s\n' "$review_output"
+  review_stdout="$(cat "$review_stdout_file")"
+  review_stderr="$(cat "$review_stderr_file")"
+  rm -f "$review_stdout_file" "$review_stderr_file"
+  if [[ -n "$review_stdout" ]]; then
+    printf '%s\n' "$review_stdout"
+  fi
+  if [[ -n "$review_stderr" ]]; then
+    printf '%s\n' "$review_stderr" >&2
+  fi
 
   if [[ "$review_rc" -eq 0 && -n "$since_base" ]] \
-    && printf '%s\n' "$review_output" | grep -Fq "no features touched by diff" \
-    && git diff --name-only "$since_base" -- | grep -q .; then
-    echo "ERROR [clawpatch]: stale map / unmapped files: review reported no features touched by diff, but git diff --name-only '$since_base' is non-empty." >&2
-    echo "ERROR [clawpatch]: run scripts/clawpatch.sh map --source heuristic and check whether changed files are mapped to features." >&2
-    exit 1
+    && grep -Fq "no features touched by diff" <<<"${review_stdout}${review_stderr}"; then
+    changed_files="$(git diff --name-only "$since_base" -- || true)"
+    if [[ -n "$changed_files" ]]; then
+      echo "ERROR [clawpatch]: stale map / unmapped files: review reported no features touched by diff, but git diff --name-only '$since_base' is non-empty." >&2
+      echo "ERROR [clawpatch]: run scripts/clawpatch.sh map --source heuristic and check whether changed files are mapped to features." >&2
+      exit 1
+    fi
   fi
 
   exit "$review_rc"


### PR DESCRIPTION
## Summary
- `clawpatch:review` now remaps (heuristic, ~1s) before reviewing, so a stale feature map can no longer silently skip files changed after the last map run
- `clawpatch-review-branch.sh` accepts a branch **or bare SHA**; when the branch is checked out in another worktree (or only resolvable via fetch), it reviews from a throwaway `review/<slug>-<sha>` branch in a temp worktree and cleans up on exit
- Fixed `"${extra_args[@]:-}"` expanding to a literal empty argument (`error: unknown arg:`) when no extra flags are passed
- Fail-closed guard: `review --since <base>` reporting "no features touched by diff" while `git diff --name-only <base>` is non-empty now exits non-zero with a stale-map error instead of reading as a pass

## Screenshots
No UI change.

## Notes
Implementation by a Codex background task; the sandbox blocked git ref writes at commit time, so the cockpit committed and pushed the completed diff. Local `bun check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the clawpatch review tooling by ensuring the feature map is always fresh before a review runs, adding robust worktree/SHA support to `clawpatch-review-branch.sh`, and implementing a fail-closed guard that exits non-zero when the review reports no features touched but `git diff` shows real changes.

- **`package.json`**: `clawpatch:review` now runs `map` then `review` in sequence, so a stale map can never silently skip changed files.
- **`clawpatch-review-branch.sh`**: Full rewrite to accept a bare commit SHA or a branch name; falls back to a throwaway `review/<slug>-<sha>` branch in a temp worktree (with EXIT-trap cleanup) when the branch is checked out elsewhere. Also fixes the `\"${extra_args[@]:-}\"` empty-array expansion bug.
- **`clawpatch.sh`**: Second `review` handler block captures stdout and stderr into separate streams, then applies the stale-map fail-closed check.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all three files make targeted, additive changes with no regressions on the happy path.

The logic for worktree creation, cleanup, SHA resolution, and the stale-map guard is all sound. The previous reviewer comments about stdout/stderr pollution and the branch-deletion guard have been addressed. The remaining observations are about robustness under concurrent use and a fragile string match, neither of which blocks correct operation in the common single-invocation case.

The package.json script change warrants a quick check if any CI steps pipe bun run clawpatch:review to a JSON parser, since the command now emits two JSON objects on stdout instead of one.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds map before review in clawpatch:review; functionally correct but now emits both map JSON and review JSON on stdout. |
| scripts/clawpatch.sh | Adds a second review handler block that captures stdout/stderr separately and implements a fail-closed stale-map guard; logic is sound with the fragile string-match caveat. |
| scripts/clawpatch-review-branch.sh | Major refactor adds SHA support, throwaway review-branch fallback, and proper cleanup via EXIT trap; branch-created guard correctly gates deletion, but FETCH_HEAD is shared across concurrent invocations. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([clawpatch-review-branch.sh target]) --> B{looks_like_commit_sha?}
    B -- yes --> C{cat-file -e locally?}
    C -- no --> D[git fetch origin target]
    D --> E{resolved?}
    E -- no --> F([exit 1: unresolvable SHA])
    C -- yes --> G[create_review_worktree]
    E -- yes --> G
    B -- no --> H[ensure-worktree.sh target]
    H -- success --> I[use existing worktree]
    H -- fail --> J[resolve_target_sha]
    J -- success --> G
    J -- fail --> K([exit with ensure-worktree error])
    G --> L[git worktree add -b review/slug-sha]
    L --> M[review_branch_created=true]
    I --> N
    M --> N([cd worktree])
    N --> O[clawpatch.sh map]
    O --> P[clawpatch.sh review --since origin/main]
    P --> Q{rc=0 AND no features touched AND git diff non-empty?}
    Q -- yes --> R([exit 1: stale map error])
    Q -- no --> S([exit review_rc])
    S --> T[EXIT trap: cleanup worktree + branch]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([clawpatch-review-branch.sh target]) --> B{looks_like_commit_sha?}
    B -- yes --> C{cat-file -e locally?}
    C -- no --> D[git fetch origin target]
    D --> E{resolved?}
    E -- no --> F([exit 1: unresolvable SHA])
    C -- yes --> G[create_review_worktree]
    E -- yes --> G
    B -- no --> H[ensure-worktree.sh target]
    H -- success --> I[use existing worktree]
    H -- fail --> J[resolve_target_sha]
    J -- success --> G
    J -- fail --> K([exit with ensure-worktree error])
    G --> L[git worktree add -b review/slug-sha]
    L --> M[review_branch_created=true]
    I --> N
    M --> N([cd worktree])
    N --> O[clawpatch.sh map]
    O --> P[clawpatch.sh review --since origin/main]
    P --> Q{rc=0 AND no features touched AND git diff non-empty?}
    Q -- yes --> R([exit 1: stale map error])
    Q -- no --> S([exit review_rc])
    S --> T[EXIT trap: cleanup worktree + branch]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Harden clawpatch review scripts per revi..."](https://github.com/youhaowei/dashframe/commit/8445636f1e717e984c31ce01d93e2638f0e8fc5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42000863)</sub>

<!-- /greptile_comment -->