### PR TITLE
fix(server): validate insight definition writes at every boundary

### DIFF
--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -1028,4 +1028,34 @@ describe("insight writes preserve `source` (Insight-on-Insight composition)", ()
       expect.objectContaining({ id }),
     ]);
   });
+
+  it("should reject a non-array in createInsight options instead of minting an undecodable row", async () => {
+    // `options` arrives as opaque `jsonb`; `encodeInsightDefinition` does not
+    // validate, and `{}` is not nullish so `?? []` does not catch it. An
+    // unvalidated INSERT is worse than an unvalidated update: it mints a row
+    // that can never be decoded, and because `listInsights` decodes every row,
+    // one such row takes out the whole list — including insights the caller
+    // never touched. `updateInsight`/`patchInsight` already parse; so must this.
+    const baseTableId = crypto.randomUUID();
+    const { id: healthyId } = (await call("createInsight", {
+      name: "Healthy sibling",
+      baseTableId,
+    })) as { id: string };
+
+    await expect(
+      call("createInsight", {
+        name: "Poison",
+        baseTableId,
+        options: { selectedFields: {} },
+      }),
+    ).rejects.toThrow();
+
+    // Nothing was minted, and the sibling is still listable.
+    const rows = await db.select().from(schema.insights);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(healthyId);
+    await expect(call("listInsights", {})).resolves.toEqual([
+      expect.objectContaining({ id: healthyId }),
+    ]);
+  });
 });

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -265,12 +265,19 @@ describe("createInsight — atomic auto-draft dedup", () => {
       options: { selectedFields: [], reuseUnmodifiedDraft: true },
     })) as { id: string };
 
+    // `call` is untyped, so pin that an id came back at all before comparing:
+    // if the handler stopped returning one, both sides would be `undefined`
+    // and the equality below would pass vacuously.
+    expect(typeof first.id).toBe("string");
+
     // Both calls must return the same id — the second reuses the first draft.
     expect(second.id).toBe(first.id);
 
-    // Exactly one row in the DB — no duplicate draft created.
+    // Exactly one row in the DB — no duplicate draft created — and the
+    // returned id is that row's, not some value the handler invented.
     const rows = await allInsights();
     expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(first.id);
   });
 
   it("should produce exactly one unmodified draft when two reuse calls fire without awaiting the first (TOCTOU simulation)", async () => {
@@ -294,12 +301,18 @@ describe("createInsight — atomic auto-draft dedup", () => {
       }),
     ])) as [{ id: string }, { id: string }];
 
+    // Pin that an id came back before comparing — two `undefined`s are equal,
+    // so the assertion below is vacuous without this.
+    expect(typeof r1.id).toBe("string");
+
     // Both calls must resolve to the same id.
     expect(r1.id).toBe(r2.id);
 
-    // Exactly one insight row — no duplicate draft.
+    // Exactly one insight row — no duplicate draft — and it is the row both
+    // calls returned.
     const rows = await allInsights();
     expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(r1.id);
   });
 
   it("should still create a draft when an unrelated insight row is corrupt", async () => {

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -1048,7 +1048,10 @@ describe("insight writes preserve `source` (Insight-on-Insight composition)", ()
         baseTableId,
         options: { selectedFields: {} },
       }),
-    ).rejects.toThrow();
+      // Pin the reason, not just the fact of a rejection: a bare `toThrow()`
+      // stays green if the call starts failing for an unrelated cause (input
+      // coercion, transaction error) while the definition guard is gone.
+    ).rejects.toThrow(/selectedFields/);
 
     // Nothing was minted, and the sibling is still listable.
     const rows = await db.select().from(schema.insights);
@@ -1057,5 +1060,33 @@ describe("insight writes preserve `source` (Insight-on-Insight composition)", ()
     await expect(call("listInsights", {})).resolves.toEqual([
       expect.objectContaining({ id: healthyId }),
     ]);
+  });
+
+  it("should reject a non-array even when the reuse branch would short-circuit the insert", async () => {
+    // The guard has to sit above EVERY exit from the handler, not just above
+    // the insert. `isUnmodifiedDraft` reads `.length` off each array, so a
+    // non-array `selectedFields: {}` gives `undefined ?? 0 === 0` and reads as
+    // "unmodified" — with an existing draft to reuse, the handler returns that
+    // draft's id and never reaches the insert. The malformed request would
+    // report success, and the fields the caller asked for would vanish.
+    const baseTableId = crypto.randomUUID();
+    const { id: draftId } = (await call("createInsight", {
+      name: "Auto draft",
+      baseTableId,
+      options: { reuseUnmodifiedDraft: true },
+    })) as { id: string };
+
+    await expect(
+      call("createInsight", {
+        name: "Poison",
+        baseTableId,
+        options: { reuseUnmodifiedDraft: true, selectedFields: {} },
+      }),
+    ).rejects.toThrow(/selectedFields/);
+
+    // The reusable draft is untouched and still the only row.
+    const rows = await db.select().from(schema.insights);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(draftId);
   });
 });

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -953,11 +953,20 @@ const createInsight = wy.procedure
 
         const [row] = (await tx.into(insights).insert({
           name,
-          definition: encodeInsightDefinition({
-            baseTableId,
-            selectedFields: opts.selectedFields,
-            metrics: opts.metrics,
-          }),
+          // `options` arrives as opaque `jsonb` and is cast, not checked, so
+          // `encodeInsightDefinition` will pass a non-array `selectedFields`
+          // straight through (`{}` is not nullish, so `?? []` does not catch
+          // it). Parse before inserting, exactly as `updateInsight` and
+          // `patchInsight` below do — an unvalidated INSERT is worse than an
+          // unvalidated update, because it mints a permanently undecodable row
+          // that fails the fail-closed read path for every later reader.
+          definition: storedInsightDefinitionSchema.parse(
+            encodeInsightDefinition({
+              baseTableId,
+              selectedFields: opts.selectedFields,
+              metrics: opts.metrics,
+            }),
+          ),
           createdBy: { kind: "user" },
         })) as InsightRow[];
         if (!row) throw new Error("insert returned no row");

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -893,18 +893,37 @@ const createInsight = wy.procedure
       };
 
       return ctx.db.transaction(async (tx) => {
-        // Reuse is opt-in and only applies when the incoming insight is itself an
-        // unmodified draft. A pre-populated insight (fields/metrics) or any
-        // non-auto-draft caller always inserts a fresh row. Extract the draft
-        // shape explicitly so the predicate reads only the fields it should —
-        // the wider `opts` bag carries the reuse flag itself, which is not part
-        // of the draft definition.
-        const shouldReuse =
-          opts.reuseUnmodifiedDraft === true &&
-          isUnmodifiedDraft({
+        // Validate BEFORE the reuse check, not merely before the insert. The
+        // guard has to sit above EVERY exit from this handler, because
+        // `isUnmodifiedDraft` reads `.length` off each array: a non-array like
+        // `selectedFields: {}` yields `undefined ?? 0 === 0` and reads as
+        // "unmodified", so a malformed request would take the reuse branch and
+        // return an existing draft's id — reporting success for input we refuse
+        // to store, and silently dropping what the caller meant to select.
+        // Parsing first makes the guard order-independent.
+        //
+        // Parsing also replaces the old hand-built draft-shape literal: the
+        // schema strips unknown keys, so `reuseUnmodifiedDraft` is already gone
+        // from `definition` and the predicate reads only definition fields.
+        const definition = storedInsightDefinitionSchema.parse(
+          // `options` arrives as opaque `jsonb` and is cast, not checked, so
+          // `encodeInsightDefinition` will pass a non-array `selectedFields`
+          // straight through (`{}` is not nullish, so `?? []` does not catch
+          // it). An unvalidated INSERT is worse than an unvalidated update: it
+          // mints a permanently undecodable row that fails the fail-closed read
+          // path for every later reader, not just this one.
+          encodeInsightDefinition({
+            baseTableId,
             selectedFields: opts.selectedFields,
             metrics: opts.metrics,
-          });
+          }),
+        );
+
+        // Reuse is opt-in and only applies when the incoming insight is itself an
+        // unmodified draft. A pre-populated insight (fields/metrics) or any
+        // non-auto-draft caller always inserts a fresh row.
+        const shouldReuse =
+          opts.reuseUnmodifiedDraft === true && isUnmodifiedDraft(definition);
 
         if (shouldReuse) {
           // Atomic check-and-create: scan-and-decide runs inside the transaction
@@ -953,20 +972,7 @@ const createInsight = wy.procedure
 
         const [row] = (await tx.into(insights).insert({
           name,
-          // `options` arrives as opaque `jsonb` and is cast, not checked, so
-          // `encodeInsightDefinition` will pass a non-array `selectedFields`
-          // straight through (`{}` is not nullish, so `?? []` does not catch
-          // it). Parse before inserting, exactly as `updateInsight` and
-          // `patchInsight` below do — an unvalidated INSERT is worse than an
-          // unvalidated update, because it mints a permanently undecodable row
-          // that fails the fail-closed read path for every later reader.
-          definition: storedInsightDefinitionSchema.parse(
-            encodeInsightDefinition({
-              baseTableId,
-              selectedFields: opts.selectedFields,
-              metrics: opts.metrics,
-            }),
-          ),
+          definition,
           createdBy: { kind: "user" },
         })) as InsightRow[];
         if (!row) throw new Error("insert returned no row");

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -9,7 +9,8 @@
  * rollback, and preview persisting nothing.
  *
  * Covers: Insight (incl. Insight-on-Insight composition and cycle rejection),
- * SelectFields, SetInsightFilter/Sort, AddJoin/UpdateJoin/RemoveJoin,
+ * SelectFields, SetInsightFilter/Sort, write-boundary validation of the
+ * definition blob, AddJoin/UpdateJoin/RemoveJoin,
  * Visualization (CreateVisualization, SetChartType, SetChartEncoding), Dashboard
  * (CreateDashboard, AddDashboardItem, UpdateDashboardItem, SetDashboardLayout,
  * RemoveDashboardItem), DeleteNode, extended RenameNode, and AddField/UpdateField
@@ -1272,7 +1273,13 @@ describe("command vocabulary", () => {
     async function storedDefinition(insightId: string): Promise<string> {
       const rows = await insightsById(insightId);
       expect(rows).toHaveLength(1);
-      return JSON.stringify(rows[0]?.definition);
+      const json = JSON.stringify(rows[0]?.definition);
+      // Anti-vacuity guard, in the helper so every caller inherits it: if the
+      // fixture ever stopped persisting a definition, `json` would be the
+      // string "undefined" and every byte-identity comparison built on it
+      // would pass without proving anything.
+      expect(json).toContain("baseTableId");
+      return json;
     }
 
     it.each([
@@ -1283,16 +1290,40 @@ describe("command vocabulary", () => {
       "%s should reject a non-array operand and leave the stored definition byte-identical",
       async (command, field) => {
         const insightId = await makeInsight();
+        // Populate BOTH operand fields first, so byte-identity proves an
+        // existing good array was not clobbered — not merely that nothing was
+        // added. Clobber-on-reject is the likelier regression.
+        await commit(
+          cmd("SetInsightFilter", {
+            id: insightId,
+            filters: [
+              {
+                field: "region",
+                operator: "eq",
+                value: { kind: "value", v: "EMEA" },
+              },
+            ],
+          }),
+          cmd("SetInsightSort", {
+            id: insightId,
+            sorts: [{ field: "amount", direction: "desc" }],
+          }),
+        );
         const before = await storedDefinition(insightId);
-        // Guard against a vacuous comparison: if the fixture ever stopped
-        // persisting a definition, `before` would be "undefined" and every
-        // byte-identity assertion below would pass without proving anything.
-        expect(before).toContain("baseTableId");
+        expect(before).toContain(
+          field === "fieldIds" ? "selectedFields" : field,
+        );
 
         for (const operand of NON_ARRAY_OPERANDS) {
           await expect(
             commit(rawCmd(command, { id: insightId, [field]: operand })),
-          ).rejects.toThrow(/definition is invalid/);
+          ).rejects.toThrow(
+            // Pin WHICH handler rejected. A copy-pasted wrong command name in
+            // `requireDefinitionShape(...)` still type-checks and would pass an
+            // unscoped /definition is invalid/ — exactly the defect a repeated
+            // fan-out manufactures.
+            new RegExp(`${command}: definition is invalid`),
+          );
           // Nothing was written — not a partial write, not a normalized one.
           expect(await storedDefinition(insightId)).toBe(before);
         }
@@ -1314,7 +1345,7 @@ describe("command vocabulary", () => {
                 [field]: operand,
               }),
             ),
-          ).rejects.toThrow(/definition is invalid/);
+          ).rejects.toThrow(/CreateInsight: definition is invalid/);
           expect(await insightsById(insightId)).toHaveLength(0);
         }
       },
@@ -1329,7 +1360,7 @@ describe("command vocabulary", () => {
 
       await expect(
         commit(rawCmd("SelectFields", { id: insightId, fieldIds: [id(), 42] })),
-      ).rejects.toThrow(/definition is invalid/);
+      ).rejects.toThrow(/SelectFields: definition is invalid/);
       expect(await storedDefinition(insightId)).toBe(before);
     });
 
@@ -1356,7 +1387,7 @@ describe("command vocabulary", () => {
 
       await expect(
         commit(rawCmd("SetInsightSort", { id: targetId, sorts: {} })),
-      ).rejects.toThrow(/definition is invalid/);
+      ).rejects.toThrow(/SetInsightSort: definition is invalid/);
 
       const listed = (await app.call("listInsights", {})).result as {
         id: string;
@@ -1364,6 +1395,41 @@ describe("command vocabulary", () => {
       }[];
       expect(listed).toHaveLength(2);
       expect(listed.map((i) => i.name).sort()).toEqual(["Sibling", "Target"]);
+    });
+
+    it("should fail the whole listInsights query if a bad operand ever does land (why the guard exists)", async () => {
+      // Characterization of the harm the guard prevents. Without this, the test
+      // above only pins the ABSENCE of blast radius and the rationale above
+      // `requireDefinitionShape` is unattested — if someone later made
+      // `listInsights` lenient, nothing here would notice that the whole
+      // argument for write-side validation had quietly evaporated.
+      const { tableId } = await makeTable();
+      const targetId = id();
+      const siblingId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: targetId,
+          name: "Target",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateInsight", {
+          id: siblingId,
+          name: "Sibling",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+
+      // Corrupt the blob directly, bypassing every write guard — this is the
+      // state the guards make unreachable, not a state a command can produce.
+      await db
+        .update(insights)
+        .set({ definition: { baseTableId: tableId, sorts: {} } })
+        .where(eq(insights.id, targetId));
+
+      // One bad row takes out the entire query, including the untouched sibling.
+      await expect(app.call("listInsights", {})).rejects.toThrow(
+        /has an invalid definition/,
+      );
     });
 
     it("should round-trip valid operands unchanged, including empty arrays", async () => {

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -23,7 +23,7 @@ import {
   SecretVault,
   TestBackend,
 } from "@wystack/secret-vault";
-import type { WyStackApp } from "@wystack/server";
+import type { Command, WyStackApp } from "@wystack/server";
 import { eq } from "drizzle-orm";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -32,7 +32,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { functions } from "../functions";
 import { wy } from "../wystack";
-import { cmd, storedInsightDefinitionSchema } from "./commands";
+import {
+  cmd,
+  COMMAND_PATHS,
+  type CommandName,
+  storedInsightDefinitionSchema,
+} from "./commands";
 
 /** Compose a SecretVault backed by TestBackend. ONLY for test setup. */
 function makeTestVault(): SecretVault {
@@ -1213,6 +1218,191 @@ describe("command vocabulary", () => {
       const rows = await insightsById(insightId);
       const def = rows[0]?.definition as { sorts: typeof sorts };
       expect(def.sorts).toEqual(sorts);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Write-boundary validation of the insight `definition` JSONB
+  // -------------------------------------------------------------------------
+  //
+  // Four commands assemble a stored definition out of opaque `jsonb` operands.
+  // Annotating the assembled object as `StoredInsightDefinition` is a
+  // compile-time assertion only, so before these handlers parsed at the write
+  // seam a non-array operand persisted successfully — and then failed the
+  // fail-closed read path on every later decode of that row. Because
+  // `listInsights` decodes EVERY row, one bad operand took out the whole list,
+  // not just the insight that was edited, while the write itself reported
+  // success. These tests pin all three properties: the reject, the untouched
+  // blob, and the blast radius.
+  describe("insight definition write validation", () => {
+    /**
+     * Build a command straight from the registry path with UNTYPED args. `cmd()`
+     * is typed per command, so a malformed operand cannot be expressed through
+     * it — which is exactly the point: the typed face is not the boundary, the
+     * wire is. This models a client posting bad JSON, and reads the path out of
+     * `COMMAND_PATHS` so it cannot drift from `cmd()`.
+     */
+    function rawCmd(name: CommandName, args: Record<string, unknown>): Command {
+      return { path: COMMAND_PATHS[name], args };
+    }
+
+    /** Operands that are not arrays. Each must be refused by all four writers. */
+    const NON_ARRAY_OPERANDS = [{}, "nope", 7, true, { length: 1 }];
+
+    async function makeInsight(): Promise<string> {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+          selectedFields: [id()],
+        }),
+      );
+      return insightId;
+    }
+
+    /**
+     * The RAW stored JSONB, serialized. Deliberately not a decoded `Insight`:
+     * decoding applies the schema's `null → []` / `null → undefined`
+     * transforms, so two decoded values compare equal even when the underlying
+     * blob changed shape. Byte-identity is the actual claim.
+     */
+    async function storedDefinition(insightId: string): Promise<string> {
+      const rows = await insightsById(insightId);
+      expect(rows).toHaveLength(1);
+      return JSON.stringify(rows[0]?.definition);
+    }
+
+    it.each([
+      ["SelectFields", "fieldIds"],
+      ["SetInsightFilter", "filters"],
+      ["SetInsightSort", "sorts"],
+    ] as const)(
+      "%s should reject a non-array operand and leave the stored definition byte-identical",
+      async (command, field) => {
+        const insightId = await makeInsight();
+        const before = await storedDefinition(insightId);
+        // Guard against a vacuous comparison: if the fixture ever stopped
+        // persisting a definition, `before` would be "undefined" and every
+        // byte-identity assertion below would pass without proving anything.
+        expect(before).toContain("baseTableId");
+
+        for (const operand of NON_ARRAY_OPERANDS) {
+          await expect(
+            commit(rawCmd(command, { id: insightId, [field]: operand })),
+          ).rejects.toThrow(/definition is invalid/);
+          // Nothing was written — not a partial write, not a normalized one.
+          expect(await storedDefinition(insightId)).toBe(before);
+        }
+      },
+    );
+
+    it.each(["selectedFields", "metrics"])(
+      "CreateInsight should reject a non-array %s and persist no row",
+      async (field) => {
+        const { tableId } = await makeTable();
+        for (const operand of NON_ARRAY_OPERANDS) {
+          const insightId = id();
+          await expect(
+            commit(
+              rawCmd("CreateInsight", {
+                id: insightId,
+                name: "I",
+                source: { sourceType: "dataTable", sourceId: tableId },
+                [field]: operand,
+              }),
+            ),
+          ).rejects.toThrow(/definition is invalid/);
+          expect(await insightsById(insightId)).toHaveLength(0);
+        }
+      },
+    );
+
+    it("should reject a non-string element inside selectedFields", async () => {
+      // `selectedFields` is typed `z.array(z.string())`, so element validation
+      // is real here — unlike `filters`/`sorts`/`metrics`, whose elements are
+      // deliberately opaque at this layer (see the insights codec header).
+      const insightId = await makeInsight();
+      const before = await storedDefinition(insightId);
+
+      await expect(
+        commit(rawCmd("SelectFields", { id: insightId, fieldIds: [id(), 42] })),
+      ).rejects.toThrow(/definition is invalid/);
+      expect(await storedDefinition(insightId)).toBe(before);
+    });
+
+    it("should keep listInsights resolvable for every sibling after a rejected write", async () => {
+      // The blast radius IS the user-visible harm: a per-call rejection alone
+      // would not prove the list survives. `listInsights` decodes every row, so
+      // a corrupt blob anywhere fails the whole query and the client renders
+      // its "couldn't load" state — the user loses insights they never touched.
+      const { tableId } = await makeTable();
+      const targetId = id();
+      const siblingId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: targetId,
+          name: "Target",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateInsight", {
+          id: siblingId,
+          name: "Sibling",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+
+      await expect(
+        commit(rawCmd("SetInsightSort", { id: targetId, sorts: {} })),
+      ).rejects.toThrow(/definition is invalid/);
+
+      const listed = (await app.call("listInsights", {})).result as {
+        id: string;
+        name: string;
+      }[];
+      expect(listed).toHaveLength(2);
+      expect(listed.map((i) => i.name).sort()).toEqual(["Sibling", "Target"]);
+    });
+
+    it("should round-trip valid operands unchanged, including empty arrays", async () => {
+      const insightId = await makeInsight();
+      const fieldA = id();
+
+      await commit(
+        cmd("SelectFields", { id: insightId, fieldIds: [fieldA] }),
+        cmd("SetInsightSort", {
+          id: insightId,
+          sorts: [{ field: "amount", direction: "desc" }],
+        }),
+      );
+      const rows = await insightsById(insightId);
+      const def = rows[0]?.definition as {
+        selectedFields: unknown;
+        sorts: unknown;
+      };
+      // Pin the type before comparing: an `as` cast over a missing key would
+      // otherwise make `toEqual` compare undefined to undefined and pass green.
+      expect(Array.isArray(def.selectedFields)).toBe(true);
+      expect(def.selectedFields).toEqual([fieldA]);
+      expect(Array.isArray(def.sorts)).toBe(true);
+      expect(def.sorts).toEqual([{ field: "amount", direction: "desc" }]);
+
+      // Empty arrays are a valid "nothing set", distinct from a rejected
+      // operand — parsing must not coerce them away or treat them as absent.
+      await commit(
+        cmd("SelectFields", { id: insightId, fieldIds: [] }),
+        cmd("SetInsightSort", { id: insightId, sorts: [] }),
+      );
+      const cleared = (await insightsById(insightId))[0]?.definition as {
+        selectedFields: unknown;
+        sorts: unknown;
+      };
+      expect(Array.isArray(cleared.selectedFields)).toBe(true);
+      expect(cleared.selectedFields).toEqual([]);
+      expect(Array.isArray(cleared.sorts)).toBe(true);
+      expect(cleared.sorts).toEqual([]);
     });
   });
 

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -187,7 +187,7 @@ async function requireInsightDefinition(
  * that went bad, this is a caller sending something we refuse to store.
  */
 function requireDefinitionShape(
-  command: string,
+  command: CommandName,
   candidate: unknown,
 ): StoredInsightDefinition {
   const parsed = storedInsightDefinitionSchema.safeParse(candidate);
@@ -667,6 +667,11 @@ const setInsightSource = wy.procedure
       }
     }
 
+    // No `requireDefinitionShape` here, deliberately: unlike the four handlers
+    // that take an opaque `jsonb` array operand, every key this writes is
+    // already checked — `definition` came back parsed from
+    // `requireInsightDefinition`, and `source` from `insightSourceSchema`. There
+    // is no unvalidated value to reject.
     const next: StoredInsightDefinition = {
       ...definition,
       baseTableId: source.sourceId,

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -172,6 +172,34 @@ async function requireInsightDefinition(
 }
 
 /**
+ * Validate a definition a command is about to persist. The write counterpart to
+ * `requireInsightDefinition` — same schema, opposite direction.
+ *
+ * Commands take their operands as opaque `jsonb`, so annotating the assembled
+ * object as `StoredInsightDefinition` asserts a shape nothing checked: a caller
+ * passing `sorts: {}` type-checks, persists, and then fails the fail-closed read
+ * path on EVERY subsequent decode of the row. Because `listInsights` decodes
+ * every row, one bad operand takes out the whole list, not just the insight that
+ * was edited, and the write reports success — so the damage is silent and there
+ * is no in-app way back. Parsing here rejects the operand before the write.
+ *
+ * "invalid" (not "corrupt") is deliberate: corruption describes a stored blob
+ * that went bad, this is a caller sending something we refuse to store.
+ */
+function requireDefinitionShape(
+  command: string,
+  candidate: unknown,
+): StoredInsightDefinition {
+  const parsed = storedInsightDefinitionSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new Error(
+      `${command}: definition is invalid: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data as StoredInsightDefinition;
+}
+
+/**
  * Assert a `{ sourceType, sourceId }` resolves to an existing row before it is
  * persisted into an Insight's `definition.source`. The source is stored as JSON,
  * not an FK, so nothing else stops a dangling reference: a `sourceId` that names
@@ -587,13 +615,15 @@ const createInsight = wy.procedure
     // The source must resolve to an existing row — JSON source has no FK, so an
     // unvalidated sourceId would persist as a dangling reference.
     await requireSourceExists(ctx, source);
-    const definition: StoredInsightDefinition = {
+    // Both operands arrive as opaque `jsonb`; the schema rejects a non-array and
+    // coalesces absent → [], so no cast and no `?? []` is needed here.
+    const definition = requireDefinitionShape("CreateInsight", {
       baseTableId: source.sourceId,
       source,
-      selectedFields: (args.selectedFields as UUID[] | undefined) ?? [],
+      selectedFields: args.selectedFields,
       // Stored as InsightMetric (sourceTable), the shape the read path expects.
-      metrics: (args.metrics as InsightMetric[] | undefined) ?? [],
-    };
+      metrics: args.metrics,
+    });
     const [row] = (await ctx.db.into(insights).insert({
       id: args.id,
       name: args.name,
@@ -658,10 +688,10 @@ const selectFields = wy.procedure
   .input({ id: uuid, fieldIds: jsonb })
   .mutation(async (ctx, { id, fieldIds }): Promise<{ ok: true }> => {
     const { definition } = await requireInsightDefinition(ctx, id);
-    const next: StoredInsightDefinition = {
+    const next = requireDefinitionShape("SelectFields", {
       ...definition,
-      selectedFields: fieldIds as UUID[],
-    };
+      selectedFields: fieldIds,
+    });
     await ctx.db
       .from(insights)
       .where(eq("id", id))
@@ -680,10 +710,10 @@ const setInsightFilter = wy.procedure
   .input({ id: uuid, filters: jsonb })
   .mutation(async (ctx, { id, filters }): Promise<{ ok: true }> => {
     const { definition } = await requireInsightDefinition(ctx, id);
-    const next: StoredInsightDefinition = {
+    const next = requireDefinitionShape("SetInsightFilter", {
       ...definition,
-      filters: filters as unknown[],
-    };
+      filters,
+    });
     await ctx.db
       .from(insights)
       .where(eq("id", id))
@@ -699,10 +729,10 @@ const setInsightSort = wy.procedure
   .input({ id: uuid, sorts: jsonb })
   .mutation(async (ctx, { id, sorts }): Promise<{ ok: true }> => {
     const { definition } = await requireInsightDefinition(ctx, id);
-    const next: StoredInsightDefinition = {
+    const next = requireDefinitionShape("SetInsightSort", {
       ...definition,
-      sorts: sorts as unknown[],
-    };
+      sorts,
+    });
     await ctx.db
       .from(insights)
       .where(eq("id", id))

--- a/apps/server/src/functions/insights.ts
+++ b/apps/server/src/functions/insights.ts
@@ -7,6 +7,12 @@
  * command handlers (`commands.ts`) consume them, so there is a single canonical
  * `storedInsightDefinitionSchema` — the read and write paths cannot drift.
  *
+ * The load-bearing property is that read and write apply the SAME SCHEMA
+ * OBJECT, not two schemas kept in agreement — `requireInsightDefinition` reads
+ * through it, `requireDefinitionShape` writes through it, so there is nothing
+ * for the two seams to drift between. Copy that property, not this file's
+ * layout.
+ *
  * Validation is STRUCTURAL, not element-deep: the schema rejects a non-object
  * blob, a missing `baseTableId`, or a non-array where an array is required, but
  * trusts element shapes (metric/filter internals). That matches the write
@@ -193,7 +199,15 @@ export function decodeInsight(row: InsightRow): Insight {
 
 /**
  * Encode domain insight fields into the stored `definition` JSONB blob.
- * Symmetric write seam for `decodeInsight`; no Zod validation in this pilot.
+ * Symmetric write seam for `decodeInsight`.
+ *
+ * This function does NOT validate — it only assembles. Callers whose inputs
+ * came off the wire (an opaque `jsonb` operand, an untyped patch) must wrap the
+ * result in `storedInsightDefinitionSchema.parse(...)` before writing; a
+ * non-array that reaches the column mints a row the fail-closed read path can
+ * never decode, which fails `listInsights` for EVERY row, not just that one.
+ * Assembling and validating are kept separate because some callers already hold
+ * a parsed definition and would otherwise pay a redundant parse.
  *
  * `source` has no counterpart on the domain `Insight`, so every caller must
  * source it from {@link decodeStoredInsightDefinition} and pass it through


### PR DESCRIPTION
Closes #241.

Four insight command handlers assembled the stored `insights.definition` JSONB out of opaque `jsonb` operands and annotated the result as `StoredInsightDefinition`. That annotation is a compile-time assertion only, so a non-array operand — `SetInsightSort` with `sorts: {}` — persisted successfully, returned `{ ok: true }`, and then failed the fail-closed read path on every later decode of that row. Because `listInsights` decodes **every** row, one bad operand took out the caller's whole insight list, including insights they never touched, with no in-app path back.

The fix parses the assembled definition with the codec's `storedInsightDefinitionSchema` before the write, via a `requireDefinitionShape` guard that mirrors `requireInsightDefinition` on the read side. Same schema object at both seams, so the two directions cannot drift.

### Scope note — one writer beyond the issue's four

Review found the issue's exact symptom still fully reachable through the `createInsight` **RPC procedure** in `app-artifacts.ts`, in a worse variant. It takes `options` as opaque `jsonb`, casts it, and hands it to `encodeInsightDefinition`, whose `?? []` does not catch a non-nullish non-array like `{}`. Its two siblings in the same file (`updateInsight`, `patchInsight`) already parsed; `createInsight` was the sole holdout.

That one is worse than the four because it is an **INSERT**: it mints a permanently undecodable row rather than corrupting a recoverable one, and the poisoned row also blocks `DeleteNode` and the DataSource-delete scan — so it cannot be cleaned up from the app at all. Reproduced end-to-end before fixing. It is folded in here rather than deferred, because leaving it would have closed #241 while its stated symptom stayed reproducible.

## Changes

- `commands.ts` — new `requireDefinitionShape(command, candidate)` write guard; applied in `CreateInsight`, `SelectFields`, `SetInsightFilter`, `SetInsightSort`. Removes four unchecked casts rather than adding a layer.
- `app-artifacts.ts` — `createInsight` now parses before inserting, matching `updateInsight`/`patchInsight`.
- `insights.ts` — docs only: `encodeInsightDefinition` now states that it assembles without validating, so wire-sourced callers must parse (it was the one seam a fan-out copier would reach for as *the* encoder while every other seam validates). Module header names the load-bearing property: read and write apply the **same schema object**, not two schemas kept in agreement.
- `setInsightSource` — comment explaining why it needs no guard (every key it writes is already validated), so the asymmetry doesn't read as an oversight.
- Error wording is `invalid`, not `corrupt`: corruption describes a stored blob that went bad, this is a caller sending something we refuse to store.

**Not changed:** the join handlers (`AddJoin`/`UpdateJoin`/`RemoveJoin`) already validate via `requireJoinShape`/`isRecord`/integer bounds and assemble through `patchJoinsCollection`. Confirmed unaffected; existing rejection coverage still green.

**Not copied:** #240's `source: stored.source` pin. That closed an untyped-patch-spread back-door which does not exist here — these handlers take named `jsonb` fields and spread an already-validated stored definition. `parse()` alone is the whole fix.

## Screenshots

No UI change.

## Verification

- **Revert-tested, which is the point.** 7 of the 8 new command tests fail against the unfixed handlers; the 8th is the valid-operand non-regression guard, correctly green both ways. The `createInsight` test was likewise confirmed failing against the unguarded insert (it returned an id instead of rejecting).
- **Blast radius reproduced, not assumed.** On unfixed code with the bad write allowed through, `listInsights` throws `Insight <id> has an invalid definition` and takes the untouched sibling with it. That is now pinned as a characterization test, so the rationale for write-side validation stays attested if anyone later makes `listInsights` lenient.
- **Byte-identity asserted on the raw JSONB**, not a decoded `Insight` — decoding applies the schema's `null → []` / `null → undefined` transforms, so decoded values compare equal across a changed blob. The cases populate `filters`/`sorts` first, so they prove an existing good array was not *clobbered*, not merely that nothing was added.
- **Assertions pin which handler rejected.** A copy-pasted wrong command name in `requireDefinitionShape` still type-checks and would have passed an unscoped `/definition is invalid/` — the defect a repeated fan-out manufactures.
- Full `bun check` green: 79/79 tasks, 450 server tests. Lint shows only the 3 pre-existing warnings in `@dashframe/ui`/`csv`, packages this diff never touches.
- Local review gate run before push (code review + clawpatch). Clawpatch reported no findings in this diff; on the follow-up commit its feature map did not resolve these files (`no features touched by diff`) and an agent-mode remap timed out, so that arm did not re-run — the follow-up was instead driven by two independent bot findings, both verified before fixing.

### Review round (commit `3351866`)

Both findings were real and are fixed:

- **Codex P2 — guard did not cover every exit.** The `createInsight` guard sat above the insert but *below* the draft-reuse short-circuit. `isUnmodifiedDraft` reads `.length` off each array, so a non-array `selectedFields: {}` yields `undefined ?? 0 === 0` and reads as "unmodified" — with a reusable draft present the handler returned that draft's id and never reached the parse. Verified by revert: the poisoned request **resolves** with an existing draft's id instead of rejecting. Fixed by parsing first and deriving both the reuse predicate and the inserted row from the validated definition; new regression test pins the reuse path.
- **CodeRabbit — unpinned rejection.** A bare `toThrow()` stays green if the call starts failing for an unrelated cause with the guard removed. Now pinned to `/selectedFields/`, matching every other test in this PR.

## AC coverage (#241)

| Criterion | Status |
|---|---|
| All four handlers reject a non-array operand and persist nothing | Covered, revert-tested |
| Rejected write leaves the stored definition byte-identical | Covered on raw JSONB, from a populated blob |
| `listInsights` still resolves after a rejected write | Covered at query level, plus a characterization test for the harm itself |
| Valid operands round-trip unchanged, incl. empty array | Covered, with `Array.isArray` pins so the assertions can't pass vacuously |
| Join handlers confirmed unaffected | Confirmed — zero diff, existing coverage green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Review round (commit `e8b2c80`)

Hoisting the guard changed what `isUnmodifiedDraft` is called with (the parsed
definition rather than a hand-built literal over raw `opts`), so the draft-reuse
tests now cover a path this PR modified. Two of them compared ids read through an
unchecked cast on the untyped test helper — if the handler stopped returning an
id, both sides would be `undefined` and `toBe` would pass vacuously. Pinned that
an id came back and anchored it to the persisted row, so those tests actually
discriminate. Re-ran green: 79/79 tasks, 450 server tests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents malformed insight definitions from reaching persistent storage.
- Applies the canonical stored-definition schema before command-handler updates and RPC inserts.
- Hoists `createInsight` validation ahead of draft reuse so malformed requests cannot return success through the short-circuit.
- Adds regression coverage for rejected writes, unchanged persisted data, healthy sibling reads, valid arrays, and non-vacuous draft reuse.
- Documents the distinction between definition assembly and validation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/app-artifacts.ts | Validates the assembled definition before both draft reuse and insertion, then consistently uses the parsed value. |
| apps/server/src/functions/commands.ts | Introduces a shared write-boundary guard and applies it to the four command handlers receiving opaque array operands. |
| apps/server/src/functions/insights.ts | Documents that encoding only assembles definitions and that wire-facing writers must apply the canonical schema. |
| apps/server/src/functions/app-artifacts.test.ts | Covers malformed RPC options, the draft-reuse short-circuit, and non-vacuous persisted-ID assertions. |
| apps/server/src/functions/commands.test.ts | Covers rejection, rollback, list-read preservation, valid round trips, and the existing corruption blast radius. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Opaque JSONB input] --> B[Assemble candidate definition]
  B --> C[Canonical stored-definition schema]
  C -->|Invalid| D[Reject without writing]
  C -->|Valid| E{Reusable unmodified draft?}
  E -->|Yes| F[Return persisted draft ID]
  E -->|No| G[Persist validated definition]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(server): pin the draft-reuse assert..."](https://github.com/youhaowei/dashframe/commit/e355f5676b04b3ce57a8c30a76c41a3dafbcfdf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47765628)</sub>

**Context used:**

- Knowledge Base — [Server API (apps/server)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-api.md)

<!-- /greptile_comment -->