### PR TITLE
Assistant sidebar live content: agent turns streaming into a draft

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -211,6 +211,25 @@ describe("createDashframeServer", () => {
       expect(body.data.version).toBe(project.meta.version);
     });
 
+    it("rejects a non-object JSON body on /assistant/run with 400, not a crash", async () => {
+      project = await openProject({
+        dir: join(root, "proj"),
+        name: "Run Co",
+      });
+      server = await createDashframeServer({ db: project.db });
+
+      // "null" is valid JSON, so JSON.parse succeeds — the route must still
+      // treat it as a client error instead of throwing at `body.prompt`.
+      const res = await fetch(`${server.url}/assistant/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "null",
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("Invalid JSON in request body");
+    });
+
     it("should require the loopback token and allow packaged Origin null", async () => {
       project = await openProject({
         dir: join(root, "proj"),

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -56,8 +56,12 @@ import { createHash, timingSafeEqual } from "node:crypto";
 
 import { type ArtifactDb } from "@dashframe/server-core";
 
+import { handleAssistantRunRequest } from "./assistant-run-route";
 import { captureCommandCredentials } from "./credential-release";
-import { createDraftController } from "./draft-controller";
+import {
+  createDraftController,
+  type DraftController,
+} from "./draft-controller";
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { functions } from "./functions";
 
@@ -644,6 +648,14 @@ export async function createDashframeServer(
       }),
     );
   }
+
+  honoApp.post("/assistant/run", (c) =>
+    handleAssistantRunRequest(c, {
+      app,
+      draftController: serverContext.draftController as DraftController,
+      resolveContext,
+    }),
+  );
 
   honoApp.route("/", createRoutes({ app, resolveContext }, upgradeWebSocket));
 

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -243,6 +243,13 @@ export async function handleAssistantRunRequest(
     return c.json({ error: "Assistant prompt is required" }, 400);
   }
 
+  if (body.provider !== undefined && body.provider !== "anthropic") {
+    return c.json(
+      { error: 'Unsupported provider — only "anthropic" is available' },
+      400,
+    );
+  }
+
   const model = resolveDefaultAnthropicModel(
     typeof body.modelId === "string" ? body.modelId : undefined,
   );
@@ -251,11 +258,32 @@ export async function handleAssistantRunRequest(
     draftController: options.draftController,
   });
 
+  // Abort the provider run when the client goes away — either the fetch is
+  // aborted (request signal) or the SSE stream consumer cancels. Without this
+  // the run keeps spending provider tokens and mutating the draft after the
+  // user has navigated away.
+  const runAbort = new AbortController();
+  const requestSignal = c.req.raw.signal;
+  if (requestSignal.aborted) {
+    runAbort.abort();
+  } else {
+    requestSignal.addEventListener("abort", () => runAbort.abort(), {
+      once: true,
+    });
+  }
+
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const encoder = new TextEncoder();
       const send = (event: AssistantSidebarEvent) => {
-        controller.enqueue(encoder.encode(encodeSse(event)));
+        // The consumer may have cancelled mid-run; enqueue on a closed
+        // stream throws and would mask the run's own termination path.
+        if (runAbort.signal.aborted) return;
+        try {
+          controller.enqueue(encoder.encode(encodeSse(event)));
+        } catch {
+          runAbort.abort();
+        }
       };
 
       send({ type: "run-start" });
@@ -268,6 +296,7 @@ export async function handleAssistantRunRequest(
               ? { artifact: body.artifact }
               : undefined,
           getApiKey: getScopedApiKey,
+          signal: runAbort.signal,
           onFirstMutation: ({ draftId }) => {
             send({ type: "first-mutation", draftId });
           },
@@ -286,10 +315,16 @@ export async function handleAssistantRunRequest(
       } catch (error) {
         send({ type: "error", message: errorMessage(error) });
       } finally {
-        controller.close();
+        try {
+          controller.close();
+        } catch {
+          // Already closed by consumer cancellation.
+        }
       }
     },
-    cancel() {},
+    cancel() {
+      runAbort.abort();
+    },
   });
 
   return new Response(stream, {

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -1,0 +1,302 @@
+import {
+  CREDENTIAL_COMMAND_ARG_FIELDS,
+  createAssistantRun,
+  getOAuthToken,
+  resolveDefaultAnthropicModel,
+  type AssistantRunTerminationReason,
+  type CreateAssistantRunOptions,
+} from "@dashframe/assistant";
+import type { WyStackApp } from "@wystack/server";
+import type { Context } from "hono";
+
+import { createDashframeAssistantHost } from "./assistant-host";
+import type { DraftController } from "./draft-controller";
+
+export type AssistantSidebarEvent =
+  | { type: "run-start" }
+  | { type: "text-delta"; delta: string }
+  | { type: "assistant-message"; text: string; stopReason?: string }
+  | {
+      type: "command-start";
+      toolCallId: string;
+      commandType: string;
+      args: unknown;
+    }
+  | {
+      type: "command-end";
+      toolCallId: string;
+      commandType: string;
+      isError: boolean;
+      result: unknown;
+    }
+  | { type: "tool-start"; toolCallId: string; toolName: string }
+  | {
+      type: "tool-end";
+      toolCallId: string;
+      toolName: string;
+      isError: boolean;
+    }
+  | { type: "first-mutation"; draftId: string }
+  | {
+      type: "run-end";
+      draftId: string;
+      firstMutationObserved: boolean;
+      terminationReason: AssistantRunTerminationReason;
+    }
+  | { type: "error"; message: string };
+
+interface AssistantRunRouteOptions {
+  app: WyStackApp;
+  draftController: DraftController;
+  resolveContext?: (req: Request) => Promise<Record<string, unknown>>;
+}
+
+interface AssistantRunRequestBody {
+  prompt?: unknown;
+  artifact?: unknown;
+  provider?: unknown;
+  modelId?: unknown;
+}
+
+type AgentEvent = Parameters<
+  NonNullable<CreateAssistantRunOptions["onEvent"]>
+>[0];
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function textFromMessage(
+  message: Extract<AgentEvent, { type: "message_end" }>["message"],
+): string {
+  if (!("content" in message) || !Array.isArray(message.content)) return "";
+  return message.content
+    .flatMap((block) =>
+      block.type === "text" && block.text.trim() ? [block.text] : [],
+    )
+    .join("\n");
+}
+
+function redact(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redact);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+      key,
+      shouldRedactKey(key) ? "[redacted]" : redact(child),
+    ]),
+  );
+}
+
+function shouldRedactKey(key: string): boolean {
+  if (
+    Object.values(CREDENTIAL_COMMAND_ARG_FIELDS).some((fields) =>
+      fields.includes(key as "apiKey" | "connectionString"),
+    )
+  ) {
+    return true;
+  }
+  return /password|secret|token/i.test(key);
+}
+
+function commandTypeFromArgs(args: unknown): string {
+  if (args && typeof args === "object") {
+    const value = (args as { type?: unknown }).type;
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return "applyCommand";
+}
+
+function commandArgsFromArgs(args: unknown): unknown {
+  if (args && typeof args === "object" && "args" in args) {
+    return redact((args as { args?: unknown }).args ?? null);
+  }
+  return null;
+}
+
+function messageEventFromAgentEvent(
+  event: Extract<AgentEvent, { type: "message_end" }>,
+): AssistantSidebarEvent[] {
+  if (event.message.role !== "assistant") return [];
+  const text = textFromMessage(event.message);
+  if (!text) return [];
+  return [
+    {
+      type: "assistant-message",
+      text,
+      stopReason: event.message.stopReason,
+    },
+  ];
+}
+
+function toolStartEventFromAgentEvent(
+  event: Extract<AgentEvent, { type: "tool_execution_start" }>,
+): AssistantSidebarEvent {
+  if (event.toolName === "applyCommand") {
+    return {
+      type: "command-start",
+      toolCallId: event.toolCallId,
+      commandType: commandTypeFromArgs(event.args),
+      args: commandArgsFromArgs(event.args),
+    };
+  }
+  return {
+    type: "tool-start",
+    toolCallId: event.toolCallId,
+    toolName: event.toolName,
+  };
+}
+
+function commandResultType(result: unknown): string {
+  if (!result || typeof result !== "object") return "applyCommand";
+  return String(
+    (result as { commandType?: unknown }).commandType ?? "applyCommand",
+  );
+}
+
+function toolEndEventFromAgentEvent(
+  event: Extract<AgentEvent, { type: "tool_execution_end" }>,
+): AssistantSidebarEvent {
+  if (event.toolName === "applyCommand") {
+    const result =
+      event.result && typeof event.result === "object"
+        ? (event.result as { details?: unknown }).details
+        : null;
+    return {
+      type: "command-end",
+      toolCallId: event.toolCallId,
+      commandType: commandResultType(result),
+      isError: event.isError,
+      result: redact(result),
+    };
+  }
+  return {
+    type: "tool-end",
+    toolCallId: event.toolCallId,
+    toolName: event.toolName,
+    isError: event.isError,
+  };
+}
+
+function sidebarEventsFromAgentEvent(
+  event: AgentEvent,
+): AssistantSidebarEvent[] {
+  switch (event.type) {
+    case "message_update": {
+      const update = event.assistantMessageEvent;
+      if (update.type === "text_delta") {
+        return [{ type: "text-delta", delta: update.delta }];
+      }
+      return [];
+    }
+    case "message_end":
+      return messageEventFromAgentEvent(event);
+    case "tool_execution_start":
+      return [toolStartEventFromAgentEvent(event)];
+    case "tool_execution_end":
+      return [toolEndEventFromAgentEvent(event)];
+    default:
+      return [];
+  }
+}
+
+async function getScopedApiKey(provider: string): Promise<string | undefined> {
+  if (provider !== "anthropic") return undefined;
+  if (process.env.ANTHROPIC_API_KEY?.trim()) {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  if (process.env.ANTHROPIC_OAUTH_TOKEN?.trim()) {
+    return process.env.ANTHROPIC_OAUTH_TOKEN;
+  }
+  return getOAuthToken();
+}
+
+function encodeSse(event: AssistantSidebarEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+async function readBody(c: Context): Promise<AssistantRunRequestBody> {
+  const raw = await c.req.text();
+  if (!raw.trim()) return {};
+  const parsed = JSON.parse(raw) as AssistantRunRequestBody;
+  return parsed;
+}
+
+export async function handleAssistantRunRequest(
+  c: Context,
+  options: AssistantRunRouteOptions,
+): Promise<Response> {
+  try {
+    await options.resolveContext?.(c.req.raw);
+  } catch (error) {
+    return c.json({ error: errorMessage(error) }, 401);
+  }
+
+  let body: AssistantRunRequestBody;
+  try {
+    body = await readBody(c);
+  } catch {
+    return c.json({ error: "Invalid JSON in request body" }, 400);
+  }
+
+  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+  if (!prompt) {
+    return c.json({ error: "Assistant prompt is required" }, 400);
+  }
+
+  const model = resolveDefaultAnthropicModel(
+    typeof body.modelId === "string" ? body.modelId : undefined,
+  );
+  const host = createDashframeAssistantHost({
+    app: options.app,
+    draftController: options.draftController,
+  });
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      const send = (event: AssistantSidebarEvent) => {
+        controller.enqueue(encoder.encode(encodeSse(event)));
+      };
+
+      send({ type: "run-start" });
+      try {
+        const result = await createAssistantRun(host, {
+          model,
+          prompt,
+          context:
+            body.artifact && typeof body.artifact === "object"
+              ? { artifact: body.artifact }
+              : undefined,
+          getApiKey: getScopedApiKey,
+          onFirstMutation: ({ draftId }) => {
+            send({ type: "first-mutation", draftId });
+          },
+          onEvent: (event) => {
+            for (const sidebarEvent of sidebarEventsFromAgentEvent(event)) {
+              send(sidebarEvent);
+            }
+          },
+        });
+        send({
+          type: "run-end",
+          draftId: result.draftId,
+          firstMutationObserved: result.firstMutationObserved,
+          terminationReason: result.terminationReason,
+        });
+      } catch (error) {
+        send({ type: "error", message: errorMessage(error) });
+      } finally {
+        controller.close();
+      }
+    },
+    cancel() {},
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -250,9 +250,22 @@ export async function handleAssistantRunRequest(
     );
   }
 
-  const model = resolveDefaultAnthropicModel(
-    typeof body.modelId === "string" ? body.modelId : undefined,
-  );
+  let model: ReturnType<typeof resolveDefaultAnthropicModel>;
+  try {
+    model = resolveDefaultAnthropicModel(
+      typeof body.modelId === "string" ? body.modelId : undefined,
+    );
+  } catch (err) {
+    // Unknown requested model id is a client error; a failure to resolve
+    // the default list is a server configuration fault — let it propagate.
+    if (typeof body.modelId === "string") {
+      return c.json(
+        { error: err instanceof Error ? err.message : "Unknown model id" },
+        400,
+      );
+    }
+    throw err;
+  }
   const host = createDashframeAssistantHost({
     app: options.app,
     draftController: options.draftController,

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -217,8 +217,13 @@ function encodeSse(event: AssistantSidebarEvent): string {
 async function readBody(c: Context): Promise<AssistantRunRequestBody> {
   const raw = await c.req.text();
   if (!raw.trim()) return {};
-  const parsed = JSON.parse(raw) as AssistantRunRequestBody;
-  return parsed;
+  const parsed = JSON.parse(raw) as unknown;
+  // JSON.parse accepts non-object payloads ("null", "42", "[]"); a null body
+  // would otherwise escape the caller's catch and throw at `body.prompt`.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Request body must be a JSON object");
+  }
+  return parsed as AssistantRunRequestBody;
 }
 
 export async function handleAssistantRunRequest(

--- a/bun.lock
+++ b/bun.lock
@@ -459,6 +459,7 @@
         "@dashframe/eslint-config": "workspace:*",
         "@types/react": "^19.2.7",
         "typescript": "5.7.2",
+        "vitest": "^4.1.6",
       },
     },
     "packages/assistant": {

--- a/packages/app-data/package.json
+++ b/packages/app-data/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
-    "check": "bun run typecheck && bun run lint"
+    "test": "vitest run",
+    "check": "bun run typecheck && bun run lint && bun run test"
   },
   "dependencies": {
     "@dashframe/engine-browser": "workspace:*",

--- a/packages/app-data/package.json
+++ b/packages/app-data/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
     "@types/react": "^19.2.7",
-    "typescript": "5.7.2"
+    "typescript": "5.7.2",
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/app-data/src/assistant-run.test.ts
+++ b/packages/app-data/src/assistant-run.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAssistantSseChunk } from "./assistant-run";
+
+describe("assistant SSE parsing", () => {
+  it("parses complete events and preserves partial carry", () => {
+    const first = parseAssistantSseChunk(
+      'data: {"type":"run-start"}\n\n' +
+        'data: {"type":"text-delta","delta":"hel',
+    );
+
+    expect(first.events).toEqual([{ type: "run-start" }]);
+    expect(first.carry).toBe('data: {"type":"text-delta","delta":"hel');
+
+    const second = parseAssistantSseChunk('lo"}\n\n', first.carry);
+
+    expect(second.events).toEqual([{ type: "text-delta", delta: "hello" }]);
+    expect(second.carry).toBe("");
+  });
+
+  it("handles multi-line data payloads", () => {
+    const parsed = parseAssistantSseChunk(
+      'data: {"type":"assistant-message",\n' +
+        'data: "text":"done","stopReason":"stop"}\n\n',
+    );
+
+    expect(parsed.events).toEqual([
+      { type: "assistant-message", text: "done", stopReason: "stop" },
+    ]);
+  });
+});

--- a/packages/app-data/src/assistant-run.test.ts
+++ b/packages/app-data/src/assistant-run.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { parseAssistantSseChunk } from "./assistant-run";
+import { parseAssistantSseChunk, runAssistantPrompt } from "./assistant-run";
+
+vi.mock("./runtime", () => ({
+  getWyStackRuntimeConfig: () => ({ url: "http://localhost:4000" }),
+}));
 
 describe("assistant SSE parsing", () => {
   it("parses complete events and preserves partial carry", () => {
@@ -27,5 +31,51 @@ describe("assistant SSE parsing", () => {
     expect(parsed.events).toEqual([
       { type: "assistant-message", text: "done", stopReason: "stop" },
     ]);
+  });
+});
+
+describe("runAssistantPrompt error paths", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("throws the server's error message on a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { error: "Unknown Anthropic model id: nope" },
+          {
+            status: 400,
+          },
+        ),
+      ),
+    );
+
+    await expect(
+      runAssistantPrompt({ prompt: "hi", onEvent: () => {} }),
+    ).rejects.toThrow("Unknown Anthropic model id: nope");
+  });
+
+  it("falls back to an HTTP-status message when the error body is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 502 })),
+    );
+
+    await expect(
+      runAssistantPrompt({ prompt: "hi", onEvent: () => {} }),
+    ).rejects.toThrow("Assistant run failed with HTTP 502");
+  });
+
+  it("throws when an OK response carries no stream body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 })),
+    );
+
+    await expect(
+      runAssistantPrompt({ prompt: "hi", onEvent: () => {} }),
+    ).rejects.toThrow("Assistant run response did not include a stream");
   });
 });

--- a/packages/app-data/src/assistant-run.ts
+++ b/packages/app-data/src/assistant-run.ts
@@ -1,0 +1,129 @@
+import { getWyStackRuntimeConfig } from "./runtime";
+
+export type AssistantSidebarEvent =
+  | { type: "run-start" }
+  | { type: "text-delta"; delta: string }
+  | { type: "assistant-message"; text: string; stopReason?: string }
+  | {
+      type: "command-start";
+      toolCallId: string;
+      commandType: string;
+      args: unknown;
+    }
+  | {
+      type: "command-end";
+      toolCallId: string;
+      commandType: string;
+      isError: boolean;
+      result: unknown;
+    }
+  | { type: "tool-start"; toolCallId: string; toolName: string }
+  | {
+      type: "tool-end";
+      toolCallId: string;
+      toolName: string;
+      isError: boolean;
+    }
+  | { type: "first-mutation"; draftId: string }
+  | {
+      type: "run-end";
+      draftId: string;
+      firstMutationObserved: boolean;
+      terminationReason:
+        | "completed"
+        | "aborted"
+        | "error"
+        | "failureCap"
+        | "oscillation";
+    }
+  | { type: "error"; message: string };
+
+export interface AssistantRunRequest {
+  prompt: string;
+  artifact?: unknown;
+  provider?: string;
+  modelId?: string;
+}
+
+export interface RunAssistantPromptOptions extends AssistantRunRequest {
+  signal?: AbortSignal;
+  onEvent: (event: AssistantSidebarEvent) => void;
+}
+
+export function parseAssistantSseChunk(
+  chunk: string,
+  carry = "",
+): { events: AssistantSidebarEvent[]; carry: string } {
+  const text = carry + chunk;
+  const parts = text.split(/\n\n/);
+  const nextCarry = parts.pop() ?? "";
+  const events = parts.flatMap((part) => {
+    const data = part
+      .split(/\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trimStart())
+      .join("\n");
+    if (!data) return [];
+    return [JSON.parse(data) as AssistantSidebarEvent];
+  });
+  return { events, carry: nextCarry };
+}
+
+export async function runAssistantPrompt({
+  prompt,
+  artifact,
+  provider,
+  modelId,
+  signal,
+  onEvent,
+}: RunAssistantPromptOptions): Promise<void> {
+  const runtime = getWyStackRuntimeConfig();
+  const res = await fetch(`${runtime.url.replace(/\/$/, "")}/assistant/run`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+      ...(runtime.token ? { Authorization: `Bearer ${runtime.token}` } : {}),
+    },
+    body: JSON.stringify({ prompt, artifact, provider, modelId }),
+    signal,
+  });
+
+  if (!res.ok) {
+    const message = await readErrorMessage(res);
+    throw new Error(message);
+  }
+  if (!res.body) {
+    throw new Error("Assistant run response did not include a stream");
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let carry = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const parsed = parseAssistantSseChunk(
+      decoder.decode(value, { stream: true }),
+      carry,
+    );
+    carry = parsed.carry;
+    for (const event of parsed.events) onEvent(event);
+  }
+  const tail = decoder.decode();
+  if (tail) {
+    const parsed = parseAssistantSseChunk(tail, carry);
+    for (const event of parsed.events) onEvent(event);
+  }
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  if (!text) return `Assistant run failed with HTTP ${res.status}`;
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown };
+    return typeof parsed.error === "string" ? parsed.error : text;
+  } catch {
+    return text;
+  }
+}

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -17,10 +17,19 @@
 export { getWyStackClient, setWyStackClient } from "./client";
 export {
   createWyStackRuntime,
+  getWyStackRuntimeConfig,
   resolveWyStackConfig,
   type WyStackRuntime,
   type WyStackRuntimeConfig,
 } from "./runtime";
+
+export {
+  parseAssistantSseChunk,
+  runAssistantPrompt,
+  type AssistantRunRequest,
+  type AssistantSidebarEvent,
+  type RunAssistantPromptOptions,
+} from "./assistant-run";
 
 // Dashboards
 export {

--- a/packages/app-data/src/runtime.ts
+++ b/packages/app-data/src/runtime.ts
@@ -28,6 +28,17 @@ export interface WyStackRuntimeConfig {
   token?: string;
 }
 
+let currentRuntimeConfig: WyStackRuntimeConfig | null = null;
+
+export function getWyStackRuntimeConfig(): WyStackRuntimeConfig {
+  if (!currentRuntimeConfig) {
+    throw new Error(
+      "WyStack runtime config not set — call createWyStackRuntime before using assistant streaming",
+    );
+  }
+  return currentRuntimeConfig;
+}
+
 /**
  * Mint the client for `config`, wire the imperative singleton, and return the
  * bound Provider. Call once per host, before rendering.
@@ -36,6 +47,7 @@ export function createWyStackRuntime(
   config: string | WyStackRuntimeConfig,
 ): WyStackRuntime {
   const runtimeConfig = typeof config === "string" ? { url: config } : config;
+  currentRuntimeConfig = runtimeConfig;
   const token = runtimeConfig.token;
   const instance = createWyStack<Functions>({
     url: runtimeConfig.url,

--- a/packages/app/src/components/assistant/AssistantSidebar.tsx
+++ b/packages/app/src/components/assistant/AssistantSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { runAssistantPrompt } from "@dashframe/core";
 import { Button, Textarea, cn } from "@wystack/ui";
@@ -47,6 +47,7 @@ function AssistantPanelBody() {
   const beginRun = useAssistantStore((s) => s.beginRun);
   const receiveRunEvent = useAssistantStore((s) => s.receiveRunEvent);
   const failRun = useAssistantStore((s) => s.failRun);
+  const abortRun = useAssistantStore((s) => s.abortRun);
   const turns = useAssistantStore((s) => s.turns);
   const streamingText = useAssistantStore((s) => s.streamingText);
   const runStatus = useAssistantStore((s) => s.runStatus);
@@ -54,19 +55,45 @@ function AssistantPanelBody() {
   const [prompt, setPrompt] = useState("");
   const isRunning = runStatus === "running";
 
+  // Cancels the in-flight run when the rail is dismissed mid-run so a
+  // stalled stream can't leave the store stuck in "running". The Dock keeps
+  // the closed rail mounted (extent 0), so this keys on the store's isOpen —
+  // plus an unmount guard for route-level teardown. The run's mutations live
+  // in a draft, so cancelling loses nothing unreviewed.
+  const isOpen = useAssistantStore((s) => s.isOpen);
+  const runAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    if (!isOpen) runAbortRef.current?.abort();
+  }, [isOpen]);
+  useEffect(
+    () => () => {
+      runAbortRef.current?.abort();
+    },
+    [],
+  );
+
   async function submitPrompt() {
     const text = prompt.trim();
     if (!text || isRunning) return;
     setPrompt("");
     beginRun(text);
+    const controller = new AbortController();
+    runAbortRef.current = controller;
     try {
       await runAssistantPrompt({
         prompt: text,
         artifact,
+        signal: controller.signal,
         onEvent: receiveRunEvent,
       });
     } catch (err) {
+      if (controller.signal.aborted) {
+        abortRun();
+        return;
+      }
       failRun(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (runAbortRef.current === controller) runAbortRef.current = null;
     }
   }
 
@@ -112,7 +139,7 @@ function AssistantPanelBody() {
         )}
 
         <div className="shrink-0 p-3 shadow-[inset_0_1px_0_var(--neutral-border)]">
-          <div className="flex items-end gap-2 rounded-xl bg-neutral-bg/70 p-1.5 ring-1 ring-neutral-border/60">
+          <div className="flex items-end gap-2 rounded-[var(--surface-radius)] bg-neutral-bg/70 p-1.5 shadow-[var(--surface-shadow)]">
             <Textarea
               rows={2}
               value={prompt}
@@ -202,7 +229,7 @@ function AssistantTurnRow({ turn }: { turn: AssistantTurn }) {
   return (
     <div
       className={cn(
-        "rounded-lg bg-neutral-bg/65 px-3 py-2 text-xs text-neutral-fg shadow-[inset_0_0_0_1px_var(--neutral-border)]",
+        "rounded-[var(--surface-radius)] bg-neutral-bg/65 px-3 py-2 text-xs text-neutral-fg shadow-[var(--surface-shadow)]",
         turn.kind === "user" && "bg-neutral-bg-subtle",
       )}
     >

--- a/packages/app/src/components/assistant/AssistantSidebar.tsx
+++ b/packages/app/src/components/assistant/AssistantSidebar.tsx
@@ -1,8 +1,21 @@
-import { useAssistantStore } from "@/lib/stores/assistant-store";
-import { Button } from "@wystack/ui";
-import { CloseIcon, SparklesIcon } from "@wystack/ui-icons";
+import { useState } from "react";
 
-import { AssistantEmptyState } from "./AssistantEmptyState";
+import { runAssistantPrompt } from "@dashframe/core";
+import { Button, Textarea, cn } from "@wystack/ui";
+import {
+  ArrowRightIcon,
+  CheckCircleIcon,
+  CloseIcon,
+  LoaderIcon,
+  SparklesIcon,
+  TerminalIcon,
+} from "@wystack/ui-icons";
+
+import {
+  type AssistantTurn,
+  useAssistantStore,
+} from "@/lib/stores/assistant-store";
+
 import { DraftReviewPanel } from "./DraftReviewPanel";
 import { useArtifactContext } from "./artifact-context";
 
@@ -12,9 +25,8 @@ import { useArtifactContext } from "./artifact-context";
  *
  * Slack-assistant shape: summonable, contextual to the current artifact,
  * dismissable. The artifact (center) stays primary; this is an input method
- * onto it, not a transcript the app is built around. Live agent content is
- * gated on the pi-agent — this ships the *shell* (toggle, context binding, the
- * empty conversation surface).
+ * onto it. The live run transcript stays in this persistent rail; review stays
+ * human-gated through the draft panel.
  */
 export function AssistantSidebar() {
   return (
@@ -32,6 +44,31 @@ function AssistantPanelBody() {
   const artifact = useArtifactContext();
   const close = useAssistantStore((s) => s.close);
   const pendingDraftId = useAssistantStore((s) => s.pendingDraftId);
+  const beginRun = useAssistantStore((s) => s.beginRun);
+  const receiveRunEvent = useAssistantStore((s) => s.receiveRunEvent);
+  const failRun = useAssistantStore((s) => s.failRun);
+  const turns = useAssistantStore((s) => s.turns);
+  const streamingText = useAssistantStore((s) => s.streamingText);
+  const runStatus = useAssistantStore((s) => s.runStatus);
+  const error = useAssistantStore((s) => s.error);
+  const [prompt, setPrompt] = useState("");
+  const isRunning = runStatus === "running";
+
+  async function submitPrompt() {
+    const text = prompt.trim();
+    if (!text || isRunning) return;
+    setPrompt("");
+    beginRun(text);
+    try {
+      await runAssistantPrompt({
+        prompt: text,
+        artifact,
+        onEvent: receiveRunEvent,
+      });
+    } catch (err) {
+      failRun(err instanceof Error ? err.message : String(err));
+    }
+  }
 
   return (
     <>
@@ -60,13 +97,146 @@ function AssistantPanelBody() {
         />
       </header>
 
-      <div className="min-h-0 flex-1">
-        {pendingDraftId ? (
-          <DraftReviewPanel draftId={pendingDraftId} />
-        ) : (
-          <AssistantEmptyState artifact={artifact} />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <AssistantTimeline
+          turns={turns}
+          streamingText={streamingText}
+          artifactTitle={artifact?.title ?? null}
+          error={error}
+        />
+
+        {pendingDraftId && (
+          <div className="shrink-0 bg-neutral-bg/70 shadow-[inset_0_1px_0_var(--neutral-border)]">
+            <DraftReviewPanel draftId={pendingDraftId} compact />
+          </div>
         )}
+
+        <div className="shrink-0 p-3 shadow-[inset_0_1px_0_var(--neutral-border)]">
+          <div className="flex items-end gap-2 rounded-xl bg-neutral-bg/70 p-1.5 ring-1 ring-neutral-border/60">
+            <Textarea
+              rows={2}
+              value={prompt}
+              disabled={isRunning}
+              placeholder={
+                artifact
+                  ? `Ask the assistant to change ${artifact.title}...`
+                  : "Ask the assistant to draft a change..."
+              }
+              onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  void submitPrompt();
+                }
+              }}
+              className="min-h-16 resize-none border-0 bg-transparent text-xs shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              aria-label="Message the assistant"
+            />
+            <Button
+              label={isRunning ? "Running" : "Send"}
+              icon={isRunning ? LoaderIcon : ArrowRightIcon}
+              iconOnly
+              size="sm"
+              disabled={!prompt.trim() || isRunning}
+              onClick={() => void submitPrompt()}
+              className="mb-0.5 size-8 shrink-0"
+              tooltip={isRunning ? "Assistant is running" : "Send"}
+            />
+          </div>
+        </div>
       </div>
     </>
   );
+}
+
+function AssistantTimeline({
+  turns,
+  streamingText,
+  artifactTitle,
+  error,
+}: {
+  turns: AssistantTurn[];
+  streamingText: string;
+  artifactTitle: string | null;
+  error: string | null;
+}) {
+  const hasContent = turns.length > 0 || streamingText.trim() || error;
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+      {!hasContent ? (
+        <div className="flex h-full flex-col items-center justify-center px-3 text-center">
+          <span className="mb-3 flex size-10 items-center justify-center rounded-2xl bg-palette-primary/10 text-palette-primary">
+            <SparklesIcon className="size-5" />
+          </span>
+          <h2 className="text-sm font-semibold text-neutral-fg">
+            {artifactTitle ? "Draft with the assistant" : "Assistant ready"}
+          </h2>
+          <p className="mt-1.5 max-w-[15rem] text-xs leading-relaxed text-neutral-fg-subtle">
+            {artifactTitle
+              ? "Ask for a change. Commands stream here, then the draft appears for review after the first mutation lands."
+              : "Open an artifact or ask for a project-level draft. Nothing publishes without review."}
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {turns.map((turn) => (
+            <AssistantTurnRow key={turn.id} turn={turn} />
+          ))}
+          {streamingText.trim() && (
+            <AssistantTurnRow
+              turn={{
+                id: "streaming",
+                kind: "assistant",
+                text: streamingText,
+                status: "running",
+              }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AssistantTurnRow({ turn }: { turn: AssistantTurn }) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg bg-neutral-bg/65 px-3 py-2 text-xs text-neutral-fg shadow-[inset_0_0_0_1px_var(--neutral-border)]",
+        turn.kind === "user" && "bg-neutral-bg-subtle",
+      )}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-[10px] font-medium uppercase text-neutral-fg-subtle">
+        <TurnIcon turn={turn} />
+        <span>{turnLabel(turn)}</span>
+      </div>
+      <p className="whitespace-pre-wrap break-words leading-relaxed">
+        {turn.text}
+      </p>
+    </div>
+  );
+}
+
+function TurnIcon({ turn }: { turn: AssistantTurn }) {
+  if (turn.kind === "command" || turn.kind === "tool") {
+    return <TerminalIcon className="size-3" />;
+  }
+  if (turn.status === "running") {
+    return <LoaderIcon className="size-3" />;
+  }
+  if (turn.kind === "assistant") {
+    return <SparklesIcon className="size-3" />;
+  }
+  return <CheckCircleIcon className="size-3" />;
+}
+
+function turnLabel(turn: AssistantTurn): string {
+  if (turn.kind === "user") return "You";
+  if (turn.kind === "command") {
+    if (turn.status === "running") return "Command";
+    return turn.status === "error" ? "Command failed" : "Command applied";
+  }
+  if (turn.kind === "tool") return "Tool";
+  if (turn.kind === "status") return "Status";
+  return turn.status === "running" ? "Assistant streaming" : "Assistant";
 }

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -33,7 +33,13 @@ import { useAssistantStore } from "@/lib/stores/assistant-store";
 /**
  * Panel body rendered in the assistant sidebar when there is a draft to review.
  */
-export function DraftReviewPanel({ draftId }: { draftId: string }) {
+export function DraftReviewPanel({
+  draftId,
+  compact = false,
+}: {
+  draftId: string;
+  compact?: boolean;
+}) {
   const navigate = useNavigate();
   const setPendingDraft = useAssistantStore((s) => s.setPendingDraft);
 
@@ -158,11 +164,11 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
 
   return (
     <>
-      <div className="flex h-full flex-col">
-        <div className="flex-1 px-4 py-5">
+      <div className={cn("flex flex-col", compact ? "" : "h-full")}>
+        <div className={compact ? "px-3 py-3" : "flex-1 px-4 py-5"}>
           <div
             className={cn(
-              "rounded-xl border border-palette-primary/20 bg-palette-primary/5 p-4",
+              "rounded-xl bg-palette-primary/5 p-4 ring-1 ring-palette-primary/20",
             )}
           >
             <div className="mb-3 flex items-center gap-2">
@@ -212,12 +218,14 @@ export function DraftReviewPanel({ draftId }: { draftId: string }) {
           </div>
         </div>
 
-        <div className="border-t border-neutral-border/60 px-4 py-3">
-          <p className="flex items-center gap-1.5 text-[10px] leading-relaxed text-neutral-fg-subtle">
-            <SparklesIcon className="size-3 shrink-0" />
-            Review the proposed changes before publishing to your project.
-          </p>
-        </div>
+        {!compact && (
+          <div className="px-4 py-3 shadow-[inset_0_1px_0_var(--neutral-border)]">
+            <p className="flex items-center gap-1.5 text-[10px] leading-relaxed text-neutral-fg-subtle">
+              <SparklesIcon className="size-3 shrink-0" />
+              Review the proposed changes before publishing to your project.
+            </p>
+          </div>
+        )}
       </div>
 
       <PreviewDiffDialog

--- a/packages/app/src/components/assistant/DraftReviewPanel.tsx
+++ b/packages/app/src/components/assistant/DraftReviewPanel.tsx
@@ -168,7 +168,7 @@ export function DraftReviewPanel({
         <div className={compact ? "px-3 py-3" : "flex-1 px-4 py-5"}>
           <div
             className={cn(
-              "rounded-xl bg-palette-primary/5 p-4 ring-1 ring-palette-primary/20",
+              "rounded-[var(--surface-radius)] bg-neutral-bg/90 p-4 shadow-[var(--surface-shadow)]",
             )}
           >
             <div className="mb-3 flex items-center gap-2">

--- a/packages/app/src/lib/stores/assistant-store.test.ts
+++ b/packages/app/src/lib/stores/assistant-store.test.ts
@@ -9,7 +9,15 @@ describe("useAssistantStore", () => {
     // Reset to defaults between tests (the store is a module singleton) and
     // drop any persisted payload from a prior test.
     useAssistantStore.persist.clearStorage();
-    useAssistantStore.setState({ isOpen: false });
+    useAssistantStore.setState({
+      isOpen: false,
+      pendingDraftId: null,
+      runStatus: "idle",
+      activeDraftId: null,
+      turns: [],
+      streamingText: "",
+      error: null,
+    });
   });
 
   it("toggles open state", () => {
@@ -39,6 +47,58 @@ describe("useAssistantStore", () => {
 
     await useAssistantStore.persist.rehydrate();
 
+    expect(useAssistantStore.getState().isOpen).toBe(true);
+  });
+
+  it("keeps eager-open draft ids hidden until first mutation", () => {
+    useAssistantStore.getState().beginRun("Make a dashboard");
+    useAssistantStore.getState().receiveRunEvent({ type: "run-start" });
+    useAssistantStore.getState().receiveRunEvent({
+      type: "run-end",
+      draftId: "draft-empty",
+      firstMutationObserved: false,
+      terminationReason: "completed",
+    });
+
+    expect(useAssistantStore.getState().activeDraftId).toBe("draft-empty");
+    expect(useAssistantStore.getState().pendingDraftId).toBeNull();
+    expect(useAssistantStore.getState().runStatus).toBe("completed");
+  });
+
+  it("surfaces the review draft only after first successful mutation", () => {
+    useAssistantStore.getState().beginRun("Rename it");
+    useAssistantStore.getState().receiveRunEvent({
+      type: "command-start",
+      toolCallId: "tool-1",
+      commandType: "RenameNode",
+      args: { id: "node-1", name: "Revenue" },
+    });
+
+    expect(useAssistantStore.getState().pendingDraftId).toBeNull();
+
+    useAssistantStore.getState().receiveRunEvent({
+      type: "first-mutation",
+      draftId: "draft-mutated",
+    });
+    useAssistantStore.getState().receiveRunEvent({
+      type: "command-end",
+      toolCallId: "tool-1",
+      commandType: "RenameNode",
+      isError: false,
+      result: { commandType: "RenameNode" },
+    });
+
+    expect(useAssistantStore.getState().pendingDraftId).toBe("draft-mutated");
+    expect(useAssistantStore.getState().turns.at(-1)?.status).toBe("success");
+  });
+
+  it("clears the surfaced draft after publish or discard", () => {
+    useAssistantStore.getState().setPendingDraft("draft-review");
+    expect(useAssistantStore.getState().isOpen).toBe(true);
+
+    useAssistantStore.getState().setPendingDraft(null);
+
+    expect(useAssistantStore.getState().pendingDraftId).toBeNull();
     expect(useAssistantStore.getState().isOpen).toBe(true);
   });
 });

--- a/packages/app/src/lib/stores/assistant-store.test.ts
+++ b/packages/app/src/lib/stores/assistant-store.test.ts
@@ -92,6 +92,27 @@ describe("useAssistantStore", () => {
     expect(useAssistantStore.getState().turns.at(-1)?.status).toBe("success");
   });
 
+  it("clears a prior run's pending draft when a new run begins", () => {
+    useAssistantStore.getState().setPendingDraft("draft-old-run");
+
+    useAssistantStore.getState().beginRun("Follow-up prompt");
+
+    expect(useAssistantStore.getState().pendingDraftId).toBeNull();
+  });
+
+  it("reports an aborted run as aborted, not as an error", () => {
+    useAssistantStore.getState().beginRun("Make a dashboard");
+    useAssistantStore.getState().receiveRunEvent({
+      type: "run-end",
+      draftId: "draft-aborted",
+      firstMutationObserved: false,
+      terminationReason: "aborted",
+    });
+
+    expect(useAssistantStore.getState().runStatus).toBe("aborted");
+    expect(useAssistantStore.getState().error).toBeNull();
+  });
+
   it("clears the surfaced draft after publish or discard", () => {
     useAssistantStore.getState().setPendingDraft("draft-review");
     expect(useAssistantStore.getState().isOpen).toBe(true);

--- a/packages/app/src/lib/stores/assistant-store.ts
+++ b/packages/app/src/lib/stores/assistant-store.ts
@@ -44,9 +44,17 @@ export type AssistantStoreEvent =
       type: "run-end";
       draftId: string;
       firstMutationObserved: boolean;
-      terminationReason: string;
+      terminationReason: AssistantRunTerminationReason;
     }
   | { type: "error"; message: string };
+
+/** Mirrors AssistantRunTerminationReason in @dashframe/assistant. */
+export type AssistantRunTerminationReason =
+  | "completed"
+  | "aborted"
+  | "error"
+  | "failureCap"
+  | "oscillation";
 
 /**
  * Whether the assistant is visible. Panel geometry lives in the shell store.
@@ -81,6 +89,8 @@ interface AssistantActions {
   beginRun: (prompt: string) => void;
   receiveRunEvent: (event: AssistantStoreEvent) => void;
   failRun: (message: string) => void;
+  /** Client-side cancel (e.g. rail dismissed mid-run) — clean, not an error. */
+  abortRun: () => void;
   clearTranscript: () => void;
 }
 
@@ -189,6 +199,24 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
             },
           ],
         })),
+      abortRun: () =>
+        set((s) => {
+          if (s.runStatus !== "running") return s;
+          return {
+            ...s,
+            runStatus: "aborted",
+            streamingText: "",
+            turns: [
+              ...flushStreamingTurn(s),
+              {
+                id: makeTurnId("aborted"),
+                kind: "status",
+                text: "Run cancelled",
+                status: "success",
+              },
+            ],
+          };
+        }),
       clearTranscript: () =>
         set({
           runStatus: "idle",
@@ -207,6 +235,19 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
     },
   ),
 );
+
+function terminationFailureMessage(
+  reason: AssistantRunTerminationReason,
+): string {
+  switch (reason) {
+    case "failureCap":
+      return "Run stopped after repeated command failures.";
+    case "oscillation":
+      return "Run stopped after repeating itself without progress.";
+    default:
+      return "Run ended with an error.";
+  }
+}
 
 let fallbackTurnCounter = 0;
 
@@ -330,12 +371,30 @@ function applyAssistantEvent(
       let runStatus: AssistantRunStatus = "error";
       if (event.terminationReason === "completed") runStatus = "completed";
       else if (event.terminationReason === "aborted") runStatus = "aborted";
+      // Abnormal terminations must leave a visible trace — without a status
+      // turn the timeline just stops and the user gets no signal the run
+      // ended early (the "error" SSE event doesn't fire for these).
+      const failureMessage =
+        runStatus === "error"
+          ? terminationFailureMessage(event.terminationReason)
+          : null;
       return {
         ...state,
         activeDraftId: event.draftId,
         runStatus,
         streamingText: "",
-        turns: flushStreamingTurn(state),
+        error: failureMessage ?? state.error,
+        turns: failureMessage
+          ? [
+              ...flushStreamingTurn(state),
+              {
+                id: makeTurnId("run-end"),
+                kind: "status",
+                text: failureMessage,
+                status: "error",
+              },
+            ]
+          : flushStreamingTurn(state),
       };
     }
     case "error":

--- a/packages/app/src/lib/stores/assistant-store.ts
+++ b/packages/app/src/lib/stores/assistant-store.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-export type AssistantRunStatus = "idle" | "running" | "completed" | "error";
+export type AssistantRunStatus =
+  | "idle"
+  | "running"
+  | "completed"
+  | "aborted"
+  | "error";
 
 export interface AssistantTurn {
   id: string;
@@ -152,6 +157,10 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
           isOpen: true,
           runStatus: "running",
           activeDraftId: null,
+          // Clear any draft left pending by a previous run — its review
+          // panel must not survive into the new run. If this run mutates,
+          // first-mutation re-populates it.
+          pendingDraftId: null,
           streamingText: "",
           error: null,
           turns: [
@@ -317,15 +326,18 @@ function applyAssistantEvent(
         pendingDraftId: event.draftId,
         isOpen: true,
       };
-    case "run-end":
+    case "run-end": {
+      let runStatus: AssistantRunStatus = "error";
+      if (event.terminationReason === "completed") runStatus = "completed";
+      else if (event.terminationReason === "aborted") runStatus = "aborted";
       return {
         ...state,
         activeDraftId: event.draftId,
-        runStatus:
-          event.terminationReason === "completed" ? "completed" : "error",
+        runStatus,
         streamingText: "",
         turns: flushStreamingTurn(state),
       };
+    }
     case "error":
       return {
         ...state,

--- a/packages/app/src/lib/stores/assistant-store.ts
+++ b/packages/app/src/lib/stores/assistant-store.ts
@@ -1,6 +1,48 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+export type AssistantRunStatus = "idle" | "running" | "completed" | "error";
+
+export interface AssistantTurn {
+  id: string;
+  kind: "user" | "assistant" | "command" | "tool" | "status";
+  text: string;
+  status?: "running" | "success" | "error";
+}
+
+export type AssistantStoreEvent =
+  | { type: "run-start" }
+  | { type: "text-delta"; delta: string }
+  | { type: "assistant-message"; text: string; stopReason?: string }
+  | {
+      type: "command-start";
+      toolCallId: string;
+      commandType: string;
+      args: unknown;
+    }
+  | {
+      type: "command-end";
+      toolCallId: string;
+      commandType: string;
+      isError: boolean;
+      result: unknown;
+    }
+  | { type: "tool-start"; toolCallId: string; toolName: string }
+  | {
+      type: "tool-end";
+      toolCallId: string;
+      toolName: string;
+      isError: boolean;
+    }
+  | { type: "first-mutation"; draftId: string }
+  | {
+      type: "run-end";
+      draftId: string;
+      firstMutationObserved: boolean;
+      terminationReason: string;
+    }
+  | { type: "error"; message: string };
+
 /**
  * Whether the assistant is visible. Panel geometry lives in the shell store.
  * This store holds only the open/closed state and its ⌘J summon.
@@ -18,6 +60,11 @@ interface AssistantState {
    * Set by the pi-agent producer; cleared on publish or discard.
    */
   pendingDraftId: string | null;
+  runStatus: AssistantRunStatus;
+  activeDraftId: string | null;
+  turns: AssistantTurn[];
+  streamingText: string;
+  error: string | null;
 }
 
 interface AssistantActions {
@@ -26,6 +73,10 @@ interface AssistantActions {
   toggle: () => void;
   /** Set (or clear) a draft waiting for review. Opens the panel when non-null. */
   setPendingDraft: (id: string | null) => void;
+  beginRun: (prompt: string) => void;
+  receiveRunEvent: (event: AssistantStoreEvent) => void;
+  failRun: (message: string) => void;
+  clearTranscript: () => void;
 }
 
 /**
@@ -81,6 +132,11 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
       // Transient — not persisted. A stale draftId across a server restart
       // would surface a "draft not found" error in the review panel.
       pendingDraftId: null,
+      runStatus: "idle",
+      activeDraftId: null,
+      turns: [],
+      streamingText: "",
+      error: null,
 
       open: () => set({ isOpen: true }),
       close: () => set({ isOpen: false }),
@@ -91,6 +147,47 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
           // Open the panel automatically when a draft is queued.
           isOpen: id !== null ? true : s.isOpen,
         })),
+      beginRun: (prompt) =>
+        set((s) => ({
+          isOpen: true,
+          runStatus: "running",
+          activeDraftId: null,
+          streamingText: "",
+          error: null,
+          turns: [
+            ...s.turns,
+            {
+              id: makeTurnId("user"),
+              kind: "user",
+              text: prompt,
+              status: "success",
+            },
+          ],
+        })),
+      receiveRunEvent: (event) => set((s) => applyAssistantEvent(s, event)),
+      failRun: (message) =>
+        set((s) => ({
+          runStatus: "error",
+          streamingText: "",
+          error: message,
+          turns: [
+            ...flushStreamingTurn(s),
+            {
+              id: makeTurnId("error"),
+              kind: "status",
+              text: message,
+              status: "error",
+            },
+          ],
+        })),
+      clearTranscript: () =>
+        set({
+          runStatus: "idle",
+          activeDraftId: null,
+          turns: [],
+          streamingText: "",
+          error: null,
+        }),
     }),
     {
       name: "dashframe:assistant",
@@ -101,3 +198,149 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
     },
   ),
 );
+
+let fallbackTurnCounter = 0;
+
+function makeTurnId(prefix: string): string {
+  const id = globalThis.crypto?.randomUUID?.() ?? String(++fallbackTurnCounter);
+  return `${prefix}-${id}`;
+}
+
+function formatCommandArgs(args: unknown): string {
+  if (args === null || args === undefined) return "";
+  try {
+    const text = JSON.stringify(args);
+    return text === "{}" ? "" : ` ${text}`;
+  } catch {
+    return "";
+  }
+}
+
+function flushStreamingTurn(state: AssistantState): AssistantTurn[] {
+  const text = state.streamingText.trim();
+  if (!text) return state.turns;
+  return [
+    ...state.turns,
+    {
+      id: makeTurnId("assistant"),
+      kind: "assistant",
+      text,
+      status: "success",
+    },
+  ];
+}
+
+function replaceTurn(
+  turns: AssistantTurn[],
+  id: string,
+  update: Partial<AssistantTurn>,
+): AssistantTurn[] {
+  return turns.map((turn) => (turn.id === id ? { ...turn, ...update } : turn));
+}
+
+function finishToolTurn(
+  state: AssistantState,
+  event: Extract<AssistantStoreEvent, { type: "command-end" | "tool-end" }>,
+): AssistantState {
+  return {
+    ...state,
+    turns: replaceTurn(state.turns, event.toolCallId, {
+      status: event.isError ? "error" : "success",
+    }),
+  };
+}
+
+function applyAssistantEvent(
+  state: AssistantState,
+  event: AssistantStoreEvent,
+): AssistantState {
+  switch (event.type) {
+    case "run-start":
+      return {
+        ...state,
+        runStatus: "running",
+        error: null,
+      };
+    case "text-delta":
+      return {
+        ...state,
+        streamingText: state.streamingText + event.delta,
+      };
+    case "assistant-message": {
+      const turns = flushStreamingTurn({
+        ...state,
+        streamingText: state.streamingText || event.text,
+      });
+      return {
+        ...state,
+        streamingText: "",
+        turns,
+      };
+    }
+    case "command-start": {
+      return {
+        ...state,
+        turns: [
+          ...flushStreamingTurn(state),
+          {
+            id: event.toolCallId,
+            kind: "command",
+            text: `${event.commandType}${formatCommandArgs(event.args)}`,
+            status: "running",
+          },
+        ],
+        streamingText: "",
+      };
+    }
+    case "command-end":
+      return finishToolTurn(state, event);
+    case "tool-start":
+      return {
+        ...state,
+        turns: [
+          ...flushStreamingTurn(state),
+          {
+            id: event.toolCallId,
+            kind: "tool",
+            text: event.toolName,
+            status: "running",
+          },
+        ],
+        streamingText: "",
+      };
+    case "tool-end":
+      return finishToolTurn(state, event);
+    case "first-mutation":
+      return {
+        ...state,
+        activeDraftId: event.draftId,
+        pendingDraftId: event.draftId,
+        isOpen: true,
+      };
+    case "run-end":
+      return {
+        ...state,
+        activeDraftId: event.draftId,
+        runStatus:
+          event.terminationReason === "completed" ? "completed" : "error",
+        streamingText: "",
+        turns: flushStreamingTurn(state),
+      };
+    case "error":
+      return {
+        ...state,
+        runStatus: "error",
+        streamingText: "",
+        error: event.message,
+        turns: [
+          ...flushStreamingTurn(state),
+          {
+            id: makeTurnId("error"),
+            kind: "status",
+            text: event.message,
+            status: "error",
+          },
+        ],
+      };
+  }
+}

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -49,6 +49,8 @@ export {
   type CreateAssistantRunOptions,
 } from "./assistant-run.js";
 
+export { resolveDefaultAnthropicModel } from "./model.js";
+
 // Public constants for server-side drift/security tests; applyCommand itself is package-internal.
 export {
   CREDENTIAL_COMMAND_ARG_FIELDS,

--- a/packages/assistant/src/model.ts
+++ b/packages/assistant/src/model.ts
@@ -1,0 +1,25 @@
+import { getModels, type Api, type Model } from "@earendil-works/pi-ai";
+
+const DEFAULT_ANTHROPIC_MODELS = [
+  "claude-haiku-4-5",
+  "claude-3-5-haiku-latest",
+  "claude-sonnet-4-5",
+] as const;
+
+export function resolveDefaultAnthropicModel(
+  requestedModelId?: string,
+): Model<Api> {
+  const models = getModels("anthropic") as Model<Api>[];
+  const model =
+    (requestedModelId
+      ? models.find((candidate) => candidate.id === requestedModelId)
+      : undefined) ??
+    DEFAULT_ANTHROPIC_MODELS.map((id) =>
+      models.find((candidate) => candidate.id === id),
+    ).find((candidate): candidate is Model<Api> => candidate !== undefined);
+
+  if (!model) {
+    throw new Error("No supported Anthropic model is registered in pi-ai");
+  }
+  return model;
+}

--- a/packages/assistant/src/model.ts
+++ b/packages/assistant/src/model.ts
@@ -10,13 +10,22 @@ export function resolveDefaultAnthropicModel(
   requestedModelId?: string,
 ): Model<Api> {
   const models = getModels("anthropic") as Model<Api>[];
-  const model =
-    (requestedModelId
-      ? models.find((candidate) => candidate.id === requestedModelId)
-      : undefined) ??
-    DEFAULT_ANTHROPIC_MODELS.map((id) =>
-      models.find((candidate) => candidate.id === id),
-    ).find((candidate): candidate is Model<Api> => candidate !== undefined);
+
+  // An explicit request must resolve exactly — silently falling back to a
+  // default would run a different model than the caller asked for.
+  if (requestedModelId) {
+    const requested = models.find(
+      (candidate) => candidate.id === requestedModelId,
+    );
+    if (!requested) {
+      throw new Error(`Unknown Anthropic model id: ${requestedModelId}`);
+    }
+    return requested;
+  }
+
+  const model = DEFAULT_ANTHROPIC_MODELS.map((id) =>
+    models.find((candidate) => candidate.id === id),
+  ).find((candidate): candidate is Model<Api> => candidate !== undefined);
 
   if (!model) {
     throw new Error("No supported Anthropic model is registered in pi-ai");


### PR DESCRIPTION
Wires the assistant rail to live draft runs: the sidebar streams a provider-backed run's turns (text deltas, tool/command activity, first-mutation, run-end) over server-sent events, and surfaces the resulting draft for the one atomic publish/discard review gate.

Tracked internally as YW-145.

## Changes

- **`POST /assistant/run` SSE route** (`apps/server`) — starts a provider-backed assistant run against the draft controller and streams typed sidebar events (`run-start`, `text-delta`, `assistant-message`, `command-start/end`, `tool-start/end`, `first-mutation`, `run-end`, `error`). Credential-bearing command args are redacted before they leave the server.
- **Client-disconnect abort** — the request signal and SSE stream cancellation feed an AbortController passed into `createAssistantRun`, so closing the tab stops provider token spend and draft mutations; the run's existing aborted-draft handling takes over.
- **Provider contract is honest** — non-`anthropic` provider values are rejected with 400 instead of silently running an Anthropic model.
- **`@dashframe/app-data` run client** — SSE parser + typed event stream consumed by the assistant store; vitest suite wired into the package's scripts so the workspace check runs it.
- **Assistant rail live turns** (`packages/app`) — the sidebar renders streaming turns as they arrive, tracks the pending draft lazily (rail surfaces the draft only once a first mutation exists), and hosts the publish/discard review surface.

## Screenshots

### 01 Rail Empty Home
![01 Rail Empty Home](https://github.com/youhaowei/DashFrame/releases/download/pr-219-screenshots/01-rail-empty-home.png)

### 02 Rail On Insight
![02 Rail On Insight](https://github.com/youhaowei/DashFrame/releases/download/pr-219-screenshots/02-rail-on-insight.png)

### 03 Rail Dark Mode
![03 Rail Dark Mode](https://github.com/youhaowei/DashFrame/releases/download/pr-219-screenshots/03-rail-dark-mode.png)

_Screenshots via pr-screenshots (prerelease `pr-219-screenshots`, not in git)._
## Verification

- `bun check` green across the workspace (84/84 tasks) including the new `@dashframe/app-data` assistant-run tests and assistant-store tests.
- Local clawpatch feature review run (8 features, 5 findings): the 3 PR-caused findings fixed in the follow-up commit (disconnect abort, provider validation, test wiring); the 2 remaining are pre-existing `local-csv-handler` issues untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the assistant rail to live SSE-backed agent runs: a new `POST /assistant/run` endpoint streams typed sidebar events, a client-side SSE parser consumes them, and the `AssistantSidebar` renders the streaming transcript with a publish/discard gate that surfaces only after the first draft mutation.

- **Server (`assistant-run-route.ts`)**: new Hono route that starts a provider-backed run, maps agent events to typed SSE frames, redacts credential args, validates provider/model, and feeds both the request signal and stream-cancel into a single `AbortController` to stop provider spend on disconnect.
- **Client (`assistant-run.ts`, `assistant-store.ts`)**: SSE parser with carry-buffer handling, store actions (`beginRun`, `receiveRunEvent`, `failRun`, `abortRun`) that drive turn-level transcript state, plus fixes for previously flagged issues (stale `pendingDraftId`, aborted/failureCap/oscillation status visibility).
- **UI (`AssistantSidebar.tsx`, `DraftReviewPanel.tsx`)**: streaming transcript timeline, compact draft-review panel docked below the turns, and an abort hook keyed on `isOpen` so dismissing the rail cancels an in-flight run without losing partial draft mutations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three previously flagged issues are resolved, the new SSE wiring is well-structured, and the one remaining gap requires an unusual server condition to trigger.

The SSE route, store, and client are all structurally sound. Provider validation, credential redaction, abort propagation, and terminal-event handling cover the normal and error paths. The only gap found is that submitPrompt's finally block does not guard against the stream closing without a terminal SSE event, which would leave runStatus stuck at "running" — but this requires a server-side bug (exception after headers flush, HTTP/2 GOAWAY mid-body) to reach. All previously flagged findings are addressed, tests are present for the new paths, and no custom-rule violations were found.

packages/app/src/components/assistant/AssistantSidebar.tsx — the submitPrompt finally block is missing a runStatus recovery guard.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/assistant-run-route.ts | New SSE route: provider/model validation, credential redaction, abort wiring, and graceful stream close all look correct. Error and run-end are mutually exclusive in the try/catch, so terminal events are always sent. |
| packages/app/src/components/assistant/AssistantSidebar.tsx | Streaming UI and abort effects look solid; submitPrompt's finally block only clears runAbortRef but doesn't guard against runStatus being stuck "running" if the stream ends without a terminal SSE event. |
| packages/app/src/lib/stores/assistant-store.ts | Store correctly addresses previously flagged issues: beginRun clears pendingDraftId, aborted maps to its own status, and failureCap/oscillation emit visible status turns. |
| packages/app-data/src/assistant-run.ts | SSE parser with carry-buffer handles split chunks correctly; error paths (non-OK, no body) throw meaningful messages caught upstream. |
| packages/assistant/src/model.ts | resolveDefaultAnthropicModel correctly throws on unknown explicit model IDs and falls back through a priority list; exported and used correctly in the route. |
| packages/app/src/components/assistant/DraftReviewPanel.tsx | compact prop added cleanly; layout logic conditioned correctly and color tokens updated to semantic variables. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as AssistantSidebar
    participant Store as assistant-store
    participant Client as runAssistantPrompt
    participant Server as POST /assistant/run
    participant Agent as createAssistantRun

    UI->>Store: beginRun(prompt)
    UI->>Client: "runAssistantPrompt({signal})"
    Client->>Server: POST /assistant/run (SSE)
    Server-->>Client: data: run-start
    Client->>Store: receiveRunEvent(run-start)

    loop Agent turns
        Server->>Agent: stream events
        Agent-->>Server: text_delta / tool_execution_start / end
        Server-->>Client: data: text-delta / command-start / command-end
        Client->>Store: receiveRunEvent(...)
        Note over Server,Agent: first mutation fires onFirstMutation
        Server-->>Client: "data: first-mutation {draftId}"
        Client->>Store: receiveRunEvent(first-mutation)
        Store-->>UI: pendingDraftId set, DraftReviewPanel shown
    end

    Server-->>Client: "data: run-end {terminationReason}"
    Client->>Store: receiveRunEvent(run-end)
    Store-->>UI: "runStatus = completed/aborted/error"

    alt Client closes rail mid-run
        UI->>Client: controller.abort()
        Client--xServer: request signal aborted
        Server->>Agent: runAbort.abort()
        UI->>Store: abortRun()
    end

    alt Network / server error
        Server-->>Client: "data: error {message}"
        Client->>Store: receiveRunEvent(error)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as AssistantSidebar
    participant Store as assistant-store
    participant Client as runAssistantPrompt
    participant Server as POST /assistant/run
    participant Agent as createAssistantRun

    UI->>Store: beginRun(prompt)
    UI->>Client: "runAssistantPrompt({signal})"
    Client->>Server: POST /assistant/run (SSE)
    Server-->>Client: data: run-start
    Client->>Store: receiveRunEvent(run-start)

    loop Agent turns
        Server->>Agent: stream events
        Agent-->>Server: text_delta / tool_execution_start / end
        Server-->>Client: data: text-delta / command-start / command-end
        Client->>Store: receiveRunEvent(...)
        Note over Server,Agent: first mutation fires onFirstMutation
        Server-->>Client: "data: first-mutation {draftId}"
        Client->>Store: receiveRunEvent(first-mutation)
        Store-->>UI: pendingDraftId set, DraftReviewPanel shown
    end

    Server-->>Client: "data: run-end {terminationReason}"
    Client->>Store: receiveRunEvent(run-end)
    Store-->>UI: "runStatus = completed/aborted/error"

    alt Client closes rail mid-run
        UI->>Client: controller.abort()
        Client--xServer: request signal aborted
        Server->>Agent: runAbort.abort()
        UI->>Store: abortRun()
    end

    alt Network / server error
        Server-->>Client: "data: error {message}"
        Client->>Store: receiveRunEvent(error)
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(server): reject non-object JSON bodi..."](https://github.com/youhaowei/dashframe/commit/33a8ecf21c834d5ca97d7e3d18496e903bee81b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42025043)</sub>

<!-- /greptile_comment -->