### PR TITLE
Demote the returning-user welcome header on Home

### DIFF
--- a/packages/app/src/app/_components/HomeView.tsx
+++ b/packages/app/src/app/_components/HomeView.tsx
@@ -1,9 +1,3 @@
-import {
-  useDataSources,
-  useDataTables,
-  useInsights,
-  useVisualizations,
-} from "@dashframe/core";
 import { QuickLinksSection } from "./QuickLinksSection";
 import { RecentInsightsSection } from "./RecentInsightsSection";
 import { RecentVisualizationsSection } from "./RecentVisualizationsSection";
@@ -11,31 +5,11 @@ import { RecentVisualizationsSection } from "./RecentVisualizationsSection";
 /**
  * HomeView - Main view for returning users with existing data
  *
- * Displays a welcome header with stats and sections for recent
- * visualizations, insights, and quick navigation links.
+ * Displays recent visualizations, insights, and quick navigation links.
  */
 export function HomeView() {
-  const { data: visualizations = [] } = useVisualizations();
-  const { data: insights = [] } = useInsights();
-  const { data: dataSources = [] } = useDataSources();
-  const { data: dataTables = [] } = useDataTables();
-
-  const totalTables = dataTables.length;
-
   return (
     <>
-      {/* Welcome Header */}
-      <div className="mb-8">
-        <h1 className="mb-2 text-3xl font-bold">Welcome back to DashFrame</h1>
-        <p className="text-neutral-fg-subtle">
-          {visualizations.length} visualization
-          {visualizations.length !== 1 ? "s" : ""} · {insights.length} insight
-          {insights.length !== 1 ? "s" : ""} · {dataSources.length} data source
-          {dataSources.length !== 1 ? "s" : ""} · {totalTables} table
-          {totalTables !== 1 ? "s" : ""}
-        </p>
-      </div>
-
       <RecentVisualizationsSection />
       <RecentInsightsSection />
       <QuickLinksSection />


### PR DESCRIPTION
## Summary
- Removes the "Welcome back to DashFrame" heading and the stats row from `HomeView` — the returning-user Home now leads directly with Recent Visualizations, Recent Insights, and Quick Links
- Drops the four `@dashframe/core` hooks that only fed the stats row
- First-run `OnboardingView` is untouched (byte-identical)

Owner-ratified per the v0.3 UX-simplification decision (M2): the first-run welcome orients an empty app and stays; the returning-user greeting repeats what the user already knows.

Tracked internally as YW-396.

## Screenshots

### Home — returning user (light)
![Home — returning user (light)](https://github.com/youhaowei/DashFrame/releases/download/pr-217-screenshots/home-light-tall.png)

### Home — returning user (dark)
![Home — returning user (dark)](https://github.com/youhaowei/DashFrame/releases/download/pr-217-screenshots/home-dark-tall.png)

_Screenshots via pr-screenshots (prerelease `pr-217-screenshots`, not in git)._
## Notes
Implementation by a Codex background task; the sandbox blocked git ref writes at commit time, so the cockpit committed and pushed the completed diff. Local `bun check` green (83/83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the "Welcome back to DashFrame" heading and the stats summary row from `HomeView` for returning users. The component now renders directly into `RecentVisualizationsSection`, `RecentInsightsSection`, and `QuickLinksSection` without any preamble.

- Drops the four `@dashframe/core` hooks (`useVisualizations`, `useInsights`, `useDataSources`, `useDataTables`) that exclusively fed the removed stats row — the child sections retain their own data fetching.
- All deleted code was self-contained in `HomeView`; no other files are touched and `OnboardingView` is unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a straightforward deletion of UI and data-fetching code; no new logic is introduced and no other components are affected.

The diff is entirely removal — deleted imports, deleted hook calls, deleted JSX. The three child sections that remain each manage their own data fetching independently, so nothing breaks from dropping the parent-level hooks. Custom rule checks all pass: no ticket IDs in source, no off-token colors, no platform forks.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/app/_components/HomeView.tsx | Pure removal of welcome header, stats row, and associated hook calls; remaining structure is unchanged and correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HomeView] --> B[RecentVisualizationsSection]
    A --> C[RecentInsightsSection]
    A --> D[QuickLinksSection]

    subgraph removed["Removed (this PR)"]
        R1["useVisualizations()"]
        R2["useInsights()"]
        R3["useDataSources()"]
        R4["useDataTables()"]
        R5["Welcome back to DashFrame h1"]
        R6["Stats paragraph (counts)"]
    end

    style removed fill:#fef2f2,stroke:#fca5a5
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[HomeView] --> B[RecentVisualizationsSection]
    A --> C[RecentInsightsSection]
    A --> D[QuickLinksSection]

    subgraph removed["Removed (this PR)"]
        R1["useVisualizations()"]
        R2["useInsights()"]
        R3["useDataSources()"]
        R4["useDataTables()"]
        R5["Welcome back to DashFrame h1"]
        R6["Stats paragraph (counts)"]
    end

    style removed fill:#fef2f2,stroke:#fca5a5
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Demote the returning-user welcome header..."](https://github.com/youhaowei/dashframe/commit/0c3f96b9224ec4cdfdbb4007e12e2f32cfc64569) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42001133)</sub>

<!-- /greptile_comment -->
