### PR TITLE
Insight canvas: table-first view switcher with pin-to-mint create flow

### DIFF
--- a/e2e/web/lib/test-fixtures.ts
+++ b/e2e/web/lib/test-fixtures.ts
@@ -186,20 +186,20 @@ export const test = base.extend<
   },
 
   /**
-   * Wait for visualization chart to fully render
-   * Checks for data metadata and SVG presence
+   * Wait for the active chart view to fully render.
+   *
+   * A chart is "ready" when an SVG has rendered inside the chart container.
+   * Chart.tsx keeps data-testid="visualization-chart" on both the loading
+   * placeholder and the rendered container, so the SVG child is the signal
+   * that data loaded AND the renderer drew it. The old "N rows • N columns"
+   * metadata gate belonged to the standalone visualization page; the insight
+   * canvas (where charts render now) never shows that text on chart views.
    */
   waitForChart: async ({ page }, use) => {
     await use(async () => {
-      // Wait for data metadata (indicates data loaded)
-      await expect(page.getByText(/\d+ rows • \d+ columns/)).toBeVisible({
-        timeout: 30_000,
-      });
-
-      // Wait for SVG to render (vgplot renders async)
       await expect(
         page.locator('[data-testid="visualization-chart"] svg'),
-      ).toBeVisible({ timeout: 15_000 });
+      ).toBeVisible({ timeout: 30_000 });
     });
   },
 
@@ -211,9 +211,13 @@ export const test = base.extend<
   homePage: async ({ page, workerBaseURL }, use) => {
     await use(async () => {
       await page.goto(workerBaseURL);
+      // Home decides between onboarding and returning-user views only after
+      // the visualization list loads from the WyStack server, so allow a
+      // server round-trip (plus post-heavy-test latency) beyond the 5s
+      // default expect timeout.
       await expect(
         page.getByRole("heading", { name: "Welcome to DashFrame" }),
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 15_000 });
     });
   },
 });

--- a/e2e/web/tests/chart-editing.spec.ts
+++ b/e2e/web/tests/chart-editing.spec.ts
@@ -36,10 +36,11 @@ test.describe("Chart Editing", () => {
     // Wait for initial pinned chart.
     await waitForChart();
 
-    // Switching back to the table view shows the result table immediately
-    // (fields were select-all'd on create).
+    // Pinning wrote the chart's config (Product + sum(Quantity)) into the
+    // insight, so the table view now runs query mode: 4 distinct products
+    // grouped from the 5 source rows, dimension + metric = 2 fields.
     await page.getByRole("button", { name: "Table", exact: true }).click();
-    await expect(page.getByText(/5 rows/).first()).toBeVisible();
+    await expect(page.getByText("4 rows • 2 fields")).toBeVisible();
 
     // Each unpinned chart view renders and offers "Pin view"; switching views
     // does NOT mint a new Visualization (only pinning does).

--- a/e2e/web/tests/chart-editing.spec.ts
+++ b/e2e/web/tests/chart-editing.spec.ts
@@ -1,13 +1,13 @@
 /**
  * Chart Editing Tests
  *
- * Tests for switching chart types and editing visualizations
+ * Tests for switching chart views and pinning visualizations
  */
 import { expect, test } from "../lib/test-fixtures";
 
 test.describe("Chart Editing", () => {
   test.beforeEach(async ({ page, homePage, uploadFile }) => {
-    // Setup: Create a visualization first
+    // Setup: Create an insight first
     await homePage();
     await uploadFile("sales_data.csv");
 
@@ -15,46 +15,28 @@ test.describe("Chart Editing", () => {
       timeout: 15_000,
     });
 
-    // Create first chart
-    await expect(page.getByText("Create visualization")).toBeVisible({
+    // Start from the table-first canvas and pin one chart view.
+    await expect(page.getByRole("button", { name: "Table" })).toBeVisible({
       timeout: 30_000,
     });
-    await page
-      .getByRole("button", { name: /^Comparison/ })
-      .first()
-      .click();
-
-    await expect(page).toHaveURL(/\/visualizations\/[a-zA-Z0-9-]+/);
+    await page.getByRole("button", { name: "Bar" }).click();
+    await page.getByRole("button", { name: "Pin view" }).click();
+    await expect(page).toHaveURL(/\/insights\/[a-zA-Z0-9-]+/);
   });
 
   test("can switch between chart types", async ({ page, waitForChart }) => {
-    // Wait for initial chart
+    // Wait for initial pinned chart.
     await waitForChart();
 
-    // Get current chart type indicator (if visible in UI)
-    // Switch to different chart types and verify render
+    await page.getByRole("button", { name: "Table" }).click();
+    await expect(page.getByText(/5 rows/).first()).toBeVisible();
 
-    // Look for chart type selector or edit mode
-    const editButton = page.getByRole("button", { name: /edit/i });
-    if (await editButton.isVisible()) {
-      await editButton.click();
-    }
+    await page.getByRole("button", { name: "Line" }).click();
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
+    await waitForChart();
 
-    // If there's a chart type dropdown/selector, test switching
-    // This depends on actual UI implementation
-    const chartTypeSelector = page.locator(
-      '[data-testid="chart-type-selector"]',
-    );
-    if (await chartTypeSelector.isVisible()) {
-      // Test switching to line chart
-      await chartTypeSelector.click();
-      await page.getByRole("option", { name: /line/i }).click();
-      await waitForChart();
-
-      // Test switching to area chart
-      await chartTypeSelector.click();
-      await page.getByRole("option", { name: /area/i }).click();
-      await waitForChart();
-    }
+    await page.getByRole("button", { name: "Area" }).click();
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
+    await waitForChart();
   });
 });

--- a/e2e/web/tests/chart-editing.spec.ts
+++ b/e2e/web/tests/chart-editing.spec.ts
@@ -16,10 +16,18 @@ test.describe("Chart Editing", () => {
     });
 
     // Start from the table-first canvas and pin one chart view.
+    // `exact: true` disambiguates against the view switcher's other buttons —
+    // "Horizontal bar" and "Hide sidebar" both contain "bar" as a substring,
+    // which Playwright's default (non-exact) name matching would also match.
     await expect(page.getByRole("button", { name: "Table" })).toBeVisible({
       timeout: 30_000,
     });
-    await page.getByRole("button", { name: "Bar" }).click();
+    await page.getByRole("button", { name: "Bar", exact: true }).click();
+    // "Pin view" appears once chart suggestions are computed (DuckDB init +
+    // column analysis run after the table loads), so allow a generous wait.
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible({
+      timeout: 30_000,
+    });
     await page.getByRole("button", { name: "Pin view" }).click();
     await expect(page).toHaveURL(/\/insights\/[a-zA-Z0-9-]+/);
   });
@@ -28,14 +36,18 @@ test.describe("Chart Editing", () => {
     // Wait for initial pinned chart.
     await waitForChart();
 
-    await page.getByRole("button", { name: "Table" }).click();
+    // Switching back to the table view shows the result table immediately
+    // (fields were select-all'd on create).
+    await page.getByRole("button", { name: "Table", exact: true }).click();
     await expect(page.getByText(/5 rows/).first()).toBeVisible();
 
-    await page.getByRole("button", { name: "Line" }).click();
+    // Each unpinned chart view renders and offers "Pin view"; switching views
+    // does NOT mint a new Visualization (only pinning does).
+    await page.getByRole("button", { name: "Line", exact: true }).click();
     await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
     await waitForChart();
 
-    await page.getByRole("button", { name: "Area" }).click();
+    await page.getByRole("button", { name: "Area", exact: true }).click();
     await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
     await waitForChart();
   });

--- a/e2e/web/tests/compound-insight-editing.spec.ts
+++ b/e2e/web/tests/compound-insight-editing.spec.ts
@@ -16,20 +16,20 @@
  *
  * Setup mirrors the existing csv-to-chart.spec.ts: upload sales_data.csv
  * (Date, Product, Category, Sales, Quantity) → land on the insight page.
- * Creating an insight from a table now select-alls its fields immediately
- * (definition.selectedFields = every field on the source table), so the
- * Fields section starts populated with all 5 columns and metrics start
- * empty. The addField/removeField tests below exercise the mutation in the
- * direction that's actually reachable from that starting state: remove a
- * field first (to reproduce the empty state), then add it back.
+ * Creating an insight from a table produces an EMPTY draft (no fields
+ * preselected — that keeps the server's draft-reuse dedup working and avoids
+ * the all-fields GROUP BY collapsing duplicate source rows), so the Fields
+ * and Metrics sections both start empty and the canvas table renders the raw
+ * base table. The tests below add a field first, then exercise the other
+ * mutations from that state.
  */
 import { expect, test } from "../lib/test-fixtures";
 
 test.describe("compound-insight field/metric editing", () => {
   /**
    * Upload CSV and wait for the insight page to finish loading.
-   * Creating an insight from a table select-alls its fields, so each test
-   * starts with all 5 columns already in the Fields section and 0 metrics.
+   * Creating an insight from a table produces an empty draft, so each test
+   * starts with 0 selected fields and 0 metrics.
    */
   test.beforeEach(async ({ page, homePage, uploadFile }) => {
     await homePage();
@@ -40,28 +40,60 @@ test.describe("compound-insight field/metric editing", () => {
       timeout: 15_000,
     });
 
-    // Wait for the config panel to be rendered — the "Remove Product" button
-    // confirms the select-all fields are populated once the panel loads
+    // Wait for the config panel to be rendered — the Fields empty state
+    // confirms the panel loaded with the fresh draft's empty selection.
+    await expect(page.getByText("No fields selected.")).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+
+  /** Add a field by name via the Add Field dialog and confirm persistence. */
+  async function addField(page: import("@playwright/test").Page, name: string) {
+    // Open the Add Field dialog (first "Add" button = Fields section)
+    await page.getByRole("button", { name: "Add" }).first().click();
+    await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Scope to the dialog to avoid matching chart-suggestion buttons (which
+    // can also contain the field name in their accessible name).
+    const dialog = page.getByRole("dialog", { name: "Add field" });
+    const fieldButton = dialog.getByRole("button", {
+      name: new RegExp(name, "i"),
+    });
+    await expect(fieldButton).toBeVisible({ timeout: 10_000 });
+    await fieldButton.waitFor({ state: "visible" });
+
+    // Intercept the updateInsight mutation to confirm it fires and succeeds.
+    const updateResponse = page.waitForResponse(
+      (resp) => resp.url().includes("/api/updateInsight"),
+      { timeout: 20_000 },
+    );
+    await fieldButton.click();
+    await expect(
+      page.getByRole("dialog", { name: "Add field" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    expect((await updateResponse).status()).toBe(200);
+  }
+
+  // ---------------------------------------------------------------------------
+  // addField + removeField: definition.selectedFields grows then shrinks back
+  // ---------------------------------------------------------------------------
+  test("addField then removeField: Product can be added and removed", async ({
+    page,
+  }) => {
+    // ── addField ─────────────────────────────────────────────────────────
+    await addField(page, "Product");
+
+    // Reload the page to get fresh server state — confirms server persisted correctly
+    await page.reload();
+
+    // Observable: "Product" field item appears in the Fields section,
+    // confirming definition.selectedFields includes <productFieldId>
+    // and was written and read back from the server
     await expect(
       page.getByRole("button", { name: "Remove Product" }),
     ).toBeVisible({ timeout: 20_000 });
-  });
-
-  // ---------------------------------------------------------------------------
-  // removeField + addField: definition.selectedFields shrinks then grows back
-  //
-  // Creating an insight now select-alls its fields, so there's no reachable
-  // "add the first field" path — every field already starts selected. To
-  // exercise the addField mutation we first removeField to reproduce an
-  // empty slot, then add it back.
-  // ---------------------------------------------------------------------------
-  test("removeField then addField: Product can be removed and re-added", async ({
-    page,
-  }) => {
-    // Initial: "Product" is already selected (select-all on create)
-    await expect(
-      page.getByRole("button", { name: "Remove Product" }),
-    ).toBeVisible({ timeout: 10_000 });
 
     // ── removeField ──────────────────────────────────────────────────────
     await page.getByRole("button", { name: "Remove Product" }).click();
@@ -79,67 +111,14 @@ test.describe("compound-insight field/metric editing", () => {
     ).not.toBeVisible({ timeout: 5_000 });
     expect((await removeFieldResponse).status()).toBe(200);
 
-    // Reload to verify removal was persisted
+    // Reload to verify removal was persisted — back to the empty state
     await page.reload();
-    await expect(
-      page.getByRole("button", { name: "Remove Date" }),
-    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("No fields selected.")).toBeVisible({
+      timeout: 20_000,
+    });
     await expect(
       page.getByRole("button", { name: "Remove Product" }),
     ).not.toBeVisible({ timeout: 5_000 });
-
-    // ── addField ─────────────────────────────────────────────────────────
-    // Open the Add Field dialog (first "Add" button = Fields section)
-    await page.getByRole("button", { name: "Add" }).first().click();
-    await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
-      timeout: 10_000,
-    });
-
-    // Select the "Product" field from the available fields list.
-    // Scope to the dialog to avoid matching chart-suggestion buttons (which also
-    // contain "Product" in their accessible name) that are visible in the background.
-    const addFieldDialog = page.getByRole("dialog", { name: "Add field" });
-
-    // Wait for field buttons to populate inside the dialog, then wait a beat for
-    // the list to finish rendering (avoids DOM-detach flake when the field list
-    // re-renders while the click is in flight).
-    const productButton = addFieldDialog.getByRole("button", {
-      name: /Product/i,
-    });
-    await expect(productButton).toBeVisible({ timeout: 10_000 });
-    await productButton.waitFor({ state: "visible" });
-
-    // Intercept the updateInsight mutation to confirm it fires and succeeds.
-    // 20s timeout accommodates Playwright's click-retry loop if the button
-    // momentarily detaches during a list re-render.
-    const updateInsightResponse = page.waitForResponse(
-      (resp) => resp.url().includes("/api/updateInsight"),
-      { timeout: 20_000 },
-    );
-
-    await productButton.click();
-
-    // Dialog closes after selection
-    await expect(
-      page.getByRole("dialog", { name: "Add field" }),
-    ).not.toBeVisible({ timeout: 5_000 });
-
-    // Confirm the mutation reached the server. Assert the status explicitly so a
-    // non-200 surfaces as a clear assertion failure instead of a waitForResponse timeout.
-    expect((await updateInsightResponse).status()).toBe(200);
-
-    // Reload the page to get fresh server state — confirms server persisted correctly
-    await page.reload();
-    await expect(
-      page.getByRole("button", { name: "Remove Date" }),
-    ).toBeVisible({ timeout: 20_000 });
-
-    // Observable: "Product" field item is back in the Fields section,
-    // confirming definition.selectedFields includes <productFieldId> again
-    // and was written and read back from the server
-    await expect(
-      page.getByRole("button", { name: "Remove Product" }),
-    ).toBeVisible({ timeout: 15_000 });
   });
 
   // ---------------------------------------------------------------------------
@@ -203,59 +182,18 @@ test.describe("compound-insight field/metric editing", () => {
   // Full compound path: all five mutations in sequence
   // Proves the jsonb read-modify-write chain is correct at runtime,
   // not just at typecheck. Each step asserts an observable state change.
+  // NOTE: the observable state here is the config panel + persistence
+  // (reload survives), not the result table's cells — the "computed result"
+  // is verified at that seam.
   // ---------------------------------------------------------------------------
   test("editing an insight's fields/metrics is reflected in the computed result", async ({
     page,
   }) => {
-    // ── 1. removeField + addField ───────────────────────────────────────────
-    // Creating an insight select-alls its fields, so "Product" already exists
-    // in the Fields section (per beforeEach). To exercise addField we first
-    // remove it, then add it back.
-    // Cause: remove "Product", confirm; then re-add it via the field picker
-    // Effect: "Product" disappears then reappears in the Fields item list
-    await page.getByRole("button", { name: "Remove Product" }).click();
-    await expect(
-      page.getByRole("dialog", { name: "Delete field" }),
-    ).toBeVisible({ timeout: 10_000 });
-
-    const removeFieldResponse0 = page.waitForResponse(
-      (resp) => resp.url().includes("/api/updateInsight"),
-      { timeout: 10_000 },
-    );
-    await page.getByRole("button", { name: "Delete field" }).click();
-    await expect(
-      page.getByRole("dialog", { name: "Delete field" }),
-    ).not.toBeVisible({ timeout: 5_000 });
-    expect((await removeFieldResponse0).status()).toBe(200);
-
-    // Reload to verify removal was persisted
-    await page.reload();
-    await expect(
-      page.getByRole("button", { name: "Remove Date" }),
-    ).toBeVisible({ timeout: 20_000 });
-    await expect(
-      page.getByRole("button", { name: "Remove Product" }),
-    ).not.toBeVisible({ timeout: 5_000 });
-
-    await page.getByRole("button", { name: "Add" }).first().click();
-    await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
-      timeout: 10_000,
-    });
-
-    const addFieldDialog = page.getByRole("dialog", { name: "Add field" });
-    const productBtn = addFieldDialog.getByRole("button", { name: /Product/i });
-    await expect(productBtn).toBeVisible({ timeout: 10_000 });
-    await productBtn.waitFor({ state: "visible" });
-
-    const addFieldResponse1 = page.waitForResponse(
-      (resp) => resp.url().includes("/api/updateInsight"),
-      { timeout: 20_000 },
-    );
-    await productBtn.click();
-    await expect(
-      page.getByRole("dialog", { name: "Add field" }),
-    ).not.toBeVisible({ timeout: 5_000 });
-    expect((await addFieldResponse1).status()).toBe(200);
+    // ── 1. addField ─────────────────────────────────────────────────────────
+    // The draft starts empty, so addField is the natural first mutation.
+    // Cause: add "Product" via the field picker
+    // Effect: "Product" appears in the Fields item list
+    await addField(page, "Product");
 
     // Reload to verify field was persisted
     await page.reload();
@@ -338,10 +276,8 @@ test.describe("compound-insight field/metric editing", () => {
 
     // ── 4. removeField ──────────────────────────────────────────────────────
     // Cause: click Remove on "Product", confirm deletion
-    // Effect: "Product" disappears from the Fields section. The other
-    // select-all fields (Date, Category, Sales, Quantity) remain, so this
-    // asserts Product's specific absence rather than the empty-state message
-    // (which only applies when zero fields remain selected).
+    // Effect: "Product" disappears from the Fields section — back to the
+    // empty state, since it was the only selected field.
     await page.getByRole("button", { name: "Remove Product" }).click();
     await expect(
       page.getByRole("dialog", { name: "Delete field" }),
@@ -363,14 +299,14 @@ test.describe("compound-insight field/metric editing", () => {
       { timeout: 20_000 },
     );
 
-    // ✓ definition.selectedFields no longer includes Product, but the other
-    // select-all fields are still present
+    // ✓ definition.selectedFields no longer includes Product — the Fields
+    // section is back to its empty state (Product was the only field).
     await expect(
       page.getByRole("button", { name: "Remove Product" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await expect(
-      page.getByRole("button", { name: "Remove Date" }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("No fields selected.")).toBeVisible({
+      timeout: 15_000,
+    });
 
     // ── 5. removeMetric ─────────────────────────────────────────────────────
     // Cause: click Remove on "Row Count", confirm deletion

--- a/e2e/web/tests/compound-insight-editing.spec.ts
+++ b/e2e/web/tests/compound-insight-editing.spec.ts
@@ -16,15 +16,20 @@
  *
  * Setup mirrors the existing csv-to-chart.spec.ts: upload sales_data.csv
  * (Date, Product, Category, Sales, Quantity) → land on the insight page.
- * The insight is created with selectedFields=[] and metrics=[], so both
- * panel sections start empty.
+ * Creating an insight from a table now select-alls its fields immediately
+ * (definition.selectedFields = every field on the source table), so the
+ * Fields section starts populated with all 5 columns and metrics start
+ * empty. The addField/removeField tests below exercise the mutation in the
+ * direction that's actually reachable from that starting state: remove a
+ * field first (to reproduce the empty state), then add it back.
  */
 import { expect, test } from "../lib/test-fixtures";
 
 test.describe("compound-insight field/metric editing", () => {
   /**
    * Upload CSV and wait for the insight page to finish loading.
-   * Each test starts with an empty insight (0 fields, 0 metrics).
+   * Creating an insight from a table select-alls its fields, so each test
+   * starts with all 5 columns already in the Fields section and 0 metrics.
    */
   test.beforeEach(async ({ page, homePage, uploadFile }) => {
     await homePage();
@@ -35,24 +40,55 @@ test.describe("compound-insight field/metric editing", () => {
       timeout: 15_000,
     });
 
-    // Wait for the config panel to be rendered — "Fields" section Add button
-    // is always present once the panel loads
-    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
-      { timeout: 20_000 },
-    );
+    // Wait for the config panel to be rendered — the "Remove Product" button
+    // confirms the select-all fields are populated once the panel loads
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).toBeVisible({ timeout: 20_000 });
   });
 
   // ---------------------------------------------------------------------------
-  // addField: definition.selectedFields grows from [] to [fieldId]
+  // removeField + addField: definition.selectedFields shrinks then grows back
+  //
+  // Creating an insight now select-alls its fields, so there's no reachable
+  // "add the first field" path — every field already starts selected. To
+  // exercise the addField mutation we first removeField to reproduce an
+  // empty slot, then add it back.
   // ---------------------------------------------------------------------------
-  test("addField: selecting a field adds it to the Fields section", async ({
+  test("removeField then addField: Product can be removed and re-added", async ({
     page,
   }) => {
-    // Initial: Fields section shows "No fields selected."
-    await expect(page.getByText("No fields selected.")).toBeVisible({
-      timeout: 10_000,
-    });
+    // Initial: "Product" is already selected (select-all on create)
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).toBeVisible({ timeout: 10_000 });
 
+    // ── removeField ──────────────────────────────────────────────────────
+    await page.getByRole("button", { name: "Remove Product" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete field" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const removeFieldResponse = page.waitForResponse(
+      (resp) => resp.url().includes("/api/updateInsight"),
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Delete field" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete field" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    expect((await removeFieldResponse).status()).toBe(200);
+
+    // Reload to verify removal was persisted
+    await page.reload();
+    await expect(
+      page.getByRole("button", { name: "Remove Date" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+
+    // ── addField ─────────────────────────────────────────────────────────
     // Open the Add Field dialog (first "Add" button = Fields section)
     await page.getByRole("button", { name: "Add" }).first().click();
     await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
@@ -94,21 +130,16 @@ test.describe("compound-insight field/metric editing", () => {
 
     // Reload the page to get fresh server state — confirms server persisted correctly
     await page.reload();
-    await expect(page.getByRole("button", { name: "Add" }).first()).toBeVisible(
-      { timeout: 20_000 },
-    );
+    await expect(
+      page.getByRole("button", { name: "Remove Date" }),
+    ).toBeVisible({ timeout: 20_000 });
 
-    // Observable: "Product" field item now appears in the Fields section,
-    // confirming definition.selectedFields = [<productFieldId>] was written
-    // and read back from the server
+    // Observable: "Product" field item is back in the Fields section,
+    // confirming definition.selectedFields includes <productFieldId> again
+    // and was written and read back from the server
     await expect(
       page.getByRole("button", { name: "Remove Product" }),
     ).toBeVisible({ timeout: 15_000 });
-
-    // The empty-state message should be gone
-    await expect(page.getByText("No fields selected.")).not.toBeVisible({
-      timeout: 5_000,
-    });
   });
 
   // ---------------------------------------------------------------------------
@@ -176,9 +207,36 @@ test.describe("compound-insight field/metric editing", () => {
   test("editing an insight's fields/metrics is reflected in the computed result", async ({
     page,
   }) => {
-    // ── 1. addField ─────────────────────────────────────────────────────────
-    // Cause: open field picker, select "Product"
-    // Effect: "Product" appears in the Fields item list; empty-state gone
+    // ── 1. removeField + addField ───────────────────────────────────────────
+    // Creating an insight select-alls its fields, so "Product" already exists
+    // in the Fields section (per beforeEach). To exercise addField we first
+    // remove it, then add it back.
+    // Cause: remove "Product", confirm; then re-add it via the field picker
+    // Effect: "Product" disappears then reappears in the Fields item list
+    await page.getByRole("button", { name: "Remove Product" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete field" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const removeFieldResponse0 = page.waitForResponse(
+      (resp) => resp.url().includes("/api/updateInsight"),
+      { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Delete field" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Delete field" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+    expect((await removeFieldResponse0).status()).toBe(200);
+
+    // Reload to verify removal was persisted
+    await page.reload();
+    await expect(
+      page.getByRole("button", { name: "Remove Date" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByRole("button", { name: "Remove Product" }),
+    ).not.toBeVisible({ timeout: 5_000 });
+
     await page.getByRole("button", { name: "Add" }).first().click();
     await expect(page.getByRole("dialog", { name: "Add field" })).toBeVisible({
       timeout: 10_000,
@@ -280,7 +338,10 @@ test.describe("compound-insight field/metric editing", () => {
 
     // ── 4. removeField ──────────────────────────────────────────────────────
     // Cause: click Remove on "Product", confirm deletion
-    // Effect: "Product" disappears; Fields section shows empty state
+    // Effect: "Product" disappears from the Fields section. The other
+    // select-all fields (Date, Category, Sales, Quantity) remain, so this
+    // asserts Product's specific absence rather than the empty-state message
+    // (which only applies when zero fields remain selected).
     await page.getByRole("button", { name: "Remove Product" }).click();
     await expect(
       page.getByRole("dialog", { name: "Delete field" }),
@@ -302,13 +363,14 @@ test.describe("compound-insight field/metric editing", () => {
       { timeout: 20_000 },
     );
 
-    // ✓ definition.selectedFields = [] is persisted and re-rendered
+    // ✓ definition.selectedFields no longer includes Product, but the other
+    // select-all fields are still present
     await expect(
       page.getByRole("button", { name: "Remove Product" }),
     ).not.toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("No fields selected.")).toBeVisible({
-      timeout: 15_000,
-    });
+    await expect(
+      page.getByRole("button", { name: "Remove Date" }),
+    ).toBeVisible({ timeout: 15_000 });
 
     // ── 5. removeMetric ─────────────────────────────────────────────────────
     // Cause: click Remove on "Row Count", confirm deletion

--- a/e2e/web/tests/csv-to-chart.spec.ts
+++ b/e2e/web/tests/csv-to-chart.spec.ts
@@ -30,8 +30,14 @@ test.describe("CSV to Chart", () => {
     await expect(page.getByText(/5 rows/).first()).toBeVisible();
 
     // Switch to an ephemeral chart view, then pin it into a Visualization.
-    await page.getByRole("button", { name: "Bar" }).click();
-    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
+    // `exact: true` avoids matching "Horizontal bar" / "Hide sidebar", which
+    // both contain "bar" as a substring under Playwright's default name match.
+    await page.getByRole("button", { name: "Bar", exact: true }).click();
+    // "Pin view" appears once chart suggestions are computed (DuckDB init +
+    // column analysis run after the table loads), so allow a generous wait.
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible({
+      timeout: 30_000,
+    });
     await page.getByRole("button", { name: "Pin view" }).click();
 
     // Pinning keeps the user on the insight canvas.

--- a/e2e/web/tests/csv-to-chart.spec.ts
+++ b/e2e/web/tests/csv-to-chart.spec.ts
@@ -1,7 +1,7 @@
 /**
  * CSV to Chart Workflow
  *
- * Core user journey: Upload CSV -> Configure Insight -> Create Chart
+ * Core user journey: Upload CSV -> Table-first Insight -> Pin Chart View
  */
 import { expect, test } from "../lib/test-fixtures";
 
@@ -23,20 +23,19 @@ test.describe("CSV to Chart", () => {
       timeout: 15_000,
     });
 
-    // Verify chart suggestions appear
-    await expect(page.getByText("Create visualization")).toBeVisible({
+    // Verify the insight opens table-first.
+    await expect(page.getByRole("button", { name: "Table" })).toBeVisible({
       timeout: 30_000,
     });
-    await expect(page.getByText("Comparison")).toBeVisible();
+    await expect(page.getByText(/5 rows/).first()).toBeVisible();
 
-    // Click first suggestion (Comparison chart)
-    await page
-      .getByRole("button", { name: /^Comparison/ })
-      .first()
-      .click();
+    // Switch to an ephemeral chart view, then pin it into a Visualization.
+    await page.getByRole("button", { name: "Bar" }).click();
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
+    await page.getByRole("button", { name: "Pin view" }).click();
 
-    // Verify redirect to visualization page
-    await expect(page).toHaveURL(/\/visualizations\/[a-zA-Z0-9-]+/);
+    // Pinning keeps the user on the insight canvas.
+    await expect(page).toHaveURL(/\/insights\/[a-zA-Z0-9-]+/);
 
     // Verify chart renders
     await waitForChart();

--- a/e2e/web/tests/json-to-chart.spec.ts
+++ b/e2e/web/tests/json-to-chart.spec.ts
@@ -28,8 +28,14 @@ test.describe("JSON to Chart", () => {
     });
 
     // Switch to an ephemeral chart view, then pin it into a Visualization.
-    await page.getByRole("button", { name: "Bar" }).click();
-    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
+    // `exact: true` avoids matching "Horizontal bar" / "Hide sidebar", which
+    // both contain "bar" as a substring under Playwright's default name match.
+    await page.getByRole("button", { name: "Bar", exact: true }).click();
+    // "Pin view" appears once chart suggestions are computed (DuckDB init +
+    // column analysis run after the table loads), so allow a generous wait.
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible({
+      timeout: 30_000,
+    });
     await page.getByRole("button", { name: "Pin view" }).click();
 
     // Pinning keeps the user on the insight canvas.

--- a/e2e/web/tests/json-to-chart.spec.ts
+++ b/e2e/web/tests/json-to-chart.spec.ts
@@ -1,7 +1,7 @@
 /**
  * JSON to Chart Workflow
  *
- * Core user journey: Upload JSON -> Configure Insight -> Create Chart
+ * Core user journey: Upload JSON -> Table-first Insight -> Pin Chart View
  */
 import { expect, test } from "../lib/test-fixtures";
 
@@ -22,19 +22,18 @@ test.describe("JSON to Chart", () => {
       timeout: 15_000,
     });
 
-    // Verify chart suggestions appear
-    await expect(page.getByText("Create visualization")).toBeVisible({
+    // Verify the insight opens table-first.
+    await expect(page.getByRole("button", { name: "Table" })).toBeVisible({
       timeout: 30_000,
     });
 
-    // Click first suggestion
-    await page
-      .getByRole("button", { name: /^Comparison/ })
-      .first()
-      .click();
+    // Switch to an ephemeral chart view, then pin it into a Visualization.
+    await page.getByRole("button", { name: "Bar" }).click();
+    await expect(page.getByRole("button", { name: "Pin view" })).toBeVisible();
+    await page.getByRole("button", { name: "Pin view" }).click();
 
-    // Verify redirect to visualization page
-    await expect(page).toHaveURL(/\/visualizations\/[a-zA-Z0-9-]+/);
+    // Pinning keeps the user on the insight canvas.
+    await expect(page).toHaveURL(/\/insights\/[a-zA-Z0-9-]+/);
 
     // Verify chart renders
     await waitForChart();

--- a/e2e/web/tests/visualize-intent.spec.ts
+++ b/e2e/web/tests/visualize-intent.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Visualize intent — landing on an insight with `?visualize=true` (the
+ * "Visualize" action from the data-source surface) auto-pins the first
+ * chart suggestion and switches the canvas to it.
+ */
+import { expect, test } from "../lib/test-fixtures";
+
+test("auto-pins a chart when landing with visualize intent", async ({
+  page,
+  homePage,
+  uploadFile,
+  waitForChart,
+}) => {
+  await homePage();
+  await uploadFile("sales_data.csv");
+  await expect(page).toHaveURL(/\/insights\/[a-zA-Z0-9-]+/, {
+    timeout: 15_000,
+  });
+
+  // Re-enter the insight with the visualize intent flag, as the
+  // "Visualize" action from the data-source surface would.
+  const url = new URL(page.url());
+  url.searchParams.set("visualize", "true");
+  await page.goto(url.toString());
+
+  // Auto-pin should create a visualization and switch the canvas to it.
+  await waitForChart();
+
+  // The pinned metric carries the field's display name, not the raw
+  // UUID column alias.
+  await expect(page.getByRole("button", { name: "Metrics 1" })).toBeVisible();
+  await expect(page.getByText("sum(Quantity)").first()).toBeVisible();
+  await expect(page.getByText(/field_[0-9a-f]{8}/).first()).not.toBeVisible();
+});

--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.test.tsx
@@ -11,7 +11,7 @@
  *   Columns from a repeat-join have _j0 / _j1 suffixes on their aliases. The
  *   analysis map must store them under distinct keys so j1 cannot overwrite j0.
  */
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock helpers ──────────────────────────────────────────────────────────────
@@ -20,12 +20,26 @@ const { mockUseDataSources } = vi.hoisted(() => ({
   mockUseDataSources: vi.fn(),
 }));
 
+const { mockUseDataTables } = vi.hoisted(() => ({
+  mockUseDataTables: vi.fn(),
+}));
+
+const { mockCreateInsightFromTable } = vi.hoisted(() => ({
+  mockCreateInsightFromTable: vi.fn(),
+}));
+
 vi.mock("@dashframe/core", () => ({
   useDataSources: () => mockUseDataSources(),
   useDataSourceMutations: () => ({ update: vi.fn() }),
   useDataFrames: () => ({ data: [] }),
   useDataTableMutations: () => ({ remove: vi.fn(), updateField: vi.fn() }),
-  useDataTables: () => ({ data: [] }),
+  useDataTables: () => mockUseDataTables(),
+}));
+
+vi.mock("@/hooks/useCreateInsight", () => ({
+  useCreateInsight: () => ({
+    createInsightFromTable: mockCreateInsightFromTable,
+  }),
 }));
 
 vi.mock("@/components/assistant/artifact-context", () => ({
@@ -205,6 +219,7 @@ const DATA_SOURCE = {
 describe("DataSourcePageContent — loading state contract", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseDataTables.mockReturnValue({ data: [] });
   });
 
   it("shows loading while useDataSources is fetching and then shows content — never 'not found'", async () => {
@@ -299,6 +314,41 @@ describe("DataSourcePageContent — loading state contract", () => {
     // Content renders; not-found never appeared for the real source
     expect(screen.queryByText("Data source not found")).toBeNull();
     screen.getByDisplayValue("My Database");
+  });
+
+  it("creates and opens a visualize-intent insight from the selected table", async () => {
+    mockUseDataSources.mockReturnValue({
+      data: [DATA_SOURCE],
+      isLoading: false,
+      isFetching: false,
+    });
+    mockUseDataTables.mockReturnValue({
+      data: [
+        {
+          id: "table-orders",
+          name: "Orders",
+          fields: [{ id: "field-a", name: "Amount" }],
+          metrics: [],
+        },
+      ],
+    });
+
+    render(<DataSourcePageContent sourceId={SOURCE_ID} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Orders" }));
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Visualize this data" }),
+      );
+    });
+
+    expect(mockCreateInsightFromTable).toHaveBeenCalledWith(
+      "table-orders",
+      "Orders",
+      { visualize: true },
+    );
   });
 });
 

--- a/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx
+++ b/packages/app/src/app/data-sources/[sourceId]/_components/DataSourcePageContent.tsx
@@ -5,6 +5,7 @@ import {
 import { ConnectorIcon } from "@/components/data-sources/renderers/ConnectorIcon";
 import { SensitivityBadge } from "@/components/data-sources/SensitivityBadge";
 import { AppLayout } from "@/components/layouts/AppLayout";
+import { useCreateInsight } from "@/hooks/useCreateInsight";
 import { useDataFrameData } from "@/hooks/useDataFrameData";
 import { getConnectorById } from "@/lib/connectors/registry";
 import { PerfStage, withPerfAsync } from "@/lib/perf";
@@ -154,6 +155,7 @@ export default function DataSourcePageContent({
   sourceId,
 }: DataSourcePageContentProps) {
   const navigate = useNavigate();
+  const { createInsightFromTable } = useCreateInsight();
 
   const { data: allDataSources = [], isLoading, isFetching } = useDataSources();
   const { update: updateDataSource } = useDataSourceMutations();
@@ -226,14 +228,12 @@ export default function DataSourcePageContent({
     }
   };
 
-  // Handle create insight from table
-  const handleCreateInsight = (tableId: UUID) => {
-    // Navigate to insights page with pre-selected table
-    // The actual insight creation will happen there
-    navigate({
-      to: "/insights",
-      search: { newInsight: "true", tableId },
-    } as never);
+  // Handle explicit visualize intent from the table detail surface.
+  const handleCreateInsight = async (tableId: UUID) => {
+    const table = dataTables.find((item) => item.id === tableId);
+    await createInsightFromTable(tableId, table?.name ?? "Untitled table", {
+      visualize: true,
+    });
   };
 
   // Cached column analysis keyed by field ID, for data-driven sensitivity
@@ -410,7 +410,7 @@ export default function DataSourcePageContent({
               </div>
               <div className="flex items-center gap-2">
                 <Button
-                  label="Create Insight"
+                  label="Visualize this data"
                   onClick={() => handleCreateInsight(selectedTableId)}
                   icon={PlusIcon}
                 />

--- a/packages/app/src/app/insights/[insightId]/_components/InsightPageContent.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightPageContent.tsx
@@ -7,6 +7,7 @@ import { NotFoundView } from "./NotFoundView";
 
 interface InsightPageContentProps {
   insightId: string;
+  visualizeIntent?: boolean;
 }
 
 /**
@@ -17,6 +18,7 @@ interface InsightPageContentProps {
  */
 export default function InsightPageContent({
   insightId,
+  visualizeIntent = false,
 }: InsightPageContentProps) {
   const { data: insight, isLoading } = useInsight(insightId);
 
@@ -43,5 +45,5 @@ export default function InsightPageContent({
     return <NotFoundView type="insight" />;
   }
 
-  return <InsightView insight={insight} />;
+  return <InsightView insight={insight} visualizeIntent={visualizeIntent} />;
 }

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -324,11 +324,11 @@ function unwrapEncodingExpression(value: string): string {
 }
 
 /**
- * Resolve an encoding channel value to a field ID. Tries, in order:
+ * Resolve an encoding channel value to a CANONICAL field ID. Tries, in order:
  * the raw value, the value with date-transform wrappers removed, and finally
  * the canonical UUID behind an instance-qualified repeat-join alias
- * (field_<uuid>_jN — those synthetic aliases are never persisted, so the
- * canonical field ID is the correct durable reference).
+ * (field_<uuid>_jN). Use this for the persisted Insight model
+ * (selectedFields/metrics), which stores canonical field IDs only.
  */
 function lookupEncodingFieldId(
   fieldIdMap: Map<string, UUID>,
@@ -346,6 +346,39 @@ function lookupEncodingFieldId(
     return fieldIdMap.get(fieldIdToColumnAlias(canonicalUuid));
   }
   return undefined;
+}
+
+/**
+ * Like lookupEncodingFieldId, but PRESERVES the repeat-join instance
+ * qualifier: a `field_<uuid>_jN` alias resolves to `<uuid>_jN`, not the
+ * canonical UUID. Visualization encodings support instance-qualified refs
+ * (VisualizationPreview resolves `field:<uuid>_jN` through the pagination
+ * hook's instance-aware fields), and collapsing to canonical would silently
+ * re-point the pinned chart at the FIRST join instance. Use this for
+ * VisualizationEncoding values; use lookupEncodingFieldId for the Insight
+ * model.
+ */
+function lookupEncodingFieldRef(
+  fieldIdMap: Map<string, UUID>,
+  value: string,
+): UUID | undefined {
+  const direct = fieldIdMap.get(value);
+  if (direct) return direct;
+
+  const unwrapped = unwrapEncodingExpression(value);
+  const unwrappedId = fieldIdMap.get(unwrapped);
+  if (unwrappedId) return unwrappedId;
+
+  const canonicalUuid = extractUUIDFromColumnAlias(unwrapped);
+  if (!canonicalUuid) return undefined;
+  const canonicalId = fieldIdMap.get(fieldIdToColumnAlias(canonicalUuid));
+  if (!canonicalId) return undefined;
+
+  const instanceSuffix = unwrapped.match(/(_j\d+)$/)?.[1];
+  // The instance-qualified id is not a bare UUID, but it IS the id the
+  // render path's instance-aware fields carry — the cast is the seam where
+  // the two id spaces meet.
+  return instanceSuffix ? (`${canonicalId}${instanceSuffix}` as UUID) : canonicalId;
 }
 
 /**
@@ -521,8 +554,8 @@ function convertToVisualizationEncoding(
     }
 
     // It's a dimension field - find field ID by column name (looking through
-    // date-transform wrappers and repeat-join instance aliases)
-    const fieldId = lookupEncodingFieldId(fieldIdMap, value);
+    // date-transform wrappers, preserving repeat-join instance qualifiers)
+    const fieldId = lookupEncodingFieldRef(fieldIdMap, value);
     if (fieldId) {
       return fieldEncoding(fieldId);
     }

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -378,7 +378,9 @@ function lookupEncodingFieldRef(
   // The instance-qualified id is not a bare UUID, but it IS the id the
   // render path's instance-aware fields carry — the cast is the seam where
   // the two id spaces meet.
-  return instanceSuffix ? (`${canonicalId}${instanceSuffix}` as UUID) : canonicalId;
+  return instanceSuffix
+    ? (`${canonicalId}${instanceSuffix}` as UUID)
+    : canonicalId;
 }
 
 /**

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -1,12 +1,27 @@
 import { AppLayout } from "@/components/layouts/AppLayout";
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
+import { VisualizationPreview } from "@/components/visualizations/VisualizationPreview";
+import { useInsightPagination } from "@/hooks/useInsightPagination";
 import { useInsightView } from "@/hooks/useInsightView";
+import { formatCellValue } from "@/lib/cell-formatter";
 import { computeCombinedFields } from "@/lib/insights/compute-combined-fields";
+import {
+  TABLE_CANVAS_VIEW,
+  canvasViewsEqual,
+  sanitizeInsightCanvasView,
+  useInsightCanvasStore,
+  type InsightCanvasView,
+} from "@/lib/stores/insight-canvas-store";
 import type { Insight as LocalInsight } from "@/lib/stores/types";
 import { mergeAnalyses } from "@/lib/visualizations/merge-analyses";
-import type { ChartSuggestion } from "@/lib/visualizations/suggest-charts";
+import {
+  suggestByChartType,
+  type ChartSuggestion,
+} from "@/lib/visualizations/suggest-charts";
 import {
   getDataFrame,
+  useDashboardMutations,
+  useDashboards,
   useDataFrameMutations,
   useDataFrames,
   useDataTables,
@@ -24,14 +39,37 @@ import type {
   InsightMetric,
   UUID,
   VegaLiteSpec,
+  VisualizationEncoding,
+  VisualizationType,
 } from "@dashframe/types";
+import { CHART_TYPE_METADATA } from "@dashframe/types";
+import {
+  CHART_ICONS,
+  VirtualTable,
+  type VirtualTableColumnConfig,
+} from "@dashframe/ui";
+import { Chart } from "@dashframe/visualization";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, cn } from "@wystack/ui";
+import {
+  CheckIcon,
+  DashboardIcon,
+  PlusIcon,
+  SparklesIcon,
+  TableIcon,
+} from "@wystack/ui-icons";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { toast } from "sonner";
 import { InsightConfigPanel } from "./config-panel";
 import { NotFoundView } from "./NotFoundView";
 import { DataModelSection } from "./sections/DataModelSection";
-import { DataPreviewSection } from "./sections/DataPreviewSection";
-import { VisualizationsSection } from "./sections/VisualizationsSection";
 
 /**
  * Remap column names in analysis results from original names to UUID aliases.
@@ -71,7 +109,7 @@ function remapAnalysisColumnNames(
 }
 
 import { useConfirmDialogStore } from "@/lib/stores/confirm-dialog-store";
-import type { ChartEncoding, VisualizationEncoding } from "@dashframe/types";
+import type { ChartEncoding } from "@dashframe/types";
 import { fieldEncoding, metricEncoding } from "@dashframe/types";
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 
@@ -253,6 +291,7 @@ async function analyzeJoinedDataFrames(
 
 interface InsightViewProps {
   insight: Insight;
+  visualizeIntent?: boolean;
 }
 
 interface ParsedEncoding {
@@ -461,6 +500,174 @@ function convertToVisualizationEncoding(
   return result;
 }
 
+const CANVAS_CHART_TYPES: VisualizationType[] = [
+  "barY",
+  "barX",
+  "line",
+  "areaY",
+  "dot",
+  "hexbin",
+  "heatmap",
+  "raster",
+];
+
+function getCanvasViewKey(view: InsightCanvasView): string {
+  if (view.kind === "chart") return `chart:${view.chartType}`;
+  if (view.kind === "visualization")
+    return `visualization:${view.visualizationId}`;
+  return "table";
+}
+
+function chartView(chartType: VisualizationType): InsightCanvasView {
+  return { kind: "chart", chartType };
+}
+
+function visualizationView(visualizationId: string): InsightCanvasView {
+  return { kind: "visualization", visualizationId };
+}
+
+function getVisualizationEncodingSignature(
+  encoding: VisualizationEncoding | undefined,
+): string {
+  if (!encoding) return "";
+  return [
+    encoding.x ?? "",
+    encoding.y ?? "",
+    encoding.color ?? "",
+    encoding.size ?? "",
+    encoding.xTransform ? JSON.stringify(encoding.xTransform) : "",
+    encoding.yTransform ? JSON.stringify(encoding.yTransform) : "",
+  ].join("|");
+}
+
+function InsightResultTable({ insight }: { insight: Insight }) {
+  const {
+    fetchData,
+    totalCount,
+    fieldCount,
+    isReady,
+    columnDisplayNames,
+    columnTypeMap,
+  } = useInsightPagination({
+    insight,
+    showModelPreview: false,
+  });
+
+  const columnConfigs = useMemo((): VirtualTableColumnConfig[] => {
+    return Object.entries(columnDisplayNames).map(([id, label]) => {
+      const colType = columnTypeMap[id];
+      return {
+        id,
+        label,
+        format:
+          colType !== undefined
+            ? (value: unknown) => formatCellValue(value, colType)
+            : undefined,
+      };
+    });
+  }, [columnDisplayNames, columnTypeMap]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-3 px-4 text-sm text-neutral-fg-subtle">
+        {isReady
+          ? `${(totalCount || 0).toLocaleString()} rows • ${(fieldCount || 0).toLocaleString()} fields`
+          : "Loading data..."}
+      </div>
+      <div className="min-h-0 flex-1 px-4 pb-4">
+        <VirtualTable
+          onFetchData={fetchData}
+          columnConfigs={columnConfigs}
+          height={520}
+          compact
+        />
+      </div>
+    </div>
+  );
+}
+
+function CanvasViewButton({
+  active,
+  muted = false,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  muted?: boolean;
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex h-8 max-w-44 items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors",
+        "focus-visible:ring-2 focus-visible:ring-palette-primary focus-visible:outline-none",
+        active
+          ? "bg-neutral-bg-emphasis text-neutral-fg shadow-sm"
+          : "text-neutral-fg-subtle hover:bg-neutral-bg-muted hover:text-neutral-fg",
+        muted && !active && "opacity-60",
+      )}
+      title={label}
+    >
+      <span className="shrink-0">
+        {active ? <CheckIcon className="h-3.5 w-3.5" /> : icon}
+      </span>
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+function EphemeralChartCanvas({
+  tableName,
+  suggestion,
+  isLoading,
+  onRegenerate,
+}: {
+  tableName?: string;
+  suggestion?: ChartSuggestion;
+  isLoading: boolean;
+  onRegenerate: () => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-neutral-fg-subtle">
+        Loading chart view...
+      </div>
+    );
+  }
+
+  if (!tableName || !suggestion) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-neutral-fg-subtle">
+        <p>This chart view needs usable fields.</p>
+        <Button
+          size="sm"
+          variant="outline"
+          icon={SparklesIcon}
+          label="Try another suggestion"
+          onClick={onRegenerate}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full px-4 pb-4">
+      <Chart
+        tableName={tableName}
+        visualizationType={suggestion.chartType}
+        encoding={suggestion.encoding}
+        height={520}
+        className="h-full w-full"
+      />
+    </div>
+  );
+}
+
 /**
  * InsightView - Unified view for insight page
  *
@@ -475,7 +682,10 @@ function convertToVisualizationEncoding(
  * - Local state for insight name with debounced updates
  * - Sections only re-render when their specific data changes
  */
-export function InsightView({ insight }: InsightViewProps) {
+export function InsightView({
+  insight,
+  visualizeIntent = false,
+}: InsightViewProps) {
   const insightId = insight.id;
   const navigate = useNavigate();
 
@@ -541,6 +751,13 @@ export function InsightView({ insight }: InsightViewProps) {
   const { data: allDataTables = [] } = useDataTables();
   const { data: allDataFrameEntries = [] } = useDataFrames();
   const { data: allVisualizations = [] } = useVisualizations();
+  const { data: dashboards = [] } = useDashboards();
+  const { create: createDashboard, addItem: addDashboardItem } =
+    useDashboardMutations();
+  const persistedActiveView = useInsightCanvasStore(
+    (s) => s.activeViewByInsight[insightId],
+  );
+  const setPersistedActiveView = useInsightCanvasStore((s) => s.setActiveView);
 
   // DuckDB connection for chart suggestions (initialized by DuckDBProvider during idle time)
   const {
@@ -563,12 +780,16 @@ export function InsightView({ insight }: InsightViewProps) {
 
   // Derived column-analysis: only return cached results if they match the
   // currently-active chart view. Otherwise treat as empty.
-  const columnAnalysis: ColumnAnalysis[] =
-    chartTableName &&
-    isChartViewReady &&
-    columnAnalysisState?.viewName === chartTableName
-      ? columnAnalysisState.columns
-      : [];
+  const columnAnalysis = useMemo<ColumnAnalysis[]>(() => {
+    if (
+      chartTableName &&
+      isChartViewReady &&
+      columnAnalysisState?.viewName === chartTableName
+    ) {
+      return columnAnalysisState.columns;
+    }
+    return [];
+  }, [chartTableName, columnAnalysisState, isChartViewReady]);
   const setColumnAnalysis = (columns: ColumnAnalysis[]) => {
     if (chartTableName) {
       setColumnAnalysisState({ viewName: chartTableName, columns });
@@ -601,6 +822,37 @@ export function InsightView({ insight }: InsightViewProps) {
   const insightVisualizations = useMemo(
     () => allVisualizations.filter((v) => v.insightId === insightId),
     [allVisualizations, insightId],
+  );
+  const pinnedVisualizationIds = useMemo(
+    () => new Set(insightVisualizations.map((viz) => viz.id)),
+    [insightVisualizations],
+  );
+  const activeView = useMemo(
+    () =>
+      sanitizeInsightCanvasView(persistedActiveView, pinnedVisualizationIds),
+    [persistedActiveView, pinnedVisualizationIds],
+  );
+  const activeVisualization =
+    activeView.kind === "visualization"
+      ? insightVisualizations.find(
+          (viz) => viz.id === activeView.visualizationId,
+        )
+      : undefined;
+
+  useEffect(() => {
+    if (
+      persistedActiveView &&
+      !canvasViewsEqual(persistedActiveView, activeView)
+    ) {
+      setPersistedActiveView(insightId, activeView);
+    }
+  }, [activeView, insightId, persistedActiveView, setPersistedActiveView]);
+
+  const handleSetActiveView = useCallback(
+    (view: InsightCanvasView) => {
+      setPersistedActiveView(insightId, view);
+    },
+    [insightId, setPersistedActiveView],
   );
 
   // Build field map for suggestions
@@ -827,6 +1079,52 @@ export function InsightView({ insight }: InsightViewProps) {
     dataTable,
   ]);
 
+  const chartSuggestionsByType = useMemo(() => {
+    const suggestions = new Map<VisualizationType, ChartSuggestion>();
+    if (
+      !insightForSuggestions ||
+      columnAnalysis.length === 0 ||
+      rowCount === 0
+    ) {
+      return suggestions;
+    }
+
+    for (const chartType of CANVAS_CHART_TYPES) {
+      const suggestion = suggestByChartType(
+        insightForSuggestions,
+        columnAnalysis,
+        rowCount,
+        fieldMap,
+        chartType,
+        { existingFields: existingFieldNames, seed: suggestionSeed },
+      );
+      if (suggestion) {
+        suggestions.set(chartType, suggestion);
+      }
+    }
+    return suggestions;
+  }, [
+    insightForSuggestions,
+    columnAnalysis,
+    rowCount,
+    fieldMap,
+    existingFieldNames,
+    suggestionSeed,
+  ]);
+
+  const firstChartSuggestion = useMemo(() => {
+    for (const chartType of CANVAS_CHART_TYPES) {
+      const suggestion = chartSuggestionsByType.get(chartType);
+      if (suggestion) return suggestion;
+    }
+    return null;
+  }, [chartSuggestionsByType]);
+
+  const activeChartSuggestion =
+    activeView.kind === "chart"
+      ? chartSuggestionsByType.get(activeView.chartType)
+      : undefined;
+
   // Parse aggregate expression like "sum(amount)" → { aggregation: "sum", columnName: "amount" }
   const parseAggregateExpression = useCallback(
     (
@@ -849,10 +1147,9 @@ export function InsightView({ insight }: InsightViewProps) {
     [],
   );
 
-  // Handle creating a chart from suggestion
-  const handleCreateChart = useCallback(
-    async (suggestion: ChartSuggestion) => {
-      if (!dataTable?.dataFrameId || !isChartViewReady) return;
+  const pinChartSuggestion = useCallback(
+    async (suggestion: ChartSuggestion): Promise<UUID | null> => {
+      if (!dataTable?.dataFrameId || !isChartViewReady) return null;
 
       // Parse encoding to extract dimensions and metrics
       const { dimensionFields, metrics } = parseChartEncoding(
@@ -920,6 +1217,18 @@ export function InsightView({ insight }: InsightViewProps) {
       );
 
       // Create visualization using encoding-driven rendering
+      const matchingVisualization = insightVisualizations.find(
+        (viz) =>
+          viz.visualizationType === suggestion.chartType &&
+          getVisualizationEncodingSignature(viz.encoding) ===
+            getVisualizationEncodingSignature(visualizationEncoding),
+      );
+
+      if (matchingVisualization) {
+        handleSetActiveView(visualizationView(matchingVisualization.id));
+        return matchingVisualization.id;
+      }
+
       const vizId = await createVisualizationLocal(
         suggestion.title,
         insightId,
@@ -928,8 +1237,8 @@ export function InsightView({ insight }: InsightViewProps) {
         visualizationEncoding,
       );
 
-      // Navigate to the visualization
-      navigate({ to: `/visualizations/${vizId}` } as never);
+      handleSetActiveView(visualizationView(vizId));
+      return vizId;
     },
     [
       dataTable,
@@ -940,7 +1249,8 @@ export function InsightView({ insight }: InsightViewProps) {
       updateInsight,
       insightId,
       createVisualizationLocal,
-      navigate,
+      insightVisualizations,
+      handleSetActiveView,
     ],
   );
 
@@ -948,6 +1258,84 @@ export function InsightView({ insight }: InsightViewProps) {
   const handleRegenerate = useCallback(() => {
     setSuggestionSeed((prev) => prev + 1);
   }, []);
+
+  const autoPinAttemptRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!visualizeIntent) return;
+    if (autoPinAttemptRef.current === insightId) return;
+    if (insightVisualizations.length > 0) return;
+    if (!firstChartSuggestion) return;
+
+    autoPinAttemptRef.current = insightId;
+    pinChartSuggestion(firstChartSuggestion).catch((error) => {
+      console.error("[InsightView] Auto-pin failed:", error);
+      toast.error("Couldn't pin the chart view");
+    });
+  }, [
+    firstChartSuggestion,
+    insightId,
+    insightVisualizations.length,
+    pinChartSuggestion,
+    visualizeIntent,
+  ]);
+
+  const handlePinActiveChart = useCallback(async () => {
+    if (!activeChartSuggestion) return;
+    try {
+      await pinChartSuggestion(activeChartSuggestion);
+      toast.success("Chart view pinned");
+    } catch (error) {
+      console.error("[InsightView] Pin failed:", error);
+      toast.error("Couldn't pin chart view");
+    }
+  }, [activeChartSuggestion, pinChartSuggestion]);
+
+  const ensureActiveVisualization =
+    useCallback(async (): Promise<UUID | null> => {
+      if (activeView.kind === "visualization")
+        return activeView.visualizationId;
+      if (activeView.kind === "chart" && activeChartSuggestion) {
+        return pinChartSuggestion(activeChartSuggestion);
+      }
+      return null;
+    }, [activeChartSuggestion, activeView, pinChartSuggestion]);
+
+  const handleAddActiveViewToDashboard = useCallback(async () => {
+    try {
+      const visualizationId = await ensureActiveVisualization();
+      if (!visualizationId) return;
+
+      const dashboard = dashboards[0];
+      const dashboardId =
+        dashboard?.id ?? (await createDashboard(`${insight.name} dashboard`));
+      const bottomY =
+        dashboard?.items.reduce(
+          (max, item) => Math.max(max, item.y + item.height),
+          0,
+        ) ?? 0;
+
+      await addDashboardItem(dashboardId, {
+        type: "visualization",
+        visualizationId,
+        position: {
+          x: 0,
+          y: bottomY,
+          width: 6,
+          height: 6,
+        },
+      });
+      toast.success("Added to dashboard");
+    } catch (error) {
+      console.error("[InsightView] Add to dashboard failed:", error);
+      toast.error("Couldn't add to dashboard");
+    }
+  }, [
+    addDashboardItem,
+    createDashboard,
+    dashboards,
+    ensureActiveVisualization,
+    insight.name,
+  ]);
 
   // Handle duplicating a visualization
   const handleDuplicateVisualization = useCallback(
@@ -984,6 +1372,24 @@ export function InsightView({ insight }: InsightViewProps) {
     [confirm, removeVisualization],
   );
 
+  let activeViewLabel = "Table";
+  if (activeView.kind === "chart") {
+    activeViewLabel = CHART_TYPE_METADATA[activeView.chartType].displayName;
+  } else if (activeView.kind === "visualization") {
+    activeViewLabel = activeVisualization?.name ?? "Pinned view";
+  }
+  let activeViewDescription = "Insight result";
+  if (activeView.kind === "chart") {
+    activeViewDescription = "Unpinned chart view";
+  } else if (activeView.kind === "visualization") {
+    activeViewDescription = "Pinned visualization";
+  }
+  const canPinActiveChart =
+    activeView.kind === "chart" && activeChartSuggestion !== undefined;
+  const canAddActiveViewToDashboard =
+    activeView.kind === "visualization" ||
+    (activeView.kind === "chart" && activeChartSuggestion !== undefined);
+
   // Data table not found - check after all hooks are called
   if (!dataTable) {
     return <NotFoundView type="dataTable" />;
@@ -1005,38 +1411,136 @@ export function InsightView({ insight }: InsightViewProps) {
         />
       }
     >
-      {/* Main content - unified view */}
-      <div className="container mx-auto max-w-6xl space-y-6 px-6 py-6">
-        {/* Data Model - shows data sources (tables and joins) */}
-        <DataModelSection
-          insight={insight}
-          dataTable={dataTable}
-          allDataTables={allDataTables}
-          combinedFieldCount={combinedFieldCount}
-        />
+      <div className="container mx-auto flex h-full max-w-7xl flex-col gap-4 px-6 py-6">
+        <section className="flex min-h-[620px] flex-1 flex-col overflow-hidden rounded-[var(--surface-radius)] bg-neutral-bg/90 shadow-[var(--surface-shadow)]">
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 px-4 py-3">
+            <div className="min-w-0">
+              <h2 className="truncate text-sm font-semibold text-neutral-fg">
+                {activeViewLabel}
+              </h2>
+              <p className="text-xs text-neutral-fg-subtle">
+                {activeViewDescription}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {canPinActiveChart && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  icon={PlusIcon}
+                  label="Pin view"
+                  onClick={handlePinActiveChart}
+                />
+              )}
+              <Button
+                size="sm"
+                variant="outline"
+                icon={DashboardIcon}
+                label="Add to dashboard"
+                onClick={handleAddActiveViewToDashboard}
+                disabled={!canAddActiveViewToDashboard}
+              />
+              {activeView.kind === "visualization" && activeVisualization && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    label="Duplicate"
+                    onClick={() =>
+                      handleDuplicateVisualization(activeVisualization.id)
+                    }
+                  />
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    color="danger"
+                    label="Delete"
+                    onClick={() =>
+                      handleDeleteVisualization(
+                        activeVisualization.id,
+                        activeVisualization.name,
+                      )
+                    }
+                  />
+                </>
+              )}
+            </div>
+          </div>
 
-        {/* Data Preview - shows table with toggle for Join Preview vs Insight Result */}
-        <DataPreviewSection
-          insight={insight}
-          combinedFieldCount={combinedFieldCount}
-        />
+          <div className="flex shrink-0 flex-wrap items-center gap-1 px-4 pb-3">
+            <CanvasViewButton
+              active={canvasViewsEqual(activeView, TABLE_CANVAS_VIEW)}
+              icon={<TableIcon className="h-3.5 w-3.5" />}
+              label="Table"
+              onClick={() => handleSetActiveView(TABLE_CANVAS_VIEW)}
+            />
+            {CANVAS_CHART_TYPES.map((chartType) => {
+              const ChartIcon = CHART_ICONS[chartType];
+              const chartAvailable = chartSuggestionsByType.has(chartType);
+              const view = chartView(chartType);
+              return (
+                <CanvasViewButton
+                  key={getCanvasViewKey(view)}
+                  active={canvasViewsEqual(activeView, view)}
+                  muted={!chartAvailable}
+                  icon={<ChartIcon size={14} />}
+                  label={CHART_TYPE_METADATA[chartType].displayName}
+                  onClick={() => handleSetActiveView(view)}
+                />
+              );
+            })}
+            {insightVisualizations.map((visualization) => {
+              const view = visualizationView(visualization.id);
+              const ChartIcon = CHART_ICONS[visualization.visualizationType];
+              return (
+                <CanvasViewButton
+                  key={getCanvasViewKey(view)}
+                  active={canvasViewsEqual(activeView, view)}
+                  icon={<ChartIcon size={14} />}
+                  label={visualization.name}
+                  onClick={() => handleSetActiveView(view)}
+                />
+              );
+            })}
+          </div>
 
-        {/* Visualizations - Shows chart type picker or grid of existing visualizations */}
-        <VisualizationsSection
-          visualizations={insightVisualizations}
-          tableName={chartTableName ?? undefined}
-          insight={insightForSuggestions ?? undefined}
-          columnAnalysis={columnAnalysis}
-          rowCount={rowCount}
-          fieldMap={fieldMap}
-          existingFields={existingFieldNames}
-          onCreateChart={handleCreateChart}
-          onDuplicateVisualization={handleDuplicateVisualization}
-          onDeleteVisualization={handleDeleteVisualization}
-          isChartViewLoading={!isChartViewReady}
-          suggestionSeed={suggestionSeed}
-          onRegenerate={handleRegenerate}
-        />
+          <div className="min-h-0 flex-1">
+            {activeView.kind === "table" && (
+              <InsightResultTable insight={insight} />
+            )}
+            {activeView.kind === "chart" && (
+              <EphemeralChartCanvas
+                tableName={chartTableName ?? undefined}
+                suggestion={activeChartSuggestion}
+                isLoading={!isChartViewReady || isAnalyzing}
+                onRegenerate={handleRegenerate}
+              />
+            )}
+            {activeView.kind === "visualization" && activeVisualization && (
+              <div className="h-full px-4 pb-4">
+                <VisualizationPreview
+                  visualization={activeVisualization}
+                  height={520}
+                />
+              </div>
+            )}
+          </div>
+        </section>
+
+        <details className="rounded-[var(--surface-radius)] bg-neutral-bg/90 shadow-[var(--surface-shadow)]">
+          <summary className="flex cursor-pointer select-none items-center gap-2 px-4 py-3 text-sm font-semibold text-neutral-fg">
+            <SparklesIcon className="h-4 w-4 text-neutral-fg-subtle" />
+            Data model
+          </summary>
+          <div className="px-4 pb-4">
+            <DataModelSection
+              insight={insight}
+              dataTable={dataTable}
+              allDataTables={allDataTables}
+              combinedFieldCount={combinedFieldCount}
+            />
+          </div>
+        </details>
       </div>
     </AppLayout>
   );

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -29,7 +29,10 @@ import {
   useVisualizationMutations,
   useVisualizations,
 } from "@dashframe/core";
-import { fieldIdToColumnAlias } from "@dashframe/engine";
+import {
+  extractUUIDFromColumnAlias,
+  fieldIdToColumnAlias,
+} from "@dashframe/engine";
 import { analyzeView, ensureTableLoaded } from "@dashframe/engine-browser";
 import type {
   ColumnAnalysis,
@@ -300,6 +303,52 @@ interface ParsedEncoding {
 }
 
 /**
+ * Unwrap a date-transform expression to its underlying column reference.
+ * Suggestion encodings wrap temporal axes in either legacy vgplot functions
+ * (dateMonth(col)) or DuckDB date_trunc('period', "col"); the transform itself
+ * travels separately as xTransform/yTransform, so field resolution must look
+ * through the wrapper to the raw column alias.
+ */
+function unwrapEncodingExpression(value: string): string {
+  const legacyMatch = value.match(
+    /^(?:dateMonth|dateYear|dateDay|monthname|dayname|quarter)\(([^)]+)\)$/i,
+  );
+  if (legacyMatch?.[1]) {
+    return legacyMatch[1].replace(/(?:^["'])|(?:["']$)/g, "");
+  }
+  const dateTruncMatch = value.match(/^date_trunc\('[^']+',\s*"([^"]+)"\)$/i);
+  if (dateTruncMatch?.[1]) {
+    return dateTruncMatch[1];
+  }
+  return value.replace(/(?:^["'])|(?:["']$)/g, "");
+}
+
+/**
+ * Resolve an encoding channel value to a field ID. Tries, in order:
+ * the raw value, the value with date-transform wrappers removed, and finally
+ * the canonical UUID behind an instance-qualified repeat-join alias
+ * (field_<uuid>_jN — those synthetic aliases are never persisted, so the
+ * canonical field ID is the correct durable reference).
+ */
+function lookupEncodingFieldId(
+  fieldIdMap: Map<string, UUID>,
+  value: string,
+): UUID | undefined {
+  const direct = fieldIdMap.get(value);
+  if (direct) return direct;
+
+  const unwrapped = unwrapEncodingExpression(value);
+  const unwrappedId = fieldIdMap.get(unwrapped);
+  if (unwrappedId) return unwrappedId;
+
+  const canonicalUuid = extractUUIDFromColumnAlias(unwrapped);
+  if (canonicalUuid) {
+    return fieldIdMap.get(fieldIdToColumnAlias(canonicalUuid));
+  }
+  return undefined;
+}
+
+/**
  * Parse a single encoding axis value to determine if it's a dimension or metric.
  * Dimensions are raw field names, metrics are aggregation expressions like "sum(revenue)".
  *
@@ -471,8 +520,9 @@ function convertToVisualizationEncoding(
       return undefined;
     }
 
-    // It's a dimension field - find field ID by column name
-    const fieldId = fieldIdMap.get(value);
+    // It's a dimension field - find field ID by column name (looking through
+    // date-transform wrappers and repeat-join instance aliases)
+    const fieldId = lookupEncodingFieldId(fieldIdMap, value);
     if (fieldId) {
       return fieldEncoding(fieldId);
     }
@@ -1188,7 +1238,7 @@ export function InsightView({
 
       // Convert dimension column names to field IDs
       const newSelectedFieldIds = dimensionFields
-        .map((colName) => fieldIdMap.get(colName))
+        .map((colName) => lookupEncodingFieldId(fieldIdMap, colName))
         .filter((id): id is UUID => id !== undefined);
 
       // Merge with existing insight fields/metrics

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -625,12 +625,17 @@ function InsightResultTable({ insight }: { insight: Insight }) {
           : "Loading data..."}
       </div>
       <div className="min-h-0 flex-1 px-4 pb-4">
-        <VirtualTable
-          onFetchData={fetchData}
-          columnConfigs={columnConfigs}
-          height={520}
-          compact
-        />
+        {/* Mount only when the pagination hook is ready (per its contract):
+            mounting earlier lets the initial fetch race the hook's own
+            init-driven fetchData identity changes. */}
+        {isReady && (
+          <VirtualTable
+            onFetchData={fetchData}
+            columnConfigs={columnConfigs}
+            height={520}
+            compact
+          />
+        )}
       </div>
     </div>
   );
@@ -889,14 +894,10 @@ export function InsightView({
         )
       : undefined;
 
-  useEffect(() => {
-    if (
-      persistedActiveView &&
-      !canvasViewsEqual(persistedActiveView, activeView)
-    ) {
-      setPersistedActiveView(insightId, activeView);
-    }
-  }, [activeView, insightId, persistedActiveView, setPersistedActiveView]);
+  // No write-back of the sanitized view into the store: right after a pin,
+  // the persisted selection can reference a visualization the list hasn't
+  // loaded yet — persisting the table fallback would clobber that intent.
+  // Read-time sanitization above is enough; the view self-heals on load.
 
   const handleSetActiveView = useCallback(
     (view: InsightCanvasView) => {
@@ -1241,10 +1242,31 @@ export function InsightView({
         .map((colName) => lookupEncodingFieldId(fieldIdMap, colName))
         .filter((id): id is UUID => id !== undefined);
 
+      // Suggestion encodings reference UUID column aliases, so metrics parsed
+      // from them carry names like "sum(field_<uuid>)". Rename to the field's
+      // display name for the Metrics panel; columnName stays untouched (it
+      // drives SQL generation and encoding matching).
+      const fieldNameById = new Map<UUID, string>();
+      (dataTable.fields ?? []).forEach((f) => fieldNameById.set(f.id, f.name));
+      insight.joins?.forEach((join) => {
+        const joinTable = allDataTables.find((t) => t.id === join.rightTableId);
+        (joinTable?.fields ?? []).forEach((f) =>
+          fieldNameById.set(f.id, f.name),
+        );
+      });
+      const namedMetrics = metrics.map((metric) => {
+        if (!metric.columnName) return metric;
+        const fieldId = lookupEncodingFieldId(fieldIdMap, metric.columnName);
+        const fieldName = fieldId ? fieldNameById.get(fieldId) : undefined;
+        return fieldName
+          ? { ...metric, name: `${metric.aggregation}(${fieldName})` }
+          : metric;
+      });
+
       // Merge with existing insight fields/metrics
       const { mergedFieldIds, mergedMetrics } = mergeFieldsAndMetrics(
         newSelectedFieldIds,
-        metrics,
+        namedMetrics,
         insight.selectedFields ?? [],
         insight.metrics ?? [],
       );

--- a/packages/app/src/app/insights/[insightId]/_components/sections/VisualizationsSection.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/sections/VisualizationsSection.tsx
@@ -1,4 +1,3 @@
-import { ChartTypePicker } from "@/components/visualizations/ChartTypePicker";
 import { ChartTypePickerModal } from "@/components/visualizations/ChartTypePickerModal";
 import { VisualizationItemCard } from "@/components/visualizations/VisualizationItemCard";
 import type { Insight } from "@/lib/stores/types";
@@ -50,15 +49,10 @@ interface VisualizationListItem extends ListItem {
 }
 
 /**
- * VisualizationsSection - Shows visualizations or creation flow
+ * VisualizationsSection - Legacy pinned visualization list.
  *
- * Two states:
- * 1. Empty state (no visualizations): Shows inline ChartTypePicker grid
- *    for immediate chart creation without modal.
- * 2. Has visualizations: Shows grid of existing visualizations with
- *    "Create visualization" button that opens modal.
- *
- * Memoized to prevent re-renders when unrelated data changes.
+ * InsightView now owns the table-first canvas and view switcher. This section
+ * intentionally does not render a standalone blank-chart picker.
  */
 export const VisualizationsSection = memo(function VisualizationsSection({
   visualizations,
@@ -151,33 +145,6 @@ export const VisualizationsSection = memo(function VisualizationsSection({
 
   // Check if we have the required props for chart creation
   const canCreateChart = tableName && insight && onCreateChart;
-  const hasVisualizations = visualizations.length > 0;
-
-  // Empty state: show inline chart type picker
-  if (!hasVisualizations && canCreateChart) {
-    return (
-      <Section
-        title="Create visualization"
-        description="Select a chart type to get started"
-      >
-        <ChartTypePicker
-          tableName={tableName}
-          insight={insight}
-          columnAnalysis={columnAnalysis}
-          rowCount={rowCount}
-          fieldMap={fieldMap}
-          existingFields={existingFields}
-          onCreateChart={onCreateChart}
-          gridColumns={3}
-          isLoading={isChartViewLoading}
-          suggestionSeed={suggestionSeed}
-          onRegenerate={onRegenerate}
-        />
-      </Section>
-    );
-  }
-
-  // Has visualizations: show grid with "Create visualization" button
   return (
     <>
       <Section

--- a/packages/app/src/app/insights/page.tsx
+++ b/packages/app/src/app/insights/page.tsx
@@ -31,6 +31,8 @@ import {
 } from "@wystack/ui-icons";
 import { useMemo, useState } from "react";
 
+import { useInsightCanvasStore } from "@/lib/stores/insight-canvas-store";
+
 // Type for insight with joined details
 type InsightWithDetails = {
   insight: Insight;
@@ -72,6 +74,7 @@ export default function InsightsPage() {
 
   const { data: allInsights = [] } = useInsights();
   const { remove: removeInsightLocal } = useInsightMutations();
+  const clearActiveView = useInsightCanvasStore((s) => s.clearActiveView);
   const { data: visualizations = [] } = useVisualizations();
   const { data: dataSources = [] } = useDataSources();
   const { data: allDataTables = [] } = useDataTables();
@@ -198,12 +201,16 @@ export default function InsightsPage() {
     e.stopPropagation();
     e.preventDefault();
     await removeInsightLocal(insightId);
+    // Drop the persisted canvas-view entry so deleted insights don't
+    // accumulate stale keys in localStorage.
+    clearActiveView(insightId);
   };
 
   // Handle delete all drafts
   const handleDeleteAllDrafts = async () => {
     for (const item of groupedInsights.drafts) {
       await removeInsightLocal(item.insight.id);
+      clearActiveView(item.insight.id);
     }
   };
 

--- a/packages/app/src/app/visualizations/page.tsx
+++ b/packages/app/src/app/visualizations/page.tsx
@@ -345,6 +345,7 @@ export default function VisualizationsPage() {
       <CreateVisualizationModal
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
+        visualizeOnCreate
       />
     </div>
   );

--- a/packages/app/src/components/providers/StoreHydration.tsx
+++ b/packages/app/src/components/providers/StoreHydration.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect } from "react";
 
 import { useAssistantStore } from "@/lib/stores/assistant-store";
+import { useInsightCanvasStore } from "@/lib/stores/insight-canvas-store";
 
 /**
  * Triggers client-side rehydration for persisted Zustand stores.
@@ -13,6 +14,9 @@ import { useAssistantStore } from "@/lib/stores/assistant-store";
 export function StoreHydration({ children }: { children: ReactNode }) {
   useEffect(() => {
     useAssistantStore.persist.rehydrate()?.catch(() => {
+      // Rehydration is best-effort; a corrupt payload just means defaults.
+    });
+    useInsightCanvasStore.persist.rehydrate()?.catch(() => {
       // Rehydration is best-effort; a corrupt payload just means defaults.
     });
   }, []);

--- a/packages/app/src/components/visualizations/CreateVisualizationModal.tsx
+++ b/packages/app/src/components/visualizations/CreateVisualizationModal.tsx
@@ -14,6 +14,7 @@ import { useCallback, useState } from "react";
 interface CreateVisualizationModalProps {
   isOpen: boolean;
   onClose: () => void;
+  visualizeOnCreate?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ interface CreateVisualizationModalProps {
 export function CreateVisualizationModal({
   isOpen,
   onClose,
+  visualizeOnCreate = false,
 }: CreateVisualizationModalProps) {
   const navigate = useNavigate();
   const { createInsightFromTable, createInsightFromInsight } =
@@ -65,10 +67,12 @@ export function CreateVisualizationModal({
   // When selecting a table, create new insight directly
   const handleTableSelect = useCallback(
     (tableId: string, tableName: string) => {
-      createInsightFromTable(tableId, tableName);
+      createInsightFromTable(tableId, tableName, {
+        visualize: visualizeOnCreate,
+      });
       onClose();
     },
-    [createInsightFromTable, onClose],
+    [createInsightFromTable, onClose, visualizeOnCreate],
   );
 
   // Close action dialog

--- a/packages/app/src/components/visualizations/CreateVisualizationModal.tsx
+++ b/packages/app/src/components/visualizations/CreateVisualizationModal.tsx
@@ -59,10 +59,12 @@ export function CreateVisualizationModal({
   const handleCreateBasedOn = useCallback(() => {
     if (!selectedInsight) return;
     // Create new insight that chains from the selected insight's DataFrame
-    createInsightFromInsight(selectedInsight.id, selectedInsight.name);
+    createInsightFromInsight(selectedInsight.id, selectedInsight.name, {
+      visualize: visualizeOnCreate,
+    });
     setSelectedInsight(null);
     onClose();
-  }, [selectedInsight, createInsightFromInsight, onClose]);
+  }, [selectedInsight, createInsightFromInsight, onClose, visualizeOnCreate]);
 
   // When selecting a table, create new insight directly
   const handleTableSelect = useCallback(

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -48,6 +48,12 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }));
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError },
+}));
+
 const SELECTED_FIELD_IDS = ["field-a", "field-b"];
 
 /**
@@ -97,7 +103,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Sales Data", // name
         "table-abc", // baseTableId
-        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: true },
+        { selectedFields: [], reuseUnmodifiedDraft: true },
       );
     });
 
@@ -132,7 +138,11 @@ describe("useCreateInsight", () => {
       expect(insightId).toBe("created-insight-789");
     });
 
-    it("should create table insight with all visible fields selected", async () => {
+    it("should create an EMPTY draft — no fields preselected", async () => {
+      // Empty selectedFields is load-bearing: it keeps the draft eligible for
+      // the server's unmodified-draft reuse gate, and the engine's unconfigured
+      // fallback shows raw rows (preselecting fields would GROUP BY them and
+      // collapse duplicate source rows).
       mockCreateInsight.mockResolvedValue("draft-insight-001");
 
       const { result } = renderHook(() => useCreateInsight());
@@ -146,7 +156,7 @@ describe("useCreateInsight", () => {
 
       const callArgs = mockCreateInsight.mock.calls[0];
       expect(callArgs[2]).toEqual({
-        selectedFields: SELECTED_FIELD_IDS,
+        selectedFields: [],
         reuseUnmodifiedDraft: true,
       });
     });
@@ -166,7 +176,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Sales (2024) - Q1",
         "table-123",
-        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: true },
+        { selectedFields: [], reuseUnmodifiedDraft: true },
       );
     });
 
@@ -180,24 +190,27 @@ describe("useCreateInsight", () => {
       });
 
       expect(mockCreateInsight).toHaveBeenCalledWith("", "table-empty", {
-        selectedFields: SELECTED_FIELD_IDS,
+        selectedFields: [],
         reuseUnmodifiedDraft: true,
       });
     });
 
-    it("should handle creation errors by propagating them", async () => {
+    it("should surface creation errors as a toast and return null, not reject", async () => {
       mockCreateInsight.mockRejectedValue(new Error("Database error"));
 
       const { result } = renderHook(() => useCreateInsight());
 
-      await expect(async () => {
-        await act(async () => {
-          await result.current.createInsightFromTable(
-            "table-fail",
-            "Fail Test",
-          );
-        });
-      }).rejects.toThrow("Database error");
+      let insightId: string | null | undefined;
+      await act(async () => {
+        insightId = await result.current.createInsightFromTable(
+          "table-fail",
+          "Fail Test",
+        );
+      });
+
+      expect(insightId).toBeNull();
+      expect(mockToastError).toHaveBeenCalledWith("Couldn't create insight");
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 
@@ -227,7 +240,7 @@ describe("useCreateInsight", () => {
 
       // No suffix: only an unmodified empty insight exists for this table.
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
-        selectedFields: SELECTED_FIELD_IDS,
+        selectedFields: [],
         reuseUnmodifiedDraft: true,
       });
       expect(mockPush).toHaveBeenCalledWith("/insights/existing-draft");
@@ -245,7 +258,7 @@ describe("useCreateInsight", () => {
       });
 
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
-        selectedFields: SELECTED_FIELD_IDS,
+        selectedFields: [],
         reuseUnmodifiedDraft: true,
       });
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft");
@@ -273,7 +286,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: false },
+        { selectedFields: [], reuseUnmodifiedDraft: false },
       );
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft-2");
     });
@@ -302,7 +315,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: false },
+        { selectedFields: [], reuseUnmodifiedDraft: false },
       );
     });
 
@@ -325,7 +338,7 @@ describe("useCreateInsight", () => {
 
       // The existing insight is for a different table — no suffix.
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
-        selectedFields: SELECTED_FIELD_IDS,
+        selectedFields: [],
         reuseUnmodifiedDraft: true,
       });
     });
@@ -358,7 +371,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)", // gap-free: (2) is missing, not (4)
         "table-orders",
-        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: false },
+        { selectedFields: [], reuseUnmodifiedDraft: false },
       );
     });
   });
@@ -518,22 +531,24 @@ describe("useCreateInsight", () => {
       expect(mockPush).not.toHaveBeenCalled();
     });
 
-    it("should handle getInsight errors by propagating them", async () => {
+    it("should surface getInsight errors as a toast and return null, not reject", async () => {
       mockGetInsight.mockRejectedValue(new Error("Fetch error"));
 
       const { result } = renderHook(() => useCreateInsight());
 
-      await expect(async () => {
-        await act(async () => {
-          await result.current.createInsightFromInsight(
-            "error-123",
-            "Error Test",
-          );
-        });
-      }).rejects.toThrow("Fetch error");
+      let insightId: string | null | undefined;
+      await act(async () => {
+        insightId = await result.current.createInsightFromInsight(
+          "error-123",
+          "Error Test",
+        );
+      });
+
+      expect(insightId).toBeNull();
+      expect(mockToastError).toHaveBeenCalledWith("Couldn't create insight");
     });
 
-    it("should handle createInsight errors after successful fetch", async () => {
+    it("should surface createInsight errors after successful fetch as a toast", async () => {
       const sourceInsight = createMockInsight({
         id: "source-fail",
         baseTableId: "table-fail",
@@ -544,14 +559,17 @@ describe("useCreateInsight", () => {
 
       const { result } = renderHook(() => useCreateInsight());
 
-      await expect(async () => {
-        await act(async () => {
-          await result.current.createInsightFromInsight(
-            "source-fail",
-            "Source Fail",
-          );
-        });
-      }).rejects.toThrow("Creation failed");
+      let insightId: string | null | undefined;
+      await act(async () => {
+        insightId = await result.current.createInsightFromInsight(
+          "source-fail",
+          "Source Fail",
+        );
+      });
+
+      expect(insightId).toBeNull();
+      expect(mockToastError).toHaveBeenCalledWith("Couldn't create insight");
+      expect(mockPush).not.toHaveBeenCalled();
     });
 
     it("should handle source insight names with '(derived)' already in them", async () => {
@@ -584,7 +602,7 @@ describe("useCreateInsight", () => {
 
   describe("integration scenarios", () => {
     it("should suffix a second table-created insight once the first is configured", async () => {
-      // First call — no existing insights, creates a new select-all insight.
+      // First call — no existing insights, creates a new empty draft.
       mockGetAllInsights.mockResolvedValueOnce([]);
       mockCreateInsight.mockResolvedValueOnce("insight-1");
 
@@ -599,8 +617,9 @@ describe("useCreateInsight", () => {
 
       vi.clearAllMocks();
 
-      // Second call for the SAME table — the first select-all insight is
-      // configured, so the hook computes the next display suffix.
+      // Second call for the SAME table — the first draft has since been
+      // configured (selectedFields below makes it a MODIFIED insight), so
+      // the hook computes the next display suffix.
       const existingDraft = createMockInsight({
         id: "insight-1",
         name: "Orders",
@@ -622,7 +641,7 @@ describe("useCreateInsight", () => {
         "Orders (2)",
         "table-shared",
         {
-          selectedFields: SELECTED_FIELD_IDS,
+          selectedFields: [],
           reuseUnmodifiedDraft: false,
         },
       );

--- a/packages/app/src/hooks/useCreateInsight.test.tsx
+++ b/packages/app/src/hooks/useCreateInsight.test.tsx
@@ -14,21 +14,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCreateInsight } from "./useCreateInsight";
 
 // Mock functions must be hoisted with vi.mock
-const { mockCreateInsight, mockGetInsight, mockGetAllInsights, mockMutations } =
-  vi.hoisted(() => {
-    const create = vi.fn();
-    return {
-      mockCreateInsight: create,
-      mockGetInsight: vi.fn(),
-      mockGetAllInsights: vi.fn(),
-      mockMutations: { create },
-    };
-  });
+const {
+  mockCreateInsight,
+  mockGetInsight,
+  mockGetAllInsights,
+  mockGetDataTable,
+  mockMutations,
+} = vi.hoisted(() => {
+  const create = vi.fn();
+  return {
+    mockCreateInsight: create,
+    mockGetInsight: vi.fn(),
+    mockGetAllInsights: vi.fn(),
+    mockGetDataTable: vi.fn(),
+    mockMutations: { create },
+  };
+});
 
 vi.mock("@dashframe/core", () => ({
   useInsightMutations: () => mockMutations,
   getInsight: mockGetInsight,
   getAllInsights: mockGetAllInsights,
+  getDataTable: mockGetDataTable,
 }));
 
 const { mockPush, mockNavigate } = vi.hoisted(() => {
@@ -40,6 +47,8 @@ const { mockPush, mockNavigate } = vi.hoisted(() => {
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mockNavigate,
 }));
+
+const SELECTED_FIELD_IDS = ["field-a", "field-b"];
 
 /**
  * Helper to create a mock Insight object
@@ -67,8 +76,12 @@ function createMockInsight(options: {
 describe("useCreateInsight", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no pre-existing insights (dedup gate finds nothing to reuse)
+    // Default: no pre-existing insights.
     mockGetAllInsights.mockResolvedValue([]);
+    mockGetDataTable.mockResolvedValue({
+      id: "table-abc",
+      fields: SELECTED_FIELD_IDS.map((id) => ({ id, name: id })),
+    });
   });
 
   describe("createInsightFromTable", () => {
@@ -84,7 +97,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Sales Data", // name
         "table-abc", // baseTableId
-        { selectedFields: [], reuseUnmodifiedDraft: true }, // Empty draft, dedup
+        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: true },
       );
     });
 
@@ -119,7 +132,7 @@ describe("useCreateInsight", () => {
       expect(insightId).toBe("created-insight-789");
     });
 
-    it("should create draft insight with empty selectedFields", async () => {
+    it("should create table insight with all visible fields selected", async () => {
       mockCreateInsight.mockResolvedValue("draft-insight-001");
 
       const { result } = renderHook(() => useCreateInsight());
@@ -131,10 +144,9 @@ describe("useCreateInsight", () => {
         );
       });
 
-      // Verify the third argument (options) has empty selectedFields
       const callArgs = mockCreateInsight.mock.calls[0];
       expect(callArgs[2]).toEqual({
-        selectedFields: [],
+        selectedFields: SELECTED_FIELD_IDS,
         reuseUnmodifiedDraft: true,
       });
     });
@@ -154,7 +166,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "Sales (2024) - Q1",
         "table-123",
-        { selectedFields: [], reuseUnmodifiedDraft: true },
+        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: true },
       );
     });
 
@@ -168,7 +180,7 @@ describe("useCreateInsight", () => {
       });
 
       expect(mockCreateInsight).toHaveBeenCalledWith("", "table-empty", {
-        selectedFields: [],
+        selectedFields: SELECTED_FIELD_IDS,
         reuseUnmodifiedDraft: true,
       });
     });
@@ -189,12 +201,10 @@ describe("useCreateInsight", () => {
     });
   });
 
-  describe("createInsightFromTable — dedup", () => {
-    it("should reuse an existing unmodified draft for the same source table", async () => {
-      // The server handles dedup atomically — the hook always calls createInsight
-      // with the base name (no suffix, because the only same-table insight is
-      // unmodified). The mocked server returns the existing draft's id, mirroring
-      // what the real server does when it finds an unmodified draft.
+  describe("createInsightFromTable — naming", () => {
+    it("should navigate to the id returned by core for the same source table", async () => {
+      // The hook calls createInsight with the base name when no modified
+      // same-table insight exists, and navigates to the id core returns.
       const existingDraft = createMockInsight({
         id: "existing-draft",
         name: "orders",
@@ -203,7 +213,6 @@ describe("useCreateInsight", () => {
       });
 
       mockGetAllInsights.mockResolvedValue([existingDraft]);
-      // Server atomically finds the existing draft and returns its id.
       mockCreateInsight.mockResolvedValue("existing-draft");
 
       const { result } = renderHook(() => useCreateInsight());
@@ -216,19 +225,16 @@ describe("useCreateInsight", () => {
         );
       });
 
-      // Hook delegates dedup to the server — createInsight IS called with the
-      // base name (no suffix: only unmodified insights exist for this table)
-      // and the reuse flag so the server returns the existing draft.
+      // No suffix: only an unmodified empty insight exists for this table.
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
-        selectedFields: [],
+        selectedFields: SELECTED_FIELD_IDS,
         reuseUnmodifiedDraft: true,
       });
-      // Must navigate to the id the server returned (the existing draft).
       expect(mockPush).toHaveBeenCalledWith("/insights/existing-draft");
       expect(insightId).toBe("existing-draft");
     });
 
-    it("should create a new draft (no suffix) when no insights exist for the table", async () => {
+    it("should create a new insight without suffix when no insights exist for the table", async () => {
       mockGetAllInsights.mockResolvedValue([]);
       mockCreateInsight.mockResolvedValue("new-draft");
 
@@ -239,13 +245,13 @@ describe("useCreateInsight", () => {
       });
 
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
-        selectedFields: [],
+        selectedFields: SELECTED_FIELD_IDS,
         reuseUnmodifiedDraft: true,
       });
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft");
     });
 
-    it("should create a suffixed draft when an existing modified insight is present", async () => {
+    it("should create a suffixed insight when an existing modified insight is present", async () => {
       const modifiedInsight = createMockInsight({
         id: "modified-insight",
         name: "orders",
@@ -263,12 +269,11 @@ describe("useCreateInsight", () => {
       });
 
       // A suffix is used rather than prompting — non-blocking, drive-feel.
-      // The suffix path signals explicit new-draft intent, so reuse is OFF:
-      // the server must create "orders (2)", not reroute to an existing draft.
+      // The suffix path signals explicit new-insight intent, so reuse is OFF.
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: [], reuseUnmodifiedDraft: false },
+        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: false },
       );
       expect(mockPush).toHaveBeenCalledWith("/insights/new-draft-2");
     });
@@ -297,11 +302,11 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)",
         "table-orders",
-        { selectedFields: [], reuseUnmodifiedDraft: false },
+        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: false },
       );
     });
 
-    it("should not affect dedup for a different source table", async () => {
+    it("should not consider a different source table when naming", async () => {
       const otherTableDraft = createMockInsight({
         id: "other-draft",
         name: "customers",
@@ -318,9 +323,9 @@ describe("useCreateInsight", () => {
         await result.current.createInsightFromTable("table-orders", "orders");
       });
 
-      // The existing draft is for a different table — a new insight is created
+      // The existing insight is for a different table — no suffix.
       expect(mockCreateInsight).toHaveBeenCalledWith("orders", "table-orders", {
-        selectedFields: [],
+        selectedFields: SELECTED_FIELD_IDS,
         reuseUnmodifiedDraft: true,
       });
     });
@@ -353,7 +358,7 @@ describe("useCreateInsight", () => {
       expect(mockCreateInsight).toHaveBeenCalledWith(
         "orders (2)", // gap-free: (2) is missing, not (4)
         "table-orders",
-        { selectedFields: [], reuseUnmodifiedDraft: false },
+        { selectedFields: SELECTED_FIELD_IDS, reuseUnmodifiedDraft: false },
       );
     });
   });
@@ -578,8 +583,8 @@ describe("useCreateInsight", () => {
   });
 
   describe("integration scenarios", () => {
-    it("should reuse the unmodified draft on a second call for the same table", async () => {
-      // First call — no existing insights, creates a new draft.
+    it("should suffix a second table-created insight once the first is configured", async () => {
+      // First call — no existing insights, creates a new select-all insight.
       mockGetAllInsights.mockResolvedValueOnce([]);
       mockCreateInsight.mockResolvedValueOnce("insight-1");
 
@@ -594,17 +599,16 @@ describe("useCreateInsight", () => {
 
       vi.clearAllMocks();
 
-      // Second call for the SAME table — the newly created draft now exists
-      // and is still unmodified. The server returns the existing draft atomically.
+      // Second call for the SAME table — the first select-all insight is
+      // configured, so the hook computes the next display suffix.
       const existingDraft = createMockInsight({
         id: "insight-1",
         name: "Orders",
         baseTableId: "table-shared",
-        selectedFields: [],
+        selectedFields: SELECTED_FIELD_IDS,
       });
       mockGetAllInsights.mockResolvedValueOnce([existingDraft]);
-      // Mocked server atomically finds the existing draft and returns its id.
-      mockCreateInsight.mockResolvedValueOnce("insight-1");
+      mockCreateInsight.mockResolvedValueOnce("insight-2");
 
       let secondId: string | null = null;
       await act(async () => {
@@ -614,16 +618,16 @@ describe("useCreateInsight", () => {
         );
       });
 
-      // Hook calls createInsight (server decides dedup) with the base name and
-      // the reuse flag — no suffix because the only same-table insight is
-      // unmodified.
-      expect(mockCreateInsight).toHaveBeenCalledWith("Orders", "table-shared", {
-        selectedFields: [],
-        reuseUnmodifiedDraft: true,
-      });
-      // Must navigate to the id the server returned (the existing draft).
-      expect(mockPush).toHaveBeenCalledWith("/insights/insight-1");
-      expect(secondId).toBe("insight-1");
+      expect(mockCreateInsight).toHaveBeenCalledWith(
+        "Orders (2)",
+        "table-shared",
+        {
+          selectedFields: SELECTED_FIELD_IDS,
+          reuseUnmodifiedDraft: false,
+        },
+      );
+      expect(mockPush).toHaveBeenCalledWith("/insights/insight-2");
+      expect(secondId).toBe("insight-2");
     });
 
     it("should create insight chain (table → insight → derived)", async () => {
@@ -679,13 +683,9 @@ describe("useCreateInsight", () => {
       expect(mockPush).toHaveBeenCalledTimes(3);
     });
 
-    it("should converge on one id for two concurrent calls on the same table (TOCTOU fix)", async () => {
-      // Simulates the TOCTOU race: both calls fire before either resolves,
-      // so both getAllInsights() calls return [] (no existing draft yet).
-      // The server (mocked here) is responsible for dedup — it returns the
-      // same id for both calls, which is what the real server does atomically.
-      // This test pins the hook contract: navigate is called twice with the
-      // same id, and no duplicate draft is created (the server prevents it).
+    it("should navigate both concurrent calls to the ids returned by core", async () => {
+      // Both calls fire before either resolves, so both getAllInsights() calls
+      // return [] and the hook sends both creates with the base name.
       mockGetAllInsights.mockResolvedValue([]);
       // Both calls hit the server; the server's transaction returns the same id.
       mockCreateInsight.mockResolvedValue("converged-draft");

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -139,7 +139,11 @@ export function useCreateInsight() {
    * allowing users to build on their previous analysis.
    */
   const createInsightFromInsight = useCallback(
-    async (sourceInsightId: string, sourceInsightName: string) => {
+    async (
+      sourceInsightId: string,
+      sourceInsightName: string,
+      options?: { visualize?: boolean },
+    ) => {
       const sourceInsight = await getInsight(sourceInsightId);
 
       if (!sourceInsight) {
@@ -158,7 +162,10 @@ export function useCreateInsight() {
       );
 
       // Navigate to new insight
-      navigate({ to: `/insights/${insightId}` } as never);
+      navigate({
+        to: `/insights/${insightId}`,
+        search: options?.visualize ? { visualize: "true" } : undefined,
+      } as never);
 
       return insightId;
     },

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -215,7 +215,11 @@ export function useCreateInsight() {
       options?: { visualize?: boolean },
     ) => {
       try {
-        return await createFromInsight(sourceInsightId, sourceInsightName, options);
+        return await createFromInsight(
+          sourceInsightId,
+          sourceInsightName,
+          options,
+        );
       } catch (error) {
         console.error("[useCreateInsight] create from insight failed:", error);
         toast.error("Couldn't create insight");

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -1,13 +1,12 @@
 import {
   getAllInsights,
-  getDataTable,
   getInsight,
   useInsightMutations,
 } from "@dashframe/core";
-import type { UUID } from "@dashframe/types";
 import { isUnmodifiedDraft } from "@dashframe/types";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
+import { toast } from "sonner";
 
 /**
  * Creates insights and navigates to their pages.
@@ -16,15 +15,18 @@ import { useCallback } from "react";
  * 1. `createInsightFromTable` - Start fresh from a data table
  * 2. `createInsightFromInsight` - Chain from an existing insight's DataFrame
  *
- * Table-created insights select the base table's fields up front so the
- * canvas opens with a result table immediately. Derived insights keep the
- * previous empty starting point.
+ * Both methods create a draft insight with empty selectedFields and navigate
+ * to the insight page. The canvas still opens with a populated result table:
+ * an unconfigured insight's query falls back to the raw base table, and
+ * pre-selecting every field would instead run query mode with all fields as
+ * GROUP BY dimensions — silently collapsing duplicate source rows.
  *
- * Name disambiguation (createInsightFromTable only):
- * - If existing modified insights use the same base table, a new insight gets a
- *   gap-free numeric suffix, e.g. "orders (2)".
- * - Table-created insights are pre-populated with selected fields, so they are
- *   not empty auto-drafts and do not use the server's empty-draft reuse path.
+ * Auto-draft deduplication (createInsightFromTable only):
+ * - If an unmodified draft for the same source table already exists, the
+ *   server returns it atomically rather than creating a duplicate. Two
+ *   concurrent calls for the same table converge on one draft (no TOCTOU race).
+ * - If the existing insight(s) have been modified/saved, a new draft is
+ *   created with a disambiguating numeric suffix, e.g. "orders (2)".
  *
  * @example From table (standard flow)
  * ```tsx
@@ -53,17 +55,24 @@ export function useCreateInsight() {
   /**
    * Creates a draft insight from a data table and navigates to it.
    *
-   * Reads existing insights only to compute a gap-free numeric suffix when the
-   * user already has modified insights for the same table.
+   * Dedup: the server handles unmodified-draft reuse atomically — if a draft
+   * already exists for this table it is returned without a new insert. This
+   * hook reads existing insights only to compute a gap-free numeric suffix
+   * when the user already has modified insights for the same table.
+   *
+   * Raw path — the exported createInsightFromTable wrapper owns error
+   * handling (toast + null return) for every call site.
    */
-  const createInsightFromTable = useCallback(
+  const createFromTable = useCallback(
     async (
       tableId: string,
       tableName: string,
       options?: { visualize?: boolean },
     ) => {
       // Read existing insights for UX-only purpose: compute a suffix name when
-      // the user already has modified insights for this table.
+      // the user already has modified insights for this table. This read is NOT
+      // the authoritative dedup gate — the server closes the TOCTOU race by
+      // wrapping the check-and-insert in one transaction.
       const allInsights = await getAllInsights();
       const sameTableInsights = allInsights.filter(
         (i) => i.baseTableId === tableId,
@@ -78,7 +87,9 @@ export function useCreateInsight() {
       // deleted and re-created (e.g. "orders (2)" deleted → next should be
       // "orders (2)", not "orders (3)").
       //
-      // When no modified insight exists for this table, pass the base name.
+      // When all existing insights for this table are unmodified drafts (or none
+      // exist), pass the base name — the server will return the existing draft
+      // or create a new one atomically.
       let name = tableName;
       const modifiedInsights = sameTableInsights.filter(
         (i) => !isUnmodifiedDraft(i),
@@ -101,24 +112,18 @@ export function useCreateInsight() {
         name = `${tableName} (${suffix})`;
       }
 
-      const dataTable = await getDataTable(tableId as UUID);
-      const visibleFieldIds =
-        dataTable?.fields
-          ?.filter((field) => !field.name.startsWith("_"))
-          .map((field) => field.id) ?? [];
-      const allFieldIds = dataTable?.fields?.map((field) => field.id) ?? [];
-      const selectedFields =
-        visibleFieldIds.length > 0 ? visibleFieldIds : allFieldIds;
-
-      // Create (or reuse) an insight with the table fields selected.
-      //
-      // Table-created insights are pre-populated, so the server will insert
-      // them even if reuseUnmodifiedDraft is true. Keep the flag tied to the
-      // old suffix rule for compatibility with any empty-table fallback.
+      // Create (or atomically reuse) an EMPTY draft. Empty selectedFields is
+      // load-bearing twice over:
+      // - the server's unmodified-draft reuse gate only matches empty drafts,
+      //   so concurrent creates for the same table converge on one row;
+      // - the engine's unconfigured query falls back to the raw base table,
+      //   so the canvas shows every source row. Pre-selecting all fields would
+      //   run query mode with the fields as GROUP BY dimensions and silently
+      //   collapse duplicate rows.
       const insightId = await createInsight(
         name,
         tableId, // baseTableId
-        { selectedFields, reuseUnmodifiedDraft: !hasModifiedInsights },
+        { selectedFields: [], reuseUnmodifiedDraft: !hasModifiedInsights },
       );
 
       // Navigate to insight page (action hub)
@@ -138,7 +143,7 @@ export function useCreateInsight() {
    * The new insight uses the same base table as the source insight,
    * allowing users to build on their previous analysis.
    */
-  const createInsightFromInsight = useCallback(
+  const createFromInsight = useCallback(
     async (
       sourceInsightId: string,
       sourceInsightName: string,
@@ -170,6 +175,54 @@ export function useCreateInsight() {
       return insightId;
     },
     [navigate, createInsight],
+  );
+
+  /**
+   * Public entry point — createFromTable with failures surfaced at this
+   * creation boundary. Call sites invoke it fire-and-forget from click
+   * handlers, so a rejection here (table deleted, server down) would
+   * otherwise be an unhandled rejection with zero user feedback.
+   */
+  const createInsightFromTable = useCallback(
+    async (
+      tableId: string,
+      tableName: string,
+      options?: { visualize?: boolean },
+    ) => {
+      try {
+        return await createFromTable(tableId, tableName, options);
+      } catch (error) {
+        console.error("[useCreateInsight] create from table failed:", error);
+        toast.error("Couldn't create insight");
+        return null;
+      }
+    },
+    [createFromTable],
+  );
+
+  /**
+   * Creates a new insight that chains from an existing insight's DataFrame.
+   *
+   * The new insight uses the same base table as the source insight,
+   * allowing users to build on their previous analysis.
+   *
+   * Same boundary rule as createInsightFromTable: failures toast here.
+   */
+  const createInsightFromInsight = useCallback(
+    async (
+      sourceInsightId: string,
+      sourceInsightName: string,
+      options?: { visualize?: boolean },
+    ) => {
+      try {
+        return await createFromInsight(sourceInsightId, sourceInsightName, options);
+      } catch (error) {
+        console.error("[useCreateInsight] create from insight failed:", error);
+        toast.error("Couldn't create insight");
+        return null;
+      }
+    },
+    [createFromInsight],
   );
 
   return {

--- a/packages/app/src/hooks/useCreateInsight.ts
+++ b/packages/app/src/hooks/useCreateInsight.ts
@@ -1,8 +1,10 @@
 import {
   getAllInsights,
+  getDataTable,
   getInsight,
   useInsightMutations,
 } from "@dashframe/core";
+import type { UUID } from "@dashframe/types";
 import { isUnmodifiedDraft } from "@dashframe/types";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
@@ -14,17 +16,15 @@ import { useCallback } from "react";
  * 1. `createInsightFromTable` - Start fresh from a data table
  * 2. `createInsightFromInsight` - Chain from an existing insight's DataFrame
  *
- * Both methods create a draft insight with empty selectedFields and navigate
- * to the insight page (action hub) for further configuration.
+ * Table-created insights select the base table's fields up front so the
+ * canvas opens with a result table immediately. Derived insights keep the
+ * previous empty starting point.
  *
- * Auto-draft deduplication (createInsightFromTable only):
- * - If an unmodified draft for the same source table already exists, the
- *   server returns it atomically rather than creating a duplicate. Two
- *   concurrent calls for the same table converge on one draft (no TOCTOU race).
- * - If the existing insight(s) have been modified/saved, a new draft is
- *   created with a disambiguating numeric suffix, e.g. "orders (2)".
- *   A prompt would be less disruptive but would interrupt a routine action;
- *   the suffix matches the drive-feel expectation of the app.
+ * Name disambiguation (createInsightFromTable only):
+ * - If existing modified insights use the same base table, a new insight gets a
+ *   gap-free numeric suffix, e.g. "orders (2)".
+ * - Table-created insights are pre-populated with selected fields, so they are
+ *   not empty auto-drafts and do not use the server's empty-draft reuse path.
  *
  * @example From table (standard flow)
  * ```tsx
@@ -53,17 +53,17 @@ export function useCreateInsight() {
   /**
    * Creates a draft insight from a data table and navigates to it.
    *
-   * Dedup: the server handles unmodified-draft reuse atomically — if a draft
-   * already exists for this table it is returned without a new insert. This
-   * hook reads existing insights only to compute a gap-free numeric suffix
-   * when the user already has modified insights for the same table.
+   * Reads existing insights only to compute a gap-free numeric suffix when the
+   * user already has modified insights for the same table.
    */
   const createInsightFromTable = useCallback(
-    async (tableId: string, tableName: string) => {
+    async (
+      tableId: string,
+      tableName: string,
+      options?: { visualize?: boolean },
+    ) => {
       // Read existing insights for UX-only purpose: compute a suffix name when
-      // the user already has modified insights for this table. This read is NOT
-      // the authoritative dedup gate — the server closes the TOCTOU race by
-      // wrapping the check-and-insert in one transaction.
+      // the user already has modified insights for this table.
       const allInsights = await getAllInsights();
       const sameTableInsights = allInsights.filter(
         (i) => i.baseTableId === tableId,
@@ -78,9 +78,7 @@ export function useCreateInsight() {
       // deleted and re-created (e.g. "orders (2)" deleted → next should be
       // "orders (2)", not "orders (3)").
       //
-      // When all existing insights for this table are unmodified drafts (or none
-      // exist), pass the base name — the server will return the existing draft
-      // or create a new one atomically.
+      // When no modified insight exists for this table, pass the base name.
       let name = tableName;
       const modifiedInsights = sameTableInsights.filter(
         (i) => !isUnmodifiedDraft(i),
@@ -103,23 +101,31 @@ export function useCreateInsight() {
         name = `${tableName} (${suffix})`;
       }
 
-      // Create (or reuse) a draft insight with empty fields.
+      const dataTable = await getDataTable(tableId as UUID);
+      const visibleFieldIds =
+        dataTable?.fields
+          ?.filter((field) => !field.name.startsWith("_"))
+          .map((field) => field.id) ?? [];
+      const allFieldIds = dataTable?.fields?.map((field) => field.id) ?? [];
+      const selectedFields =
+        visibleFieldIds.length > 0 ? visibleFieldIds : allFieldIds;
+
+      // Create (or reuse) an insight with the table fields selected.
       //
-      // Only opt into reuseUnmodifiedDraft when NO modified insight forces a
-      // suffix. When the suffix path fires, the user is explicitly making a new
-      // distinguishable draft ("orders (2)") — reusing an existing "orders"
-      // draft would discard that name and land them on the wrong insight. With
-      // the flag set, the server returns an existing unmodified draft for this
-      // baseTableId atomically, so two concurrent first-clicks converge on one
-      // draft (no TOCTOU race).
+      // Table-created insights are pre-populated, so the server will insert
+      // them even if reuseUnmodifiedDraft is true. Keep the flag tied to the
+      // old suffix rule for compatibility with any empty-table fallback.
       const insightId = await createInsight(
         name,
         tableId, // baseTableId
-        { selectedFields: [], reuseUnmodifiedDraft: !hasModifiedInsights },
+        { selectedFields, reuseUnmodifiedDraft: !hasModifiedInsights },
       );
 
       // Navigate to insight page (action hub)
-      navigate({ to: `/insights/${insightId}` } as never);
+      navigate({
+        to: `/insights/${insightId}`,
+        search: options?.visualize ? { visualize: "true" } : undefined,
+      } as never);
 
       return insightId;
     },

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -3,6 +3,10 @@ import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame, getDataTable } from "@dashframe/core";
 import type { EffectiveParams } from "@dashframe/engine";
 import {
+  buildInsightAvailableFields,
+  fieldIdToColumnAlias,
+} from "@dashframe/engine";
+import {
   buildInsightSQL,
   ensureTableLoaded,
   loadArrowData,
@@ -49,8 +53,13 @@ interface CachedView {
 // This survives React Strict Mode's double-invoke and HMR remounts
 const createdViewsCache = new Map<string, CachedView>(); // configKey -> CachedView
 
-// Module-level set to track in-flight requests (prevents race conditions)
-const pendingRequests = new Set<string>();
+// Module-level map of in-flight view creations. Deduplicates work AND lets
+// every concurrent hook instance for the same configKey subscribe to the one
+// in-flight creation — the module cache is not reactive, so an instance that
+// merely early-returned on "already pending" would never re-render when the
+// first creation completes. Resolves with the CachedView on success, null on
+// failure.
+const pendingRequests = new Map<string, Promise<CachedView | null>>();
 
 /**
  * Clear the view cache.
@@ -363,13 +372,30 @@ export function useInsightView(
       return;
     }
 
-    // Prevent duplicate in-flight requests for same config (module-level)
-    if (pendingRequests.has(configKey)) {
-      return;
+    // Another hook instance is already creating this view (e.g. the canvas
+    // and VisualizationPreview mount for the same insight). Subscribe to its
+    // promise instead of returning silently — a bare return would leave this
+    // instance permanently not-ready because nothing re-renders it when the
+    // module cache fills.
+    const pending = pendingRequests.get(configKey);
+    if (pending) {
+      let cancelled = false;
+      pending.then((cached) => {
+        if (cancelled || currentConfigKeyRef.current !== configKey) return;
+        if (cached) {
+          setResolvedViewName(cached.viewName);
+          setResolvedConfigKey(configKey);
+          setNativeCapable(cached.nativeCapable);
+          setError(null);
+        } else {
+          setError("Failed to create view");
+          setResolvedViewName(null);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
     }
-
-    // Mark this config as in-flight (module-level, survives unmount/remount)
-    pendingRequests.add(configKey);
 
     // Capture stable values at effect start (insight object may change during async)
     const joins = insight?.joins ?? [];
@@ -380,7 +406,7 @@ export function useInsightView(
     const snapshotEffectiveFilters = effectiveParams?.filters ?? null;
 
     // eslint-disable-next-line sonarjs/cognitive-complexity -- defensive stale-state guards (currentConfigKeyRef checks) after every await legitimately raise complexity; extracting further would obscure the guard pattern
-    const createView = async () => {
+    const createView = async (): Promise<CachedView | null> => {
       try {
         // Double-check cache in case another effect already created it
         if (createdViewsCache.has(configKey)) {
@@ -389,28 +415,27 @@ export function useInsightView(
           setResolvedConfigKey(configKey);
           // Restore the cached fallback decision — never assume native-capable.
           setNativeCapable(cached.nativeCapable);
-          pendingRequests.delete(configKey);
-          return;
+          return cached;
         }
 
         // Get base table
         const baseTable = await getDataTable(baseTableId);
         if (!baseTable || !baseTable.dataFrameId) {
-          pendingRequests.delete(configKey);
-          if (currentConfigKeyRef.current !== configKey) return;
-          setError("Base table not found");
-          setResolvedViewName(null);
-          return;
+          if (currentConfigKeyRef.current === configKey) {
+            setError("Base table not found");
+            setResolvedViewName(null);
+          }
+          return null;
         }
 
         // Ensure base DataFrame is loaded
         const baseDataFrame = await getDataFrame(baseTable.dataFrameId);
         if (!baseDataFrame) {
-          pendingRequests.delete(configKey);
-          if (currentConfigKeyRef.current !== configKey) return;
-          setError("Base DataFrame not found");
-          setResolvedViewName(null);
-          return;
+          if (currentConfigKeyRef.current === configKey) {
+            setError("Base DataFrame not found");
+            setResolvedViewName(null);
+          }
+          return null;
         }
 
         // Collect all DataFrames to load (base + joined tables) for parallel loading
@@ -490,11 +515,11 @@ export function useInsightView(
         );
 
         if (!sql) {
-          pendingRequests.delete(configKey);
-          if (currentConfigKeyRef.current !== configKey) return;
-          setError("Failed to build SQL for insight view");
-          setResolvedViewName(null);
-          return;
+          if (currentConfigKeyRef.current === configKey) {
+            setError("Failed to build SQL for insight view");
+            setResolvedViewName(null);
+          }
+          return null;
         }
 
         // View name: base insight view for the unfiltered case.  When effective
@@ -509,7 +534,29 @@ export function useInsightView(
         const newViewName = hasFilterOverride
           ? `insight_view_${idSafe}_cell_${toViewSuffix(JSON.stringify(snapshotEffectiveFilters))}`
           : `insight_view_${idSafe}`;
-        const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${sql}`;
+
+        // Normalize date-typed columns to TIMESTAMP in the chart view.
+        // CSV/Arrow ingest can produce TIMESTAMP_MS columns, which vgplot's
+        // DuckDB type map does not recognize (throws "Unsupported type:
+        // TIMESTAMP_MS" and the chart renders blank). The cast is lossless
+        // (ms → µs) and applies only to this chart-facing view — the table
+        // pagination path builds its own SQL and is unaffected.
+        // REPLACE targets assume the model-mode full projection above: every
+        // available-field alias exists in the subquery. Routing this view
+        // through query/aggregation mode would break unselected date aliases.
+        const dateAliases = (
+          buildInsightAvailableFields(baseTable, joinedTables, { joins }) ??
+          baseTable.fields ??
+          []
+        )
+          .filter((f) => f.type === "date")
+          .map((f) => fieldIdToColumnAlias(f.id));
+        const viewSql = dateAliases.length
+          ? `SELECT * REPLACE (${dateAliases
+              .map((a) => `CAST("${a}" AS TIMESTAMP) AS "${a}"`)
+              .join(", ")}) FROM (${sql})`
+          : sql;
+        const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${viewSql}`;
         await connection.query(createViewSql);
 
         // Desktop: chart queries run against the native engine, so the view
@@ -524,31 +571,45 @@ export function useInsightView(
         // Store in module-level cache (survives Strict Mode and HMR). The
         // fallback decision travels with the view name so a later remount that
         // hits this cache restores the correct engine routing.
-        createdViewsCache.set(configKey, {
+        const created: CachedView = {
           viewName: newViewName,
           nativeCapable: allNativeCapable,
-        });
-        pendingRequests.delete(configKey);
+        };
+        createdViewsCache.set(configKey, created);
 
         // Guard: if the component has moved on to a different configKey while
-        // this async path was in-flight, discard these results. The newer
-        // config's createView will (or already did) set the correct state.
-        if (currentConfigKeyRef.current !== configKey) return;
-
-        setResolvedViewName(newViewName);
-        setResolvedConfigKey(configKey);
-        setNativeCapable(allNativeCapable);
-        setError(null);
+        // this async path was in-flight, discard these results (but still
+        // resolve with the created view so subscribed followers get it). The
+        // newer config's createView will (or already did) set the correct state.
+        if (currentConfigKeyRef.current === configKey) {
+          setResolvedViewName(newViewName);
+          setResolvedConfigKey(configKey);
+          setNativeCapable(allNativeCapable);
+          setError(null);
+        }
+        return created;
       } catch (err) {
         console.error("[useInsightView] Failed to create view:", err);
-        pendingRequests.delete(configKey);
-        if (currentConfigKeyRef.current !== configKey) return;
-        setError(err instanceof Error ? err.message : "Failed to create view");
-        setResolvedViewName(null);
+        if (currentConfigKeyRef.current === configKey) {
+          setError(
+            err instanceof Error ? err.message : "Failed to create view",
+          );
+          setResolvedViewName(null);
+        }
+        return null;
       }
     };
 
-    createView();
+    // Register the in-flight creation so concurrent hook instances subscribe
+    // to it (see the `pending` branch above), then clean up the entry once it
+    // settles — guarded so a retry that re-registered the key isn't clobbered.
+    const creation = createView();
+    pendingRequests.set(configKey, creation);
+    creation.finally(() => {
+      if (pendingRequests.get(configKey) === creation) {
+        pendingRequests.delete(configKey);
+      }
+    });
 
     // No cleanup needed - module-level state persists across unmounts
     // IMPORTANT: Only depend on stable primitive values

--- a/packages/app/src/lib/stores/insight-canvas-store.test.ts
+++ b/packages/app/src/lib/stores/insight-canvas-store.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  TABLE_CANVAS_VIEW,
+  canvasViewsEqual,
+  sanitizeInsightCanvasView,
+  useInsightCanvasStore,
+} from "./insight-canvas-store";
+
+describe("insight canvas view state", () => {
+  it("stores last active view per insight", () => {
+    useInsightCanvasStore.setState({ activeViewByInsight: {} });
+
+    useInsightCanvasStore
+      .getState()
+      .setActiveView("insight-a", { kind: "chart", chartType: "barY" });
+    useInsightCanvasStore
+      .getState()
+      .setActiveView("insight-b", { kind: "table" });
+
+    expect(useInsightCanvasStore.getState().activeViewByInsight).toMatchObject({
+      "insight-a": { kind: "chart", chartType: "barY" },
+      "insight-b": { kind: "table" },
+    });
+  });
+
+  it("falls back to table when a persisted pinned visualization no longer exists", () => {
+    expect(
+      sanitizeInsightCanvasView(
+        { kind: "visualization", visualizationId: "missing-viz" },
+        new Set(["other-viz"]),
+      ),
+    ).toEqual(TABLE_CANVAS_VIEW);
+  });
+
+  it("compares chart and pinned visualization views by payload", () => {
+    expect(
+      canvasViewsEqual(
+        { kind: "chart", chartType: "line" },
+        { kind: "chart", chartType: "line" },
+      ),
+    ).toBe(true);
+    expect(
+      canvasViewsEqual(
+        { kind: "visualization", visualizationId: "viz-a" },
+        { kind: "visualization", visualizationId: "viz-b" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/app/src/lib/stores/insight-canvas-store.ts
+++ b/packages/app/src/lib/stores/insight-canvas-store.ts
@@ -1,0 +1,95 @@
+import type { VisualizationType } from "@dashframe/types";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export type InsightCanvasView =
+  | { kind: "table" }
+  | { kind: "chart"; chartType: VisualizationType }
+  | { kind: "visualization"; visualizationId: string };
+
+interface InsightCanvasState {
+  activeViewByInsight: Record<string, InsightCanvasView>;
+  setActiveView: (insightId: string, view: InsightCanvasView) => void;
+  clearActiveView: (insightId: string) => void;
+}
+
+const safeLocalStorage = {
+  getItem: (name: string): string | null => {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage.getItem(name);
+    } catch {
+      return null;
+    }
+  },
+  setItem: (name: string, value: string): void => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(name, value);
+    } catch {
+      // Best-effort artifact UI state.
+    }
+  },
+  removeItem: (name: string): void => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(name);
+    } catch {
+      // Best-effort artifact UI state.
+    }
+  },
+};
+
+export const TABLE_CANVAS_VIEW: InsightCanvasView = { kind: "table" };
+
+export function canvasViewsEqual(
+  left: InsightCanvasView,
+  right: InsightCanvasView,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "chart" && right.kind === "chart") {
+    return left.chartType === right.chartType;
+  }
+  if (left.kind === "visualization" && right.kind === "visualization") {
+    return left.visualizationId === right.visualizationId;
+  }
+  return true;
+}
+
+export function sanitizeInsightCanvasView(
+  view: InsightCanvasView | undefined,
+  existingVisualizationIds: Set<string>,
+): InsightCanvasView {
+  if (view?.kind === "visualization") {
+    return existingVisualizationIds.has(view.visualizationId)
+      ? view
+      : TABLE_CANVAS_VIEW;
+  }
+  return view ?? TABLE_CANVAS_VIEW;
+}
+
+export const useInsightCanvasStore = create<InsightCanvasState>()(
+  persist(
+    (set) => ({
+      activeViewByInsight: {},
+      setActiveView: (insightId, view) =>
+        set((state) => ({
+          activeViewByInsight: {
+            ...state.activeViewByInsight,
+            [insightId]: view,
+          },
+        })),
+      clearActiveView: (insightId) =>
+        set((state) => {
+          const next = { ...state.activeViewByInsight };
+          delete next[insightId];
+          return { activeViewByInsight: next };
+        }),
+    }),
+    {
+      name: "dashframe:insight-canvas",
+      storage: createJSONStorage(() => safeLocalStorage),
+      skipHydration: true,
+    },
+  ),
+);

--- a/packages/app/src/lib/visualizations/suggest-charts.ts
+++ b/packages/app/src/lib/visualizations/suggest-charts.ts
@@ -302,9 +302,19 @@ function buildTemporalEncoding(col: ExtendedDateAnalysis): {
   const aggregation = selectTemporalAggregation(col.minDate, col.maxDate);
   const transform = temporalTransform(aggregation);
 
-  // Generate SQL expression using DuckDB date_trunc
-  // Use UUID column name for SQL, not display name
-  const xExpr = applyDateTransformToSql(col.columnName, transform);
+  // Generate SQL expression using DuckDB date_trunc.
+  // Use UUID column name for SQL, not display name.
+  //
+  // For the identity aggregation ("none") use the PLAIN column name, not
+  // applyDateTransformToSql's output: that helper quotes the identifier at
+  // the sink, and a bare quoted identifier violates the encoding convention
+  // (plain column name OR function-wrapped expression). Downstream consumers
+  // quote plain names themselves — a pre-quoted one gets double-quoted and
+  // fails to bind.
+  const xExpr =
+    transform.kind === "temporal" && transform.aggregation === "none"
+      ? col.columnName
+      : applyDateTransformToSql(col.columnName, transform);
 
   // Get appropriate axis type based on data
   const xType = getAxisTypeForTransform(transform) as "temporal" | "ordinal";

--- a/packages/app/src/routes/insights/$insightId.tsx
+++ b/packages/app/src/routes/insights/$insightId.tsx
@@ -2,10 +2,16 @@ import InsightPageContent from "@/app/insights/[insightId]/_components/InsightPa
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/insights/$insightId")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    visualize: search.visualize === "true",
+  }),
   component: InsightRoute,
 });
 
 function InsightRoute() {
   const { insightId } = Route.useParams();
-  return <InsightPageContent insightId={insightId} />;
+  const { visualize } = Route.useSearch();
+  return (
+    <InsightPageContent insightId={insightId} visualizeIntent={visualize} />
+  );
 }

--- a/packages/app/src/routes/insights/$insightId.tsx
+++ b/packages/app/src/routes/insights/$insightId.tsx
@@ -3,7 +3,9 @@ import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/insights/$insightId")({
   validateSearch: (search: Record<string, unknown>) => ({
-    visualize: search.visualize === "true",
+    // The router's default search parser JSON-parses values, so
+    // `?visualize=true` arrives as boolean true — accept both forms.
+    visualize: search.visualize === true || search.visualize === "true",
   }),
   component: InsightRoute,
 });

--- a/packages/ui/src/components/VirtualTable.tsx
+++ b/packages/ui/src/components/VirtualTable.tsx
@@ -306,11 +306,15 @@ export function VirtualTable({
       setTotalCount(result.totalCount);
 
       const firstResultRow = result.rows[0];
-      if (firstResultRow && inferredColumns.length === 0) {
+      if (firstResultRow) {
         const cols = Object.keys(firstResultRow)
           .filter((key) => !key.startsWith("_"))
           .map((name) => ({ name }));
-        setInferredColumns(cols);
+        // Functional update: the closure's `inferredColumns` can be stale when
+        // a data-source reset cleared columns after this fetch started — a
+        // closure-based emptiness check would skip the set and leave the table
+        // with zero columns forever.
+        setInferredColumns((prev) => (prev.length === 0 ? cols : prev));
       }
 
       setData((prev) => {
@@ -379,11 +383,13 @@ export function VirtualTable({
         setTotalCount(result.totalCount);
 
         const firstResetRow = result.rows[0];
-        if (firstResetRow && inferredColumns.length === 0) {
+        if (firstResetRow) {
           const cols = Object.keys(firstResetRow)
             .filter((key) => !key.startsWith("_"))
             .map((name) => ({ name }));
-          setInferredColumns(cols);
+          // Functional update — see processQueue: a concurrent reset can clear
+          // columns after this fetch started; the closure check would go stale.
+          setInferredColumns((prev) => (prev.length === 0 ? cols : prev));
         }
 
         setData(result.rows);


### PR DESCRIPTION
Implements the settled Insight canvas model (D1): the Insight page presents its result through a table-first view switcher; charts are ephemeral views until explicitly pinned into durable Visualization children.

Tracked internally as YW-395.

## Changes

- **View switcher on the Insight canvas** — table view is the default; chart types are alternate views of the same result, reachable by switching. Switching never writes a Visualization row.
- **Pin-to-mint** — an explicit pin converts the active chart view into a persisted Visualization under the Insight; duplicate pins (same type + encoding signature) reuse the existing child instead of minting another.
- **Empty-draft create flow** — "Visualize this data" from a table detail creates an empty draft Insight immediately (the engine's unconfigured query falls back to the raw base table, so the canvas opens showing every source row) and, on explicit visualize intent, auto-pins the first chart suggestion so the user always lands with ≥1 addressable Visualization. Empty `selectedFields` is load-bearing: it keeps the server's unmodified-draft reuse gate working (concurrent creates converge on one draft) and avoids the GROUP-BY-all-fields query that silently collapsed duplicate source rows.
- **Creation-boundary error handling** — the exported create hooks catch failures, toast, and return null, so fire-and-forget click handlers never leave an unhandled rejection with zero user feedback.
- **Encoding resolution on pin** — date-transformed axes (`dateMonth(...)`, `date_trunc(...)`) resolve through their wrappers instead of being silently dropped, and repeat-join instance aliases (`field_<uuid>_jN`) persist their instance qualifier in the Visualization encoding (the render path resolves `field:<uuid>_jN` through instance-aware fields; collapsing to the canonical UUID re-pointed pinned charts at the first join instance). The Insight model itself keeps canonical field IDs.
- **View-state pruning on delete** — insights-page delete paths clear the per-insight canvas view entry so removed insights don't leave stale localStorage keys.
- **Derived-insight path carries visualize intent** — "Create new based on this" forwards `visualizeOnCreate` so it enters the same visualization flow as table creation.
- **Per-insight view state** persisted in a new `insight-canvas-store` (last-active view per Insight, no global default-view setting).
- E2E specs updated for the new create flow and canvas.

## Screenshots

### 01 Datasource Table Detail Visualize Button
![01 Datasource Table Detail Visualize Button](https://github.com/youhaowei/DashFrame/releases/download/pr-218-screenshots/01-datasource-table-detail-visualize-button.png)

### 02 Visualize Intent Auto Pinned Chart
![02 Visualize Intent Auto Pinned Chart](https://github.com/youhaowei/DashFrame/releases/download/pr-218-screenshots/02-visualize-intent-auto-pinned-chart.png)

### 03 View Switcher Table Active Default
![03 View Switcher Table Active Default](https://github.com/youhaowei/DashFrame/releases/download/pr-218-screenshots/03-view-switcher-table-active-default.png)

### 04 View Switcher Bar Ephemeral Pin Affordance
![04 View Switcher Bar Ephemeral Pin Affordance](https://github.com/youhaowei/DashFrame/releases/download/pr-218-screenshots/04-view-switcher-bar-ephemeral-pin-affordance.png)

### 06 Data Model Panel Collapsed
![06 Data Model Panel Collapsed](https://github.com/youhaowei/DashFrame/releases/download/pr-218-screenshots/06-data-model-panel-collapsed.png)

### 07 Dark Mode Canvas
![07 Dark Mode Canvas](https://github.com/youhaowei/DashFrame/releases/download/pr-218-screenshots/07-dark-mode-canvas.png)

_Screenshots via pr-screenshots (prerelease `pr-218-screenshots`, not in git)._
## Verification

- `bun check` green across the workspace (83/83 tasks), including new unit tests for `insight-canvas-store` and the create-flow hook.
- Full local E2E suite green (15/15) after the review fix round, including the rewritten empty-start compound-editing spec and the post-pin query-mode caption assertion.
- Local clawpatch feature review run (15 features): PR-caused findings fixed in the follow-up commit (pin-path encoding resolution, derived-path visualize intent); remaining findings are pre-existing issues in touched features, not introduced by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the Insight page's section-based layout (data model / data preview / visualizations) with a unified table-first canvas: the insight result is shown in a `VirtualTable` by default, chart types are ephemeral switcher views, and a pin gesture mints a durable `Visualization` child. A new "visualize intent" flag (passed via `?visualize=true`) auto-pins the first chart suggestion on landing so new insights from table surfaces always open with at least one addressable visualization.

- **View switcher + `insight-canvas-store`**: a new Zustand persist store (`dashframe:insight-canvas`) tracks the last-active view per insight (table / ephemeral chart / pinned visualization) in localStorage, with read-time sanitization for deleted visualization references and `clearActiveView` wired into both delete paths.
- **Encoding resolution hardening**: `lookupEncodingFieldRef` / `lookupEncodingFieldId` unwrap legacy `dateMonth(…)` and DuckDB `date_trunc('…', col)` wrappers and preserve repeat-join instance qualifiers (`_jN`) so pinned charts point at the correct join instance.
- **`useInsightView` concurrency fix**: the module-level `pendingRequests` sentinel was upgraded from a `Set` to a `Map<string, Promise<…>>` so secondary hook instances subscribe to the in-flight creation promise instead of silently waiting for a re-render that never comes.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge. All new async paths have error boundaries; the view store, auto-pin guard, and concurrent hook deduplication are well-reasoned and covered by unit tests.

The canvas redesign is large but self-contained. The useInsightView SQL is always built in model mode, so the new SELECT * REPLACE date-cast wrapper is never applied to a partial projection. The autoPinAttemptRef guard is correct under StrictMode double-invoke, React re-renders, and navigation reuse. The pendingRequests Map upgrade correctly handles primary-creation cleanup without clobbering concurrent registrations. No off-token colours, no platform forks, and no ticket-ID references appear in the source.

No files require special attention beyond the two style notes on the hardcoded 520 px heights and the non-retrying auto-pin ref in InsightView.tsx.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/app/insights/[insightId]/_components/InsightView.tsx | Core of the PR — rewrites the canvas to a view-switcher layout, introduces InsightResultTable, EphemeralChartCanvas, CanvasViewButton, and the auto-pin effect; encoding resolution helpers are correct; handleAddActiveViewToDashboard still targets dashboards[0] (pre-existing behaviour, flagged in prior review). |
| packages/app/src/hooks/useInsightView.ts | Upgrades pending-request deduplication from Set to Map-of-Promises so concurrent hook instances subscribe to one in-flight creation; adds SELECT * REPLACE cast to normalise TIMESTAMP_MS date columns — always safe because SQL is built in model mode (full projection). |
| packages/app/src/hooks/useCreateInsight.ts | Adds visualize-intent option that appends ?visualize=true to navigation target; wraps inner createFrom* helpers in public entry points that catch, toast, and return null. |
| packages/app/src/lib/stores/insight-canvas-store.ts | New Zustand persist store for per-insight canvas view state; safe localStorage wrapper, sanitizeInsightCanvasView for deleted-visualization fallback, and clearActiveView now wired into delete paths. |
| packages/ui/src/components/VirtualTable.tsx | Fixes stale-closure bug in column inference: switches from closure-captured length check to functional setState so a concurrent reset can't leave the table with zero columns. |
| packages/app/src/app/insights/page.tsx | Wires clearActiveView into handleDeleteInsight and handleDeleteAllDrafts so deleted insights don't leave stale localStorage keys. |
| packages/app/src/routes/insights/$insightId.tsx | Adds validateSearch to accept ?visualize as boolean or string 'true' and passes it down through InsightPageContent to InsightView. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DataSourcePage
    participant useCreateInsight
    participant Router
    participant InsightView
    participant useInsightView
    participant pinChartSuggestion
    participant Store as insight-canvas-store

    User->>DataSourcePage: Click "Visualize this data"
    DataSourcePage->>useCreateInsight: "createInsightFromTable(tableId, name, {visualize:true})"
    useCreateInsight->>useCreateInsight: "createInsight(name, tableId, {selectedFields:[]})"
    useCreateInsight->>Router: "navigate(/insights/:id?visualize=true)"

    Router->>InsightView: "render(insight, visualizeIntent=true)"
    InsightView->>useInsightView: build chart view SQL (model mode)
    useInsightView-->>InsightView: "chartTableName, isChartViewReady=true"

    Note over InsightView: columnAnalysis populated → firstChartSuggestion available
    InsightView->>pinChartSuggestion: auto-pin effect fires (autoPinAttemptRef guard)
    pinChartSuggestion->>pinChartSuggestion: parseChartEncoding + lookupEncodingFieldRef
    pinChartSuggestion->>pinChartSuggestion: createVisualizationLocal(...)
    pinChartSuggestion->>Store: "setActiveView(insightId, {kind:visualization, id})"
    Store-->>InsightView: "activeView = visualization view"

    Note over InsightView: View switcher shows pinned visualization as active tab

    User->>InsightView: Click chart type tab (ephemeral)
    InsightView->>Store: "setActiveView(insightId, {kind:chart, chartType})"
    Store-->>InsightView: "activeView = chart view → EphemeralChartCanvas shown"

    User->>InsightView: Click "Pin view"
    InsightView->>pinChartSuggestion: pinChartSuggestion(activeChartSuggestion)
    pinChartSuggestion->>pinChartSuggestion: duplicate-pin check (encoding signature)
    pinChartSuggestion->>pinChartSuggestion: createVisualizationLocal(...)
    pinChartSuggestion->>Store: setActiveView → visualization view

    User->>InsightView: Delete pinned visualization
    InsightView->>InsightView: removeVisualization(id)
    Note over InsightView: sanitizeInsightCanvasView falls back to TABLE_CANVAS_VIEW at read time
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DataSourcePage
    participant useCreateInsight
    participant Router
    participant InsightView
    participant useInsightView
    participant pinChartSuggestion
    participant Store as insight-canvas-store

    User->>DataSourcePage: Click "Visualize this data"
    DataSourcePage->>useCreateInsight: "createInsightFromTable(tableId, name, {visualize:true})"
    useCreateInsight->>useCreateInsight: "createInsight(name, tableId, {selectedFields:[]})"
    useCreateInsight->>Router: "navigate(/insights/:id?visualize=true)"

    Router->>InsightView: "render(insight, visualizeIntent=true)"
    InsightView->>useInsightView: build chart view SQL (model mode)
    useInsightView-->>InsightView: "chartTableName, isChartViewReady=true"

    Note over InsightView: columnAnalysis populated → firstChartSuggestion available
    InsightView->>pinChartSuggestion: auto-pin effect fires (autoPinAttemptRef guard)
    pinChartSuggestion->>pinChartSuggestion: parseChartEncoding + lookupEncodingFieldRef
    pinChartSuggestion->>pinChartSuggestion: createVisualizationLocal(...)
    pinChartSuggestion->>Store: "setActiveView(insightId, {kind:visualization, id})"
    Store-->>InsightView: "activeView = visualization view"

    Note over InsightView: View switcher shows pinned visualization as active tab

    User->>InsightView: Click chart type tab (ephemeral)
    InsightView->>Store: "setActiveView(insightId, {kind:chart, chartType})"
    Store-->>InsightView: "activeView = chart view → EphemeralChartCanvas shown"

    User->>InsightView: Click "Pin view"
    InsightView->>pinChartSuggestion: pinChartSuggestion(activeChartSuggestion)
    pinChartSuggestion->>pinChartSuggestion: duplicate-pin check (encoding signature)
    pinChartSuggestion->>pinChartSuggestion: createVisualizationLocal(...)
    pinChartSuggestion->>Store: setActiveView → visualization view

    User->>InsightView: Delete pinned visualization
    InsightView->>InsightView: removeVisualization(id)
    Note over InsightView: sanitizeInsightCanvasView falls back to TABLE_CANVAS_VIEW at read time
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app/src/app/insights/[insightId]/_components/InsightView.tsx`, line 925-960 ([link](https://github.com/youhaowei/dashframe/blob/57228278bf32af8e4e070f7f455fc80503183198/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx#L925-L960)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`handleAddActiveViewToDashboard` always targets `dashboards[0]`**

   When `dashboards` has more than one entry, the chart is silently appended to the very first dashboard. The success toast says "Added to dashboard" without identifying which one, so users with multiple dashboards have no way to know — or choose — where their item lands. At minimum, surfacing the dashboard name in the toast (`Added to "${dashboard.name}"`) would make the behavior discoverable without blocking the action.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
   Line: 925-960

   Comment:
   **`handleAddActiveViewToDashboard` always targets `dashboards[0]`**

   When `dashboards` has more than one entry, the chart is silently appended to the very first dashboard. The success toast says "Added to dashboard" without identifying which one, so users with multiple dashboards have no way to know — or choose — where their item lands. At minimum, surfacing the dashboard name in the toast (`Added to "${dashboard.name}"`) would make the behavior discoverable without blocking the action.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Finsights%2F%5BinsightId%5D%2F_components%2FInsightView.tsx%0ALine%3A%20925-960%0A%0AComment%3A%0A**%60handleAddActiveViewToDashboard%60%20always%20targets%20%60dashboards%5B0%5D%60**%0A%0AWhen%20%60dashboards%60%20has%20more%20than%20one%20entry%2C%20the%20chart%20is%20silently%20appended%20to%20the%20very%20first%20dashboard.%20The%20success%20toast%20says%20%22Added%20to%20dashboard%22%20without%20identifying%20which%20one%2C%20so%20users%20with%20multiple%20dashboards%20have%20no%20way%20to%20know%20%E2%80%94%20or%20choose%20%E2%80%94%20where%20their%20item%20lands.%20At%20minimum%2C%20surfacing%20the%20dashboard%20name%20in%20the%20toast%20%28%60Added%20to%20%22%24%7Bdashboard.name%7D%22%60%29%20would%20make%20the%20behavior%20discoverable%20without%20blocking%20the%20action.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-395-insight-canvas-create-flow-table-first-view-switcher-select%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-395-insight-canvas-create-flow-table-first-view-switcher-select%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Finsights%2F%5BinsightId%5D%2F_components%2FInsightView.tsx%0ALine%3A%20925-960%0A%0AComment%3A%0A**%60handleAddActiveViewToDashboard%60%20always%20targets%20%60dashboards%5B0%5D%60**%0A%0AWhen%20%60dashboards%60%20has%20more%20than%20one%20entry%2C%20the%20chart%20is%20silently%20appended%20to%20the%20very%20first%20dashboard.%20The%20success%20toast%20says%20%22Added%20to%20dashboard%22%20without%20identifying%20which%20one%2C%20so%20users%20with%20multiple%20dashboards%20have%20no%20way%20to%20know%20%E2%80%94%20or%20choose%20%E2%80%94%20where%20their%20item%20lands.%20At%20minimum%2C%20surfacing%20the%20dashboard%20name%20in%20the%20toast%20%28%60Added%20to%20%22%24%7Bdashboard.name%7D%22%60%29%20would%20make%20the%20behavior%20discoverable%20without%20blocking%20the%20action.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp%2Fsrc%2Fapp%2Finsights%2F%5BinsightId%5D%2F_components%2FInsightView.tsx%0ALine%3A%20925-960%0A%0AComment%3A%0A**%60handleAddActiveViewToDashboard%60%20always%20targets%20%60dashboards%5B0%5D%60**%0A%0AWhen%20%60dashboards%60%20has%20more%20than%20one%20entry%2C%20the%20chart%20is%20silently%20appended%20to%20the%20very%20first%20dashboard.%20The%20success%20toast%20says%20%22Added%20to%20dashboard%22%20without%20identifying%20which%20one%2C%20so%20users%20with%20multiple%20dashboards%20have%20no%20way%20to%20know%20%E2%80%94%20or%20choose%20%E2%80%94%20where%20their%20item%20lands.%20At%20minimum%2C%20surfacing%20the%20dashboard%20name%20in%20the%20toast%20%28%60Added%20to%20%22%24%7Bdashboard.name%7D%22%60%29%20would%20make%20the%20behavior%20discoverable%20without%20blocking%20the%20action.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["style: prettier formatting"](https://github.com/youhaowei/dashframe/commit/f9231d3b9076ff9364af74e9fe320acfc87a2255) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42021848)</sub>

<!-- /greptile_comment -->