### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+DashFrame is a local-first BI tool (import data → DuckDB → charts). It ships as
+two surfaces of the same UI (`packages/app`): an Electron **desktop** app and a
+browser **web** app, both backed by the same Hono HTTP+WS server code.
+
+Package manager is **Bun** (pinned `bun@1.3.5`); orchestration is Turborepo.
+`bun` is on `PATH` via `/usr/local/bin/bun`. Dependency refresh (submodules +
+install + build of the vendored `@wystack/*` packages) is handled by the startup
+update script; see root `package.json` `setup` for the equivalent steps.
+
+### Running for browser/headless testing (recommended in the cloud VM)
+
+The web app is **not** purely client-side despite the stale `README.md`. It
+needs the backend API, or data import fails with `404` on `/api/*` and a failed
+`/api/ws` WebSocket. Run two processes:
+
+1. API server (fixed loopback port; loopback needs no token):
+   `cd apps/server && bun run src/index.ts --host 127.0.0.1 --port 4000`
+   (bare `bun run dev` also works but picks an OS-assigned port). It opens a
+   project at `~/.DashFrame/web-project`.
+2. Web app pointed at it:
+   `cd apps/web && PORT=3000 VITE_WYSTACK_URL=http://127.0.0.1:4000 bun run dev:direct`
+   Open `http://127.0.0.1:3000/`. In dev the browser talks same-origin and Vite
+   proxies `/api` (incl. ws) to `VITE_WYSTACK_URL`. Use `dev:direct` (plain
+   Vite) rather than `bun run dev`, which wraps Vite in `portless`.
+
+Root `bun run dev` launches the **Electron desktop** app (embeds the server
+in-process, auto-starts the renderer on 5173). It needs a display, so it is not
+suitable for the headless VM — prefer the web+server combo above.
+
+### Lint / test / build
+
+Use the project's own gate `bun check` (or filter `--filter='!@wystack/*'`).
+The vendored `@wystack/*` submodule packages lint with `oxlint`, which is not
+installed, so a raw `bun run lint` / `turbo lint` fails on `@wystack/ui`. The
+project deliberately excludes them (`bun check` = `turbo check --filter=!@wystack/*`).
+
+- Lint: `bunx turbo lint --filter='!@wystack/*'`
+- Test: `bunx turbo test --filter='!@wystack/*'`
+- Build: `bunx turbo build --filter='!@wystack/*'`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,26 @@ Root `bun run dev` launches the **Electron desktop** app (embeds the server
 in-process, auto-starts the renderer on 5173). It needs a display, so it is not
 suitable for the headless VM — prefer the web+server combo above.
 
+### Committing (pre-commit worktree guard)
+
+`.husky/pre-commit` refuses feature-branch commits made from the **main
+checkout** (it's meant to force human/local multi-agent work into isolated
+worktrees via `scripts/ensure-worktree.sh`, per `CLAUDE.md`). A Cursor Cloud
+agent works on its branch directly in the single main checkout, so that guard
+would block every commit. Commit with the documented bypass:
+`ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit ...`. The hook still runs `lint-staged`
+(prettier) on staged files.
+
 ### Lint / test / build
 
-Use the project's own gate `bun check` (or filter `--filter='!@wystack/*'`).
-The vendored `@wystack/*` submodule packages lint with `oxlint`, which is not
-installed, so a raw `bun run lint` / `turbo lint` fails on `@wystack/ui`. The
-project deliberately excludes them (`bun check` = `turbo check --filter=!@wystack/*`).
+Use the project's own gate `bun check`, which runs the ticket-ref check
+(`scripts/check-no-ticket-refs.mjs`) and then `turbo check --filter=!@wystack/*`
+(lint + typecheck + test, excluding the vendored submodule packages). The
+`@wystack/*` packages lint with `oxlint`, which is not installed, so a raw
+`bun run lint` / `turbo lint` fails on `@wystack/ui`; the project deliberately
+filters them out. The per-task commands below skip the ticket-ref gate — run
+`bun check` (or `bun run check:ticket-refs`) if you touched code that might carry
+ticket references.
 
 - Lint: `bunx turbo lint --filter='!@wystack/*'`
 - Test: `bunx turbo test --filter='!@wystack/*'`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sets up the DashFrame development environment for Cursor Cloud agents and documents the non-obvious startup caveats in a new `AGENTS.md`.

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: Bun 1.3.5 as the pinned package manager, the required web+server run combo (the web app needs `apps/server` + `VITE_WYSTACK_URL` or `/api/*` calls 404), the Electron desktop caveat (needs a display), and the lint/test/build gate that must exclude the `oxlint`-based `@wystack/*` submodule packages.

The startup update script (submodule init + `bun install` + `bun run build:wystack`) is registered separately via the environment setup tool, not committed here.

## Screenshots

Environment verification — imported `samples/revenue.csv` and rendered a chart in the running web app:

[dashframe_csv_import_and_chart.mp4](https://cursor.com/agents/bc-44527ea8-41c8-4d01-a70e-d3626ee1c8a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashframe_csv_import_and_chart.mp4)

[Imported revenue data table (20 rows x 10 fields)](https://cursor.com/agents/bc-44527ea8-41c8-4d01-a70e-d3626ee1c8a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashframe_imported_data_table.webp)
[Rendered bar chart of revenue data](https://cursor.com/agents/bc-44527ea8-41c8-4d01-a70e-d3626ee1c8a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashframe_rendered_chart.webp)

## Verification

- ✅ `bunx turbo lint --filter='!@wystack/*'` (all DashFrame packages pass; warnings only)
- ✅ `bunx turbo test --filter='!@wystack/*'` (34 tasks, 401+ tests pass)
- ✅ `bunx turbo build --filter='!@wystack/*'` (20 tasks pass)
- ✅ Ran `apps/server` (`--port 4000`) + `apps/web` (`VITE_WYSTACK_URL=http://127.0.0.1:4000 bun run dev:direct`), then imported a CSV and rendered a chart end-to-end (see video).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44527ea8-41c8-4d01-a70e-d3626ee1c8a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44527ea8-41c8-4d01-a70e-d3626ee1c8a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `AGENTS.md` to document DashFrame's development environment for Cursor Cloud agents, covering the Bun 1.3.5 package manager, the required web+server two-process startup, the Electron desktop display caveat, the pre-commit worktree-guard bypass, and the `bun check` / per-task turbo filter commands.

- The startup commands (`bun run src/index.ts --host 127.0.0.1 --port 4000`, `dev:direct`, `PORT` env var) are verified accurate against `apps/server/src/index.ts` and `apps/web/vite.config.ts`.
- The `bun check` description (ticket-ref gate + `turbo check --filter=!@wystack/*`) matches `package.json`; the note that per-task `bunx turbo …` skips the ticket-ref gate is correctly called out.
- One gap: `CLAUDE.md` requires every PR to follow `.github/pull_request_template.md` and marks screenshots as merge-blocking for UI-touching PRs — this isn't mentioned in `AGENTS.md`, so agents that create PRs may produce non-conforming descriptions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a documentation-only addition with no source code changes.

All startup commands, env vars, port defaults, and gate commands in AGENTS.md are verified accurate against the actual source files. The only gap is missing PR-template guidance, which affects agents that later create PRs but does not affect the repository or its builds in any way.

No files require special attention; AGENTS.md is the sole changed file and contains only documentation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | New documentation file for Cursor Cloud agents; startup commands, env vars, and lint/test gates are accurate against the codebase. Missing: PR template and screenshot requirements from CLAUDE.md. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify bun check gate and documen..."](https://github.com/youhaowei/dashframe/commit/2f8fb80219c62f410e45d51b44a916abf15db768) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43045055)</sub>

<!-- /greptile_comment -->