### PR TITLE
fix(server): classify loopback by parsing the IP, not by string prefix

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -135,6 +135,31 @@ describe("bind-auth gate", () => {
     ).not.toThrow();
   });
 
+  // Regression for #243. `assertBindAuthorized` carried its own copy of the
+  // loopback check, so the same prefix-matching bypass existed on the
+  // `createDashframeServer` path independently of the CLI path. Both now share
+  // `isLoopbackHost`; these pin that the factory gate rejects them too. Only
+  // the two DNS names were the actual bypass — see the per-case notes in
+  // index.test.ts for why `127foo` and `127.1` ride along.
+  it.each([
+    "127.attacker.example",
+    "127.0.0.1.evil.example",
+    "127foo",
+    "127.1",
+  ])("host %s is not loopback → refuses without a token", (hostname) => {
+    expect(() =>
+      assertBindAuthorized({ hostname, authToken: undefined }),
+    ).toThrow(/refusing to bind.*without an auth token/i);
+  });
+
+  it("real 127.0.0.0/8 literals stay loopback → no token required", () => {
+    for (const hostname of ["127.0.0.1", "127.0.0.53", "127.1.2.3"]) {
+      expect(() =>
+        assertBindAuthorized({ hostname, authToken: undefined }),
+      ).not.toThrow();
+    }
+  });
+
   it("non-loopback + no token + insecure → allowed (deliberate opt-out)", () => {
     expect(() =>
       assertBindAuthorized({

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -58,6 +58,7 @@ import { type ArtifactDb } from "@dashframe/server-core";
 
 import type { AppContext } from "./app-context";
 import { handleAssistantRunRequest } from "./assistant-run-route";
+import { isLoopbackHost } from "./bind-host";
 import { captureCommandCredentials } from "./credential-release";
 import {
   createDraftController,
@@ -75,22 +76,6 @@ type CorsOrigin =
       origin: string,
       c: Context,
     ) => Promise<string | undefined | null> | string | undefined | null);
-
-/**
- * Returns true when `hostname` is a loopback address (127.0.0.0/8, ::1, or
- * the "localhost" name). Loopback-only binds are reachable from this machine
- * alone; no network auth token is required. Undefined / absent hostname
- * defaults to 127.0.0.1 (loopback).
- */
-function isLoopbackHost(hostname: string | undefined): boolean {
-  return (
-    hostname === undefined ||
-    hostname === "localhost" ||
-    // Entire 127.0.0.0/8 block is loopback (RFC 3330), not just 127.0.0.1.
-    hostname.startsWith("127.") ||
-    hostname === "::1"
-  );
-}
 
 /**
  * Secure-by-default bind-auth gate. Throws when a non-loopback bind has no

--- a/apps/server/src/bind-host.ts
+++ b/apps/server/src/bind-host.ts
@@ -1,0 +1,41 @@
+/**
+ * Loopback classification for the bind-auth gate.
+ *
+ * Both bind gates — `assertBindIsSafe` (the `dashframe serve` CLI) and
+ * `assertBindAuthorized` (`createDashframeServer`) — decide whether a bind
+ * needs an auth token by asking whether the host is loopback. They shared the
+ * *intent* but each carried its own copy of the check, so the answer could
+ * drift between the two entry points. One implementation, imported by both.
+ */
+import { isIPv4 } from "node:net";
+
+/**
+ * Returns true when `hostname` names a loopback interface — reachable only
+ * from this machine, so a network auth token is not required.
+ *
+ * Loopback is: an absent hostname (the default bind is 127.0.0.1), the
+ * `localhost` name, the IPv6 loopback `::1`, or any IPv4 literal in
+ * 127.0.0.0/8 (RFC 3330 — the whole block, not just 127.0.0.1).
+ *
+ * The IPv4 test parses the value as a dotted-quad literal before looking at
+ * the first octet. A bare `hostname.startsWith("127.")` prefix test is a
+ * string test on a *hostname*, so it also accepts DNS names like
+ * `127.attacker.example` or `127.0.0.1.evil.example`, which resolve wherever
+ * their owner points them. Classifying those as loopback waives the token
+ * requirement on a network-reachable bind — the exact mistake this gate
+ * exists to catch. See issue #243.
+ *
+ * Anything that is not one of the forms above is non-loopback, so the gate
+ * fails closed on ambiguity. That deliberately includes shorthand IPv4 forms
+ * such as `127.1`: `getaddrinfo` widens it to 127.0.0.1, but it is not a
+ * dotted-quad literal, and requiring an explicit `--token` for an unusual
+ * spelling is the safe direction to be wrong in.
+ */
+export function isLoopbackHost(hostname: string | undefined): boolean {
+  if (hostname === undefined) return true;
+  if (hostname === "localhost") return true;
+  if (hostname === "::1") return true;
+  // `isIPv4` accepts only a four-octet dotted-quad, so `startsWith` here is
+  // checking an octet boundary rather than an arbitrary string prefix.
+  return isIPv4(hostname) && hostname.startsWith("127.");
+}

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -84,6 +84,36 @@ describe("dashframe serve CLI", () => {
       );
     });
 
+    // Regression for #243: the gate used to classify loopback with
+    // `hostname.startsWith("127.")`, a string prefix test on a *hostname*.
+    it.each([
+      // The bypass. Both pass the old prefix test while resolving wherever
+      // their owner points them, so each silently waived the token
+      // requirement on a network-reachable bind.
+      "127.attacker.example",
+      "127.0.0.1.evil.example",
+      // Already rejected by the old test (no dot after `127`). Pins the
+      // adjacent shape so a looser rewrite of the parse can't admit it.
+      "127foo",
+      // Not a dotted-quad literal, and not attacker-controlled — a genuine
+      // loopback shorthand that getaddrinfo widens to 127.0.0.1. The gate
+      // fails closed on spellings it cannot parse rather than guessing, so
+      // this one is over-strict by design, not a bypass.
+      "127.1",
+    ])("should reject the non-loopback host %s without a token", (hostname) => {
+      expect(() => assertBindIsSafe({ hostname })).toThrow(/without --token/);
+    });
+
+    it("should still allow real 127.0.0.0/8 literals without a token", () => {
+      // The fix must not narrow loopback to 127.0.0.1 — local dev and Electron
+      // bind elsewhere in the block.
+      for (const hostname of ["127.0.0.1", "127.0.0.53", "127.1.2.3"]) {
+        expect(() => assertBindIsSafe({ hostname })).not.toThrow();
+      }
+      expect(() => assertBindIsSafe({ hostname: "localhost" })).not.toThrow();
+      expect(() => assertBindIsSafe({ hostname: "::1" })).not.toThrow();
+    });
+
     it("should allow a non-loopback bind when a token is set", () => {
       expect(() =>
         assertBindIsSafe({ hostname: "0.0.0.0", token: "secret" }),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 import { createDashframeServer, type DashframeServer } from "./app";
+import { isLoopbackHost } from "./bind-host";
 
 interface CliOptions {
   hostname?: string;
@@ -187,16 +188,6 @@ function parseArgAt(opts: CliOptions, args: string[], index: number): number {
   }
 }
 
-function isLoopback(hostname: string | undefined): boolean {
-  return (
-    hostname === undefined ||
-    hostname === "localhost" ||
-    // Entire 127.0.0.0/8 block is loopback (RFC 3330), not just 127.0.0.1.
-    hostname.startsWith("127.") ||
-    hostname === "::1"
-  );
-}
-
 /**
  * Fail-closed auth gate. Loopback binds are reachable only from this machine,
  * so a token is optional there. A non-loopback bind exposes the project to the
@@ -204,7 +195,7 @@ function isLoopback(hostname: string | undefined): boolean {
  * Throws (rather than warns) so a forgotten token never silently exposes data.
  */
 export function assertBindIsSafe(opts: CliOptions): void {
-  if (isLoopback(opts.hostname) || opts.token || opts.insecure) {
+  if (isLoopbackHost(opts.hostname) || opts.token || opts.insecure) {
     return;
   }
   throw new Error(
@@ -242,7 +233,7 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
 
   assertBindIsSafe(opts);
 
-  if (opts.insecure && !opts.token && !isLoopback(opts.hostname)) {
+  if (opts.insecure && !opts.token && !isLoopbackHost(opts.hostname)) {
     console.warn(
       "[dashframe] warning: --insecure non-loopback bind without --token exposes this project to the network",
     );


### PR DESCRIPTION
Fixes #243.

The bind-auth gate decides whether a bind needs an auth token by asking whether the host is loopback. It answered that question with `hostname.startsWith("127.")` — a string prefix test applied to a *hostname*. `127.attacker.example` and `127.0.0.1.evil.example` are valid DNS names that pass that test while resolving wherever their owner points them, so the gate waived the token requirement on a network-reachable bind. A security gate failing open in the permissive direction.

Both gates had the bug independently, because each carried its own byte-identical copy of the check.

## Changes

- New `apps/server/src/bind-host.ts` — one `isLoopbackHost`, imported by both gates. It parses with `net.isIPv4` *before* looking at the first octet, so `startsWith("127.")` is now checking an octet boundary rather than an arbitrary string prefix.
- Removed the duplicate local helpers from `apps/server/src/index.ts` (`isLoopback`) and `apps/server/src/app.ts` (`isLoopbackHost`). Consolidating is part of the fix, not drive-by cleanup: two copies of a security predicate can drift, and here they had both drifted the same wrong way.
- Regression tests on **both** entry points, covering the bypass strings and pinning that real 127.0.0.0/8 literals still need no token.

Loopback stays the whole 127.0.0.0/8 block (RFC 3330), plus `localhost`, `::1`, and an absent hostname. The fix does not narrow it to 127.0.0.1 — local dev and Electron bind elsewhere in the block.

## Deliberate: fail-closed on ambiguity

Anything not in the allow-list is treated as non-loopback, so unusual spellings demand a `--token` rather than getting a guess. That deliberately includes `127.1` (which `getaddrinfo` widens to 127.0.0.1), `LOCALHOST`, the trailing-dot FQDN `localhost.`, expanded/mapped IPv6 loopback forms (`0:0:0:0:0:0:0:1`, `::ffff:127.0.0.1`), and decimal/hex encodings.

Every one of these errs toward *requiring* auth for something that is actually local-only — a usability papercut, never an exposure. None is a regression: the old prefix test rejected all of them too, except `127.1`. Widening the parse to accept them would grow the set of binds that skip authentication, which is the direction that created this bug.

## Verification

Not just that it compiles:

- **Anti-vacuity check.** Reverted `bind-host.ts` to the old prefix logic and re-ran: 6 of the 8 new cases fail. They discriminate. (`127foo` passes under both — the old prefix required the dot — and is kept as a boundary case.)
- **`net.isIPv4` strictness probed** on Node 25.8.2 and Bun 1.3.5 rather than assumed: it rejects leading zeros (`127.0.0.01`, `127.000.000.001`), leading/trailing whitespace and `\n`, `0x7f.0.0.1`, `2130706433`, `127.0.0.1.`, `127.0.0.1%eth0`, and `127.0.0.1:80`. Since the octet check runs only after a successful dotted-quad parse, a `true` return implies 127.0.0.0/8 by construction.
- **End-to-end through the real CLI**, not only unit tests: `--host 127.attacker.example` is refused with exit 1; `--host 127.0.0.1 --port 0` starts and listens; the same `127.`-prefixed shape with `--token` starts and listens (verified against `127.0.0.1.nip.io`, a real wildcard-DNS host, since `.example` does not resolve).
- **Callers audited.** All four `createDashframeServer` call sites checked — Electron main and `verify-native-engine.mjs` pass no hostname and take the `app.ts` default; the CLI passes the gated value. Repo-wide sweep for other host classifiers found only an exact-match CORS check and an SSRF *deny*-list of opposite polarity. No third classifier.
- `bun run check` green (79/79 turbo tasks); `apps/server` 449/449.

## Found while verifying, filed separately

#244 — `dashframe serve` never forwards `--insecure` to `createDashframeServer`, so the documented opt-out throws instead of starting. Pre-existing and untouched by this diff (the call site is byte-identical before and after). Deliberately not folded in: this PR is a purely restrictive security change, and a permissive behavior change does not belong in the same diff.

## Screenshots

No UI change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes and hardens loopback-host classification for both server bind-auth gates.
- Adds strict IPv4-literal parsing before accepting the 127.0.0.0/8 range.
- Routes the CLI and server-factory authorization checks through the shared predicate.
- Adds regression coverage for malicious DNS names, ambiguous host forms, and valid loopback literals.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/bind-host.ts | Introduces a shared fail-closed loopback classifier that validates IPv4 syntax before accepting 127.0.0.0/8. |
| apps/server/src/app.ts | Replaces the server factory's vulnerable local hostname-prefix check with the shared classifier. |
| apps/server/src/index.ts | Replaces both CLI loopback decisions with the shared classifier. |
| apps/server/src/app.test.ts | Adds factory-gate regression tests for DNS-prefix bypasses and valid 127.0.0.0/8 literals. |
| apps/server/src/index.test.ts | Adds equivalent CLI-gate coverage for bypass strings, ambiguous forms, and supported loopback hosts. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    H[Bind hostname] --> P{isLoopbackHost}
    P -->|Absent, localhost, ::1, or parsed 127/8 IPv4| L[Loopback bind]
    P -->|Any other hostname| N[Non-loopback bind]
    L --> A[Allow without token]
    N --> G{Token, auth ref, or explicit insecure opt-out?}
    G -->|Yes| A
    G -->|No| R[Refuse server startup]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): classify loopback by parsin..."](https://github.com/youhaowei/dashframe/commit/0dd3d677942900825cdc4f76ec79eb0650c70286) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47787453)</sub>

<!-- /greptile_comment -->