### PR TITLE
[codex] feat: add assistant provider configuration

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -261,6 +261,7 @@ app
     });
     secretRegistry.setClassDefault("connector-key", "electron-keychain");
     secretRegistry.setClassDefault("serve-token", "electron-keychain");
+    secretRegistry.setClassDefault("assistant-provider", "electron-keychain");
     // Compose the vault from the registry. The mapping store persists the
     // ref→{backend, locator} binding in the project DB (`secret_mappings` table)
     // so refs stay resolvable across restarts: the ref in `data_sources.config`,

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -230,6 +230,39 @@ describe("createDashframeServer", () => {
       expect(body.error).toBe("Invalid JSON in request body");
     });
 
+    it("rejects a nonexistent requested assistant provider config instead of falling back", async () => {
+      project = await openProject({
+        dir: join(root, "proj"),
+        name: "Run Co",
+      });
+      const seedApp = await buildDashframeApp({ db: project.db });
+      await seedApp.call("saveAssistantProviderConfig", {
+        input: {
+          providerId: "ollama",
+          displayLabel: "Ollama",
+          authKind: "local",
+          baseUrl: "http://localhost:11434/v1",
+          defaultModel: "llama3.1",
+          isDefault: true,
+        },
+      });
+      server = await createDashframeServer({ db: project.db });
+
+      const missingId = "00000000-0000-4000-8000-000000000000";
+      const res = await fetch(`${server.url}/assistant/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt: "Say hello",
+          provider: missingId,
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain(missingId);
+    });
+
     it("should require the loopback token and allow packaged Origin null", async () => {
       project = await openProject({
         dir: join(root, "proj"),

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -655,6 +655,7 @@ export async function createDashframeServer(
       db: opts.db as ArtifactDb,
       draftController: serverContext.draftController as DraftController,
       vault: opts.vault,
+      flushSnapshot: opts.flushSnapshot,
       resolveContext,
     }),
   );

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -652,7 +652,9 @@ export async function createDashframeServer(
   honoApp.post("/assistant/run", (c) =>
     handleAssistantRunRequest(c, {
       app,
+      db: opts.db as ArtifactDb,
       draftController: serverContext.draftController as DraftController,
+      vault: opts.vault,
       resolveContext,
     }),
   );

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -54,6 +54,7 @@ interface AssistantRunRouteOptions {
   db: ArtifactDb;
   draftController: DraftController;
   vault?: SecretVault;
+  flushSnapshot?: () => Promise<void>;
   resolveContext?: (req: Request) => Promise<Record<string, unknown>>;
 }
 
@@ -257,6 +258,7 @@ async function resolveRunProvider(args: {
   body: AssistantRunRequestBody;
   db: ArtifactDb;
   vault?: SecretVault;
+  flushSnapshot?: () => Promise<void>;
 }): Promise<{
   model: ReturnType<typeof resolveDefaultAnthropicModel>;
   getApiKey: CreateAssistantRunOptions["getApiKey"];
@@ -277,6 +279,7 @@ async function resolveRunProvider(args: {
   const resolved = await resolveAssistantProviderConfigForRun({
     row,
     vault: args.vault,
+    flushSnapshot: args.flushSnapshot,
     updateCredentialRef: async (ref) => {
       await args.db
         .update(schema.assistantProviderConfigs)
@@ -336,6 +339,7 @@ export async function handleAssistantRunRequest(
       body,
       db: options.db,
       vault: options.vault,
+      flushSnapshot: options.flushSnapshot,
     });
   } catch (err) {
     // Unknown requested model id is a client error; a failure to resolve

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -231,7 +231,14 @@ async function selectAssistantProviderConfigForRun(args: {
   const rows = (await args.db
     .select()
     .from(schema.assistantProviderConfigs)) as AssistantProviderConfigRow[];
-  if (rows.length === 0) return undefined;
+  if (rows.length === 0) {
+    if (args.provider) {
+      throw new Error(
+        `Assistant provider/config ${args.provider} was not found`,
+      );
+    }
+    return undefined;
+  }
 
   const selected = args.provider
     ? rows.find(
@@ -240,7 +247,9 @@ async function selectAssistantProviderConfigForRun(args: {
     : (rows.find((row) => row.isDefault) ??
       rows.find((row) => row.providerId === "anthropic") ??
       rows[0]);
-  if (!selected) return undefined;
+  if (!selected) {
+    throw new Error(`Assistant provider/config ${args.provider} was not found`);
+  }
   return args.modelId ? { ...selected, defaultModel: args.modelId } : selected;
 }
 

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -6,11 +6,15 @@ import {
   type AssistantRunTerminationReason,
   type CreateAssistantRunOptions,
 } from "@dashframe/assistant";
+import { schema, type ArtifactDb } from "@dashframe/server-core";
+import type { SecretVault } from "@wystack/secret-vault";
 import type { WyStackApp } from "@wystack/server";
+import { eq } from "drizzle-orm";
 import type { Context } from "hono";
 
 import { createDashframeAssistantHost } from "./assistant-host";
 import type { DraftController } from "./draft-controller";
+import { resolveAssistantProviderConfigForRun } from "./functions/assistant-provider-configs";
 
 export type AssistantSidebarEvent =
   | { type: "run-start" }
@@ -47,7 +51,9 @@ export type AssistantSidebarEvent =
 
 interface AssistantRunRouteOptions {
   app: WyStackApp;
+  db: ArtifactDb;
   draftController: DraftController;
+  vault?: SecretVault;
   resolveContext?: (req: Request) => Promise<Record<string, unknown>>;
 }
 
@@ -57,6 +63,9 @@ interface AssistantRunRequestBody {
   provider?: unknown;
   modelId?: unknown;
 }
+
+type AssistantProviderConfigRow =
+  typeof schema.assistantProviderConfigs.$inferSelect;
 
 type AgentEvent = Parameters<
   NonNullable<CreateAssistantRunOptions["onEvent"]>
@@ -210,6 +219,70 @@ async function getScopedApiKey(provider: string): Promise<string | undefined> {
   return getOAuthToken();
 }
 
+function requestedText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+async function selectAssistantProviderConfigForRun(args: {
+  db: ArtifactDb;
+  provider?: string;
+  modelId?: string;
+}): Promise<AssistantProviderConfigRow | undefined> {
+  const rows = (await args.db
+    .select()
+    .from(schema.assistantProviderConfigs)) as AssistantProviderConfigRow[];
+  if (rows.length === 0) return undefined;
+
+  const selected = args.provider
+    ? rows.find(
+        (row) => row.id === args.provider || row.providerId === args.provider,
+      )
+    : (rows.find((row) => row.isDefault) ??
+      rows.find((row) => row.providerId === "anthropic") ??
+      rows[0]);
+  if (!selected) return undefined;
+  return args.modelId ? { ...selected, defaultModel: args.modelId } : selected;
+}
+
+async function resolveRunProvider(args: {
+  body: AssistantRunRequestBody;
+  db: ArtifactDb;
+  vault?: SecretVault;
+}): Promise<{
+  model: ReturnType<typeof resolveDefaultAnthropicModel>;
+  getApiKey: CreateAssistantRunOptions["getApiKey"];
+}> {
+  const provider = requestedText(args.body.provider);
+  const modelId = requestedText(args.body.modelId);
+  const row = await selectAssistantProviderConfigForRun({
+    db: args.db,
+    provider,
+    modelId,
+  });
+
+  if (!row) {
+    const model = resolveDefaultAnthropicModel(modelId);
+    return { model, getApiKey: getScopedApiKey };
+  }
+
+  const resolved = await resolveAssistantProviderConfigForRun({
+    row,
+    vault: args.vault,
+    updateCredentialRef: async (ref) => {
+      await args.db
+        .update(schema.assistantProviderConfigs)
+        .set({ credentialRef: ref })
+        .where(eq(schema.assistantProviderConfigs.id, row.id));
+    },
+  });
+  const apiKey = (resolved.options as { apiKey?: string }).apiKey;
+  return {
+    model: resolved.model as ReturnType<typeof resolveDefaultAnthropicModel>,
+    getApiKey: (requestedProvider) =>
+      requestedProvider === resolved.model.provider ? apiKey : undefined,
+  };
+}
+
 function encodeSse(event: AssistantSidebarEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
@@ -248,24 +321,24 @@ export async function handleAssistantRunRequest(
     return c.json({ error: "Assistant prompt is required" }, 400);
   }
 
-  if (body.provider !== undefined && body.provider !== "anthropic") {
-    return c.json(
-      { error: 'Unsupported provider — only "anthropic" is available' },
-      400,
-    );
-  }
-
-  let model: ReturnType<typeof resolveDefaultAnthropicModel>;
+  let runProvider: Awaited<ReturnType<typeof resolveRunProvider>>;
   try {
-    model = resolveDefaultAnthropicModel(
-      typeof body.modelId === "string" ? body.modelId : undefined,
-    );
+    runProvider = await resolveRunProvider({
+      body,
+      db: options.db,
+      vault: options.vault,
+    });
   } catch (err) {
     // Unknown requested model id is a client error; a failure to resolve
     // the default list is a server configuration fault — let it propagate.
-    if (typeof body.modelId === "string") {
+    if (typeof body.modelId === "string" || typeof body.provider === "string") {
       return c.json(
-        { error: err instanceof Error ? err.message : "Unknown model id" },
+        {
+          error:
+            err instanceof Error
+              ? err.message
+              : "Unknown assistant provider or model",
+        },
         400,
       );
     }
@@ -307,13 +380,13 @@ export async function handleAssistantRunRequest(
       send({ type: "run-start" });
       try {
         const result = await createAssistantRun(host, {
-          model,
+          model: runProvider.model,
           prompt,
           context:
             body.artifact && typeof body.artifact === "object"
               ? { artifact: body.artifact }
               : undefined,
-          getApiKey: getScopedApiKey,
+          getApiKey: runProvider.getApiKey,
           signal: runAbort.signal,
           onFirstMutation: ({ draftId }) => {
             send({ type: "first-mutation", draftId });

--- a/apps/server/src/functions.ts
+++ b/apps/server/src/functions.ts
@@ -12,6 +12,7 @@ import { schema } from "@dashframe/server-core";
 import { query } from "@wystack/server";
 
 import { appArtifactFunctions } from "./functions/app-artifacts";
+import { assistantProviderConfigFunctions } from "./functions/assistant-provider-configs";
 import { commandFunctions } from "./functions/commands";
 import { dashboardFunctions } from "./functions/dashboards";
 import { draftLifecycleFunctions } from "./functions/draft-lifecycle";
@@ -60,6 +61,7 @@ const projectInfo = query<Record<string, never>, ProjectInfoResult>({
 export const functions = {
   projectInfo,
   ...appArtifactFunctions,
+  ...assistantProviderConfigFunctions,
   ...commandFunctions,
   ...dashboardFunctions,
   ...draftLifecycleFunctions,

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -16,7 +16,7 @@ import { eq } from "drizzle-orm";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AssistantProviderConfig } from "@dashframe/types";
 import { buildDashframeApp } from "../app";
@@ -94,6 +94,46 @@ describe("assistant provider config functions", () => {
     expect(
       await db.select().from(schema.assistantProviderConfigs),
     ).toHaveLength(0);
+  });
+
+  it("an error after the row commit never releases the credential the row references", async () => {
+    const { result } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "anthropic",
+        displayLabel: "Anthropic API",
+        authKind: "api-key",
+        credential: "first-secret",
+        defaultModel: "claude-sonnet-4-5",
+      },
+    })) as { result: AssistantProviderConfig };
+    const [before] = await db.select().from(schema.assistantProviderConfigs);
+    const oldRef = before!.credentialRef! as SecretRef;
+
+    // Fail the post-commit release of the replaced ref. The update row is
+    // already committed with the new ref, so the error must propagate WITHOUT
+    // the handler releasing that new ref as "compensation".
+    vi.spyOn(vault, "delete").mockRejectedValueOnce(
+      new Error("vault backend unavailable"),
+    );
+    await expect(
+      app.call("saveAssistantProviderConfig", {
+        input: {
+          id: result.id,
+          providerId: "anthropic",
+          displayLabel: "Anthropic API",
+          authKind: "api-key",
+          credential: "second-secret",
+          defaultModel: "claude-sonnet-4-5",
+        },
+      }),
+    ).rejects.toThrow();
+
+    const [after] = await db.select().from(schema.assistantProviderConfigs);
+    const newRef = after!.credentialRef! as SecretRef;
+    expect(newRef).not.toBe(oldRef);
+    await expect(
+      vault.withSecret(newRef, async (value) => value),
+    ).resolves.toBe("second-secret");
   });
 
   it("refresh rotation persists a new OAuth credential ref and releases the old ref", async () => {

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -96,6 +96,50 @@ describe("assistant provider config functions", () => {
     ).toHaveLength(0);
   });
 
+  it("setting a non-default config's model leaves provider defaults untouched", async () => {
+    const { result: defaultConfig } = (await app.call(
+      "saveAssistantProviderConfig",
+      {
+        input: {
+          providerId: "anthropic",
+          displayLabel: "Anthropic API",
+          authKind: "api-key",
+          credential: "anthropic-secret",
+          defaultModel: "claude-sonnet-4-5",
+          isDefault: true,
+        },
+      },
+    )) as { result: AssistantProviderConfig };
+    const { result: secondaryConfig } = (await app.call(
+      "saveAssistantProviderConfig",
+      {
+        input: {
+          providerId: "openai",
+          displayLabel: "OpenAI",
+          authKind: "api-key",
+          credential: "openai-secret",
+          defaultModel: "gpt-4.1",
+          isDefault: false,
+        },
+      },
+    )) as { result: AssistantProviderConfig };
+
+    await app.call("setAssistantDefaultModel", {
+      input: {
+        id: secondaryConfig.id,
+        defaultModel: "gpt-4.1-mini",
+      },
+    });
+
+    const rows = await db.select().from(schema.assistantProviderConfigs);
+    const defaultRow = rows.find((row) => row.id === defaultConfig.id);
+    const secondaryRow = rows.find((row) => row.id === secondaryConfig.id);
+    expect(defaultRow?.defaultModel).toBe("claude-sonnet-4-5");
+    expect(defaultRow?.isDefault).toBe(true);
+    expect(secondaryRow?.defaultModel).toBe("gpt-4.1-mini");
+    expect(secondaryRow?.isDefault).toBe(false);
+  });
+
   it("an error after the row commit never releases the credential the row references", async () => {
     const { result } = (await app.call("saveAssistantProviderConfig", {
       input: {
@@ -186,5 +230,40 @@ describe("assistant provider config functions", () => {
         JSON.parse(value),
       ),
     ).resolves.toMatchObject({ access: "new-access" });
+  });
+
+  it("rejects device-code OAuth when the host cannot display the user code", async () => {
+    const { result } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "device-code-test",
+        displayLabel: "Device Code Test",
+        authKind: "oauth",
+        defaultModel: "test-model",
+      },
+    })) as { result: AssistantProviderConfig };
+    const credentials: OAuthCredentials = {
+      access: "access",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    };
+    registerOAuthProvider({
+      id: "device-code-test",
+      name: "Device Code Test",
+      login: async (callbacks) => {
+        callbacks.onDeviceCode({
+          userCode: "ABCD-EFGH",
+          verificationUri: "https://example.test/device",
+        });
+        return credentials;
+      },
+      refreshToken: async () => credentials,
+      getApiKey: (value) => value.access,
+    });
+
+    await expect(
+      app.call("startAssistantOAuthLogin", { id: result.id }),
+    ).rejects.toThrow(
+      "device-code flow requires displaying a user code, not supported in this host flow yet",
+    );
   });
 });

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -39,7 +39,18 @@ describe("assistant provider config functions", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-assistant-provider-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     vault = makeTestVault();
-    app = await buildDashframeApp({ db, vault });
+    const baseApp = await buildDashframeApp({ db, vault });
+    // Mirror createDashframeServer's serverContext seam: production merges a
+    // durable flushSnapshot hook into every call context, and the post-commit
+    // credential release is gated on it (fail-closed).
+    app = {
+      ...baseApp,
+      call: (path, args, ctx) =>
+        baseApp.call(path, args, {
+          ...(ctx ?? {}),
+          flushSnapshot: async () => {},
+        }),
+    };
   });
 
   afterEach(async () => {
@@ -156,7 +167,7 @@ describe("assistant provider config functions", () => {
     ).toHaveLength(0);
   });
 
-  it("an error after the row commit never releases the credential the row references", async () => {
+  it("a release failure after the row commit is swallowed and never touches the committed ref", async () => {
     const { result } = (await app.call("saveAssistantProviderConfig", {
       input: {
         providerId: "anthropic",
@@ -170,23 +181,22 @@ describe("assistant provider config functions", () => {
     const oldRef = before!.credentialRef! as SecretRef;
 
     // Fail the post-commit release of the replaced ref. The update row is
-    // already committed with the new ref, so the error must propagate WITHOUT
-    // the handler releasing that new ref as "compensation".
+    // already committed with the new ref, so the failure must be swallowed
+    // (best-effort release — an inert orphan) and the handler must never
+    // release that new ref as "compensation".
     vi.spyOn(vault, "delete").mockRejectedValueOnce(
       new Error("vault backend unavailable"),
     );
-    await expect(
-      app.call("saveAssistantProviderConfig", {
-        input: {
-          id: result.id,
-          providerId: "anthropic",
-          displayLabel: "Anthropic API",
-          authKind: "api-key",
-          credential: "second-secret",
-          defaultModel: "claude-sonnet-4-5",
-        },
-      }),
-    ).rejects.toThrow();
+    await app.call("saveAssistantProviderConfig", {
+      input: {
+        id: result.id,
+        providerId: "anthropic",
+        displayLabel: "Anthropic API",
+        authKind: "api-key",
+        credential: "second-secret",
+        defaultModel: "claude-sonnet-4-5",
+      },
+    });
 
     const [after] = await db.select().from(schema.assistantProviderConfigs);
     const newRef = after!.credentialRef! as SecretRef;
@@ -194,9 +204,11 @@ describe("assistant provider config functions", () => {
     await expect(
       vault.withSecret(newRef, async (value) => value),
     ).resolves.toBe("second-secret");
+    // The failed release leaves the replaced ref as an inert orphan.
+    await expect(vault.has(oldRef)).resolves.toBe(true);
   });
 
-  it("an error after the OAuth login commit never releases the credential the row references", async () => {
+  it("a release failure after the OAuth login commit is swallowed and never touches the committed ref", async () => {
     await app.call("saveAssistantProviderConfig", {
       input: {
         providerId: "anthropic",
@@ -227,14 +239,13 @@ describe("assistant provider config functions", () => {
     });
 
     // Fail the post-commit release of the replaced ref. The row is already
-    // committed with the new ref, so the error must propagate WITHOUT the
-    // handler releasing that new ref as "compensation".
+    // committed with the new ref, so the failure must be swallowed
+    // (best-effort release — an inert orphan) and the handler must never
+    // release that new ref as "compensation".
     vi.spyOn(vault, "delete").mockRejectedValueOnce(
       new Error("vault backend unavailable"),
     );
-    await expect(
-      app.call("startAssistantOAuthLogin", { id: before!.id }),
-    ).rejects.toThrow();
+    await app.call("startAssistantOAuthLogin", { id: before!.id });
 
     const [after] = await db.select().from(schema.assistantProviderConfigs);
     const newRef = after!.credentialRef! as SecretRef;
@@ -242,6 +253,8 @@ describe("assistant provider config functions", () => {
     await expect(
       vault.withSecret(newRef, async (value) => JSON.parse(value)),
     ).resolves.toMatchObject({ access: "fresh-access" });
+    // The failed release leaves the replaced ref as an inert orphan.
+    await expect(vault.has(oldRef)).resolves.toBe(true);
   });
 
   it("refresh rotation persists a new OAuth credential ref and releases the old ref", async () => {
@@ -277,6 +290,7 @@ describe("assistant provider config functions", () => {
     await resolveAssistantProviderConfigForRun({
       row: row!,
       vault,
+      flushSnapshot: async () => {},
       updateCredentialRef: async (ref) => {
         await db
           .update(schema.assistantProviderConfigs)

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -140,6 +140,22 @@ describe("assistant provider config functions", () => {
     expect(secondaryRow?.isDefault).toBe(false);
   });
 
+  it("rejects a providerId that is not in the catalog", async () => {
+    await expect(
+      app.call("saveAssistantProviderConfig", {
+        input: {
+          providerId: "not-a-provider",
+          displayLabel: "Mystery",
+          authKind: "api-key",
+          defaultModel: "some-model",
+        },
+      }),
+    ).rejects.toThrow(/Unknown assistant provider/);
+    expect(
+      await db.select().from(schema.assistantProviderConfigs),
+    ).toHaveLength(0);
+  });
+
   it("an error after the row commit never releases the credential the row references", async () => {
     const { result } = (await app.call("saveAssistantProviderConfig", {
       input: {
@@ -283,7 +299,7 @@ describe("assistant provider config functions", () => {
   it("rejects device-code OAuth when the host cannot display the user code", async () => {
     const { result } = (await app.call("saveAssistantProviderConfig", {
       input: {
-        providerId: "device-code-test",
+        providerId: "anthropic",
         displayLabel: "Device Code Test",
         authKind: "oauth",
         defaultModel: "test-model",
@@ -295,7 +311,7 @@ describe("assistant provider config functions", () => {
       expires: Date.now() + 60_000,
     };
     registerOAuthProvider({
-      id: "device-code-test",
+      id: "anthropic",
       name: "Device Code Test",
       login: async (callbacks) => {
         callbacks.onDeviceCode({

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -180,6 +180,54 @@ describe("assistant provider config functions", () => {
     ).resolves.toBe("second-secret");
   });
 
+  it("an error after the OAuth login commit never releases the credential the row references", async () => {
+    await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "anthropic",
+        displayLabel: "Anthropic Pro",
+        authKind: "oauth",
+        credential: JSON.stringify({
+          access: "old-access",
+          refresh: "old-refresh",
+          expires: Date.now() + 60_000,
+        }),
+        defaultModel: "claude-haiku-4-5",
+      },
+    });
+    const [before] = await db.select().from(schema.assistantProviderConfigs);
+    const oldRef = before!.credentialRef! as SecretRef;
+    registerOAuthProvider({
+      id: "anthropic",
+      name: "Test Anthropic",
+      login: async () => ({
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: Date.now() + 60_000,
+      }),
+      refreshToken: async () => {
+        throw new Error("not used");
+      },
+      getApiKey: (credentials) => credentials.access,
+    });
+
+    // Fail the post-commit release of the replaced ref. The row is already
+    // committed with the new ref, so the error must propagate WITHOUT the
+    // handler releasing that new ref as "compensation".
+    vi.spyOn(vault, "delete").mockRejectedValueOnce(
+      new Error("vault backend unavailable"),
+    );
+    await expect(
+      app.call("startAssistantOAuthLogin", { id: before!.id }),
+    ).rejects.toThrow();
+
+    const [after] = await db.select().from(schema.assistantProviderConfigs);
+    const newRef = after!.credentialRef! as SecretRef;
+    expect(newRef).not.toBe(oldRef);
+    await expect(
+      vault.withSecret(newRef, async (value) => JSON.parse(value)),
+    ).resolves.toMatchObject({ access: "fresh-access" });
+  });
+
   it("refresh rotation persists a new OAuth credential ref and releases the old ref", async () => {
     const expired: OAuthCredentials = {
       access: "old-access",

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -1,0 +1,150 @@
+import {
+  registerOAuthProvider,
+  resetOAuthProviders,
+  type OAuthCredentials,
+} from "@dashframe/assistant";
+import { openArtifactDb, schema } from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  isSecretRef,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+  type SecretRef,
+} from "@wystack/secret-vault";
+import { eq } from "drizzle-orm";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AssistantProviderConfig } from "@dashframe/types";
+import { buildDashframeApp } from "../app";
+import { resolveAssistantProviderConfigForRun } from "./assistant-provider-configs";
+
+function makeTestVault(): SecretVault {
+  const registry = new SecretRegistry();
+  registry.register("test", new TestBackend(), { fallback: true });
+  registry.setClassDefault("assistant-provider", "test");
+  return new SecretVault(registry, new InMemoryMappingStore());
+}
+
+describe("assistant provider config functions", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: Awaited<ReturnType<typeof buildDashframeApp>>;
+  let vault: SecretVault;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-assistant-provider-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    vault = makeTestVault();
+    app = await buildDashframeApp({ db, vault });
+  });
+
+  afterEach(async () => {
+    resetOAuthProviders();
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("stores an API key as a SecretRef and returns only credential presence", async () => {
+    const { result } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "anthropic",
+        displayLabel: "Anthropic API",
+        authKind: "api-key",
+        credential: "test-api-key-input",
+        defaultModel: "claude-sonnet-4-5",
+        isDefault: true,
+      },
+    })) as { result: AssistantProviderConfig };
+
+    expect(result.hasCredential).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("test-api-key-input");
+
+    const rows = await db.select().from(schema.assistantProviderConfigs);
+    expect(rows).toHaveLength(1);
+    expect(isSecretRef(rows[0]!.credentialRef)).toBe(true);
+    expect(rows[0]!.credentialRef).not.toBe("test-api-key-input");
+    await expect(
+      vault.withSecret(
+        rows[0]!.credentialRef! as SecretRef,
+        async (value) => value,
+      ),
+    ).resolves.toBe("test-api-key-input");
+  });
+
+  it("deleting a provider releases the stored SecretRef", async () => {
+    const { result } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "openai",
+        displayLabel: "OpenAI",
+        authKind: "api-key",
+        credential: "openai-secret",
+        defaultModel: "gpt-4.1",
+      },
+    })) as { result: AssistantProviderConfig };
+    const rows = await db.select().from(schema.assistantProviderConfigs);
+    const ref = rows[0]!.credentialRef! as SecretRef;
+
+    await app.call("removeAssistantProviderConfig", { id: result.id });
+
+    expect(await vault.has(ref)).toBe(false);
+    expect(
+      await db.select().from(schema.assistantProviderConfigs),
+    ).toHaveLength(0);
+  });
+
+  it("refresh rotation persists a new OAuth credential ref and releases the old ref", async () => {
+    const expired: OAuthCredentials = {
+      access: "old-access",
+      refresh: "old-refresh",
+      expires: Date.now() - 1_000,
+    };
+    const rotated: OAuthCredentials = {
+      access: "new-access",
+      refresh: "new-refresh",
+      expires: Date.now() + 60_000,
+    };
+    await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "anthropic",
+        displayLabel: "Anthropic Pro",
+        authKind: "oauth",
+        credential: JSON.stringify(expired),
+        defaultModel: "claude-haiku-4-5",
+      },
+    });
+    const [row] = await db.select().from(schema.assistantProviderConfigs);
+    const oldRef = row!.credentialRef! as SecretRef;
+    registerOAuthProvider({
+      id: "anthropic",
+      name: "Test Anthropic",
+      login: async () => rotated,
+      refreshToken: async () => rotated,
+      getApiKey: (credentials) => credentials.access,
+    });
+
+    await resolveAssistantProviderConfigForRun({
+      row: row!,
+      vault,
+      updateCredentialRef: async (ref) => {
+        await db
+          .update(schema.assistantProviderConfigs)
+          .set({ credentialRef: ref })
+          .where(eq(schema.assistantProviderConfigs.id, row!.id));
+      },
+    });
+
+    const [updated] = await db.select().from(schema.assistantProviderConfigs);
+    expect(updated!.credentialRef).not.toBe(oldRef);
+    expect(isSecretRef(updated!.credentialRef)).toBe(true);
+    await expect(vault.has(oldRef)).resolves.toBe(false);
+    await expect(
+      vault.withSecret(updated!.credentialRef! as SecretRef, async (value) =>
+        JSON.parse(value),
+      ),
+    ).resolves.toMatchObject({ access: "new-access" });
+  });
+});

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -253,15 +253,22 @@ const removeAssistantProviderConfig = mutation({
   args: { id: uuid },
   handler: async (ctx, { id }): Promise<{ ok: true }> => {
     const vault = vaultFromCtx(ctx);
-    await ctx.db.transaction(async (tx) => {
+    // The vault release stays OUTSIDE the transaction: it is not rolled back
+    // with the DB, so releasing inside could leave a surviving row with a
+    // dangling ref if the transaction aborts afterwards. Worst case post-commit
+    // is a leaked (unreferenced) secret, never a dangling reference.
+    const removed = await ctx.db.transaction(async (tx) => {
       const current = (await tx
         .from(assistantProviderConfigs)
         .where(eq("id", id))
         .first()) as AssistantProviderConfigRow | undefined;
-      if (!current) return;
+      if (!current) return undefined;
       await tx.from(assistantProviderConfigs).where(eq("id", id)).delete();
-      await deleteRef(vault, current.credentialRef);
+      return current;
     });
+    if (removed) {
+      await deleteRef(vault, removed.credentialRef);
+    }
     return { ok: true };
   },
 });
@@ -328,17 +335,21 @@ const startAssistantOAuthLogin = mutation({
     if (!ref) {
       throw new Error("OAuth login returned no credential to store");
     }
+    let updated: AssistantProviderConfigRow | undefined;
     try {
-      const [updated] = (await ctx.db
+      [updated] = (await ctx.db
         .from(assistantProviderConfigs)
         .where(eq("id", row.id))
         .update({ credentialRef: ref })) as AssistantProviderConfigRow[];
-      await deleteRef(vault, row.credentialRef);
-      return rowToDto(updated ?? { ...row, credentialRef: ref });
     } catch (error) {
+      // Update never committed → releasing the freshly minted ref is safe.
       await deleteRef(vault, ref);
       throw error;
     }
+    // Post-commit: the row references the new ref, so only release the
+    // replaced one. Never the new ref past this point.
+    await deleteRef(vault, row.credentialRef);
+    return rowToDto(updated ?? { ...row, credentialRef: ref });
   },
 });
 

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -144,76 +144,81 @@ const saveAssistantProviderConfig = mutation({
     const parsed = saveInputSchema.parse(input);
     const vault = vaultFromCtx(ctx);
     const id = parsed.id ?? crypto.randomUUID();
-    const mintedRef = await storeAssistantCredential({
-      vault,
-      plaintext: parsed.credential,
-      locatorHint: `assistant-provider-${id}`,
-    });
     const current = parsed.id
       ? ((await ctx.db
           .from(assistantProviderConfigs)
           .where(eq("id", parsed.id))
           .first()) as AssistantProviderConfigRow | undefined)
       : undefined;
+    const mintedRef = await storeAssistantCredential({
+      vault,
+      plaintext: parsed.credential,
+      locatorHint: `assistant-provider-${id}`,
+    });
 
+    // The row write and the default-reset commit atomically; a failure rolls
+    // back the whole transaction, so no committed row can reference mintedRef.
+    // Only then is the compensating deleteRef(mintedRef) safe — releasing a
+    // ref that a committed row references would corrupt the config.
+    let row: AssistantProviderConfigRow;
     try {
-      let row: AssistantProviderConfigRow | undefined;
-      if (current) {
-        const [updated] = (await ctx.db
-          .from(assistantProviderConfigs)
-          .where(eq("id", current.id))
-          .update({
+      row = await ctx.db.transaction(async (tx) => {
+        let written: AssistantProviderConfigRow | undefined;
+        if (current) {
+          const [updated] = (await tx
+            .from(assistantProviderConfigs)
+            .where(eq("id", current.id))
+            .update({
+              providerId: parsed.providerId,
+              displayLabel: parsed.displayLabel,
+              authKind: parsed.authKind,
+              baseUrl: parsed.baseUrl?.trim() || null,
+              credentialRef: mintedRef ?? current.credentialRef,
+              defaultModel: parsed.defaultModel,
+              isDefault: parsed.isDefault ?? current.isDefault,
+            })) as AssistantProviderConfigRow[];
+          written = updated;
+        } else {
+          const [inserted] = (await tx.into(assistantProviderConfigs).insert({
+            id,
             providerId: parsed.providerId,
             displayLabel: parsed.displayLabel,
             authKind: parsed.authKind,
             baseUrl: parsed.baseUrl?.trim() || null,
-            credentialRef: mintedRef ?? current.credentialRef,
+            credentialRef: mintedRef ?? null,
             defaultModel: parsed.defaultModel,
-            isDefault: parsed.isDefault ?? current.isDefault,
+            isDefault: parsed.isDefault ?? false,
           })) as AssistantProviderConfigRow[];
-        row = updated;
-      } else {
-        const [inserted] = (await ctx.db.into(assistantProviderConfigs).insert({
-          id,
-          providerId: parsed.providerId,
-          displayLabel: parsed.displayLabel,
-          authKind: parsed.authKind,
-          baseUrl: parsed.baseUrl?.trim() || null,
-          credentialRef: mintedRef ?? null,
-          defaultModel: parsed.defaultModel,
-          isDefault: parsed.isDefault ?? false,
-        })) as AssistantProviderConfigRow[];
-        row = inserted;
-      }
-      if (!row)
-        throw new Error("assistant provider config write returned no row");
+          written = inserted;
+        }
+        if (!written)
+          throw new Error("assistant provider config write returned no row");
 
-      if (row.isDefault) {
-        const rows = (await ctx.db
-          .from(assistantProviderConfigs)
-          .all()) as AssistantProviderConfigRow[];
-        await Promise.all(
-          rows
-            .filter(
-              (candidate) => candidate.id !== row!.id && candidate.isDefault,
-            )
-            .map((candidate) =>
-              ctx.db
-                .from(assistantProviderConfigs)
-                .where(eq("id", candidate.id))
-                .update({ isDefault: false }),
-            ),
-        );
-      }
-
-      if (mintedRef && current?.credentialRef !== mintedRef) {
-        await deleteRef(vault, current?.credentialRef);
-      }
-      return rowToDto(row);
+        if (written.isDefault) {
+          const rows = (await tx
+            .from(assistantProviderConfigs)
+            .all()) as AssistantProviderConfigRow[];
+          for (const candidate of rows) {
+            if (candidate.id === written.id || !candidate.isDefault) continue;
+            await tx
+              .from(assistantProviderConfigs)
+              .where(eq("id", candidate.id))
+              .update({ isDefault: false });
+          }
+        }
+        return written;
+      });
     } catch (error) {
       await deleteRef(vault, mintedRef);
       throw error;
     }
+
+    // Post-commit: the row now references mintedRef, so release the replaced
+    // ref. Never mintedRef itself past this point.
+    if (mintedRef && current?.credentialRef !== mintedRef) {
+      await deleteRef(vault, current?.credentialRef);
+    }
+    return rowToDto(row);
   },
 });
 

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -18,7 +18,13 @@ import { mutation, query } from "@wystack/server";
 import { spawn } from "node:child_process";
 import { z } from "zod";
 
-import { vaultFromCtx } from "./utils";
+import { flushThenReleaseRefs, vaultFromCtx } from "./utils";
+
+function flushSnapshotFromCtx(ctx: unknown): (() => Promise<void>) | undefined {
+  return (ctx as Record<string, unknown>).flushSnapshot as
+    | (() => Promise<void>)
+    | undefined;
+}
 
 const { assistantProviderConfigs } = schema;
 
@@ -250,10 +256,18 @@ const saveAssistantProviderConfig = mutation({
       throw error;
     }
 
-    // Post-commit: the row now references mintedRef, so release the replaced
-    // ref. Never mintedRef itself past this point.
-    if (mintedRef && current?.credentialRef !== mintedRef) {
-      await deleteRef(vault, current?.credentialRef);
+    // Post-commit: the row now references mintedRef, so the replaced ref is
+    // superseded. Release only after a durable snapshot (fail-closed,
+    // best-effort) — releasing before the snapshot holding the new ref is on
+    // disk could leave a restored row pointing at a deleted vault entry.
+    // Never mintedRef itself past this point.
+    if (mintedRef && isSecretRef(current?.credentialRef)) {
+      await flushThenReleaseRefs(
+        flushSnapshotFromCtx(ctx),
+        [current.credentialRef],
+        vault ?? undefined,
+        "saveAssistantProviderConfig",
+      );
     }
     return rowToDto(row);
   },
@@ -276,8 +290,13 @@ const removeAssistantProviderConfig = mutation({
       await tx.from(assistantProviderConfigs).where(eq("id", id)).delete();
       return current;
     });
-    if (removed) {
-      await deleteRef(vault, removed.credentialRef);
+    if (removed && isSecretRef(removed.credentialRef)) {
+      await flushThenReleaseRefs(
+        flushSnapshotFromCtx(ctx),
+        [removed.credentialRef],
+        vault ?? undefined,
+        "removeAssistantProviderConfig",
+      );
     }
     return { ok: true };
   },
@@ -356,9 +375,17 @@ const startAssistantOAuthLogin = mutation({
       await deleteRef(vault, ref);
       throw error;
     }
-    // Post-commit: the row references the new ref, so only release the
-    // replaced one. Never the new ref past this point.
-    await deleteRef(vault, row.credentialRef);
+    // Post-commit: the row references the new ref, so only the replaced one is
+    // superseded. Release after a durable snapshot (fail-closed, best-effort);
+    // never the new ref past this point.
+    if (isSecretRef(row.credentialRef)) {
+      await flushThenReleaseRefs(
+        flushSnapshotFromCtx(ctx),
+        [row.credentialRef],
+        vault ?? undefined,
+        "startAssistantOAuthLogin",
+      );
+    }
     return rowToDto(updated ?? { ...row, credentialRef: ref });
   },
 });
@@ -367,6 +394,7 @@ export async function resolveAssistantProviderConfigForRun(args: {
   row: AssistantProviderConfigRow;
   vault: ReturnType<typeof vaultFromCtx>;
   updateCredentialRef: (ref: SecretRef) => Promise<void>;
+  flushSnapshot?: () => Promise<void>;
 }): Promise<Awaited<ReturnType<typeof resolveAssistantProvider>>> {
   const resolved = await resolveAssistantProvider(
     rowToStored(args.row),
@@ -386,7 +414,16 @@ export async function resolveAssistantProviderConfigForRun(args: {
     await deleteRef(args.vault, newRef);
     throw error;
   }
-  await deleteRef(args.vault, oldRef);
+  // Post-commit: the row references newRef, so only the rotated-out ref is
+  // superseded. Release after a durable snapshot (fail-closed, best-effort).
+  if (isSecretRef(oldRef)) {
+    await flushThenReleaseRefs(
+      args.flushSnapshot,
+      [oldRef],
+      args.vault ?? undefined,
+      "resolveAssistantProviderConfigForRun",
+    );
+  }
   return resolved;
 }
 

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -169,6 +169,16 @@ const saveAssistantProviderConfig = mutation({
   args: { input: jsonb },
   handler: async (ctx, { input }): Promise<AssistantProviderConfig> => {
     const parsed = saveInputSchema.parse(input);
+    // The schema keeps providerId a plain string (the catalog is runtime
+    // data); reject unknown providers here so a bad id can never reach the
+    // KnownProvider casts in the model-resolution path.
+    if (
+      !getAssistantProviderCatalog().some(
+        (entry) => entry.providerId === parsed.providerId,
+      )
+    ) {
+      throw new Error(`Unknown assistant provider: ${parsed.providerId}`);
+    }
     const vault = vaultFromCtx(ctx);
     const id = parsed.id ?? crypto.randomUUID();
     const current = parsed.id

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -42,6 +42,9 @@ const setDefaultModelSchema = z.object({
   defaultModel: z.string().min(1),
 }) satisfies z.ZodType<SetAssistantDefaultModelInput>;
 
+// Opens the OAuth URL in a browser ON THE SERVER HOST — a desktop-app
+// assumption (Electron main runs next to the user's browser). A hosted
+// deployment must replace this with a client-side redirect flow.
 function openAuthUrl(url: string): void {
   let opener = "xdg-open";
   if (process.platform === "darwin") {

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -1,0 +1,344 @@
+import {
+  getAssistantProviderCatalog,
+  loginAssistantProviderOAuth,
+  resolveAssistantProvider,
+  type StoredAssistantProviderConfig,
+} from "@dashframe/assistant";
+import { schema } from "@dashframe/server-core";
+import type {
+  AssistantProviderAuthKind,
+  AssistantProviderCatalogEntry,
+  AssistantProviderConfig,
+  SaveAssistantProviderConfigInput,
+  SetAssistantDefaultModelInput,
+} from "@dashframe/types";
+import { eq, jsonb, uuid } from "@wystack/db";
+import { isSecretRef, type SecretRef } from "@wystack/secret-vault";
+import { mutation, query } from "@wystack/server";
+import { spawn } from "node:child_process";
+import { z } from "zod";
+
+import { vaultFromCtx } from "./utils";
+
+const { assistantProviderConfigs } = schema;
+
+type AssistantProviderConfigRow = typeof assistantProviderConfigs.$inferSelect;
+
+const authKindSchema = z.enum(["api-key", "local", "oauth"]);
+
+const saveInputSchema = z.object({
+  id: z.string().uuid().optional(),
+  providerId: z.string().min(1),
+  displayLabel: z.string().min(1),
+  authKind: authKindSchema,
+  baseUrl: z.string().trim().optional(),
+  credential: z.string().optional(),
+  defaultModel: z.string().min(1),
+  isDefault: z.boolean().optional(),
+}) satisfies z.ZodType<SaveAssistantProviderConfigInput>;
+
+const setDefaultModelSchema = z.object({
+  id: z.string().uuid(),
+  defaultModel: z.string().min(1),
+}) satisfies z.ZodType<SetAssistantDefaultModelInput>;
+
+function openAuthUrl(url: string): void {
+  let opener = "xdg-open";
+  if (process.platform === "darwin") {
+    opener = "open";
+  } else if (process.platform === "win32") {
+    opener = "cmd";
+  }
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  const child = spawn(opener, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}
+
+function millis(value: Date): number {
+  return value.getTime();
+}
+
+function rowToDto(row: AssistantProviderConfigRow): AssistantProviderConfig {
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    displayLabel: row.displayLabel,
+    authKind: row.authKind as AssistantProviderAuthKind,
+    baseUrl: row.baseUrl ?? undefined,
+    hasCredential: isSecretRef(row.credentialRef),
+    defaultModel: row.defaultModel,
+    isDefault: row.isDefault,
+    createdAt: millis(row.createdAt),
+    updatedAt: millis(row.updatedAt),
+  };
+}
+
+function rowToStored(
+  row: AssistantProviderConfigRow,
+): StoredAssistantProviderConfig {
+  return {
+    id: row.id,
+    providerId: row.providerId,
+    displayLabel: row.displayLabel,
+    authKind: row.authKind as AssistantProviderAuthKind,
+    baseUrl: row.baseUrl,
+    credentialRef: row.credentialRef,
+    defaultModel: row.defaultModel,
+  };
+}
+
+async function storeAssistantCredential(args: {
+  vault: ReturnType<typeof vaultFromCtx>;
+  plaintext: string | undefined;
+  locatorHint: string;
+}): Promise<SecretRef | undefined> {
+  if (args.plaintext === undefined || args.plaintext.length === 0) {
+    return undefined;
+  }
+  if (args.vault == null) {
+    throw new Error(
+      "[secret-vault] cannot store assistant provider credential: no vault injected",
+    );
+  }
+  return args.vault.store(args.plaintext, {
+    class: "assistant-provider",
+    locatorHint: args.locatorHint,
+  });
+}
+
+async function deleteRef(
+  vault: ReturnType<typeof vaultFromCtx>,
+  ref: unknown,
+): Promise<void> {
+  if (!isSecretRef(ref)) return;
+  if (vault == null) {
+    throw new Error(
+      "[secret-vault] cannot release assistant provider credential: no vault injected",
+    );
+  }
+  await vault.delete(ref);
+}
+
+const listAssistantProviderCatalog = query({
+  args: {},
+  handler: async (): Promise<AssistantProviderCatalogEntry[]> =>
+    getAssistantProviderCatalog(),
+});
+
+const listAssistantProviderConfigs = query({
+  args: {},
+  handler: async (ctx): Promise<AssistantProviderConfig[]> => {
+    const rows = (await ctx.db
+      .from(assistantProviderConfigs)
+      .all()) as AssistantProviderConfigRow[];
+    return rows.map(rowToDto);
+  },
+});
+
+const saveAssistantProviderConfig = mutation({
+  args: { input: jsonb },
+  handler: async (ctx, { input }): Promise<AssistantProviderConfig> => {
+    const parsed = saveInputSchema.parse(input);
+    const vault = vaultFromCtx(ctx);
+    const id = parsed.id ?? crypto.randomUUID();
+    const mintedRef = await storeAssistantCredential({
+      vault,
+      plaintext: parsed.credential,
+      locatorHint: `assistant-provider-${id}`,
+    });
+    const current = parsed.id
+      ? ((await ctx.db
+          .from(assistantProviderConfigs)
+          .where(eq("id", parsed.id))
+          .first()) as AssistantProviderConfigRow | undefined)
+      : undefined;
+
+    try {
+      let row: AssistantProviderConfigRow | undefined;
+      if (current) {
+        const [updated] = (await ctx.db
+          .from(assistantProviderConfigs)
+          .where(eq("id", current.id))
+          .update({
+            providerId: parsed.providerId,
+            displayLabel: parsed.displayLabel,
+            authKind: parsed.authKind,
+            baseUrl: parsed.baseUrl?.trim() || null,
+            credentialRef: mintedRef ?? current.credentialRef,
+            defaultModel: parsed.defaultModel,
+            isDefault: parsed.isDefault ?? current.isDefault,
+          })) as AssistantProviderConfigRow[];
+        row = updated;
+      } else {
+        const [inserted] = (await ctx.db.into(assistantProviderConfigs).insert({
+          id,
+          providerId: parsed.providerId,
+          displayLabel: parsed.displayLabel,
+          authKind: parsed.authKind,
+          baseUrl: parsed.baseUrl?.trim() || null,
+          credentialRef: mintedRef ?? null,
+          defaultModel: parsed.defaultModel,
+          isDefault: parsed.isDefault ?? false,
+        })) as AssistantProviderConfigRow[];
+        row = inserted;
+      }
+      if (!row)
+        throw new Error("assistant provider config write returned no row");
+
+      if (row.isDefault) {
+        const rows = (await ctx.db
+          .from(assistantProviderConfigs)
+          .all()) as AssistantProviderConfigRow[];
+        await Promise.all(
+          rows
+            .filter(
+              (candidate) => candidate.id !== row!.id && candidate.isDefault,
+            )
+            .map((candidate) =>
+              ctx.db
+                .from(assistantProviderConfigs)
+                .where(eq("id", candidate.id))
+                .update({ isDefault: false }),
+            ),
+        );
+      }
+
+      if (mintedRef && current?.credentialRef !== mintedRef) {
+        await deleteRef(vault, current?.credentialRef);
+      }
+      return rowToDto(row);
+    } catch (error) {
+      await deleteRef(vault, mintedRef);
+      throw error;
+    }
+  },
+});
+
+const removeAssistantProviderConfig = mutation({
+  args: { id: uuid },
+  handler: async (ctx, { id }): Promise<{ ok: true }> => {
+    const vault = vaultFromCtx(ctx);
+    await ctx.db.transaction(async (tx) => {
+      const current = (await tx
+        .from(assistantProviderConfigs)
+        .where(eq("id", id))
+        .first()) as AssistantProviderConfigRow | undefined;
+      if (!current) return;
+      await tx.from(assistantProviderConfigs).where(eq("id", id)).delete();
+      await deleteRef(vault, current.credentialRef);
+    });
+    return { ok: true };
+  },
+});
+
+const setAssistantDefaultModel = mutation({
+  args: { input: jsonb },
+  handler: async (ctx, { input }): Promise<{ ok: true }> => {
+    const parsed = setDefaultModelSchema.parse(input);
+    await ctx.db
+      .from(assistantProviderConfigs)
+      .where(eq("id", parsed.id))
+      .update({ defaultModel: parsed.defaultModel, isDefault: true });
+    const rows = (await ctx.db
+      .from(assistantProviderConfigs)
+      .all()) as AssistantProviderConfigRow[];
+    await Promise.all(
+      rows
+        .filter((row) => row.id !== parsed.id && row.isDefault)
+        .map((row) =>
+          ctx.db
+            .from(assistantProviderConfigs)
+            .where(eq("id", row.id))
+            .update({ isDefault: false }),
+        ),
+    );
+    return { ok: true };
+  },
+});
+
+const startAssistantOAuthLogin = mutation({
+  args: { id: uuid },
+  handler: async (ctx, { id }): Promise<AssistantProviderConfig> => {
+    const vault = vaultFromCtx(ctx);
+    const row = (await ctx.db
+      .from(assistantProviderConfigs)
+      .where(eq("id", id))
+      .first()) as AssistantProviderConfigRow | undefined;
+    if (!row) {
+      throw new Error("Assistant provider config not found");
+    }
+    if (row.authKind !== "oauth") {
+      throw new Error("Assistant provider is not configured for OAuth");
+    }
+    const credentials = await loginAssistantProviderOAuth(row.providerId, {
+      onAuth: (info) => openAuthUrl(info.url),
+      onDeviceCode: (info) => openAuthUrl(info.verificationUri),
+      onPrompt: async () => {
+        throw new Error(
+          "Manual OAuth code entry is not available in this host flow.",
+        );
+      },
+      onSelect: async (prompt) =>
+        prompt.options.find((option) => option.id === "browser")?.id ??
+        prompt.options[0]?.id,
+    });
+    const ref = await storeAssistantCredential({
+      vault,
+      plaintext: JSON.stringify(credentials),
+      locatorHint: `assistant-provider-${row.id}`,
+    });
+    if (!ref) {
+      throw new Error("OAuth login returned no credential to store");
+    }
+    try {
+      const [updated] = (await ctx.db
+        .from(assistantProviderConfigs)
+        .where(eq("id", row.id))
+        .update({ credentialRef: ref })) as AssistantProviderConfigRow[];
+      await deleteRef(vault, row.credentialRef);
+      return rowToDto(updated ?? { ...row, credentialRef: ref });
+    } catch (error) {
+      await deleteRef(vault, ref);
+      throw error;
+    }
+  },
+});
+
+export async function resolveAssistantProviderConfigForRun(args: {
+  row: AssistantProviderConfigRow;
+  vault: ReturnType<typeof vaultFromCtx>;
+  updateCredentialRef: (ref: SecretRef) => Promise<void>;
+}): Promise<Awaited<ReturnType<typeof resolveAssistantProvider>>> {
+  const resolved = await resolveAssistantProvider(
+    rowToStored(args.row),
+    args.vault,
+  );
+  if (!resolved.rotatedCredential) return resolved;
+  const oldRef = args.row.credentialRef;
+  const newRef = await storeAssistantCredential({
+    vault: args.vault,
+    plaintext: JSON.stringify(resolved.rotatedCredential),
+    locatorHint: `assistant-provider-${args.row.id}`,
+  });
+  if (!newRef) return resolved;
+  try {
+    await args.updateCredentialRef(newRef);
+  } catch (error) {
+    await deleteRef(args.vault, newRef);
+    throw error;
+  }
+  await deleteRef(args.vault, oldRef);
+  return resolved;
+}
+
+export const assistantProviderConfigFunctions = {
+  listAssistantProviderCatalog,
+  listAssistantProviderConfigs,
+  saveAssistantProviderConfig,
+  removeAssistantProviderConfig,
+  setAssistantDefaultModel,
+  startAssistantOAuthLogin,
+};

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -45,7 +45,7 @@ const setDefaultModelSchema = z.object({
 // Opens the OAuth URL in a browser ON THE SERVER HOST — a desktop-app
 // assumption (Electron main runs next to the user's browser). A hosted
 // deployment must replace this with a client-side redirect flow.
-function openAuthUrl(url: string): void {
+function openAuthUrl(url: string): Promise<void> {
   let opener = "xdg-open";
   if (process.platform === "darwin") {
     opener = "open";
@@ -57,7 +57,31 @@ function openAuthUrl(url: string): void {
     detached: true,
     stdio: "ignore",
   });
-  child.unref();
+  return new Promise((resolve, reject) => {
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+    child.once("error", reject);
+  });
+}
+
+function deviceCodeVerificationUrl(info: {
+  verificationUri: string;
+  userCode: string;
+}): string {
+  const verificationUriComplete = (
+    info as { verificationUriComplete?: unknown }
+  ).verificationUriComplete;
+  if (
+    typeof verificationUriComplete === "string" &&
+    verificationUriComplete.trim()
+  ) {
+    return verificationUriComplete;
+  }
+  throw new Error(
+    "device-code flow requires displaying a user code, not supported in this host flow yet",
+  );
 }
 
 function millis(value: Date): number {
@@ -249,20 +273,7 @@ const setAssistantDefaultModel = mutation({
     await ctx.db
       .from(assistantProviderConfigs)
       .where(eq("id", parsed.id))
-      .update({ defaultModel: parsed.defaultModel, isDefault: true });
-    const rows = (await ctx.db
-      .from(assistantProviderConfigs)
-      .all()) as AssistantProviderConfigRow[];
-    await Promise.all(
-      rows
-        .filter((row) => row.id !== parsed.id && row.isDefault)
-        .map((row) =>
-          ctx.db
-            .from(assistantProviderConfigs)
-            .where(eq("id", row.id))
-            .update({ isDefault: false }),
-        ),
-    );
+      .update({ defaultModel: parsed.defaultModel });
     return { ok: true };
   },
 });
@@ -281,18 +292,34 @@ const startAssistantOAuthLogin = mutation({
     if (row.authKind !== "oauth") {
       throw new Error("Assistant provider is not configured for OAuth");
     }
-    const credentials = await loginAssistantProviderOAuth(row.providerId, {
-      onAuth: (info) => openAuthUrl(info.url),
-      onDeviceCode: (info) => openAuthUrl(info.verificationUri),
-      onPrompt: async () => {
-        throw new Error(
-          "Manual OAuth code entry is not available in this host flow.",
-        );
-      },
-      onSelect: async (prompt) =>
-        prompt.options.find((option) => option.id === "browser")?.id ??
-        prompt.options[0]?.id,
+    let rejectOpenerFailure: (error: Error) => void = () => {};
+    const openerFailure = new Promise<never>((_, reject) => {
+      rejectOpenerFailure = reject;
     });
+    const openAndTrack = (url: string): Promise<void> => {
+      const opened = openAuthUrl(url);
+      opened.catch((error: unknown) => {
+        rejectOpenerFailure(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      });
+      return opened;
+    };
+    const credentials = await Promise.race([
+      loginAssistantProviderOAuth(row.providerId, {
+        onAuth: (info) => openAndTrack(info.url),
+        onDeviceCode: (info) => openAndTrack(deviceCodeVerificationUrl(info)),
+        onPrompt: async () => {
+          throw new Error(
+            "Manual OAuth code entry is not available in this host flow.",
+          );
+        },
+        onSelect: async (prompt) =>
+          prompt.options.find((option) => option.id === "browser")?.id ??
+          prompt.options[0]?.id,
+      }),
+      openerFailure,
+    ]);
     const ref = await storeAssistantCredential({
       vault,
       plaintext: JSON.stringify(credentials),

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -103,6 +103,7 @@ import {
   applyCredentialField,
   coerceProvenance,
   type DataSourceConfig,
+  flushThenReleaseRefs,
   isRecord,
   modeFromCtx,
   releaseCredentialRefs,
@@ -438,36 +439,7 @@ async function flushAndReleaseRefs(
   const flushSnapshot = (ctx as Record<string, unknown>).flushSnapshot as
     | (() => Promise<void>)
     | undefined;
-  if (flushSnapshot == null) {
-    console.error(
-      `[dashframe] ${label}: no flushSnapshot hook — skipping credential release ` +
-        "(fail-closed). Wire flushSnapshot to ensure replaced credential refs are released.",
-    );
-    return;
-  }
-  try {
-    await flushSnapshot();
-  } catch (err) {
-    console.error(
-      `[dashframe] ${label}: flushSnapshot failed, skipping credential release:`,
-      err,
-    );
-    return;
-  }
-  // Best-effort: a release failure leaves an inert orphan; it must never fail the
-  // committed write. Parallel deletes; log any failures.
-  const results = await Promise.allSettled(
-    supersededRefs.map((ref) => vault?.delete(ref)),
-  );
-  const failures = results.filter(
-    (r): r is PromiseRejectedResult => r.status === "rejected",
-  );
-  if (failures.length > 0) {
-    console.error(
-      `[dashframe] ${label}: ${failures.length} of ${supersededRefs.length} credential ref(s) failed to release (inert orphan):`,
-      failures.map((f) => f.reason),
-    );
-  }
+  await flushThenReleaseRefs(flushSnapshot, supersededRefs, vault, label);
 }
 
 const setDataSourceConfig = mutation({

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -241,6 +241,52 @@ export async function releaseCredentialRefs(
 }
 
 /**
+ * Flush a durable snapshot, then best-effort release superseded credential
+ * refs. The ordering closes the crash window: releasing before the snapshot
+ * that drops or replaces a ref is on disk can leave a restored row pointing at
+ * a deleted vault entry. Fail-closed: when `flushSnapshot` is absent or
+ * throws, release is skipped — inert orphan, never a dangling live reference.
+ * A release failure is logged, never thrown — it must not fail the committed
+ * write it follows.
+ */
+export async function flushThenReleaseRefs(
+  flushSnapshot: (() => Promise<void>) | undefined,
+  supersededRefs: SecretRef[],
+  vault: SecretVault | undefined,
+  label: string,
+): Promise<void> {
+  if (supersededRefs.length === 0) return;
+  if (flushSnapshot == null) {
+    console.error(
+      `[dashframe] ${label}: no flushSnapshot hook — skipping credential release ` +
+        "(fail-closed). Wire flushSnapshot to ensure replaced credential refs are released.",
+    );
+    return;
+  }
+  try {
+    await flushSnapshot();
+  } catch (err) {
+    console.error(
+      `[dashframe] ${label}: flushSnapshot failed, skipping credential release:`,
+      err,
+    );
+    return;
+  }
+  const results = await Promise.allSettled(
+    supersededRefs.map((ref) => vault?.delete(ref)),
+  );
+  const failures = results.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  );
+  if (failures.length > 0) {
+    console.error(
+      `[dashframe] ${label}: ${failures.length} of ${supersededRefs.length} credential ref(s) failed to release (inert orphan):`,
+      failures.map((f) => f.reason),
+    );
+  }
+}
+
+/**
  * Push the prior ref into the superseded collector (when one is provided) or
  * release it immediately via `releaseCredentialRefs`. Extracted to reduce
  * `applyCredentialField`'s cognitive complexity — the two call sites have

--- a/packages/app-data/src/assistant-provider-configs.ts
+++ b/packages/app-data/src/assistant-provider-configs.ts
@@ -1,0 +1,62 @@
+import type {
+  AssistantProviderCatalogEntry,
+  AssistantProviderConfig,
+  AssistantProviderConfigMutations,
+  SaveAssistantProviderConfigInput,
+  UseAssistantProviderCatalogResult,
+  UseAssistantProviderConfigsResult,
+} from "@dashframe/types";
+import { useMutation, useQuery } from "@wystack/client";
+import { useMemo } from "react";
+
+import { api } from "./api";
+import { loose } from "./wystack-args";
+
+export function useAssistantProviderCatalog(): UseAssistantProviderCatalogResult {
+  const result = useQuery(api.listAssistantProviderCatalog);
+  return {
+    data: result.data as AssistantProviderCatalogEntry[] | undefined,
+    isLoading: result.isLoading,
+    isFetching: result.isFetching,
+  };
+}
+
+export function useAssistantProviderConfigs(): UseAssistantProviderConfigsResult {
+  const result = useQuery(api.listAssistantProviderConfigs);
+  return {
+    data: result.data as AssistantProviderConfig[] | undefined,
+    isLoading: result.isLoading,
+    isFetching: result.isFetching,
+  };
+}
+
+export function useAssistantProviderConfigMutations(): AssistantProviderConfigMutations {
+  const saveMutation = useMutation(api.saveAssistantProviderConfig);
+  const removeMutation = useMutation(api.removeAssistantProviderConfig);
+  const setDefaultModelMutation = useMutation(api.setAssistantDefaultModel);
+  const startOAuthLoginMutation = useMutation(api.startAssistantOAuthLogin);
+
+  return useMemo(
+    () => ({
+      save: async (input: SaveAssistantProviderConfigInput) =>
+        (await saveMutation.mutateAsync(
+          loose({ input }),
+        )) as AssistantProviderConfig,
+      remove: async (id) => {
+        await removeMutation.mutateAsync({ id });
+      },
+      setDefaultModel: async (input) => {
+        await setDefaultModelMutation.mutateAsync(loose({ input }));
+      },
+      startOAuthLogin: async (id) => {
+        await startOAuthLoginMutation.mutateAsync({ id });
+      },
+    }),
+    [
+      removeMutation,
+      saveMutation,
+      setDefaultModelMutation,
+      startOAuthLoginMutation,
+    ],
+  );
+}

--- a/packages/app-data/src/index.ts
+++ b/packages/app-data/src/index.ts
@@ -40,6 +40,12 @@ export {
 } from "./dashboards";
 
 export {
+  useAssistantProviderCatalog,
+  useAssistantProviderConfigMutations,
+  useAssistantProviderConfigs,
+} from "./assistant-provider-configs";
+
+export {
   addDataSource,
   getAllDataSources,
   getDataSource,

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -25,6 +25,8 @@ export function AssistantModelPicker() {
   const setSelectedModel = useAssistantStore((s) => s.setSelectedModel);
   const configs = useMemo(() => configsResult.data ?? [], [configsResult.data]);
   const catalog = useMemo(() => catalogResult.data ?? [], [catalogResult.data]);
+  const configsLoaded =
+    configsResult.data !== undefined && !configsResult.isLoading;
   const selected =
     configs.find((config) => config.id === selectedProviderConfigId) ??
     configs.find((config) => config.isDefault) ??
@@ -42,9 +44,21 @@ export function AssistantModelPicker() {
   }, [catalog, selected?.providerId]);
 
   useEffect(() => {
-    if (!selected || activeModel) return;
+    if (!selected) return;
+    const storedConfigMissing =
+      configsLoaded &&
+      selectedProviderConfigId !== null &&
+      configs.every((config) => config.id !== selectedProviderConfigId);
+    if (!storedConfigMissing && activeModel) return;
     setSelectedModel(selected.id, selected.defaultModel);
-  }, [activeModel, selected, setSelectedModel]);
+  }, [
+    activeModel,
+    configs,
+    configsLoaded,
+    selected,
+    selectedProviderConfigId,
+    setSelectedModel,
+  ]);
 
   if (!selected) {
     return (

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -63,6 +63,8 @@ export function AssistantModelPicker() {
           const next = configs.find((config) => config.id === id);
           if (next) {
             setSelectedModel(next.id, next.defaultModel);
+            // Selecting a provider also persists it as the default — the
+            // picker is the "active provider" control, not a per-run choice.
             mutations.save({ ...next, isDefault: true });
           }
         }}

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -12,6 +12,7 @@ import {
 } from "@wystack/ui";
 import { useEffect, useMemo } from "react";
 
+import { useToastStore } from "@/lib/stores";
 import { useAssistantStore } from "@/lib/stores/assistant-store";
 
 export function AssistantModelPicker() {
@@ -23,6 +24,7 @@ export function AssistantModelPicker() {
   );
   const selectedModelId = useAssistantStore((s) => s.selectedModelId);
   const setSelectedModel = useAssistantStore((s) => s.setSelectedModel);
+  const showError = useToastStore((s) => s.showError);
   const configs = useMemo(() => configsResult.data ?? [], [configsResult.data]);
   const catalog = useMemo(() => catalogResult.data ?? [], [catalogResult.data]);
   const configsLoaded =
@@ -79,7 +81,12 @@ export function AssistantModelPicker() {
             setSelectedModel(next.id, next.defaultModel);
             // Selecting a provider also persists it as the default — the
             // picker is the "active provider" control, not a per-run choice.
-            mutations.save({ ...next, isDefault: true });
+            void mutations.save({ ...next, isDefault: true }).catch((error) => {
+              showError("Failed to switch assistant provider", {
+                description:
+                  error instanceof Error ? error.message : "Please try again.",
+              });
+            });
           }
         }}
       >
@@ -99,7 +106,14 @@ export function AssistantModelPicker() {
         onValueChange={(defaultModel) => {
           if (!defaultModel) return;
           setSelectedModel(selected.id, defaultModel);
-          mutations.setDefaultModel({ id: selected.id, defaultModel });
+          void mutations
+            .setDefaultModel({ id: selected.id, defaultModel })
+            .catch((error) => {
+              showError("Failed to set assistant model", {
+                description:
+                  error instanceof Error ? error.message : "Please try again.",
+              });
+            });
         }}
       >
         <SelectTrigger className="h-7 w-32 px-2 text-[11px]">

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -81,7 +81,7 @@ export function AssistantModelPicker() {
             setSelectedModel(next.id, next.defaultModel);
             // Selecting a provider also persists it as the default — the
             // picker is the "active provider" control, not a per-run choice.
-            void mutations.save({ ...next, isDefault: true }).catch((error) => {
+            mutations.save({ ...next, isDefault: true }).catch((error) => {
               showError("Failed to switch assistant provider", {
                 description:
                   error instanceof Error ? error.message : "Please try again.",
@@ -106,7 +106,7 @@ export function AssistantModelPicker() {
         onValueChange={(defaultModel) => {
           if (!defaultModel) return;
           setSelectedModel(selected.id, defaultModel);
-          void mutations
+          mutations
             .setDefaultModel({ id: selected.id, defaultModel })
             .catch((error) => {
               showError("Failed to set assistant model", {

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -1,0 +1,102 @@
+import {
+  useAssistantProviderCatalog,
+  useAssistantProviderConfigMutations,
+  useAssistantProviderConfigs,
+} from "@dashframe/core";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@wystack/ui";
+import { useEffect, useMemo } from "react";
+
+import { useAssistantStore } from "@/lib/stores/assistant-store";
+
+export function AssistantModelPicker() {
+  const configsResult = useAssistantProviderConfigs();
+  const catalogResult = useAssistantProviderCatalog();
+  const mutations = useAssistantProviderConfigMutations();
+  const selectedProviderConfigId = useAssistantStore(
+    (s) => s.selectedProviderConfigId,
+  );
+  const selectedModelId = useAssistantStore((s) => s.selectedModelId);
+  const setSelectedModel = useAssistantStore((s) => s.setSelectedModel);
+  const configs = useMemo(() => configsResult.data ?? [], [configsResult.data]);
+  const catalog = useMemo(() => catalogResult.data ?? [], [catalogResult.data]);
+  const selected =
+    configs.find((config) => config.id === selectedProviderConfigId) ??
+    configs.find((config) => config.isDefault) ??
+    configs[0];
+  const activeModel =
+    selectedProviderConfigId === selected?.id
+      ? (selectedModelId ?? selected.defaultModel)
+      : selected?.defaultModel;
+
+  const models = useMemo(() => {
+    const entry = catalog.find(
+      (candidate) => candidate.providerId === selected?.providerId,
+    );
+    return entry?.models ?? [];
+  }, [catalog, selected?.providerId]);
+
+  useEffect(() => {
+    if (!selected || activeModel) return;
+    setSelectedModel(selected.id, selected.defaultModel);
+  }, [activeModel, selected, setSelectedModel]);
+
+  if (!selected) {
+    return (
+      <span className="max-w-32 truncate rounded-md bg-neutral-bg-muted px-2 py-1 text-[11px] text-neutral-fg-subtle">
+        No model
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <Select
+        value={selected.id}
+        onValueChange={(id) => {
+          if (!id) return;
+          const next = configs.find((config) => config.id === id);
+          if (next) {
+            setSelectedModel(next.id, next.defaultModel);
+            mutations.save({ ...next, isDefault: true });
+          }
+        }}
+      >
+        <SelectTrigger className="h-7 w-28 px-2 text-[11px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {configs.map((config) => (
+            <SelectItem key={config.id} value={config.id}>
+              {config.displayLabel}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        value={activeModel}
+        onValueChange={(defaultModel) => {
+          if (!defaultModel) return;
+          setSelectedModel(selected.id, defaultModel);
+          mutations.setDefaultModel({ id: selected.id, defaultModel });
+        }}
+      >
+        <SelectTrigger className="h-7 w-32 px-2 text-[11px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {models.slice(0, 80).map((model) => (
+            <SelectItem key={model.id} value={model.id}>
+              {model.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -27,7 +27,12 @@ import {
   SelectValue,
 } from "@wystack/ui";
 import { DeleteIcon, ExternalLinkIcon, PlusIcon } from "@wystack/ui-icons";
-import { useEffect, useMemo, useState } from "react";
+import {
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 
 interface AssistantProviderSettingsDialogProps {
   open: boolean;
@@ -61,19 +66,6 @@ function formFromCatalog(
   };
 }
 
-const emptyCatalogForm = formFromCatalog([]);
-
-function isPristineEmptySeed(form: DraftProviderForm): boolean {
-  return (
-    form.providerId === emptyCatalogForm.providerId &&
-    form.displayLabel === emptyCatalogForm.displayLabel &&
-    form.authKind === emptyCatalogForm.authKind &&
-    form.baseUrl === emptyCatalogForm.baseUrl &&
-    form.credential === emptyCatalogForm.credential &&
-    form.defaultModel === emptyCatalogForm.defaultModel
-  );
-}
-
 export function AssistantProviderSettingsDialog({
   open,
   onOpenChange,
@@ -84,9 +76,19 @@ export function AssistantProviderSettingsDialog({
   const { showError, showSuccess } = useToastStore();
   const catalog = useMemo(() => catalogResult.data ?? [], [catalogResult.data]);
   const configs = useMemo(() => configsResult.data ?? [], [configsResult.data]);
-  const [form, setForm] = useState<DraftProviderForm>(() =>
-    formFromCatalog(catalog),
+  // The form derives from the catalog until the user edits it; the first
+  // edit pins it as an override so a late-arriving catalog can't clobber
+  // user input.
+  const [formOverride, setFormOverride] = useState<DraftProviderForm | null>(
+    null,
   );
+  const form = formOverride ?? formFromCatalog(catalog);
+  const setForm: Dispatch<SetStateAction<DraftProviderForm>> = (action) => {
+    setFormOverride((current) => {
+      const base = current ?? formFromCatalog(catalog);
+      return typeof action === "function" ? action(base) : action;
+    });
+  };
   const [saving, setSaving] = useState(false);
 
   const selectedCatalog = useMemo(
@@ -95,13 +97,6 @@ export function AssistantProviderSettingsDialog({
   );
   const selectedCatalogIsLocal =
     selectedCatalog?.authKinds.includes("local") || form.authKind === "local";
-
-  useEffect(() => {
-    if (catalog.length === 0) return;
-    setForm((current) =>
-      isPristineEmptySeed(current) ? formFromCatalog(catalog) : current,
-    );
-  }, [catalog]);
 
   function chooseProvider(providerId: string | null) {
     if (!providerId) return;

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -27,7 +27,7 @@ import {
   SelectValue,
 } from "@wystack/ui";
 import { DeleteIcon, ExternalLinkIcon, PlusIcon } from "@wystack/ui-icons";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface AssistantProviderSettingsDialogProps {
   open: boolean;
@@ -61,6 +61,19 @@ function formFromCatalog(
   };
 }
 
+const emptyCatalogForm = formFromCatalog([]);
+
+function isPristineEmptySeed(form: DraftProviderForm): boolean {
+  return (
+    form.providerId === emptyCatalogForm.providerId &&
+    form.displayLabel === emptyCatalogForm.displayLabel &&
+    form.authKind === emptyCatalogForm.authKind &&
+    form.baseUrl === emptyCatalogForm.baseUrl &&
+    form.credential === emptyCatalogForm.credential &&
+    form.defaultModel === emptyCatalogForm.defaultModel
+  );
+}
+
 export function AssistantProviderSettingsDialog({
   open,
   onOpenChange,
@@ -80,6 +93,22 @@ export function AssistantProviderSettingsDialog({
     () => catalog.find((entry) => entry.providerId === form.providerId),
     [catalog, form.providerId],
   );
+  const selectedCatalogIsLocal =
+    selectedCatalog?.authKinds.includes("local") || form.authKind === "local";
+
+  useEffect(() => {
+    if (catalog.length === 0) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setForm((current) =>
+        isPristineEmptySeed(current) ? formFromCatalog(catalog) : current,
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [catalog]);
 
   function chooseProvider(providerId: string | null) {
     if (!providerId) return;
@@ -286,24 +315,40 @@ export function AssistantProviderSettingsDialog({
             )}
             <Field>
               <FieldLabel>Default model</FieldLabel>
-              <Select
-                value={form.defaultModel}
-                onValueChange={(value) => {
-                  if (!value) return;
-                  setForm((current) => ({ ...current, defaultModel: value }));
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {selectedCatalog?.models.slice(0, 80).map((model) => (
-                    <SelectItem key={model.id} value={model.id}>
-                      {model.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              {selectedCatalogIsLocal ? (
+                <Input
+                  value={form.defaultModel}
+                  placeholder={firstModel(selectedCatalog)}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      defaultModel: event.target.value,
+                    }))
+                  }
+                />
+              ) : (
+                <Select
+                  value={form.defaultModel}
+                  onValueChange={(value) => {
+                    if (!value) return;
+                    setForm((current) => ({
+                      ...current,
+                      defaultModel: value,
+                    }));
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {selectedCatalog?.models.slice(0, 80).map((model) => (
+                      <SelectItem key={model.id} value={model.id}>
+                        {model.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
             </Field>
           </section>
         </div>

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -1,0 +1,322 @@
+import { useToastStore } from "@/lib/stores";
+import {
+  useAssistantProviderCatalog,
+  useAssistantProviderConfigMutations,
+  useAssistantProviderConfigs,
+} from "@dashframe/core";
+import type {
+  AssistantProviderAuthKind,
+  AssistantProviderCatalogEntry,
+} from "@dashframe/types";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldDescription,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@wystack/ui";
+import { DeleteIcon, ExternalLinkIcon, PlusIcon } from "@wystack/ui-icons";
+import { useMemo, useState } from "react";
+
+interface AssistantProviderSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface DraftProviderForm {
+  providerId: string;
+  displayLabel: string;
+  authKind: AssistantProviderAuthKind;
+  baseUrl: string;
+  credential: string;
+  defaultModel: string;
+}
+
+function firstModel(catalog?: AssistantProviderCatalogEntry): string {
+  return catalog?.models[0]?.id ?? "";
+}
+
+function formFromCatalog(
+  catalog: AssistantProviderCatalogEntry[],
+): DraftProviderForm {
+  const first = catalog[0];
+  return {
+    providerId: first?.providerId ?? "anthropic",
+    displayLabel: first?.label ?? "Anthropic",
+    authKind: first?.authKinds[0] ?? "api-key",
+    baseUrl: first?.defaultBaseUrl ?? "",
+    credential: "",
+    defaultModel: firstModel(first),
+  };
+}
+
+export function AssistantProviderSettingsDialog({
+  open,
+  onOpenChange,
+}: AssistantProviderSettingsDialogProps) {
+  const catalogResult = useAssistantProviderCatalog();
+  const configsResult = useAssistantProviderConfigs();
+  const mutations = useAssistantProviderConfigMutations();
+  const { showError, showSuccess } = useToastStore();
+  const catalog = useMemo(() => catalogResult.data ?? [], [catalogResult.data]);
+  const configs = useMemo(() => configsResult.data ?? [], [configsResult.data]);
+  const [form, setForm] = useState<DraftProviderForm>(() =>
+    formFromCatalog(catalog),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const selectedCatalog = useMemo(
+    () => catalog.find((entry) => entry.providerId === form.providerId),
+    [catalog, form.providerId],
+  );
+
+  function chooseProvider(providerId: string | null) {
+    if (!providerId) return;
+    const entry = catalog.find(
+      (candidate) => candidate.providerId === providerId,
+    );
+    setForm({
+      providerId,
+      displayLabel: entry?.label ?? providerId,
+      authKind: entry?.authKinds[0] ?? "api-key",
+      baseUrl: entry?.defaultBaseUrl ?? "",
+      credential: "",
+      defaultModel: firstModel(entry),
+    });
+  }
+
+  async function save() {
+    setSaving(true);
+    try {
+      await mutations.save({
+        providerId: form.providerId,
+        displayLabel: form.displayLabel,
+        authKind: form.authKind,
+        baseUrl: form.baseUrl || undefined,
+        credential: form.credential || undefined,
+        defaultModel: form.defaultModel,
+        isDefault: configs.length === 0,
+      });
+      setForm((current) => ({ ...current, credential: "" }));
+      showSuccess("Assistant provider saved");
+    } catch (error) {
+      showError("Failed to save assistant provider", {
+        description:
+          error instanceof Error ? error.message : "Please check the form.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function login(id: string) {
+    setSaving(true);
+    try {
+      await mutations.startOAuthLogin(id);
+      showSuccess("Assistant provider connected");
+    } catch (error) {
+      showError("Failed to connect assistant provider", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Assistant Providers</DialogTitle>
+          <DialogDescription>
+            Configure model providers and keep credentials in the local vault.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-5 md:grid-cols-[1fr_1.15fr]">
+          <section className="space-y-2">
+            {configs.length === 0 ? (
+              <div className="rounded-lg bg-neutral-bg-muted/60 p-3 text-sm text-neutral-fg-subtle">
+                No providers configured.
+              </div>
+            ) : (
+              configs.map((config) => (
+                <div
+                  key={config.id}
+                  className="rounded-lg bg-neutral-bg-muted/60 p-3"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-neutral-fg">
+                        {config.displayLabel}
+                      </div>
+                      <div className="truncate text-xs text-neutral-fg-subtle">
+                        {config.providerId} · {config.defaultModel}
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={DeleteIcon}
+                      iconOnly
+                      label="Remove provider"
+                      tooltip="Remove provider"
+                      onClick={() => mutations.remove(config.id)}
+                      className="size-7 text-neutral-fg-subtle hover:text-palette-danger"
+                    />
+                  </div>
+                  <div className="mt-2 text-[11px] text-neutral-fg-subtle">
+                    {config.hasCredential
+                      ? "Credential stored"
+                      : "No credential"}
+                    {config.isDefault ? " · Default" : ""}
+                  </div>
+                  {config.authKind === "oauth" && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      icon={ExternalLinkIcon}
+                      label={config.hasCredential ? "Reconnect" : "Log in"}
+                      disabled={saving}
+                      onClick={() => void login(config.id)}
+                      className="mt-2 h-7"
+                    />
+                  )}
+                </div>
+              ))
+            )}
+          </section>
+
+          <section className="space-y-3">
+            <Field>
+              <FieldLabel>Provider</FieldLabel>
+              <Select value={form.providerId} onValueChange={chooseProvider}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {catalog.map((entry) => (
+                    <SelectItem key={entry.providerId} value={entry.providerId}>
+                      {entry.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <FieldLabel>Label</FieldLabel>
+              <Input
+                value={form.displayLabel}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    displayLabel: event.target.value,
+                  }))
+                }
+              />
+            </Field>
+            <Field>
+              <FieldLabel>Auth</FieldLabel>
+              <Select
+                value={form.authKind}
+                onValueChange={(value) => {
+                  if (!value) return;
+                  setForm((current) => ({
+                    ...current,
+                    authKind: value as AssistantProviderAuthKind,
+                  }));
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {selectedCatalog?.authKinds.map((kind) => (
+                    <SelectItem key={kind} value={kind}>
+                      {kind}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+            {form.authKind === "api-key" && (
+              <Field>
+                <FieldLabel>API key</FieldLabel>
+                <Input
+                  type="password"
+                  value={form.credential}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      credential: event.target.value,
+                    }))
+                  }
+                />
+                <FieldDescription>
+                  Write-only. Saved values are not returned to the UI.
+                </FieldDescription>
+              </Field>
+            )}
+            {(form.authKind === "local" || form.providerId === "opencode") && (
+              <Field>
+                <FieldLabel>Base URL</FieldLabel>
+                <Input
+                  value={form.baseUrl}
+                  placeholder={selectedCatalog?.defaultBaseUrl}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      baseUrl: event.target.value,
+                    }))
+                  }
+                />
+              </Field>
+            )}
+            <Field>
+              <FieldLabel>Default model</FieldLabel>
+              <Select
+                value={form.defaultModel}
+                onValueChange={(value) => {
+                  if (!value) return;
+                  setForm((current) => ({ ...current, defaultModel: value }));
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {selectedCatalog?.models.slice(0, 80).map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          </section>
+        </div>
+
+        <DialogFooter>
+          <Button
+            icon={PlusIcon}
+            label={saving ? "Saving..." : "Save provider"}
+            disabled={saving || !form.defaultModel}
+            onClick={save}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -98,16 +98,9 @@ export function AssistantProviderSettingsDialog({
 
   useEffect(() => {
     if (catalog.length === 0) return;
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (cancelled) return;
-      setForm((current) =>
-        isPristineEmptySeed(current) ? formFromCatalog(catalog) : current,
-      );
-    });
-    return () => {
-      cancelled = true;
-    };
+    setForm((current) =>
+      isPristineEmptySeed(current) ? formFromCatalog(catalog) : current,
+    );
   }, [catalog]);
 
   function chooseProvider(providerId: string | null) {
@@ -164,6 +157,17 @@ export function AssistantProviderSettingsDialog({
     }
   }
 
+  async function removeProvider(id: string) {
+    try {
+      await mutations.remove(id);
+    } catch (error) {
+      showError("Failed to remove assistant provider", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl">
@@ -177,14 +181,14 @@ export function AssistantProviderSettingsDialog({
         <div className="grid gap-5 md:grid-cols-[1fr_1.15fr]">
           <section className="space-y-2">
             {configs.length === 0 ? (
-              <div className="rounded-lg bg-neutral-bg-muted/60 p-3 text-sm text-neutral-fg-subtle">
+              <div className="rounded-[var(--surface-radius)] bg-neutral-bg-muted/60 p-3 text-sm text-neutral-fg-subtle">
                 No providers configured.
               </div>
             ) : (
               configs.map((config) => (
                 <div
                   key={config.id}
-                  className="rounded-lg bg-neutral-bg-muted/60 p-3"
+                  className="rounded-[var(--surface-radius)] bg-neutral-bg-muted/60 p-3"
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
@@ -202,7 +206,7 @@ export function AssistantProviderSettingsDialog({
                       iconOnly
                       label="Remove provider"
                       tooltip="Remove provider"
-                      onClick={() => mutations.remove(config.id)}
+                      onClick={() => void removeProvider(config.id)}
                       className="size-7 text-neutral-fg-subtle hover:text-palette-danger"
                     />
                   </div>

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -27,12 +27,7 @@ import {
   SelectValue,
 } from "@wystack/ui";
 import { DeleteIcon, ExternalLinkIcon, PlusIcon } from "@wystack/ui-icons";
-import {
-  useMemo,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from "react";
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
 
 interface AssistantProviderSettingsDialogProps {
   open: boolean;

--- a/packages/app/src/components/assistant/AssistantSidebar.tsx
+++ b/packages/app/src/components/assistant/AssistantSidebar.tsx
@@ -16,6 +16,7 @@ import {
   useAssistantStore,
 } from "@/lib/stores/assistant-store";
 
+import { AssistantModelPicker } from "./AssistantModelPicker";
 import { DraftReviewPanel } from "./DraftReviewPanel";
 import { useArtifactContext } from "./artifact-context";
 
@@ -52,6 +53,10 @@ function AssistantPanelBody() {
   const streamingText = useAssistantStore((s) => s.streamingText);
   const runStatus = useAssistantStore((s) => s.runStatus);
   const error = useAssistantStore((s) => s.error);
+  const selectedProviderConfigId = useAssistantStore(
+    (s) => s.selectedProviderConfigId,
+  );
+  const selectedModelId = useAssistantStore((s) => s.selectedModelId);
   const [prompt, setPrompt] = useState("");
   const isRunning = runStatus === "running";
 
@@ -83,6 +88,8 @@ function AssistantPanelBody() {
       await runAssistantPrompt({
         prompt: text,
         artifact,
+        provider: selectedProviderConfigId ?? undefined,
+        modelId: selectedModelId ?? undefined,
         signal: controller.signal,
         onEvent: receiveRunEvent,
       });
@@ -112,6 +119,7 @@ function AssistantPanelBody() {
             {artifact ? artifact.title : "No artifact in focus"}
           </span>
         </div>
+        <AssistantModelPicker />
         <Button
           variant="ghost"
           icon={CloseIcon}

--- a/packages/app/src/components/navigation.tsx
+++ b/packages/app/src/components/navigation.tsx
@@ -34,6 +34,7 @@ import {
 } from "@wystack/ui-icons";
 import { type ReactNode, useState } from "react";
 
+import { AssistantProviderSettingsDialog } from "./assistant/AssistantProviderSettingsDialog";
 import {
   DESKTOP_NAV_BREAKPOINT_CLASS,
   DESKTOP_NAV_WIDTH,
@@ -75,6 +76,7 @@ const navItems: NavItem[] = [
 
 interface SidebarContentProps {
   onClearData?: () => void;
+  onAssistantProviders?: () => void;
   /**
    * Extra rows for the footer, below Settings/Open source — dev tooling like
    * the perf HUD. Supplied only by the desktop nav so the mobile dialog doesn't
@@ -83,7 +85,11 @@ interface SidebarContentProps {
   footerSlot?: ReactNode;
 }
 
-function SidebarContent({ onClearData, footerSlot }: SidebarContentProps) {
+function SidebarContent({
+  onClearData,
+  onAssistantProviders,
+  footerSlot,
+}: SidebarContentProps) {
   const pathname = useLocation({ select: (l) => l.pathname });
 
   return (
@@ -148,6 +154,10 @@ function SidebarContent({ onClearData, footerSlot }: SidebarContentProps) {
             }
           />
           <DropdownMenuContent align="start" side="top">
+            <DropdownMenuItem onClick={onAssistantProviders}>
+              <SparklesIcon className="mr-2 h-4 w-4" />
+              Assistant providers
+            </DropdownMenuItem>
             <DropdownMenuItem
               onClick={onClearData}
               className="text-palette-danger focus:text-palette-danger"
@@ -176,6 +186,7 @@ export function Navigation() {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [showAssistantProviders, setShowAssistantProviders] = useState(false);
 
   const leftNavOpen = useShellStore((s) => s.leftNavOpen);
 
@@ -214,6 +225,7 @@ export function Navigation() {
         >
           <SidebarContent
             onClearData={() => setShowClearConfirm(true)}
+            onAssistantProviders={() => setShowAssistantProviders(true)}
             footerSlot={<PerfHud />}
           />
         </div>
@@ -244,7 +256,10 @@ export function Navigation() {
               />
             </div>
             <div className="flex-1 overflow-y-auto">
-              <SidebarContent onClearData={() => setShowClearConfirm(true)} />
+              <SidebarContent
+                onClearData={() => setShowClearConfirm(true)}
+                onAssistantProviders={() => setShowAssistantProviders(true)}
+              />
             </div>
           </div>
         </DialogContent>
@@ -274,6 +289,10 @@ export function Navigation() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <AssistantProviderSettingsDialog
+        open={showAssistantProviders}
+        onOpenChange={setShowAssistantProviders}
+      />
     </>
   );
 }

--- a/packages/app/src/lib/stores/assistant-store.ts
+++ b/packages/app/src/lib/stores/assistant-store.ts
@@ -75,6 +75,8 @@ interface AssistantState {
   pendingDraftId: string | null;
   runStatus: AssistantRunStatus;
   activeDraftId: string | null;
+  selectedProviderConfigId: string | null;
+  selectedModelId: string | null;
   turns: AssistantTurn[];
   streamingText: string;
   error: string | null;
@@ -86,6 +88,7 @@ interface AssistantActions {
   toggle: () => void;
   /** Set (or clear) a draft waiting for review. Opens the panel when non-null. */
   setPendingDraft: (id: string | null) => void;
+  setSelectedModel: (providerConfigId: string, modelId: string) => void;
   beginRun: (prompt: string) => void;
   receiveRunEvent: (event: AssistantStoreEvent) => void;
   failRun: (message: string) => void;
@@ -149,6 +152,8 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
       pendingDraftId: null,
       runStatus: "idle",
       activeDraftId: null,
+      selectedProviderConfigId: null,
+      selectedModelId: null,
       turns: [],
       streamingText: "",
       error: null,
@@ -162,6 +167,11 @@ export const useAssistantStore = create<AssistantState & AssistantActions>()(
           // Open the panel automatically when a draft is queued.
           isOpen: id !== null ? true : s.isOpen,
         })),
+      setSelectedModel: (providerConfigId, modelId) =>
+        set({
+          selectedProviderConfigId: providerConfigId,
+          selectedModelId: modelId,
+        }),
       beginRun: (prompt) =>
         set((s) => ({
           isOpen: true,

--- a/packages/assistant/src/index.ts
+++ b/packages/assistant/src/index.ts
@@ -51,6 +51,23 @@ export {
 
 export { resolveDefaultAnthropicModel } from "./model.js";
 
+export {
+  getAssistantProviderCatalog,
+  loginAssistantProviderOAuth,
+  resolveAssistantProvider,
+  type AssistantProviderAuthKind,
+  type AssistantProviderCatalogEntry,
+  type AssistantProviderModelOption,
+  type ResolvedAssistantProvider,
+  type StoredAssistantProviderConfig,
+} from "./provider-config.js";
+
+export {
+  registerOAuthProvider,
+  resetOAuthProviders,
+  type OAuthCredentials,
+} from "@earendil-works/pi-ai/oauth";
+
 // Public constants for server-side drift/security tests; applyCommand itself is package-internal.
 export {
   CREDENTIAL_COMMAND_ARG_FIELDS,

--- a/packages/assistant/src/provider-config.test.ts
+++ b/packages/assistant/src/provider-config.test.ts
@@ -1,0 +1,94 @@
+import {
+  registerOAuthProvider,
+  resetOAuthProviders,
+  type OAuthCredentials,
+} from "@earendil-works/pi-ai/oauth";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveAssistantProvider } from "./provider-config";
+
+function makeVault(): SecretVault {
+  const registry = new SecretRegistry();
+  registry.register("test", new TestBackend(), { fallback: true });
+  registry.setClassDefault("assistant-provider", "test");
+  return new SecretVault(registry, new InMemoryMappingStore());
+}
+
+describe("assistant provider resolution", () => {
+  afterEach(() => {
+    resetOAuthProviders();
+  });
+
+  it("resolves API keys through the vault without exposing the SecretRef", async () => {
+    const vault = makeVault();
+    const ref = await vault.store("test-api-key-value", {
+      class: "assistant-provider",
+    });
+
+    const resolved = await resolveAssistantProvider(
+      {
+        id: crypto.randomUUID(),
+        providerId: "anthropic",
+        displayLabel: "Anthropic",
+        authKind: "api-key",
+        credentialRef: ref,
+        defaultModel: "claude-haiku-4-5",
+      },
+      vault,
+    );
+
+    expect((resolved.options as { apiKey?: string }).apiKey).toBe(
+      "test-api-key-value",
+    );
+    expect(JSON.stringify(resolved)).not.toContain(ref);
+  });
+
+  it("returns rotated OAuth credentials only after pi refresh succeeds", async () => {
+    const vault = makeVault();
+    const expired: OAuthCredentials = {
+      access: "old-access",
+      refresh: "old-refresh",
+      expires: Date.now() - 1_000,
+    };
+    const rotated: OAuthCredentials = {
+      access: "new-access",
+      refresh: "new-refresh",
+      expires: Date.now() + 60_000,
+    };
+    const ref = await vault.store(JSON.stringify(expired), {
+      class: "assistant-provider",
+    });
+    registerOAuthProvider({
+      id: "anthropic",
+      name: "Test Anthropic",
+      login: async () => rotated,
+      refreshToken: async (credentials) => {
+        expect(credentials.refresh).toBe("old-refresh");
+        return rotated;
+      },
+      getApiKey: (credentials) => credentials.access,
+    });
+
+    const resolved = await resolveAssistantProvider(
+      {
+        id: crypto.randomUUID(),
+        providerId: "anthropic",
+        displayLabel: "Anthropic Pro",
+        authKind: "oauth",
+        credentialRef: ref,
+        defaultModel: "claude-haiku-4-5",
+      },
+      vault,
+    );
+
+    expect((resolved.options as { apiKey?: string }).apiKey).toBe("new-access");
+    expect(resolved.rotatedCredential).toEqual(rotated);
+    await expect(vault.has(ref)).resolves.toBe(true);
+  });
+});

--- a/packages/assistant/src/provider-config.ts
+++ b/packages/assistant/src/provider-config.ts
@@ -1,0 +1,239 @@
+import {
+  getModels,
+  type Api,
+  type KnownProvider,
+  type Model,
+  type ProviderStreamOptions,
+} from "@earendil-works/pi-ai";
+import {
+  getOAuthProvider,
+  type OAuthCredentials,
+  type OAuthLoginCallbacks,
+} from "@earendil-works/pi-ai/oauth";
+import type { SecretRef, SecretVault } from "@wystack/secret-vault";
+import { isSecretRef } from "@wystack/secret-vault";
+
+import { resolveDefaultAnthropicModel } from "./model.js";
+
+export type AssistantProviderAuthKind = "api-key" | "local" | "oauth";
+
+export interface AssistantProviderModelOption {
+  id: string;
+  name: string;
+  providerId: string;
+  api: string;
+}
+
+export interface AssistantProviderCatalogEntry {
+  providerId: string;
+  label: string;
+  authKinds: AssistantProviderAuthKind[];
+  defaultBaseUrl?: string;
+  models: AssistantProviderModelOption[];
+}
+
+export interface StoredAssistantProviderConfig {
+  id: string;
+  providerId: string;
+  displayLabel: string;
+  authKind: AssistantProviderAuthKind;
+  baseUrl?: string | null;
+  credentialRef?: string | null;
+  defaultModel: string;
+}
+
+export interface ResolvedAssistantProvider {
+  model: Model<Api>;
+  options: ProviderStreamOptions;
+  rotatedCredential?: OAuthCredentials;
+}
+
+export async function loginAssistantProviderOAuth(
+  providerId: string,
+  callbacks: OAuthLoginCallbacks,
+): Promise<OAuthCredentials> {
+  const provider = getOAuthProvider(providerId);
+  if (!provider) {
+    throw new Error(`No pi OAuth provider registered for ${providerId}`);
+  }
+  return provider.login(callbacks);
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  "openai-codex": "ChatGPT Plus",
+  openrouter: "OpenRouter",
+  opencode: "OpenCode Zen",
+  ollama: "Ollama",
+  "lm-studio": "LM Studio",
+};
+
+const CATALOG_PROVIDER_IDS = [
+  "anthropic",
+  "openai",
+  "openai-codex",
+  "openrouter",
+  "opencode",
+] as const;
+
+const LOCAL_PROVIDERS: AssistantProviderCatalogEntry[] = [
+  {
+    providerId: "ollama",
+    label: "Ollama",
+    authKinds: ["local"],
+    defaultBaseUrl: "http://localhost:11434/v1",
+    models: [
+      {
+        id: "llama3.1",
+        name: "llama3.1",
+        providerId: "ollama",
+        api: "openai-completions",
+      },
+    ],
+  },
+  {
+    providerId: "lm-studio",
+    label: "LM Studio",
+    authKinds: ["local"],
+    defaultBaseUrl: "http://localhost:1234/v1",
+    models: [
+      {
+        id: "local-model",
+        name: "Local model",
+        providerId: "lm-studio",
+        api: "openai-completions",
+      },
+    ],
+  },
+];
+
+function providerLabel(providerId: string): string {
+  return PROVIDER_LABELS[providerId] ?? providerId;
+}
+
+function mapModels(providerId: string): AssistantProviderModelOption[] {
+  return (getModels(providerId as KnownProvider) as Model<Api>[]).map(
+    (model) => ({
+      id: model.id,
+      name: model.name,
+      providerId,
+      api: model.api,
+    }),
+  );
+}
+
+function defaultBaseUrl(providerId: string): string | undefined {
+  return (getModels(providerId as KnownProvider) as Model<Api>[])[0]?.baseUrl;
+}
+
+export function getAssistantProviderCatalog(): AssistantProviderCatalogEntry[] {
+  return [
+    ...CATALOG_PROVIDER_IDS.map((providerId) => ({
+      providerId,
+      label: providerLabel(providerId),
+      defaultBaseUrl: defaultBaseUrl(providerId),
+      authKinds: authKindsForProvider(providerId),
+      models: mapModels(providerId),
+    })),
+    ...LOCAL_PROVIDERS,
+  ];
+}
+
+function authKindsForProvider(providerId: string): AssistantProviderAuthKind[] {
+  if (providerId === "anthropic") return ["api-key", "oauth"];
+  if (providerId === "openai-codex") return ["oauth"];
+  return ["api-key"];
+}
+
+function modelForConfig(config: StoredAssistantProviderConfig): Model<Api> {
+  if (config.providerId === "anthropic" && !config.defaultModel) {
+    return resolveDefaultAnthropicModel();
+  }
+
+  if (config.providerId === "ollama" || config.providerId === "lm-studio") {
+    return {
+      id: config.defaultModel,
+      name: config.defaultModel,
+      api: "openai-completions",
+      provider: config.providerId,
+      baseUrl: config.baseUrl ?? "",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 16_384,
+    };
+  }
+
+  const model = (
+    getModels(config.providerId as KnownProvider) as Model<Api>[]
+  ).find((candidate) => candidate.id === config.defaultModel);
+  if (!model) {
+    throw new Error(
+      `Assistant provider model ${config.providerId}/${config.defaultModel} is not registered in pi`,
+    );
+  }
+  return config.baseUrl ? { ...model, baseUrl: config.baseUrl } : model;
+}
+
+function parseOAuthCredentials(raw: string): OAuthCredentials {
+  const parsed = JSON.parse(raw) as OAuthCredentials;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof parsed.access !== "string" ||
+    typeof parsed.refresh !== "string" ||
+    typeof parsed.expires !== "number"
+  ) {
+    throw new Error("Stored OAuth credential is malformed");
+  }
+  return parsed;
+}
+
+export async function resolveAssistantProvider(
+  config: StoredAssistantProviderConfig,
+  vault: SecretVault | undefined,
+): Promise<ResolvedAssistantProvider> {
+  const model = modelForConfig(config);
+
+  if (config.authKind === "local") {
+    return { model, options: { apiKey: "local" } };
+  }
+
+  const ref = config.credentialRef;
+  if (!isSecretRef(ref)) {
+    throw new Error(
+      `Assistant provider ${config.displayLabel} has no stored credential`,
+    );
+  }
+  if (vault == null) {
+    throw new Error(
+      "Assistant provider credential resolution requires a SecretVault",
+    );
+  }
+
+  return vault.withSecret(ref as SecretRef, async (plaintext) => {
+    if (config.authKind === "api-key") {
+      return { model, options: { apiKey: plaintext } };
+    }
+
+    const provider = getOAuthProvider(config.providerId);
+    if (!provider) {
+      throw new Error(
+        `No pi OAuth provider registered for ${config.providerId}`,
+      );
+    }
+    const credentials = parseOAuthCredentials(plaintext);
+    const freshCredentials =
+      credentials.expires <= Date.now()
+        ? await provider.refreshToken(credentials)
+        : credentials;
+    return {
+      model,
+      options: { apiKey: provider.getApiKey(freshCredentials) },
+      rotatedCredential:
+        freshCredentials === credentials ? undefined : freshCredentials,
+    };
+  });
+}

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -47,6 +47,7 @@ export {
   // Constants
   PROJECT_META_ID,
   PROJECT_META_SINGLETON_KEY,
+  assistantProviderConfigs,
   dashboards,
   dashboardsDraft,
   dataFrames,

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -164,6 +164,10 @@ describe("security boundary — no shadow for credential/infra tables", () => {
     expect(await tableExists("project_meta__draft")).toBe(false);
   });
 
+  test("assistant_provider_configs__draft does NOT exist", async () => {
+    expect(await tableExists("assistant_provider_configs__draft")).toBe(false);
+  });
+
   test("schema export has no secret_mappings draft entry", () => {
     const keys = Object.keys(schema);
     const forbidden = keys.filter(

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -233,6 +233,36 @@ export const secretMappings = pgTable("secret_mappings", {
     .defaultNow(),
 });
 
+// assistant_provider_configs — assistant model-provider settings.
+//
+// Credentials are stored in the vault and referenced here only by SecretRef.
+// NOT drafted: credential infrastructure. A draft shadow would allow transient
+// assistant credentials to leak into command logs / preview state.
+export const assistantProviderConfigs = pgTable(
+  "assistant_provider_configs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    providerId: text("provider_id").notNull(),
+    displayLabel: text("display_label").notNull(),
+    authKind: text("auth_kind").notNull(), // 'api-key' | 'local' | 'oauth'
+    baseUrl: text("base_url"),
+    credentialRef: text("credential_ref"),
+    defaultModel: text("default_model").notNull(),
+    isDefault: boolean("is_default").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    index("assistant_provider_configs_provider_id_idx").on(t.providerId),
+    index("assistant_provider_configs_is_default_idx").on(t.isDefault),
+  ],
+);
+
 // ─── Draft shadow tables ──────────────────────────────────────────────────────
 //
 // Each `<table>__draft` is the sparse overlay the @wystack/db `withDraft`
@@ -440,6 +470,7 @@ export const schema = {
   dashboards,
   // Credential infrastructure — NOT drafted (security boundary)
   secretMappings,
+  assistantProviderConfigs,
   // Draft shadow tables (artifact overlay)
   dataSourcesDraft,
   dataTablesDraft,

--- a/packages/types/src/assistant-provider-configs.ts
+++ b/packages/types/src/assistant-provider-configs.ts
@@ -1,0 +1,64 @@
+import type { UseQueryResult } from "./repository-base";
+import type { UUID } from "./uuid";
+
+export type AssistantProviderAuthKind = "api-key" | "local" | "oauth";
+
+export interface AssistantProviderModelOption {
+  id: string;
+  name: string;
+  providerId: string;
+  api: string;
+}
+
+export interface AssistantProviderCatalogEntry {
+  providerId: string;
+  label: string;
+  authKinds: AssistantProviderAuthKind[];
+  defaultBaseUrl?: string;
+  models: AssistantProviderModelOption[];
+}
+
+export interface AssistantProviderConfig {
+  id: UUID;
+  providerId: string;
+  displayLabel: string;
+  authKind: AssistantProviderAuthKind;
+  baseUrl?: string;
+  hasCredential: boolean;
+  defaultModel: string;
+  isDefault: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SaveAssistantProviderConfigInput {
+  id?: UUID;
+  providerId: string;
+  displayLabel: string;
+  authKind: AssistantProviderAuthKind;
+  baseUrl?: string;
+  credential?: string;
+  defaultModel: string;
+  isDefault?: boolean;
+}
+
+export interface SetAssistantDefaultModelInput {
+  id: UUID;
+  defaultModel: string;
+}
+
+export interface AssistantProviderConfigMutations {
+  save: (
+    input: SaveAssistantProviderConfigInput,
+  ) => Promise<AssistantProviderConfig>;
+  remove: (id: UUID) => Promise<void>;
+  setDefaultModel: (input: SetAssistantDefaultModelInput) => Promise<void>;
+  startOAuthLogin: (id: UUID) => Promise<void>;
+}
+
+export type UseAssistantProviderConfigsResult = UseQueryResult<
+  AssistantProviderConfig[]
+>;
+export type UseAssistantProviderCatalogResult = UseQueryResult<
+  AssistantProviderCatalogEntry[]
+>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,18 @@ export type { DataTableField, DataTableInfo } from "./data-table-info";
 export type { UseQueryResult } from "./repository-base";
 
 export type {
+  AssistantProviderAuthKind,
+  AssistantProviderCatalogEntry,
+  AssistantProviderConfig,
+  AssistantProviderConfigMutations,
+  AssistantProviderModelOption,
+  SaveAssistantProviderConfigInput,
+  SetAssistantDefaultModelInput,
+  UseAssistantProviderCatalogResult,
+  UseAssistantProviderConfigsResult,
+} from "./assistant-provider-configs";
+
+export type {
   ConnectorConfig,
   CreateDataSourceInput,
   DataSource,


### PR DESCRIPTION
<!-- Brief summary of what this PR does and why. -->

Adds vault-backed assistant provider configuration and model selection so DashFrame can route pi assistant runs through configured API-key, local endpoint, gateway, or OAuth-backed providers.

## Changes

- Add an `assistant_provider_configs` server-core table plus WyStack mutations for catalog/list/save/delete/default-model/OAuth login.
- Resolve assistant run provider/model host-side through SecretVault refs, with successful OAuth refresh rotation persisted before use.
- Add assistant provider settings UI and per-run sidebar model picker.
- Register the new `assistant-provider` credential class in the desktop vault registry and bump the Wystack submodule to youhaowei/wystack#54.

## Screenshots

### Assistant model picker

![assistant-model-picker](https://github.com/youhaowei/DashFrame/releases/download/pr-221-screenshots/01-assistant-model-picker.png)

### Provider settings dialog

![provider-settings-dialog](https://github.com/youhaowei/DashFrame/releases/download/pr-221-screenshots/02-provider-settings-dialog.png)

### Provider settings dialog (dark)

![provider-settings-dialog-dark](https://github.com/youhaowei/DashFrame/releases/download/pr-221-screenshots/03-provider-settings-dialog-dark.png)

### Assistant model picker (dark)

![assistant-model-picker-dark](https://github.com/youhaowei/DashFrame/releases/download/pr-221-screenshots/04-assistant-model-picker-dark.png)


### Local provider — free-text model id (light)

![provider-settings-local-model-input](https://github.com/youhaowei/DashFrame/releases/download/pr-221-screenshots/05-provider-settings-local-model-input.png)

### Local provider — free-text model id (dark)

![provider-settings-local-model-input-dark](https://github.com/youhaowei/DashFrame/releases/download/pr-221-screenshots/06-provider-settings-local-model-input-dark.png)
_Screenshots via pr-screenshots (prerelease `pr-221-screenshots`, not in git)._

## Verification

- `TMPDIR=/private/tmp bun run --cwd libs/wystack/packages/secret-vault build`
- `TMPDIR=/private/tmp bun run check`
- `TMPDIR=/private/tmp bun test packages/assistant/src/provider-config.test.ts`
- `TMPDIR=/private/tmp bun test apps/server/src/functions/assistant-provider-configs.test.ts`
- `TMPDIR=/private/tmp bun run --filter @dashframe/server typecheck`
- `TMPDIR=/private/tmp bun run --filter @dashframe/server lint`
- `TMPDIR=/private/tmp bun run check:ticket-refs`

Tracked internally as YW-259

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds vault-backed assistant provider configuration, letting DashFrame route assistant runs through user-configured API-key, local-endpoint, gateway, or OAuth providers. It introduces the `assistant_provider_configs` DB table, server mutations for CRUD/OAuth/default-model, host-side provider resolution with OAuth token rotation, a provider settings dialog, and a per-run model picker in the sidebar.

- **Vault credential lifecycle** (mint → commit → rotate → flush-then-release) is carefully ordered across all write paths (`saveAssistantProviderConfig`, `startAssistantOAuthLogin`, `resolveAssistantProviderConfigForRun`), with compensating deletes only on pre-commit failure and best-effort post-commit release guarded by `flushThenReleaseRefs`.
- **Model picker has a local-provider regression**: for Ollama/LM Studio configs with free-text custom model IDs, the model `<Select>` renders blank and exposes only catalog placeholder options — selecting one silently overwrites the user's stored model via `setDefaultModel`.
- **Provider settings dialog** has no update path for existing entries; every "Save provider" click inserts a new row, making credential rotation require a delete-and-recreate cycle.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one targeted fix needed in AssistantModelPicker before local-provider model selection is relied upon.

The vault credential lifecycle across all server-side write paths is well-sequenced and backed by thorough tests. The one concrete defect is in AssistantModelPicker: local providers (Ollama, LM Studio) that have a user-defined free-text model ID will show a blank model dropdown, and clicking the only visible catalog entry silently replaces the stored model via setDefaultModel. This is a real data-modification bug that fires on any local-provider user who opens the picker after setting a custom model.

packages/app/src/components/assistant/AssistantModelPicker.tsx — the model Select needs special handling for local providers with free-text model IDs.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app/src/components/assistant/AssistantModelPicker.tsx | Model picker works correctly for catalog providers. For local providers (Ollama, LM Studio) with user-defined free-text model IDs, the model Select has no matching item, renders blank, and clicking the only catalog option silently overwrites the user's custom model in the DB via setDefaultModel. |
| apps/server/src/functions/assistant-provider-configs.ts | Core CRUD for assistant provider configs. Vault credential lifecycle (mint, commit, rotate, release) is carefully sequenced: new refs are stored before DB writes, compensating deletes fire only on transaction failure, and post-commit old-ref releases go through flushThenReleaseRefs. Default-flag promotion is transactional. setAssistantDefaultModel now updates only defaultModel (prior issue fixed). OAuth login path similarly correct. |
| apps/server/src/assistant-run-route.ts | New resolveRunProvider / selectAssistantProviderConfigForRun plumbs vault-backed provider selection into the SSE run route. Provider/model selection logic is reasonable. Error catch at line 347 remains broad (returns 400 for vault/OAuth server faults when body.provider is a string), but this was flagged in a previous review cycle. |
| packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx | Provider settings dialog with add/remove/OAuth-login flows. Form seeding fixed (no longer captures empty catalog at mount). Save always inserts new rows — no update path for existing entries, which will confuse users who need to rotate credentials. |
| packages/assistant/src/provider-config.ts | Provider catalog, model resolution, and OAuth credential refresh. Token refresh correctly sets rotatedCredential only when credentials actually change. Local provider model construction falls back to empty string for missing baseUrl rather than throwing a clear error. |
| packages/server-core/src/schema.ts | Adds assistant_provider_configs table with correct column types, SecretRef-as-text for credentialRef, and two covering indexes. Not drafted (correct — credentials must not enter the draft overlay). Schema design is solid. |
| apps/server/src/functions/assistant-provider-configs.test.ts | Comprehensive test coverage for vault lifecycle (mint, rotate, OAuth login, release-failure swallowing), default-flag isolation, and provider validation. Tests correctly mirror the production flushSnapshot seam. |
| packages/app/src/lib/stores/assistant-store.ts | Adds selectedProviderConfigId and selectedModelId to persisted (but partialize-excluded) store state; setSelectedModel action is straightforward. safeLocalStorage wrapper is correct SSR-safe pattern. |
| apps/desktop/src/main.ts | Registers the new assistant-provider credential class with the electron-keychain backend, consistent with how connector-key and serve-token are registered. |
| packages/app/src/components/assistant/AssistantSidebar.tsx | Threads selectedProviderConfigId and selectedModelId from the store into the runAssistantPrompt call. AssistantModelPicker embedded in header. No platform-conditional rendering. Clean change. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as AssistantSidebar
    participant Store as AssistantStore
    participant API as /assistant/run
    participant Route as assistant-run-route
    participant DB as ArtifactDb
    participant Vault as SecretVault
    participant Provider as pi-ai provider

    UI->>Store: selectedProviderConfigId, selectedModelId
    UI->>API: "POST {prompt, provider, modelId}"
    API->>Route: handleAssistantRunRequest
    Route->>DB: selectAssistantProviderConfigForRun
    DB-->>Route: AssistantProviderConfigRow
    Route->>Vault: resolveAssistantProviderConfigForRun
    Vault->>Vault: withSecret(credentialRef)
    alt OAuth token expired
        Vault->>Provider: provider.refreshToken()
        Provider-->>Vault: freshCredentials
        Vault->>Vault: storeAssistantCredential (new ref)
        Vault->>DB: updateCredentialRef
        Vault->>Vault: flushThenReleaseRefs (old ref)
    end
    Vault-->>Route: "{model, apiKey}"
    Route->>Provider: createAssistantRun (SSE stream)
    Provider-->>UI: SSE events (text-delta, run-end...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as AssistantSidebar
    participant Store as AssistantStore
    participant API as /assistant/run
    participant Route as assistant-run-route
    participant DB as ArtifactDb
    participant Vault as SecretVault
    participant Provider as pi-ai provider

    UI->>Store: selectedProviderConfigId, selectedModelId
    UI->>API: "POST {prompt, provider, modelId}"
    API->>Route: handleAssistantRunRequest
    Route->>DB: selectAssistantProviderConfigForRun
    DB-->>Route: AssistantProviderConfigRow
    Route->>Vault: resolveAssistantProviderConfigForRun
    Vault->>Vault: withSecret(credentialRef)
    alt OAuth token expired
        Vault->>Provider: provider.refreshToken()
        Provider-->>Vault: freshCredentials
        Vault->>Vault: storeAssistantCredential (new ref)
        Vault->>DB: updateCredentialRef
        Vault->>Vault: flushThenReleaseRefs (old ref)
    end
    Vault-->>Route: "{model, apiKey}"
    Route->>Provider: createAssistantRun (SSE stream)
    Provider-->>UI: SSE events (text-delta, run-end...)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/server/src/assistant-run-route.ts`, line 337-356 ([link](https://github.com/youhaowei/dashframe/blob/7fe567502c36a83d4c04f81fed90b6e82dbbe947/apps/server/src/assistant-run-route.ts#L337-L356)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Server-side vault errors surfaced as 400 to caller**

   The catch block returns HTTP 400 with `err.message` whenever `body.provider` is a string — but `resolveRunProvider` can fail for reasons that have nothing to do with the client's input: the vault backend being locked, a `credentialRef` that no longer exists, a failed OAuth token refresh, etc. All of these will produce a 400 response whose body contains raw vault/OAuth error messages (e.g. `"Keychain access denied"`, `"Secret not found"`), leaking internal system state and incorrectly telling the caller it made a bad request. Server-side failures should propagate as 500 (let them re-throw) while only genuine "no such provider" cases return 400.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/assistant-run-route.ts
   Line: 337-356

   Comment:
   **Server-side vault errors surfaced as 400 to caller**

   The catch block returns HTTP 400 with `err.message` whenever `body.provider` is a string — but `resolveRunProvider` can fail for reasons that have nothing to do with the client's input: the vault backend being locked, a `credentialRef` that no longer exists, a failed OAuth token refresh, etc. All of these will produce a 400 response whose body contains raw vault/OAuth error messages (e.g. `"Keychain access denied"`, `"Secret not found"`), leaking internal system state and incorrectly telling the caller it made a bad request. Server-side failures should propagate as 500 (let them re-throw) while only genuine "no such provider" cases return 400.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Fassistant-run-route.ts%0ALine%3A%20337-356%0A%0AComment%3A%0A**Server-side%20vault%20errors%20surfaced%20as%20400%20to%20caller**%0A%0AThe%20catch%20block%20returns%20HTTP%20400%20with%20%60err.message%60%20whenever%20%60body.provider%60%20is%20a%20string%20%E2%80%94%20but%20%60resolveRunProvider%60%20can%20fail%20for%20reasons%20that%20have%20nothing%20to%20do%20with%20the%20client's%20input%3A%20the%20vault%20backend%20being%20locked%2C%20a%20%60credentialRef%60%20that%20no%20longer%20exists%2C%20a%20failed%20OAuth%20token%20refresh%2C%20etc.%20All%20of%20these%20will%20produce%20a%20400%20response%20whose%20body%20contains%20raw%20vault%2FOAuth%20error%20messages%20%28e.g.%20%60%22Keychain%20access%20denied%22%60%2C%20%60%22Secret%20not%20found%22%60%29%2C%20leaking%20internal%20system%20state%20and%20incorrectly%20telling%20the%20caller%20it%20made%20a%20bad%20request.%20Server-side%20failures%20should%20propagate%20as%20500%20%28let%20them%20re-throw%29%20while%20only%20genuine%20%22no%20such%20provider%22%20cases%20return%20400.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-259-assistant-providermodel-configuration-multi-provider-matrix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-259-assistant-providermodel-configuration-multi-provider-matrix%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Fassistant-run-route.ts%0ALine%3A%20337-356%0A%0AComment%3A%0A**Server-side%20vault%20errors%20surfaced%20as%20400%20to%20caller**%0A%0AThe%20catch%20block%20returns%20HTTP%20400%20with%20%60err.message%60%20whenever%20%60body.provider%60%20is%20a%20string%20%E2%80%94%20but%20%60resolveRunProvider%60%20can%20fail%20for%20reasons%20that%20have%20nothing%20to%20do%20with%20the%20client's%20input%3A%20the%20vault%20backend%20being%20locked%2C%20a%20%60credentialRef%60%20that%20no%20longer%20exists%2C%20a%20failed%20OAuth%20token%20refresh%2C%20etc.%20All%20of%20these%20will%20produce%20a%20400%20response%20whose%20body%20contains%20raw%20vault%2FOAuth%20error%20messages%20%28e.g.%20%60%22Keychain%20access%20denied%22%60%2C%20%60%22Secret%20not%20found%22%60%29%2C%20leaking%20internal%20system%20state%20and%20incorrectly%20telling%20the%20caller%20it%20made%20a%20bad%20request.%20Server-side%20failures%20should%20propagate%20as%20500%20%28let%20them%20re-throw%29%20while%20only%20genuine%20%22no%20such%20provider%22%20cases%20return%20400.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Fassistant-run-route.ts%0ALine%3A%20337-356%0A%0AComment%3A%0A**Server-side%20vault%20errors%20surfaced%20as%20400%20to%20caller**%0A%0AThe%20catch%20block%20returns%20HTTP%20400%20with%20%60err.message%60%20whenever%20%60body.provider%60%20is%20a%20string%20%E2%80%94%20but%20%60resolveRunProvider%60%20can%20fail%20for%20reasons%20that%20have%20nothing%20to%20do%20with%20the%20client's%20input%3A%20the%20vault%20backend%20being%20locked%2C%20a%20%60credentialRef%60%20that%20no%20longer%20exists%2C%20a%20failed%20OAuth%20token%20refresh%2C%20etc.%20All%20of%20these%20will%20produce%20a%20400%20response%20whose%20body%20contains%20raw%20vault%2FOAuth%20error%20messages%20%28e.g.%20%60%22Keychain%20access%20denied%22%60%2C%20%60%22Secret%20not%20found%22%60%29%2C%20leaking%20internal%20system%20state%20and%20incorrectly%20telling%20the%20caller%20it%20made%20a%20bad%20request.%20Server-side%20failures%20should%20propagate%20as%20500%20%28let%20them%20re-throw%29%20while%20only%20genuine%20%22no%20such%20provider%22%20cases%20return%20400.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

2. `apps/server/src/functions/assistant-provider-configs.ts`, line 641-656 ([link](https://github.com/youhaowei/dashframe/blob/2f2e6b652ee1b620f2ccb05a20d833fe1fcda36b/apps/server/src/functions/assistant-provider-configs.ts#L641-L656)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Vault delete fires before transaction commits in `removeAssistantProviderConfig`**

   `deleteRef(vault, current.credentialRef)` is called inside the transaction callback, before the transaction has committed. If the DB commit fails after the vault delete succeeds (e.g. connection drop), the row is restored by the rollback but its credential is already gone from the vault. Any subsequent assistant run will fail with a "credential not found" error.

   The fix follows the same post-commit pattern used in `saveAssistantProviderConfig`: capture the `credentialRef` inside the transaction, commit the delete, and only then release the vault secret.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/functions/assistant-provider-configs.ts
   Line: 641-656

   Comment:
   **Vault delete fires before transaction commits in `removeAssistantProviderConfig`**

   `deleteRef(vault, current.credentialRef)` is called inside the transaction callback, before the transaction has committed. If the DB commit fails after the vault delete succeeds (e.g. connection drop), the row is restored by the rollback but its credential is already gone from the vault. Any subsequent assistant run will fail with a "credential not found" error.

   The fix follows the same post-commit pattern used in `saveAssistantProviderConfig`: capture the `credentialRef` inside the transaction, commit the delete, and only then release the vault secret.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fassistant-provider-configs.ts%0ALine%3A%20641-656%0A%0AComment%3A%0A**Vault%20delete%20fires%20before%20transaction%20commits%20in%20%60removeAssistantProviderConfig%60**%0A%0A%60deleteRef%28vault%2C%20current.credentialRef%29%60%20is%20called%20inside%20the%20transaction%20callback%2C%20before%20the%20transaction%20has%20committed.%20If%20the%20DB%20commit%20fails%20after%20the%20vault%20delete%20succeeds%20%28e.g.%20connection%20drop%29%2C%20the%20row%20is%20restored%20by%20the%20rollback%20but%20its%20credential%20is%20already%20gone%20from%20the%20vault.%20Any%20subsequent%20assistant%20run%20will%20fail%20with%20a%20%22credential%20not%20found%22%20error.%0A%0AThe%20fix%20follows%20the%20same%20post-commit%20pattern%20used%20in%20%60saveAssistantProviderConfig%60%3A%20capture%20the%20%60credentialRef%60%20inside%20the%20transaction%2C%20commit%20the%20delete%2C%20and%20only%20then%20release%20the%20vault%20secret.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-259-assistant-providermodel-configuration-multi-provider-matrix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-259-assistant-providermodel-configuration-multi-provider-matrix%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fassistant-provider-configs.ts%0ALine%3A%20641-656%0A%0AComment%3A%0A**Vault%20delete%20fires%20before%20transaction%20commits%20in%20%60removeAssistantProviderConfig%60**%0A%0A%60deleteRef%28vault%2C%20current.credentialRef%29%60%20is%20called%20inside%20the%20transaction%20callback%2C%20before%20the%20transaction%20has%20committed.%20If%20the%20DB%20commit%20fails%20after%20the%20vault%20delete%20succeeds%20%28e.g.%20connection%20drop%29%2C%20the%20row%20is%20restored%20by%20the%20rollback%20but%20its%20credential%20is%20already%20gone%20from%20the%20vault.%20Any%20subsequent%20assistant%20run%20will%20fail%20with%20a%20%22credential%20not%20found%22%20error.%0A%0AThe%20fix%20follows%20the%20same%20post-commit%20pattern%20used%20in%20%60saveAssistantProviderConfig%60%3A%20capture%20the%20%60credentialRef%60%20inside%20the%20transaction%2C%20commit%20the%20delete%2C%20and%20only%20then%20release%20the%20vault%20secret.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fassistant-provider-configs.ts%0ALine%3A%20641-656%0A%0AComment%3A%0A**Vault%20delete%20fires%20before%20transaction%20commits%20in%20%60removeAssistantProviderConfig%60**%0A%0A%60deleteRef%28vault%2C%20current.credentialRef%29%60%20is%20called%20inside%20the%20transaction%20callback%2C%20before%20the%20transaction%20has%20committed.%20If%20the%20DB%20commit%20fails%20after%20the%20vault%20delete%20succeeds%20%28e.g.%20connection%20drop%29%2C%20the%20row%20is%20restored%20by%20the%20rollback%20but%20its%20credential%20is%20already%20gone%20from%20the%20vault.%20Any%20subsequent%20assistant%20run%20will%20fail%20with%20a%20%22credential%20not%20found%22%20error.%0A%0AThe%20fix%20follows%20the%20same%20post-commit%20pattern%20used%20in%20%60saveAssistantProviderConfig%60%3A%20capture%20the%20%60credentialRef%60%20inside%20the%20transaction%2C%20commit%20the%20delete%2C%20and%20only%20then%20release%20the%20vault%20secret.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

3. `apps/server/src/functions/assistant-provider-configs.ts`, line 717-728 ([link](https://github.com/youhaowei/dashframe/blob/2f2e6b652ee1b620f2ccb05a20d833fe1fcda36b/apps/server/src/functions/assistant-provider-configs.ts#L717-L728)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Catch block deletes new credential after DB has already committed in `startAssistantOAuthLogin`**

   The `try` block contains two sequential operations: the DB update that writes `ref` (commits immediately), then `deleteRef(vault, row.credentialRef)` that removes the old secret. If the vault delete throws, the catch block runs `deleteRef(vault, ref)` — deleting the newly stored credential that the DB row now points to. The row persists with a dangling `credentialRef` that no longer exists in the vault; every subsequent assistant run for that provider will fail.

   The correct fix mirrors `resolveAssistantProviderConfigForRun`: separate the two phases so only DB failure triggers releasing `ref`. The old ref deletion should either be outside the try/catch or its failure allowed to propagate without destroying the new ref.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/server/src/functions/assistant-provider-configs.ts
   Line: 717-728

   Comment:
   **Catch block deletes new credential after DB has already committed in `startAssistantOAuthLogin`**

   The `try` block contains two sequential operations: the DB update that writes `ref` (commits immediately), then `deleteRef(vault, row.credentialRef)` that removes the old secret. If the vault delete throws, the catch block runs `deleteRef(vault, ref)` — deleting the newly stored credential that the DB row now points to. The row persists with a dangling `credentialRef` that no longer exists in the vault; every subsequent assistant run for that provider will fail.

   The correct fix mirrors `resolveAssistantProviderConfigForRun`: separate the two phases so only DB failure triggers releasing `ref`. The old ref deletion should either be outside the try/catch or its failure allowed to propagate without destroying the new ref.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fassistant-provider-configs.ts%0ALine%3A%20717-728%0A%0AComment%3A%0A**Catch%20block%20deletes%20new%20credential%20after%20DB%20has%20already%20committed%20in%20%60startAssistantOAuthLogin%60**%0A%0AThe%20%60try%60%20block%20contains%20two%20sequential%20operations%3A%20the%20DB%20update%20that%20writes%20%60ref%60%20%28commits%20immediately%29%2C%20then%20%60deleteRef%28vault%2C%20row.credentialRef%29%60%20that%20removes%20the%20old%20secret.%20If%20the%20vault%20delete%20throws%2C%20the%20catch%20block%20runs%20%60deleteRef%28vault%2C%20ref%29%60%20%E2%80%94%20deleting%20the%20newly%20stored%20credential%20that%20the%20DB%20row%20now%20points%20to.%20The%20row%20persists%20with%20a%20dangling%20%60credentialRef%60%20that%20no%20longer%20exists%20in%20the%20vault%3B%20every%20subsequent%20assistant%20run%20for%20that%20provider%20will%20fail.%0A%0AThe%20correct%20fix%20mirrors%20%60resolveAssistantProviderConfigForRun%60%3A%20separate%20the%20two%20phases%20so%20only%20DB%20failure%20triggers%20releasing%20%60ref%60.%20The%20old%20ref%20deletion%20should%20either%20be%20outside%20the%20try%2Fcatch%20or%20its%20failure%20allowed%20to%20propagate%20without%20destroying%20the%20new%20ref.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22charixandra%2Fyw-259-assistant-providermodel-configuration-multi-provider-matrix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22charixandra%2Fyw-259-assistant-providermodel-configuration-multi-provider-matrix%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fassistant-provider-configs.ts%0ALine%3A%20717-728%0A%0AComment%3A%0A**Catch%20block%20deletes%20new%20credential%20after%20DB%20has%20already%20committed%20in%20%60startAssistantOAuthLogin%60**%0A%0AThe%20%60try%60%20block%20contains%20two%20sequential%20operations%3A%20the%20DB%20update%20that%20writes%20%60ref%60%20%28commits%20immediately%29%2C%20then%20%60deleteRef%28vault%2C%20row.credentialRef%29%60%20that%20removes%20the%20old%20secret.%20If%20the%20vault%20delete%20throws%2C%20the%20catch%20block%20runs%20%60deleteRef%28vault%2C%20ref%29%60%20%E2%80%94%20deleting%20the%20newly%20stored%20credential%20that%20the%20DB%20row%20now%20points%20to.%20The%20row%20persists%20with%20a%20dangling%20%60credentialRef%60%20that%20no%20longer%20exists%20in%20the%20vault%3B%20every%20subsequent%20assistant%20run%20for%20that%20provider%20will%20fail.%0A%0AThe%20correct%20fix%20mirrors%20%60resolveAssistantProviderConfigForRun%60%3A%20separate%20the%20two%20phases%20so%20only%20DB%20failure%20triggers%20releasing%20%60ref%60.%20The%20old%20ref%20deletion%20should%20either%20be%20outside%20the%20try%2Fcatch%20or%20its%20failure%20allowed%20to%20propagate%20without%20destroying%20the%20new%20ref.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=youhaowei%2Fdashframe&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fserver%2Fsrc%2Ffunctions%2Fassistant-provider-configs.ts%0ALine%3A%20717-728%0A%0AComment%3A%0A**Catch%20block%20deletes%20new%20credential%20after%20DB%20has%20already%20committed%20in%20%60startAssistantOAuthLogin%60**%0A%0AThe%20%60try%60%20block%20contains%20two%20sequential%20operations%3A%20the%20DB%20update%20that%20writes%20%60ref%60%20%28commits%20immediately%29%2C%20then%20%60deleteRef%28vault%2C%20row.credentialRef%29%60%20that%20removes%20the%20old%20secret.%20If%20the%20vault%20delete%20throws%2C%20the%20catch%20block%20runs%20%60deleteRef%28vault%2C%20ref%29%60%20%E2%80%94%20deleting%20the%20newly%20stored%20credential%20that%20the%20DB%20row%20now%20points%20to.%20The%20row%20persists%20with%20a%20dangling%20%60credentialRef%60%20that%20no%20longer%20exists%20in%20the%20vault%3B%20every%20subsequent%20assistant%20run%20for%20that%20provider%20will%20fail.%0A%0AThe%20correct%20fix%20mirrors%20%60resolveAssistantProviderConfigForRun%60%3A%20separate%20the%20two%20phases%20so%20only%20DB%20failure%20triggers%20releasing%20%60ref%60.%20The%20old%20ref%20deletion%20should%20either%20be%20outside%20the%20try%2Fcatch%20or%20its%20failure%20allowed%20to%20propagate%20without%20destroying%20the%20new%20ref.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["style(app): apply prettier to the assist..."](https://github.com/youhaowei/dashframe/commit/888b23c4ac304b9c0b68bbee14ede4a129136250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42060645)</sub>

<!-- /greptile_comment -->