### PR TITLE
feat(drafts): block conflicting publishes and surface the conflict report

### DIFF
--- a/apps/server/src/assistant-read-host.test.ts
+++ b/apps/server/src/assistant-read-host.test.ts
@@ -314,7 +314,7 @@ describe("assistant read host (resolver over the real server seam)", () => {
   it("masks (fail-closed) when a joined table is DELETED out from under the insight", async () => {
     // AddJoin validates rightTableId at write time, so a dangling ref arises via
     // DELETION: deleting a DataTable does NOT cascade-delete dependent insights
-    // (drift-repair territory), leaving the join's rightTableId dangling. The
+    // (repair target TBD), leaving the join's rightTableId dangling. The
     // base is cleared, so masking depends entirely on the dangling-ref →
     // forceMask path — a vanished table may have held the only sensitive column.
     const sourceId = id();

--- a/apps/server/src/assistant-read-host.ts
+++ b/apps/server/src/assistant-read-host.ts
@@ -162,7 +162,7 @@ export function createAssistantReadHost(
     let unresolvedReason: string | undefined;
     // Add a referenced table's fields. A DANGLING ref (null table) forces
     // masking: deleting a DataTable does NOT cascade-delete dependent insights
-    // (the server routes them to drift-repair), so an insight can carry a
+    // (the repair target is TBD), so an insight can carry a
     // dangling join `rightTableId` / metric `sourceTable`. A draft can also
     // delete a table the insight still references. If that vanished table held
     // the only sensitive column, silently contributing nothing would fail OPEN —

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -553,6 +553,13 @@ export function createDraftController(
     return cells;
   }
 
+  /**
+   * Probe whether any canonical row advanced after `baseVersion`. Uses strict
+   * `>` — not `>=` — so rows written in `baseVersion`'s own millisecond (the
+   * draft-open instant) are not mistaken for post-open canonical writes. The
+   * trade-off is a same-millisecond false-negative; see
+   * {@link overlappingCellsSince} and {@link deletedTouchedCells}.
+   */
   async function hasCanonicalWritesSince(
     baseVersion: Date,
     exec: SqlExecutor = db,

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -49,25 +49,34 @@
  * draft, or make vault.store draft-aware) before routing untrusted drafts.
  */
 import {
+  dashboards,
   dashboardsDraft,
+  dataFrames,
   dataFramesDraft,
+  dataSources,
   dataSourcesDraft,
+  dataTables,
   dataTablesDraft,
   draftCommandLog,
+  draftMetadata,
+  insights,
   insightsDraft,
+  visualizations,
   visualizationsDraft,
   type ArtifactDb,
 } from "@dashframe/server-core";
 import {
   applyCommands,
   compactLog,
+  type Cell,
   type Command,
   type CommandResult,
   type CommitResult,
+  type ConflictReport,
   type DraftCommand,
   type WyStackApp,
 } from "@wystack/server";
-import { eq } from "drizzle-orm";
+import { eq, getTableName, sql } from "drizzle-orm";
 
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { computeLogSignature } from "./draft-log-signature";
@@ -89,6 +98,15 @@ const DRAFT_SHADOW_TABLES = [
   dashboardsDraft,
 ] as const;
 
+const DRAFT_CONFLICT_TABLES = [
+  { canonical: dataSources, draft: dataSourcesDraft },
+  { canonical: dataTables, draft: dataTablesDraft },
+  { canonical: dataFrames, draft: dataFramesDraft },
+  { canonical: insights, draft: insightsDraft },
+  { canonical: visualizations, draft: visualizationsDraft },
+  { canonical: dashboards, draft: dashboardsDraft },
+] as const;
+
 /**
  * The DB-handle surface the teardown helpers (`deleteLog`/`sweepShadows`) need:
  * just `.delete()`. Narrowing to this (rather than the full `ArtifactDb`) is
@@ -97,7 +115,33 @@ const DRAFT_SHADOW_TABLES = [
  * regardless of what the runtime handle happens to support.
  */
 type DeleteExecutor = Pick<ArtifactDb, "delete">;
+type SqlExecutor = Pick<ArtifactDb, "execute">;
 export type LogReader = Pick<ArtifactDb, "select">;
+
+function normalizeRows(result: unknown): Record<string, unknown>[] {
+  if (Array.isArray(result)) return result as Record<string, unknown>[];
+  const rows = (result as { rows?: unknown })?.rows;
+  return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+}
+
+function normalizeBaseVersion(baseVersion: unknown): Date {
+  if (baseVersion instanceof Date && !Number.isNaN(baseVersion.getTime())) {
+    return baseVersion;
+  }
+  if (typeof baseVersion === "number") {
+    const date = new Date(baseVersion);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  if (typeof baseVersion === "string") {
+    const date = new Date(baseVersion);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  return new Date();
+}
+
+function timestampExpression(tableAlias: string): string {
+  return `COALESCE(${tableAlias}."updated_at", ${tableAlias}."created_at")`;
+}
 
 /** A persisted log row mapped back to the `DraftCommand` shape replay consumes. */
 function rowToDraftCommand(row: {
@@ -178,6 +222,11 @@ export interface DraftController {
    * `DiscardDraftOptions.beforeDiscard`.
    */
   discardDraft(draftId: string, options?: DiscardDraftOptions): Promise<void>;
+  /**
+   * Detect whether canonical has moved under this draft's base version and
+   * whether that movement overlaps cells the draft touched.
+   */
+  detectConflict(draftId: string): Promise<ConflictReport>;
   /** Read-only peek at a draft's persisted (compacted) command log. */
   getDraftLog(draftId: string): Promise<Command[]>;
 }
@@ -271,6 +320,18 @@ export interface PublishDraftOptions {
    * narrowed type, regardless of what the runtime handle supports.
    */
   beforeReplay?: (log: Command[], tx: LogReader) => Promise<void> | void;
+  /**
+   * When true, publish checks the draft's base version against canonical writes
+   * inside the same transaction as replay and blocks overlapping stale cells.
+   */
+  blockOnConflict?: boolean;
+}
+
+export class DraftPublishConflictError extends Error {
+  constructor(readonly conflictReport: ConflictReport) {
+    super("publishDraft: draft conflicts with canonical changes");
+    this.name = "DraftPublishConflictError";
+  }
 }
 
 /**
@@ -396,6 +457,86 @@ export function createDraftController(
       .where(eq(draftCommandLog.draftId, draftId));
   }
 
+  async function deleteDraftMetadata(
+    draftId: string,
+    exec: DeleteExecutor = db,
+  ): Promise<void> {
+    await exec.delete(draftMetadata).where(eq(draftMetadata.draftId, draftId));
+  }
+
+  async function readBaseVersion(
+    draftId: string,
+    exec: LogReader = db,
+  ): Promise<Date | null> {
+    const rows = await exec
+      .select({ baseVersion: draftMetadata.baseVersion })
+      .from(draftMetadata)
+      .where(eq(draftMetadata.draftId, draftId));
+    return rows[0]?.baseVersion ?? null;
+  }
+
+  async function hasCanonicalWritesSince(
+    baseVersion: Date,
+    exec: SqlExecutor = db,
+  ): Promise<boolean> {
+    for (const table of DRAFT_CONFLICT_TABLES) {
+      const canonicalName = getTableName(table.canonical);
+      const prefix = sql.raw(
+        `SELECT 1 FROM "${canonicalName}" c WHERE ${timestampExpression("c")} > `,
+      );
+      const rows = normalizeRows(
+        await exec.execute(sql`${prefix}${baseVersion}${sql.raw(" LIMIT 1")}`),
+      );
+      if (rows.length > 0) return true;
+    }
+    return false;
+  }
+
+  async function overlappingCellsSince(
+    draftId: string,
+    baseVersion: Date,
+    exec: SqlExecutor = db,
+  ): Promise<Cell[]> {
+    const cells: Cell[] = [];
+    for (const table of DRAFT_CONFLICT_TABLES) {
+      const canonicalName = getTableName(table.canonical);
+      const draftName = getTableName(table.draft);
+      const prefix = sql.raw(
+        `SELECT d."id" AS id FROM "${draftName}" d ` +
+          `INNER JOIN "${canonicalName}" c ON c."id" = d."id" ` +
+          `WHERE d."draft_id" = `,
+      );
+      const rows = normalizeRows(
+        await exec.execute(
+          sql`${prefix}${draftId}${sql.raw(
+            ` AND ${timestampExpression("c")} > `,
+          )}${baseVersion}`,
+        ),
+      );
+      for (const row of rows) {
+        cells.push({ table: canonicalName, id: row.id });
+      }
+    }
+    return cells;
+  }
+
+  async function detectConflictReport(
+    draftId: string,
+    exec: LogReader & SqlExecutor = db,
+  ): Promise<ConflictReport> {
+    const baseVersion = await readBaseVersion(draftId, exec);
+    if (baseVersion === null) {
+      return { staleBase: false, overlappingCells: [] };
+    }
+
+    const staleBase = await hasCanonicalWritesSince(baseVersion, exec);
+    const overlappingCells = staleBase
+      ? await overlappingCellsSince(draftId, baseVersion, exec)
+      : [];
+
+    return { staleBase, overlappingCells };
+  }
+
   /**
    * Sweep a draft's `<table>__draft` shadow rows across the closed set. `exec` is
    * the Drizzle handle the DELETEs run against — BOTH callers now pass their
@@ -461,14 +602,20 @@ export function createDraftController(
       await options.beforeDiscard?.(log, tx);
       await deleteLog(draftId, tx);
       await sweepShadows(draftId, tx);
+      await deleteDraftMetadata(draftId, tx);
     });
   }
 
   return {
-    async openDraft(_baseVersion?: unknown): Promise<string> {
+    async openDraft(baseVersion?: unknown): Promise<string> {
       // DashFrame owns the handle. `withDraft` accepts any id, so a UUID is the
       // durable draftId across the shadow tables and the command log.
-      return crypto.randomUUID();
+      const draftId = crypto.randomUUID();
+      await db.insert(draftMetadata).values({
+        draftId,
+        baseVersion: normalizeBaseVersion(baseVersion),
+      });
+      return draftId;
     },
 
     async appendToDraft(draftId, batch, context = {}) {
@@ -598,6 +745,18 @@ export function createDraftController(
         }
         assertPublishLogHasNoLateBound(log);
         validatePublishLog?.(log);
+        if (options.blockOnConflict === true) {
+          const conflictReport = await detectConflictReport(
+            draftId,
+            tx.raw as LogReader & SqlExecutor,
+          );
+          if (
+            conflictReport.staleBase &&
+            conflictReport.overlappingCells.length > 0
+          ) {
+            throw new DraftPublishConflictError(conflictReport);
+          }
+        }
         // Pre-replay hook: runs on the AUTHORITATIVE reloaded log, after both
         // guards above, before replay mutates canonical rows. See
         // `PublishDraftOptions.beforeReplay` for why this must live here and
@@ -626,6 +785,7 @@ export function createDraftController(
         const exec = tx.raw as DeleteExecutor;
         await deleteLog(draftId, exec);
         await sweepShadows(draftId, exec);
+        await deleteDraftMetadata(draftId, exec);
         return committed;
       });
       // The host flushes result.tablesWritten to invalidation (the controller
@@ -637,6 +797,10 @@ export function createDraftController(
 
     async discardDraft(draftId, options = {}) {
       await dropDraft(draftId, options);
+    },
+
+    async detectConflict(draftId) {
+      return detectConflictReport(draftId);
     },
 
     async getDraftLog(draftId) {

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -492,6 +492,19 @@ export function createDraftController(
     return false;
   }
 
+  /**
+   * Overlap is ROW-granular by design: a cell is `(table, id)`, so a draft
+   * edit and a canonical write touching DIFFERENT COLUMNS of the same row
+   * still count as a conflict. That is the safe (false-positive) direction
+   * and matches the wystack `Cell` contract — do not "optimize" to
+   * column-level.
+   *
+   * The strict `>` against a wall-clock `baseVersion` has a same-millisecond
+   * false-negative: a canonical write landing in the exact ms the draft was
+   * opened is not seen (the tests' `delay()` calls dodge this window). A
+   * monotonic version token would close it; accepted for now — the window is
+   * one clock tick on a local single-writer DB.
+   */
   async function overlappingCellsSince(
     draftId: string,
     baseVersion: Date,
@@ -526,6 +539,9 @@ export function createDraftController(
   ): Promise<ConflictReport> {
     const baseVersion = await readBaseVersion(draftId, exec);
     if (baseVersion === null) {
+      // Fail-open by choice: only legacy drafts opened before draft_metadata
+      // existed lack a base version (openDraft always inserts one now), and
+      // blocking every such publish would strand them.
       return { staleBase: false, overlappingCells: [] };
     }
 

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -125,6 +125,8 @@ function normalizeRows(result: unknown): Record<string, unknown>[] {
 }
 
 function normalizeBaseVersion(baseVersion: unknown): Date {
+  // No base supplied → the draft's base is "now" (the legitimate default).
+  if (baseVersion === undefined) return new Date();
   if (baseVersion instanceof Date && !Number.isNaN(baseVersion.getTime())) {
     return baseVersion;
   }
@@ -136,7 +138,12 @@ function normalizeBaseVersion(baseVersion: unknown): Date {
     const date = new Date(baseVersion);
     if (!Number.isNaN(date.getTime())) return date;
   }
-  return new Date();
+  // A value was supplied but is not a valid Date/epoch/ISO string. Silently
+  // coercing it to `new Date()` would push the base to "now" and quietly mask
+  // every prior canonical write from conflict detection — throw instead.
+  throw new Error(
+    `openDraft: invalid baseVersion (${typeof baseVersion}); expected a Date, epoch number, or ISO string`,
+  );
 }
 
 function timestampExpression(tableAlias: string): string {
@@ -475,6 +482,77 @@ export function createDraftController(
     return rows[0]?.baseVersion ?? null;
   }
 
+  /**
+   * The canonical id inventory captured at open, as `{ table: id[] }`, or null
+   * for a legacy draft opened before the column existed (delete detection then
+   * fails open). See {@link snapshotCanonicalInventory} and the `base_inventory`
+   * schema note.
+   */
+  async function readBaseInventory(
+    draftId: string,
+    exec: LogReader = db,
+  ): Promise<Record<string, unknown[]> | null> {
+    const rows = await exec
+      .select({ baseInventory: draftMetadata.baseInventory })
+      .from(draftMetadata)
+      .where(eq(draftMetadata.draftId, draftId));
+    const inventory = rows[0]?.baseInventory;
+    return inventory != null && typeof inventory === "object"
+      ? (inventory as Record<string, unknown[]>)
+      : null;
+  }
+
+  /** Read every canonical id in one conflict table. */
+  async function canonicalIds(
+    canonicalName: string,
+    exec: SqlExecutor = db,
+  ): Promise<Set<unknown>> {
+    const rows = normalizeRows(
+      // `canonicalName` is a static schema table name (getTableName), never
+      // caller input — no injection surface.
+      await exec.execute(sql.raw(`SELECT "id" AS id FROM "${canonicalName}"`)),
+    );
+    return new Set(rows.map((row) => row.id));
+  }
+
+  /**
+   * Delete conflicts the timestamp probe cannot see. A canonical DELETE removes
+   * the row, so `hasCanonicalWritesSince`/`overlappingCellsSince` (which read
+   * `updated_at` on surviving rows) miss it entirely. Instead, diff each
+   * draft-touched id against the base inventory: an id the draft touched that
+   * EXISTED at open but is now ABSENT from canonical was deleted underneath the
+   * draft — a genuine conflict (the draft edits, or re-deletes, a row that is
+   * gone). draft-CREATED ids (not in the base inventory) are correctly ignored.
+   */
+  async function deletedTouchedCells(
+    draftId: string,
+    baseInventory: Record<string, unknown[]>,
+    exec: SqlExecutor = db,
+  ): Promise<Cell[]> {
+    const cells: Cell[] = [];
+    for (const table of DRAFT_CONFLICT_TABLES) {
+      const canonicalName = getTableName(table.canonical);
+      const baseIds = baseInventory[canonicalName];
+      if (!Array.isArray(baseIds) || baseIds.length === 0) continue;
+      const draftName = getTableName(table.draft);
+      const prefix = sql.raw(
+        `SELECT d."id" AS id FROM "${draftName}" d WHERE d."draft_id" = `,
+      );
+      const touched = normalizeRows(
+        await exec.execute(sql`${prefix}${draftId}`),
+      );
+      if (touched.length === 0) continue;
+      const baseIdSet = new Set(baseIds);
+      const surviving = await canonicalIds(canonicalName, exec);
+      for (const row of touched) {
+        if (baseIdSet.has(row.id) && !surviving.has(row.id)) {
+          cells.push({ table: canonicalName, id: row.id });
+        }
+      }
+    }
+    return cells;
+  }
+
   async function hasCanonicalWritesSince(
     baseVersion: Date,
     exec: SqlExecutor = db,
@@ -504,6 +582,10 @@ export function createDraftController(
    * opened is not seen (the tests' `delay()` calls dodge this window). A
    * monotonic version token would close it; accepted for now — the window is
    * one clock tick on a local single-writer DB.
+   *
+   * Covers UPDATEs only: this INNER JOIN matches surviving canonical rows, so a
+   * DELETE (the row is gone) is invisible here and detected separately against
+   * the base inventory — see {@link deletedTouchedCells}.
    */
   async function overlappingCellsSince(
     draftId: string,
@@ -545,10 +627,24 @@ export function createDraftController(
       return { staleBase: false, overlappingCells: [] };
     }
 
-    const staleBase = await hasCanonicalWritesSince(baseVersion, exec);
-    const overlappingCells = staleBase
+    const timestampStale = await hasCanonicalWritesSince(baseVersion, exec);
+    const updatedCells = timestampStale
       ? await overlappingCellsSince(draftId, baseVersion, exec)
       : [];
+    // Deletes bump no surviving row's timestamp, so they must be detected
+    // separately against the base inventory (independent of `timestampStale`).
+    const baseInventory = await readBaseInventory(draftId, exec);
+    const deletedCells = baseInventory
+      ? await deletedTouchedCells(draftId, baseInventory, exec)
+      : [];
+
+    // `updatedCells` requires the canonical row to still exist (INNER JOIN);
+    // `deletedCells` requires it absent — the two sets are disjoint by
+    // construction, so a plain concat cannot double-count a cell.
+    const overlappingCells = [...updatedCells, ...deletedCells];
+    // A delete IS a canonical advance even when no surviving row's timestamp
+    // moved, so a delete-only conflict must still report `staleBase: true`.
+    const staleBase = timestampStale || deletedCells.length > 0;
 
     return { staleBase, overlappingCells };
   }
@@ -622,14 +718,36 @@ export function createDraftController(
     });
   }
 
+  /**
+   * Snapshot the canonical id inventory across the conflict tables at open, as
+   * `{ [canonicalTableName]: id[] }`. This is the base against which delete
+   * detection later diffs (see {@link deletedTouchedCells}) — the only way to
+   * see a canonical row that a later publish finds already gone. Tables here are
+   * small artifact-metadata tables, so a full id scan per table is cheap and
+   * open is rare.
+   */
+  async function snapshotCanonicalInventory(
+    exec: SqlExecutor = db,
+  ): Promise<Record<string, unknown[]>> {
+    const inventory: Record<string, unknown[]> = {};
+    for (const table of DRAFT_CONFLICT_TABLES) {
+      const canonicalName = getTableName(table.canonical);
+      inventory[canonicalName] = [...(await canonicalIds(canonicalName, exec))];
+    }
+    return inventory;
+  }
+
   return {
     async openDraft(baseVersion?: unknown): Promise<string> {
       // DashFrame owns the handle. `withDraft` accepts any id, so a UUID is the
       // durable draftId across the shadow tables and the command log.
       const draftId = crypto.randomUUID();
+      // Capture baseVersion and the id inventory together at open — the paired
+      // base for both timestamp- and delete-based conflict detection.
       await db.insert(draftMetadata).values({
         draftId,
         baseVersion: normalizeBaseVersion(baseVersion),
+        baseInventory: await snapshotCanonicalInventory(),
       });
       return draftId;
     },

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2880,7 +2880,7 @@ describe("command vocabulary", () => {
       // The Artifact Model's typed-edge rule: DataTable → Insight is a reference
       // edge. Deleting the DataTable must NOT auto-delete the Insight; instead it
       // must return the Insight in orphanedNodes so the caller can route it to
-      // drift-repair. The Insight remains in the DB, reachable but broken.
+      // the TBD repair target. The Insight remains in the DB, reachable but broken.
       const { tableId } = await makeTable();
       const insight1Id = id();
       const insight2Id = id();

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1806,8 +1806,8 @@ const renameNode = mutation({
 
 /**
  * An orphaned node description returned by DeleteNode when a delete stops at a
- * reference edge. The caller (UI or agent) routes these into the Data-Drift
- * Repair flow — from a reference child's perspective, a deleted parent is
+ * reference edge. The caller (UI or agent) routes these into a TBD repair
+ * target — from a reference child's perspective, a deleted parent is
  * indistinguishable from drift.
  */
 export interface OrphanedNode {
@@ -1824,7 +1824,7 @@ export interface OrphanedNode {
  * kind, instead of hard-coding `dataTable` (which mislabeled a deleted Visualization
  * / Dashboard / Insight / DataSource and read the wrong before-slice). Mirrors the
  * RenameNodeResult precedent. `orphanedNodes` is the reference-boundary warning
- * surface routed into Data-Drift Repair (orphan-and-warn is by design).
+ * surface routed into a TBD repair target (orphan-and-warn is by design).
  */
 export interface DeleteNodeResult {
   ok: true;
@@ -1835,7 +1835,7 @@ export interface DeleteNodeResult {
 /**
  * Walk all Insights whose primary source OR any join dependency equals
  * `sourceId`. These are the reference-boundary nodes that must be routed to
- * drift-repair when `sourceId` is deleted.
+ * a TBD repair target when `sourceId` is deleted.
  *
  * The check covers:
  *   • The new `source.sourceId` field (CreateInsight / SetInsightSource).
@@ -2099,8 +2099,8 @@ function assertVaultPresentForCredentialDelete(
  *       • Insights that SOURCE any of those DataTables are returned as
  *         `orphanedNodes`.
  *
- * The returned `orphanedNodes` list is the "warning surface" the ticket
- * describes — the UI/agent routes these into the Data-Drift Repair flow.
+ * The returned `orphanedNodes` list is the warning surface; the UI/agent
+ * repair target is TBD.
  * Nothing is silently orphaned and no authored artifact is silently destroyed.
  */
 const deleteNode = mutation({
@@ -2109,7 +2109,7 @@ const deleteNode = mutation({
     // --- Visualization -------------------------------------------------------
     // No owned children. Reference boundary: Dashboards that contain this
     // visualization via a layout item's `visualizationId` are orphaned when the
-    // visualization is deleted — surface them in orphanedNodes for drift-repair.
+    // visualization is deleted — surface them in orphanedNodes for TBD repair.
     const viz = await ctx.db.from(visualizations).where(eq("id", id)).first();
     if (viz) {
       const allDashboards = (await ctx.db
@@ -2144,9 +2144,9 @@ const deleteNode = mutation({
     // --- Insight ------------------------------------------------------------
     // Owned visualizations cascade-delete via the DB schema FK
     // (visualizations.insight_id references insights.id ON DELETE CASCADE).
-    // Reference-boundary: Insights that SOURCE this Insight enter drift-repair.
-    // Dashboard items that reference any of the owned Visualizations also enter
-    // drift-repair (the FK cascade removes the viz, the layout item becomes stale).
+    // Reference-boundary: Insights that SOURCE this Insight need repair. Dashboard
+    // items that reference owned Visualizations need the same TBD repair target
+    // (the FK cascade removes the viz, the layout item becomes stale).
     const insight = (await ctx.db
       .from(insights)
       .where(eq("id", id))
@@ -2195,7 +2195,8 @@ const deleteNode = mutation({
 
     // --- DataTable ----------------------------------------------------------
     // No owned children (DataTable is owned by DataSource, not by DataTable).
-    // Reference-boundary: Insights that SOURCE this DataTable enter drift-repair.
+    // Reference-boundary: Insights that SOURCE this DataTable need the TBD
+    // repair target.
     // Arrow cleanup: delete the DataTable's DataFrame metadata if it has one.
     const table = (await ctx.db
       .from(dataTables)

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -107,6 +107,7 @@ async function getOk<T>(url: string, path: string, args: unknown): Promise<T> {
   return json.data;
 }
 
+/** Wall-clock pause so a subsequent canonical write's `updated_at` clears the draft's `baseVersion`. */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -291,6 +292,11 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
       cmd("RenameNode", { id: sourceId, name: "Draft rename" }),
     ]);
 
+    // Separate the draft's baseVersion from the canonical write by ~5ms of real
+    // elapsed time. Both timestamps are independent `new Date()` reads, not
+    // coalesced DB writes — CI contention only widens the gap. An explicit
+    // past baseVersion would pull seed writes into the stale window and break
+    // the disjoint-cell test below.
     await delay(5);
     await db
       .update(dataSources)
@@ -344,6 +350,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
       cmd("RenameNode", { id: draftSourceId, name: "Draft rename" }),
     ]);
 
+    // Same ordering guarantee as the overlapping-cell conflict test above.
     await delay(5);
     await db
       .update(dataSources)

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -107,6 +107,10 @@ async function getOk<T>(url: string, path: string, args: unknown): Promise<T> {
   return json.data;
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -160,6 +164,18 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     ]);
 
     return draftId;
+  }
+
+  async function seedCanonicalSource(db: ArtifactDb, name: string) {
+    const seedApp = await buildDashframeApp({ db });
+    const seedController = createDraftController(seedApp, db);
+    const sourceId = crypto.randomUUID();
+    const seedDraftId = await seedController.openDraft();
+    await seedController.appendToDraft(seedDraftId, [
+      cmd("CreateDataSource", { id: sourceId, type: "csv", name }),
+    ]);
+    await seedController.publishDraft(seedDraftId);
+    return { sourceId, seedController };
   }
 
   // -------------------------------------------------------------------------
@@ -263,6 +279,91 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     expect(body.data).not.toHaveProperty("__extraTablesWritten");
     // The public field is still present.
     expect(body.data).toHaveProperty("tablesWritten");
+  });
+
+  it("publishDraft blocks a stale draft when canonical changed the same touched cell and surfaces the conflict report", async () => {
+    project = await openProject({ dir: join(root, "conflict") });
+    const db = project.db as ArtifactDb;
+    const { sourceId, seedController } = await seedCanonicalSource(db, "Base");
+
+    const draftId = await seedController.openDraft();
+    await seedController.appendToDraft(draftId, [
+      cmd("RenameNode", { id: sourceId, name: "Draft rename" }),
+    ]);
+
+    await delay(5);
+    await db
+      .update(dataSources)
+      .set({ name: "Canonical rename" })
+      .where(eq(dataSources.id, sourceId));
+
+    server = await createDashframeServer({ db });
+
+    const res = await post(server.url, "publishDraft", { draftId });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      issues: Array<{
+        params?: {
+          kind?: string;
+          conflictReport?: {
+            staleBase: boolean;
+            overlappingCells: Array<{ table: string; id: string }>;
+          };
+        };
+      }>;
+    };
+
+    expect(body.error).toContain("draft conflicts with canonical changes");
+    const report = body.issues[0]?.params?.conflictReport;
+    expect(body.issues[0]?.params?.kind).toBe("draft_conflict");
+    expect(report).toEqual({
+      staleBase: true,
+      overlappingCells: [{ table: "data_sources", id: sourceId }],
+    });
+
+    expect(await seedController.getDraftLog(draftId)).toHaveLength(1);
+    const rows = await db.select().from(dataSources);
+    expect(rows.find((row) => row.id === sourceId)?.name).toBe(
+      "Canonical rename",
+    );
+  });
+
+  it("publishDraft still succeeds when canonical changed a disjoint cell after the draft opened", async () => {
+    project = await openProject({ dir: join(root, "disjoint") });
+    const db = project.db as ArtifactDb;
+    const { sourceId: draftSourceId, seedController } =
+      await seedCanonicalSource(db, "Draft target");
+    const { sourceId: canonicalSourceId } = await seedCanonicalSource(
+      db,
+      "Canonical target",
+    );
+
+    const draftId = await seedController.openDraft();
+    await seedController.appendToDraft(draftId, [
+      cmd("RenameNode", { id: draftSourceId, name: "Draft rename" }),
+    ]);
+
+    await delay(5);
+    await db
+      .update(dataSources)
+      .set({ name: "Disjoint canonical rename" })
+      .where(eq(dataSources.id, canonicalSourceId));
+
+    server = await createDashframeServer({ db });
+
+    await postOk<{ tablesWritten: string[] }>(server.url, "publishDraft", {
+      draftId,
+    });
+
+    const rows = await db.select().from(dataSources);
+    expect(rows.find((row) => row.id === draftSourceId)?.name).toBe(
+      "Draft rename",
+    );
+    expect(rows.find((row) => row.id === canonicalSourceId)?.name).toBe(
+      "Disjoint canonical rename",
+    );
+    expect(await seedController.getDraftLog(draftId)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -366,6 +366,81 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     expect(await seedController.getDraftLog(draftId)).toHaveLength(0);
   });
 
+  it("publishDraft blocks when canonical DELETED a row the draft touched and surfaces the conflict report", async () => {
+    project = await openProject({ dir: join(root, "delete-conflict") });
+    const db = project.db as ArtifactDb;
+    const { sourceId, seedController } = await seedCanonicalSource(db, "Base");
+
+    const draftId = await seedController.openDraft();
+    await seedController.appendToDraft(draftId, [
+      cmd("RenameNode", { id: sourceId, name: "Draft rename" }),
+    ]);
+
+    // Another session deletes the row the draft is editing. A delete bumps no
+    // surviving row's timestamp, so this is caught only against the base
+    // inventory — no `delay()` needed (the row's absence, not its timestamp, is
+    // the signal).
+    await db.delete(dataSources).where(eq(dataSources.id, sourceId));
+
+    server = await createDashframeServer({ db });
+
+    const res = await post(server.url, "publishDraft", { draftId });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      issues: Array<{
+        params?: {
+          kind?: string;
+          conflictReport?: {
+            staleBase: boolean;
+            overlappingCells: Array<{ table: string; id: string }>;
+          };
+        };
+      }>;
+    };
+
+    expect(body.issues[0]?.params?.kind).toBe("draft_conflict");
+    expect(body.issues[0]?.params?.conflictReport).toEqual({
+      staleBase: true,
+      overlappingCells: [{ table: "data_sources", id: sourceId }],
+    });
+    // The blocked publish leaves the draft intact for a rebase/repair.
+    expect(await seedController.getDraftLog(draftId)).toHaveLength(1);
+  });
+
+  it("publishDraft still succeeds when canonical DELETED a row the draft did not touch", async () => {
+    project = await openProject({ dir: join(root, "delete-disjoint") });
+    const db = project.db as ArtifactDb;
+    const { sourceId: draftSourceId, seedController } =
+      await seedCanonicalSource(db, "Draft target");
+    const { sourceId: deletedSourceId } = await seedCanonicalSource(
+      db,
+      "Deleted elsewhere",
+    );
+
+    const draftId = await seedController.openDraft();
+    await seedController.appendToDraft(draftId, [
+      cmd("RenameNode", { id: draftSourceId, name: "Draft rename" }),
+    ]);
+
+    // Canonical deletes a DIFFERENT source than the draft touches — disjoint,
+    // so the publish must proceed.
+    await db.delete(dataSources).where(eq(dataSources.id, deletedSourceId));
+
+    server = await createDashframeServer({ db });
+
+    await postOk<{ tablesWritten: string[] }>(server.url, "publishDraft", {
+      draftId,
+    });
+
+    const rows = await db.select().from(dataSources);
+    expect(rows.find((row) => row.id === draftSourceId)?.name).toBe(
+      "Draft rename",
+    );
+    expect(rows.some((row) => row.id === deletedSourceId)).toBe(false);
+    expect(await seedController.getDraftLog(draftId)).toHaveLength(0);
+  });
+
   // -------------------------------------------------------------------------
   // TOCTOU guard: expectedCommandCount
   // -------------------------------------------------------------------------

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -23,7 +23,7 @@ import type { ArtifactDb } from "@dashframe/server-core";
 import { text } from "@wystack/db";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import type { Command } from "@wystack/server";
-import { mutation, query } from "@wystack/server";
+import { mutation, query, ValidationError } from "@wystack/server";
 
 import {
   collectDeletedSourceRefs,
@@ -31,7 +31,10 @@ import {
   collectSupersededRefs,
   releaseRefsAtTransition,
 } from "../credential-release";
-import type { DraftController } from "../draft-controller";
+import {
+  DraftPublishConflictError,
+  type DraftController,
+} from "../draft-controller";
 import { PUBLISH_REPLAY_CONTEXT_KEY } from "./utils";
 
 /**
@@ -46,6 +49,22 @@ import { PUBLISH_REPLAY_CONTEXT_KEY } from "./utils";
 interface PublishDraftInternalResult {
   tablesWritten: string[];
   __extraTablesWritten: string[];
+}
+
+function draftConflictError(
+  conflictReport: Awaited<ReturnType<DraftController["detectConflict"]>>,
+): ValidationError {
+  return new ValidationError([
+    {
+      code: "custom",
+      path: ["draftId"],
+      message: "publishDraft: draft conflicts with canonical changes",
+      params: {
+        kind: "draft_conflict",
+        conflictReport,
+      },
+    },
+  ] as ConstructorParameters<typeof ValidationError>[0]);
 }
 
 /**
@@ -182,23 +201,32 @@ const publishDraft = mutation({
 
     // Mark the replay as the sanctioned canonical-commit path so the credential
     // command handlers' direct-call guard accepts it (release is handled here).
-    const result = await draftController.publishDraft(
-      draftId,
-      { [PUBLISH_REPLAY_CONTEXT_KEY]: true },
-      {
-        expectedCommandCount: expected,
-        expectedLogSignature,
-        beforeReplay: async (log, tx) => {
-          publishLogLength = log.length;
-          if (artifactDb != null) {
-            replacedRefs = [
-              ...(await collectSupersededRefs(tx, log)),
-              ...(await collectDeletedSourceRefs(tx, log)),
-            ];
-          }
+    let result: Awaited<ReturnType<DraftController["publishDraft"]>>;
+    try {
+      result = await draftController.publishDraft(
+        draftId,
+        { [PUBLISH_REPLAY_CONTEXT_KEY]: true },
+        {
+          expectedCommandCount: expected,
+          expectedLogSignature,
+          blockOnConflict: true,
+          beforeReplay: async (log, tx) => {
+            publishLogLength = log.length;
+            if (artifactDb != null) {
+              replacedRefs = [
+                ...(await collectSupersededRefs(tx, log)),
+                ...(await collectDeletedSourceRefs(tx, log)),
+              ];
+            }
+          },
         },
-      },
-    );
+      );
+    } catch (err) {
+      if (err instanceof DraftPublishConflictError) {
+        throw draftConflictError(err.conflictReport);
+      }
+      throw err;
+    }
 
     // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does
     // NOT fire `onWrite` here (its tracker sees zero writes from the sub-tracker

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -374,7 +374,7 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
     args: { id: "UUID" },
     notes:
       "Cascades ownership edges (source→table); stops at reference edges and " +
-      "reports orphanedNodes for drift-repair.",
+      "reports orphanedNodes for a TBD repair target.",
   },
 ] as const;
 

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -59,6 +59,7 @@ export {
   dataTablesDraft,
   // Draft command log
   draftCommandLog,
+  draftMetadata,
   insights,
   insightsDraft,
   // Canonical artifact tables

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -248,6 +248,7 @@ describe("draft_metadata table", () => {
     const cols = await liveColumns("draft_metadata");
     expect(cols.has("draft_id")).toBe(true);
     expect(cols.has("base_version")).toBe(true);
+    expect(cols.has("base_inventory")).toBe(true);
     expect(cols.has("created_at")).toBe(true);
   });
 

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -27,6 +27,7 @@ import {
   dataSourcesDraft,
   dataTablesDraft,
   draftCommandLog,
+  draftMetadata,
   insightsDraft,
   schema,
   visualizationsDraft,
@@ -235,6 +236,23 @@ describe("draft_command_log table", () => {
         ),
       ),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("draft_metadata table", () => {
+  test("draft_metadata is materialised by syncSchema", async () => {
+    expect(await tableExists("draft_metadata")).toBe(true);
+  });
+
+  test("draft_metadata has the expected columns", async () => {
+    const cols = await liveColumns("draft_metadata");
+    expect(cols.has("draft_id")).toBe(true);
+    expect(cols.has("base_version")).toBe(true);
+    expect(cols.has("created_at")).toBe(true);
+  });
+
+  test("draft_metadata Drizzle table name is 'draft_metadata'", () => {
+    expect(getTableName(draftMetadata)).toBe("draft_metadata");
   });
 });
 

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -468,6 +468,13 @@ export const draftCommandLog = pgTable(
 export const draftMetadata = pgTable("draft_metadata", {
   draftId: text("draft_id").primaryKey(),
   baseVersion: timestamp("base_version", { withTimezone: true }).notNull(),
+  // Snapshot of the canonical id inventory (per conflict table) at the instant
+  // the draft opened: `{ [canonicalTableName]: id[] }`. Deletes leave no
+  // surviving row for the timestamp probe to see, so conflict detection diffs a
+  // draft-touched id against this base inventory — an id present at open but
+  // gone from canonical now is a delete conflict. Nullable: drafts opened before
+  // this column existed have no inventory and skip delete detection (fail-open).
+  baseInventory: jsonb("base_inventory"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -109,6 +109,9 @@ export const dataTables = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+      () => new Date(),
+    ),
     lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   },
   (t) => [index("data_tables_data_source_id_idx").on(t.dataSourceId)],
@@ -131,6 +134,9 @@ export const dataFrames = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+      () => new Date(),
+    ),
   },
   (t) => [index("data_frames_insight_id_idx").on(t.insightId)],
 );
@@ -320,6 +326,7 @@ export const dataTablesDraft = pgTable(
     metrics: jsonb("metrics"),
     dataFrameId: uuid("data_frame_id"),
     createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
     lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
     // Draft control columns.
     tombstone: boolean("__tombstone").notNull().default(false),
@@ -342,6 +349,7 @@ export const dataFramesDraft = pgTable(
     columnCount: integer("column_count"),
     analysis: jsonb("analysis"),
     createdAt: timestamp("created_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
     // Draft control columns.
     tombstone: boolean("__tombstone").notNull().default(false),
   },
@@ -457,6 +465,14 @@ export const draftCommandLog = pgTable(
   ],
 );
 
+export const draftMetadata = pgTable("draft_metadata", {
+  draftId: text("draft_id").primaryKey(),
+  baseVersion: timestamp("base_version", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
 // ─── Schema export ────────────────────────────────────────────────────────────
 
 export const schema = {
@@ -471,6 +487,8 @@ export const schema = {
   // Credential infrastructure — NOT drafted (security boundary)
   secretMappings,
   assistantProviderConfigs,
+  // Draft metadata — base version for conflict detection
+  draftMetadata,
   // Draft shadow tables (artifact overlay)
   dataSourcesDraft,
   dataTablesDraft,


### PR DESCRIPTION
<!-- Brief summary of what this PR does and why. -->

Blocks draft publish when the draft overlaps with canonical changes made after the draft base version, and returns the structured conflict report so callers can render the touched cells.

Tracked internally as YW-127

## Changes

- Store draft base-version metadata when opening drafts and clean it up on drop/publish.
- Detect publish conflicts inside the publish transaction and block only stale overlapping cells.
- Surface conflict reports through the existing structured publish error body.
- Update stale repair-flow comments to say the routing target is TBD.

## Screenshots

No UI change

## Verification

- `bunx prettier --write apps/server/src/assistant-read-host.test.ts apps/server/src/assistant-read-host.ts apps/server/src/draft-controller.ts apps/server/src/functions/commands.test.ts apps/server/src/functions/commands.ts apps/server/src/functions/draft-lifecycle.test.ts apps/server/src/functions/draft-lifecycle.ts packages/assistant/src/read/command-guide.ts packages/server-core/src/index.ts packages/server-core/src/schema.test.ts packages/server-core/src/schema.ts`
- `(cd apps/server && bunx vitest run src/functions/draft-lifecycle.test.ts)`
- `(cd apps/server && bunx vitest run src/draft-controller.test.ts)`
- `(cd packages/server-core && bunx vitest run src/schema.test.ts)`
- `bun run check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds draft-publish conflict detection: when a draft's base is stale and overlaps with canonical changes made after the draft was opened, the publish is blocked and a structured conflict report is returned to callers. Draft metadata (base version + canonical ID inventory) is written at `openDraft` and cleaned up at publish/discard.

- Adds the `draft_metadata` table (base version + ID inventory snapshot), updated on open, deleted on publish or discard — covering both timestamp-based UPDATE conflicts and inventory-diff DELETE conflicts that surviving-row probes cannot see.
- Wraps the conflict check inside the same transaction as the command-log replay so the guard is atomic, and converts the typed `DraftPublishConflictError` into a structured 400 `ValidationError` with `kind: "draft_conflict"` and the full `ConflictReport`.
- Adds `updatedAt` to the `dataTables` and `dataFrames` canonical and draft shadow tables so the `COALESCE(updated_at, created_at)` timestamp expression used by the probe is accurate for all six conflict tables.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The conflict check runs atomically inside the publish transaction, both UPDATE and DELETE conflicts are correctly detected via complementary probes, and all four publish branches (overlap/disjoint × update/delete) are covered by integration tests.

The two-probe design (timestamp for surviving-row updates, base-inventory diff for deletes) closes the gaps correctly and the existing code patterns (tx.raw narrowing, sql-template parameterisation, fail-open for legacy drafts) are applied consistently throughout the new additions. All three cleanup call-sites — discardDraft, publishDraft success, and publishDraft conflict throw — correctly handle the draft_metadata row, leaving no orphaned metadata on any path.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/draft-controller.ts | Core conflict-detection logic: normalizeBaseVersion, snapshotCanonicalInventory, overlappingCellsSince (UPDATE probe via timestamp), deletedTouchedCells (DELETE probe via base inventory), and detectConflictReport — all well-documented and atomically guarded inside the publish transaction. Metadata cleanup added to both publishDraft and discardDraft paths. |
| apps/server/src/functions/draft-lifecycle.ts | Catches DraftPublishConflictError and converts it to a typed ValidationError (kind: draft_conflict + full ConflictReport) before the 400 response, enabling structured conflict surfacing to callers without leaking raw error types. |
| packages/server-core/src/schema.ts | Adds draftMetadata table (draft_id PK, base_version, base_inventory JSONB, created_at) and updatedAt columns to dataTables and dataFrames (canonical and draft shadow tables) needed by the COALESCE timestamp probe. |
| apps/server/src/functions/draft-lifecycle.test.ts | Four integration tests covering all branches: UPDATE conflict on overlapping cell (blocked), UPDATE on disjoint cell (allowed), DELETE conflict on touched row (blocked), DELETE on untouched row (allowed). Good coverage of the core happy and blocking paths. |
| packages/server-core/src/schema.test.ts | Adds schema-level tests verifying draft_metadata is materialized by syncSchema and has the expected columns. |
| apps/server/src/functions/commands.ts | Comment-only changes: replaces drift-repair references with TBD repair target throughout the deleteNode and related JSDoc. |
| apps/server/src/assistant-read-host.ts | Single-line comment update: drift-repair to repair target is TBD. |
| packages/assistant/src/read/command-guide.ts | Single-line comment update in COMMAND_GUIDE: drift-repair to TBD repair target. |
| packages/server-core/src/index.ts | Exports draftMetadata from the package so consumers can reference the table in Drizzle queries. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant publishDraft as publishDraft (draft-lifecycle.ts)
    participant DC as DraftController (draft-controller.ts)
    participant DB as DB (canonical + draft + metadata)

    Note over Client,DB: openDraft — capture baseline
    Client->>DC: openDraft(baseVersion?)
    DC->>DB: snapshotCanonicalInventory()
    DC->>DB: INSERT draft_metadata (draftId, baseVersion, baseInventory)
    DC-->>Client: draftId

    Note over Client,DB: publishDraft — atomic conflict check + replay
    Client->>publishDraft: "POST publishDraft {draftId}"
    publishDraft->>DC: "publishDraft(draftId, ctx, {blockOnConflict:true})"
    Note over DC: inside transaction tx
    DC->>DB: readBaseVersion(draftId, tx)
    DB-->>DC: "baseVersion (Date | null)"
    alt baseVersion exists
        DC->>DB: hasCanonicalWritesSince(baseVersion, tx)
        DB-->>DC: timestampStale
        opt "timestampStale == true"
            DC->>DB: overlappingCellsSince(draftId, baseVersion, tx)
            DB-->>DC: updatedCells[]
        end
        DC->>DB: readBaseInventory(draftId, tx)
        DB-->>DC: baseInventory
        opt "baseInventory != null"
            DC->>DB: deletedTouchedCells(draftId, baseInventory, tx)
            DB-->>DC: deletedCells[]
        end
        alt "staleBase and overlappingCells.length > 0"
            DC-->>publishDraft: throw DraftPublishConflictError
            publishDraft-->>Client: "400 {kind:draft_conflict, conflictReport}"
        else no conflict
            DC->>DB: applyCommands (log replay)
            DC->>DB: deleteLog + sweepShadows + deleteDraftMetadata
            DC-->>publishDraft: CommitResult
            publishDraft-->>Client: "200 {tablesWritten}"
        end
    else no baseVersion (legacy draft — fail open)
        DC->>DB: applyCommands (log replay)
        DC-->>publishDraft: CommitResult
        publishDraft-->>Client: "200 {tablesWritten}"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant publishDraft as publishDraft (draft-lifecycle.ts)
    participant DC as DraftController (draft-controller.ts)
    participant DB as DB (canonical + draft + metadata)

    Note over Client,DB: openDraft — capture baseline
    Client->>DC: openDraft(baseVersion?)
    DC->>DB: snapshotCanonicalInventory()
    DC->>DB: INSERT draft_metadata (draftId, baseVersion, baseInventory)
    DC-->>Client: draftId

    Note over Client,DB: publishDraft — atomic conflict check + replay
    Client->>publishDraft: "POST publishDraft {draftId}"
    publishDraft->>DC: "publishDraft(draftId, ctx, {blockOnConflict:true})"
    Note over DC: inside transaction tx
    DC->>DB: readBaseVersion(draftId, tx)
    DB-->>DC: "baseVersion (Date | null)"
    alt baseVersion exists
        DC->>DB: hasCanonicalWritesSince(baseVersion, tx)
        DB-->>DC: timestampStale
        opt "timestampStale == true"
            DC->>DB: overlappingCellsSince(draftId, baseVersion, tx)
            DB-->>DC: updatedCells[]
        end
        DC->>DB: readBaseInventory(draftId, tx)
        DB-->>DC: baseInventory
        opt "baseInventory != null"
            DC->>DB: deletedTouchedCells(draftId, baseInventory, tx)
            DB-->>DC: deletedCells[]
        end
        alt "staleBase and overlappingCells.length > 0"
            DC-->>publishDraft: throw DraftPublishConflictError
            publishDraft-->>Client: "400 {kind:draft_conflict, conflictReport}"
        else no conflict
            DC->>DB: applyCommands (log replay)
            DC->>DB: deleteLog + sweepShadows + deleteDraftMetadata
            DC-->>publishDraft: CommitResult
            publishDraft-->>Client: "200 {tablesWritten}"
        end
    else no baseVersion (legacy draft — fail open)
        DC->>DB: applyCommands (log replay)
        DC-->>publishDraft: CommitResult
        publishDraft-->>Client: "200 {tablesWritten}"
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["docs(tests): document why draft-lifecycl..."](https://github.com/youhaowei/dashframe/commit/84107152a5ab58f5f77e2a9969224fc92ff5ab63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42076704)</sub>

<!-- /greptile_comment -->