### PR TITLE
docs: make the local review gate precise (AGENTS.md) + reference from CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,64 @@
 # AGENTS.md
 
-## Cursor Cloud specific instructions
-
 DashFrame is a local-first BI tool (import data → DuckDB → charts). It ships as
 two surfaces of the same UI (`packages/app`): an Electron **desktop** app and a
 browser **web** app, both backed by the same Hono HTTP+WS server code.
 
 Package manager is **Bun** (pinned `bun@1.3.5`); orchestration is Turborepo.
-`bun` is on `PATH` via `/usr/local/bin/bun`. Dependency refresh (submodules +
-install + build of the vendored `@wystack/*` packages) is handled by the startup
-update script; see root `package.json` `setup` for the equivalent steps.
+`bun` is on `PATH` (`/usr/local/bin/bun` in the cloud VM, Homebrew locally).
+
+## Local review gate (run before every push)
+
+Every change is reviewed **locally before it is pushed** — CI _confirms_ a clean
+result, it does not _discover_ problems. Before you push a branch, and again
+before you mark any PR ready for review, run all three checks below against the
+branch diff (`git diff origin/main...HEAD`) and resolve what they surface. A red
+result or an unresolved finding is a **push-blocker** — do not defer it to CI or
+to a human reviewer.
+
+1. **Code review.** Review the full branch diff for correctness, security, and
+   fit with the surrounding code. In Claude Code run `/code-review`; otherwise
+   dispatch a reviewer over `git diff origin/main...HEAD`. Fix every blocker and
+   consciously dismiss lower findings — never push past an open blocker.
+   (`/code-review ultra` is the heavier multi-agent cloud pass, user-triggered
+   only; it does not replace this local pass.)
+
+2. **QA — behavioral.** Boot the app and exercise the _changed surface_ against
+   what it is supposed to do; do not infer behavior from the diff alone.
+   - Desktop: `bun run dev` (needs a display).
+   - Web + server, headless: see **Running for browser/headless testing** below.
+   - UI changes additionally require visual proof from the running app in the PR
+     (relevant states, light + dark) — see `CLAUDE.md` → **Pull requests**.
+
+3. **Clawpatch.** Run `bun run clawpatch:review:branch -- <branch-or-sha>`. It
+   maps the repo and reviews the branch diff (`--since origin/main`) in an
+   isolated worktree with shared Clawpatch state. Work the results before
+   pushing with `scripts/clawpatch.sh next` / `triage` / `fix` (or
+   `bun run clawpatch` for the raw CLI). Land or explicitly triage every
+   finding — an untriaged Clawpatch finding blocks the push.
+
+Docs-only changes (no code) may skip QA and Clawpatch, but still review the diff.
+
+## Lint / test / build
+
+Use the project's own gate `bun check`, which runs the ticket-ref check
+(`scripts/check-no-ticket-refs.mjs`) and then `turbo check --filter=!@wystack/*`
+(lint + typecheck + test, excluding the vendored submodule packages). The
+`@wystack/*` packages lint with `oxlint`, which is not installed, so a raw
+`bun run lint` / `turbo lint` fails on `@wystack/ui`; the project deliberately
+filters them out. The per-task commands below skip the ticket-ref gate — run
+`bun check` (or `bun run check:ticket-refs`) if you touched code that might carry
+ticket references.
+
+- Lint: `bunx turbo lint --filter='!@wystack/*'`
+- Test: `bunx turbo test --filter='!@wystack/*'`
+- Build: `bunx turbo build --filter='!@wystack/*'`
+
+## Cursor Cloud specific instructions
+
+Dependency refresh (submodules + install + build of the vendored `@wystack/*`
+packages) is handled by the startup update script; see root `package.json`
+`setup` for the equivalent steps.
 
 ### Running for browser/headless testing (recommended in the cloud VM)
 
@@ -40,18 +89,3 @@ agent works on its branch directly in the single main checkout, so that guard
 would block every commit. Commit with the documented bypass:
 `ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit ...`. The hook still runs `lint-staged`
 (prettier) on staged files.
-
-### Lint / test / build
-
-Use the project's own gate `bun check`, which runs the ticket-ref check
-(`scripts/check-no-ticket-refs.mjs`) and then `turbo check --filter=!@wystack/*`
-(lint + typecheck + test, excluding the vendored submodule packages). The
-`@wystack/*` packages lint with `oxlint`, which is not installed, so a raw
-`bun run lint` / `turbo lint` fails on `@wystack/ui`; the project deliberately
-filters them out. The per-task commands below skip the ticket-ref gate — run
-`bun check` (or `bun run check:ticket-refs`) if you touched code that might carry
-ticket references.
-
-- Lint: `bunx turbo lint --filter='!@wystack/*'`
-- Test: `bunx turbo test --filter='!@wystack/*'`
-- Build: `bunx turbo build --filter='!@wystack/*'`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,42 @@ ticket references.
 - Test: `bunx turbo test --filter='!@wystack/*'`
 - Build: `bunx turbo build --filter='!@wystack/*'`
 
+## Git submodules (`libs/wystack`, `libs/stdui`)
+
+Two vendored dependencies are **git submodules**, each with its own GitHub repo:
+
+- `libs/wystack` → `youhaowei/wystack` — the RPC/data substrate (`@wystack/*`).
+- `libs/stdui` → `youhaowei/stdui` — the `@wystack/ui-*` design system.
+
+The `@dashframe/*` packages consume their **built** output, so `bun run setup`
+(and CI) init the submodules and run `bun run build:wystack` before anything
+else. If imports from `@wystack/*` fail to resolve, the submodule is
+uninitialized or unbuilt — run `git submodule update --init --recursive && bun run build:wystack`.
+
+**Changing submodule code is a two-repo change — never edit in place and commit
+only the pin.** The parent repo records a submodule as a pinned commit SHA; a
+bare pin bump merges even when the submodule code it points at was never
+reviewed. The workflow:
+
+1. **Land the submodule change first, in its own repo.** Open and merge a PR in
+   `youhaowei/wystack` (or `youhaowei/stdui`) against that repo's default branch.
+   Run its own gate there — the parent's `bun check` filters `@wystack/*` out
+   (`--filter=!@wystack/*`), so it does **not** cover submodule code.
+2. **Then bump the pin in DashFrame.** In the submodule dir, check out the merged
+   commit; from the repo root, `git add libs/wystack` (or `libs/stdui`) and commit
+   the new SHA. Rebuild: `bun run build:wystack`, then run the full `bun check` so
+   the parent is verified against the new substrate — a pin that merges is not the
+   same as a submodule that is compatible.
+3. **Re-point after the submodule merges.** If the submodule PR merged with a
+   squash/rebase, the pin must point at the merged commit on the default branch,
+   not the pre-merge feature SHA.
+
+**Worktree isolation applies to submodules too.** Parallel agents that both touch
+`libs/wystack` need their **own** wystack worktree each — two agents sharing one
+submodule checkout revert each other exactly like the parent repo (`CLAUDE.md` →
+worktree isolation). Trust the submodule PR's own remote state as the source of
+truth for what has landed.
+
 ## Cursor Cloud specific instructions
 
 Dependency refresh (submodules + install + build of the vendored `@wystack/*`
@@ -62,9 +98,9 @@ packages) is handled by the startup update script; see root `package.json`
 
 ### Running for browser/headless testing (recommended in the cloud VM)
 
-The web app is **not** purely client-side despite the stale `README.md`. It
-needs the backend API, or data import fails with `404` on `/api/*` and a failed
-`/api/ws` WebSocket. Run two processes:
+The web app is **not** purely client-side — it needs the backend API, or data
+import fails with `404` on `/api/*` and a failed `/api/ws` WebSocket. Run two
+processes:
 
 1. API server (fixed loopback port; loopback needs no token):
    `cd apps/server && bun run src/index.ts --host 127.0.0.1 --port 4000`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # DashFrame
 
+## Operations — see [AGENTS.md](AGENTS.md)
+
+[AGENTS.md](AGENTS.md) is the operational companion to this file: how to run the app (desktop and headless web+server), the lint/test/build commands, and the **local review gate**. That gate — code review + behavioral QA + Clawpatch, run on the branch diff (`git diff origin/main...HEAD`) — is **mandatory before every push and before marking any PR ready**. CI only _confirms_ it; it does not replace it. Read AGENTS.md before pushing.
+
 ## Design Context
 
 Visual design system: see [DESIGN.md](DESIGN.md). Load it before any UI work.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DashFrame is a local-first business intelligence tool focused on the data → ch
 
 ## Project Layout
 
-```
+```text
 apps/
   desktop/          # Electron shell (main process + packaging)
   renderer/         # Electron renderer entry
@@ -75,8 +75,8 @@ depends on.
 
 Each package is a TypeScript-first workspace member that exposes its source through
 `src/`. Turbo treats `build` / `lint` / `typecheck` / `test` as common tasks
-(`bun build`, `bun lint`, `bun typecheck`, `bun test`). See **Project Layout** above
-for what each package owns.
+(`bun run build`, `bun run lint`, `bun run typecheck`, `bun run test`). See
+**Project Layout** above for what each package owns.
 
 ## Using Notion Integration
 

--- a/README.md
+++ b/README.md
@@ -2,102 +2,81 @@
 
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/youhaowei/DashFrame)](https://coderabbit.ai)
 
-DashFrame is a business intelligence playground focused on the DataFrame → chart journey. This MVP supports importing data from CSV files and Notion databases, and provides a builder shell to iterate on visuals. Architecture and design docs are maintained separately (not in this repo).
+DashFrame is a local-first business intelligence tool focused on the data → chart journey: import data, query it with DuckDB, and build visualizations. It ships as **two surfaces of the same UI** (`packages/app`) — an Electron **desktop** app and a browser **web** app — both backed by the same Hono HTTP+WS server. Architecture and design docs are maintained separately (not in this repo).
 
 ## Stack
 
-- **Next.js 16** (App Router) + React 19
-- **Bun** for package management and runtime
-- **Dexie (IndexedDB)** for client-side data persistence
-- **DuckDB-WASM** for in-browser data processing
-- **Tailwind CSS v4** (via PostCSS) — shadcn components
-- **Turborepo** for workspace orchestration
-- **Vega-Lite** for declarative chart rendering
-- **Papaparse** for CSV ingest, **@notionhq/client** for Notion
+- **Electron** desktop app + **Vite/React 19** web app — one shared UI (`packages/app`)
+- **Hono** HTTP+WS server (`apps/server`, `packages/server-core`) — the web app is _not_ purely client-side; it talks to this backend
+- **DuckDB** for query — native (`@duckdb/node-api`) on desktop, **DuckDB-WASM** in the browser
+- **WyStack** (`libs/wystack`) — the RPC/data substrate; **stdui** (`libs/stdui`) — the `@wystack/ui-*` design system (both git submodules)
+- **Bun** for package management and runtime, **Turborepo** for workspace orchestration
+- **Tailwind CSS v4**, **Vega-Lite** for declarative chart rendering
+- Connectors for CSV, Notion, Postgres, and REST sources
 
 ## Project Layout
 
 ```
 apps/
-  web/              # Next.js app (App Router)
+  desktop/          # Electron shell (main process + packaging)
+  renderer/         # Electron renderer entry
+  web/              # Vite web app
+  server/           # Standalone Hono server (`dashframe serve`)
 packages/
+  app/              # The shared React UI (desktop + web render the same code)
   types/            # Pure type contracts
-  core/             # Backend selector
-  core-dexie/       # Dexie/IndexedDB backend
-  engine/           # Abstract engine interfaces
+  core/             # Client data layer / hooks
+  engine/           # Abstract engine interfaces (TS-only)
   engine-browser/   # DuckDB-WASM implementation
-  connector-csv/    # CSV file connector
+  engine-server/    # Native DuckDB implementation
+  server-core/      # Server runtime shared by apps/server and the Electron main
+  connector-local/  # Local file (CSV/JSON) connector
   connector-notion/ # Notion API connector
+  connector-postgres/ # Postgres connector
+  connector-rest/   # REST connector
   visualization/    # Chart rendering system
-  ui/               # Shared UI primitives/components
+  ui/               # App-local UI primitives
+libs/
+  wystack/          # RPC/data substrate (submodule)
+  stdui/            # @wystack/ui-* design system (submodule)
 ```
 
 ## Naming Conventions
 
 - Use `DashFrame` for user-facing copy, branding, React components, and TypeScript types.
-- Use `dashframe` for package names, config identifiers, workspace scopes (e.g. `@dashframe/dataframe`), directories, and persisted storage keys.
+- Use `dashframe` for package names, config identifiers, workspace scopes (e.g. `@dashframe/core`), directories, and persisted storage keys.
 - Keep new packages under the `@dashframe/*` scope so tooling and imports remain consistent.
 
 ### Quick start
 
 ```bash
-bun run setup
-bun dev
-bun check
-bun run test
-bun dev:desktop
+bun run setup     # init submodules, install deps, build the vendored @wystack/* packages
+bun dev           # launch the Electron desktop app (embeds the server; renderer on Vite)
+bun check         # lint + typecheck + tests (the project gate)
+bun run test      # run all tests
 ```
+
+`bun run setup` is required on a fresh clone — it initializes the `libs/wystack`
+and `libs/stdui` git submodules and builds the `@wystack/*` packages the app
+depends on.
+
+### Running the app
+
+- **Desktop (default):** `bun dev` runs `@dashframe/desktop` — the Electron shell with
+  the server embedded in-process and native DuckDB.
+- **Web + server:** the web app needs the backend API running, or data import fails
+  with `404` on `/api/*`. Start the server on a fixed port
+  (`cd apps/server && bun run src/index.ts --host 127.0.0.1 --port 4000`) and point
+  the web app at it
+  (`cd apps/web && VITE_WYSTACK_URL=http://127.0.0.1:4000 bun run dev:direct`).
+  See [`AGENTS.md`](AGENTS.md) for the full headless recipe.
 
 ### Packages
 
-Each package is a TypeScript-first workspace member that exposes its source through `src/` and ships declarations from `dist/`. Every package follows the same `package.json` script contract:
-
-- `build`: `tsc`
-- `dev`: `tsc --watch`
-- `lint`: `eslint src`
-- `typecheck`: `tsc --noEmit`
-
-Turbo treats these as common tasks (`bun build`, `bun lint`, `bun typecheck`, `bun dev`). When you run `bun dev`, it launches `next dev` for the app and puts all library packages into TypeScript watch mode so changes flow through immediately.
-
-Package responsibilities:
-
-- `@dashframe/dataframe`: DataFrame is a snapshot of the data in columns and rows, inspired by pandas, representing a table of data at a point in time. This package defines the DataFrame type and the functions to manipulate it.
-- `@dashframe/csv`: This package is for handling CSV files and converting them to a DataFrame.
-- `@dashframe/notion`: This package integrates with Notion databases via the official Notion API client, fetching database schemas and data, and converting them to a DataFrame.
-- `@dashframe/ui`: This package is for shared UI primitives and components.
-
-## Getting Started
-
-1. Install dependencies (requires Bun 1.x):
-
-   ```bash
-   bun install
-   ```
-
-2. Start the workspace in development mode:
-
-   ```bash
-   bun dev
-   ```
-
-   This single command starts:
-   - **Next.js web app** at `http://localhost:3000`
-   - TypeScript watch mode for all packages
-   - Hot-reload with instant feedback
-
-   Need a single package? Target explicitly: `bun dev --filter @dashframe/web`
-
-3. Optional scripts:
-   ```bash
-   bun dev           # turbo dev (runs all dev targets)
-   bun build         # turbo build
-   bun format        # prettier --check with shared config
-   bun format:write  # prettier --write with shared config
-   bun check         # lint + typecheck + prettier check
-   bun lint          # workspace linting (eslint 9)
-   bun typecheck     # TypeScript checks for all packages
-   bun test          # run all tests
-   ```
+Each package is a TypeScript-first workspace member that exposes its source through
+`src/`. Turbo treats `build` / `lint` / `typecheck` / `test` as common tasks
+(`bun build`, `bun lint`, `bun typecheck`, `bun test`). See **Project Layout** above
+for what each package owns.
 
 ## Using Notion Integration
 
@@ -127,20 +106,18 @@ DashFrame supports importing data directly from Notion databases:
 
 ## Current Status
 
-- ✅ **Client-side persistence** with Dexie (IndexedDB)
-- ✅ **In-browser query engine** with DuckDB-WASM
-- ✅ **Route-based architecture** - `/data-sources`, `/insights`, `/visualizations` pages
-- ✅ CSV upload → DataFrame → Vega-Lite charts
-- ✅ Notion database integration with property selection
-- ✅ Pluggable backend architecture for custom implementations
-- ✅ Real-time reactive updates with useLiveQuery
+- ✅ **Electron desktop app** with native DuckDB and an in-process server
+- ✅ **Web app** backed by the same Hono server (shared `packages/app` UI)
+- ✅ **Query engine** over DuckDB — native on desktop, WASM in the browser
+- ✅ Route-based shell — `/data-sources`, `/insights`, `/visualizations`, `/dashboards`
+- ✅ Data → Vega-Lite charts
+- ✅ Connectors for CSV/JSON, Notion, Postgres, and REST sources
 
 ## Roadmap
 
-- Add richer chart customization (mark type, color palettes, formatting)
-- Implement cross-source joins (CSV + Notion)
-- Add automated tests (unit, Playwright)
-- OAuth authentication (currently using anonymous auth)
+- Richer chart customization (mark type, color palettes, formatting)
+- Cross-source joins
+- Named, revocable API access credentials for external clients
 
 ## Contributing
 


### PR DESCRIPTION
## What

Codifies the mandatory **local review gate** so an agent can't skip it for lack of a precise instruction (it was skipped this session for exactly that reason).

- **AGENTS.md**: new top-level **"Local review gate (run before every push)"** section with exact commands for all three checks — code review (`/code-review` or a reviewer over `git diff origin/main...HEAD`), behavioral QA (boot + exercise the changed surface), and Clawpatch (`bun run clawpatch:review:branch -- <branch>`). Restructured so the gate and lint/test/build are general sections above the Cursor-Cloud-specific running/committing notes. Docs-only changes are explicitly exempted from QA/Clawpatch.
- **CLAUDE.md**: new "Operations — see AGENTS.md" pointer at the top tying the gate to "before every push and before marking any PR ready," and noting CI only *confirms* it.

## Why

The gate (code review + QA + Clawpatch, resolved before push — CI confirms, doesn't discover) existed as practice but wasn't written down precisely or referenced from CLAUDE.md, so it was easy to skip.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the repository operating docs. The main changes are:

- Adds a local review gate to `AGENTS.md`.
- Moves lint, test, build, and submodule guidance into shared agent instructions.
- Adds a `CLAUDE.md` pointer to the operational guide.
- Updates `README.md` to describe the current app architecture and setup flow.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Documents the local review gate, project checks, submodule workflow, and headless run commands. |
| CLAUDE.md | Adds a top-level pointer to the operational guidance in `AGENTS.md`. |
| README.md | Refreshes setup, architecture, running, package, status, and roadmap documentation. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: address review nits on README (fen..."](https://github.com/youhaowei/dashframe/commit/148f7e27f3686950c03ab040849e2b580493f281) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45762310)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/lumony/github/youhaowei/dashframe/-/custom-context?memory=7ea875b1-438c-48c5-b53d-9017ef842cd8))
- Context used - AGENTS.md ([source](https://app.greptile.com/lumony/github/youhaowei/dashframe/-/custom-context?memory=63aaec3b-e5bf-4f96-973c-1a31658d5fcb))

<!-- /greptile_comment -->