### PR TITLE
chore(deps): bump the wystack pin to 8eddcee

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -545,6 +545,97 @@ describe("createDashframeServer", () => {
   });
 });
 
+describe("write → subscription invalidation", () => {
+  /**
+   * Guards the RE-MIRROR POINT documented in app.ts's `call` wrapper.
+   *
+   * wystack collapsed invalidation onto one per-app source: `rawApp.call` fuses
+   * `emit(tablesWritten)` after a write, and `createRoutes` no longer publishes
+   * from the returned `tablesWritten`. DashFrame's `call` chain never reaches
+   * `rawApp.call` — the draft seam composes `createTracked → runHandler` itself —
+   * so the fuse does not fire for us and our wrapper has to emit explicitly.
+   *
+   * Why this test and not a unit assertion on `emit`: when that emit went
+   * missing, typecheck and all 48 package test suites stayed green and only the
+   * chart E2E caught it, ~5 minutes downstream. The contract that actually
+   * matters is observable at the wire — a subscriber must receive `invalidate`
+   * after somebody else's write — so that is what this asserts, over a real WS
+   * against a real server. A future pin bump that moves the emit seam again
+   * fails HERE, in unit-test time.
+   */
+  let root: string;
+  let project: ProjectHandle | null;
+  let server: DashframeServer | null;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-invalidate-"));
+    project = null;
+    server = null;
+  });
+
+  afterEach(async () => {
+    server?.stop();
+    await project?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("delivers invalidate to a live subscriber after a mutation on another surface", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    server = await createDashframeServer({ db: project.db });
+
+    const ws = new WebSocket(`${server.url.replace(/^http/, "ws")}/api/ws`);
+    const subscriptionId = "sub-invalidate-1";
+
+    const invalidated = new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("no invalidate frame within 10s")),
+        10_000,
+      );
+      ws.onerror = () => reject(new Error("WebSocket failed"));
+      ws.onopen = () => ws.send(JSON.stringify({ type: "auth", token: null }));
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(String(event.data)) as {
+          type?: string;
+          id?: string;
+        };
+        if (msg.type === "authenticated") {
+          ws.send(
+            JSON.stringify({
+              type: "subscribe",
+              id: subscriptionId,
+              path: "listDataSources",
+              args: {},
+            }),
+          );
+          return;
+        }
+        // Wait for the server's ack before writing: subscribing is not
+        // instantaneous, and a write that lands before the entry is in the
+        // store would produce no invalidate for reasons unrelated to the seam.
+        if (msg.type === "subscribed" && msg.id === subscriptionId) {
+          void fetch(`${server!.url}/api/getOrCreateDataSource`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              id: crypto.randomUUID(),
+              type: "csv",
+              name: "Invalidation Source",
+            }),
+          });
+          return;
+        }
+        if (msg.type === "invalidate" && msg.id === subscriptionId) {
+          clearTimeout(timer);
+          resolve(msg.id);
+        }
+      };
+    });
+
+    await expect(invalidated).resolves.toBe(subscriptionId);
+    ws.close();
+  });
+});
+
 describe("onWrite hook", () => {
   /**
    * Tests for the `onWrite` durability hook (see GitHub issue #88 / #90).

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -572,6 +572,25 @@ export async function createDashframeServer(
   // wrapper; wyStackApp is populated after assignment because it IS the wrapped
   // app reference. Both keys win over per-request context (spread LAST).
   const serverContext: Record<string, unknown> = {};
+  // Invalidation emit — the RE-MIRROR POINT in `buildDashframeApp` come due.
+  //
+  // wystack collapsed invalidation onto a single per-app source: `rawApp.call`
+  // fuses `emit(tablesWritten)` after any write, and `createRoutes` no longer
+  // publishes from the returned `tablesWritten` at all. Our `call` chain never
+  // reaches `rawApp.call` (the draft seam in `buildDashframeApp` composes
+  // `createTracked → runHandler` itself so it can hand the draft-scoped handle
+  // to the handler), so that fuse never fires for us — without this, every
+  // subscription across every surface silently stops invalidating.
+  //
+  // Emitted HERE, at the outermost wrapper, and with the MERGED set: the
+  // `__extraTablesWritten` writes come from sub-trackers (publishDraft's
+  // `applyCommands`) that no inner tracker ever saw, so emitting deeper would
+  // miss them. Guarded on size so the router's own read-only recompute — which
+  // re-enters `call` — cannot start a recompute storm.
+  const emitInvalidation = (tablesWritten: Set<string>) => {
+    if (tablesWritten.size > 0) vaultWrapped.emit(tablesWritten);
+  };
+
   const app: WyStackApp = {
     ...vaultWrapped,
     async call(path, args, context) {
@@ -603,6 +622,7 @@ export async function createDashframeServer(
           extra.length > 0
             ? new Set([...callResult.tablesWritten, ...extra])
             : callResult.tablesWritten;
+        emitInvalidation(mergedTables);
         return {
           ...callResult,
           result: cleanResult,
@@ -610,6 +630,7 @@ export async function createDashframeServer(
         };
       }
 
+      emitInvalidation(callResult.tablesWritten);
       return callResult;
     },
     async runHandler(path, args, tracked, context) {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -230,9 +230,18 @@ export interface DashframeServerOptions {
    * of persisting the plaintext. Read mutations use `vault.has(ref)` for
    * presence checks (hasApiKey / hasConnectionString).
    *
-   * Optional at the factory level — omitting it falls back to the legacy
-   * plaintext-in-config path (pre-vault callers, tests that don't exercise
-   * the credential boundary). Desktop always injects the keychain vault.
+   * Optional at the factory level, but the credential boundary FAILS CLOSED
+   * when it is absent — there is no plaintext fallback. `storeCredential`
+   * throws rather than persist plaintext (`functions/utils.ts`), and so do
+   * `releaseCredentialRefs`, the assistant-provider release, and the connector
+   * bound-resolver. Omitting it is for callers that never cross the credential
+   * boundary (tests, read-only hosts); any credential-bearing mutation on a
+   * vault-less server is an error, not a downgrade. The one vault-absent branch
+   * that does not throw is the read-side `hasApiKey` presence check, which
+   * tolerates legacy plaintext rows written before this boundary existed.
+   *
+   * Desktop always injects the keychain vault. `dashframe serve` currently
+   * injects none — see #254.
    */
   vault?: SecretVault;
   /** Generic external-access credentials backed by the injected SecretVault. */


### PR DESCRIPTION
Bumps the `libs/wystack` submodule pin from `db1728c6` to `8eddcee`, seven commits of server-side fixes — **and restores DashFrame's subscription invalidation**, which `#84`'s invalidation collapse silently took out from under our custom `call` seam.

The wystack public-surface delta is additive, so no callsite needed a *signature* edit. But `#84` moved invalidation onto a single per-app source: `rawApp.call` now fuses `emit(tablesWritten)` after a write, and `createRoutes` no longer publishes from the returned `tablesWritten` at all. DashFrame's `call` chain never reaches `rawApp.call` — the draft seam in `buildDashframeApp` composes `createTracked → runHandler` itself so it can hand the draft-scoped handle to the handler — so that fuse never fires for us. Without the emit added here, **every subscription on every surface silently stops invalidating**: no error, no failing typecheck, no failing unit test.

## Changes

- `apps/server/src/app.ts`: emit invalidation from the outer `call` wrapper, using the **merged** write set. Merged because `publishDraft`'s `__extraTablesWritten` comes from sub-trackers (`applyCommands`) that no inner tracker ever saw — emitting deeper would miss them. Guarded on non-empty so the router's own read-only recompute, which re-enters `call`, cannot start a recompute storm.
- `apps/server/src/app.test.ts`: wire-level regression test — real WS to `/api/ws`, subscribe to `listDataSources`, POST `getOrCreateDataSource` over HTTP, assert the `invalidate` frame arrives.
- `apps/server/src/app.ts` (comment-only): correct the `vault` option's docblock, which claimed omitting the vault "falls back to the legacy plaintext-in-config path". It does not — the credential boundary fails closed. See the Clawpatch note below; this stale comment produced a false high-severity finding.
- `libs/wystack`: `db1728c6` → `8eddcee`, picking up:
  - `#84` typed caller + single-source invalidation collapse
  - `#80` forbid shared caching of identity-scoped GET responses
  - `#93` Node adapter reports a real bound port; terminates WebSockets on `stop(true)`
  - `#92` close draft publish/discard races, own invalidation, skip dead-subscription recomputes
  - `#95` contain a throwing `onClose` hook; stop `__proto__` corrupting the caller
  - `#81`/`#82` docs and comment hygiene
- Public surface delta is **additive only**: `createCaller`, `CallerFromFunctions`, `MountedRoutes`. No signature DashFrame depends on changed.

**Reach caveat — `#93`:** fixes `serve-node.ts`, which DashFrame does not use — `apps/server/src/app.ts` deliberately mirrors `serve()`'s composition instead of calling it, so it can insert a CORS layer (see the file header). Those two fixes therefore do **not** reach us; if the inlined adapter ever needs the same behavior it has to be ported deliberately. `#80` lands in `routes.ts` and does reach us, since we call `createRoutes`.

**Reach caveat — `#92`:** the draft-lifecycle own-invalidation half does not reach us either. DashFrame does not use `createDraftLifecycle`; `apps/server/src/draft-controller.ts` reimplements the controller and relies on the host emit added here. Checked both halves of that seam explicitly:

- **Publish** signals through `__extraTablesWritten`, which this PR merges and emits. It carries the canonical tables from replay; the log delete and shadow sweep run through `tx.raw` (untracked) *by design* (`draft-controller.ts:922-926`), matching wystack's own posture — clients subscribe to canonical, not to `<table>__draft`.
- **Discard** runs `dropDraft` on the raw `ArtifactDb` (`draft-controller.ts:711`), so its `tablesWritten` is empty and the emit no-ops. That is **unchanged from before the bump** — old wystack published from the same empty set — and both client callsites leave draft scope immediately after discarding (`DraftReviewPanel.tsx:144-171`), unmounting the subscription. No behavior regressed here; this PR restores exact parity, no more and no less.

## Screenshots

No UI change.

## Verification

Local review gate (per `AGENTS.md`) run against `git diff origin/main...HEAD`, re-run in full after rebasing onto `main` (head `eb421c87`):

**Static / unit — `bun check`, exit 0, 79/79 tasks.** Run after rebuilding wystack dist bottom-up (`bun install && bun run build:wystack`) so the on-disk dist matches the new pin — without that, package-scoped typecheck reads a stale dist and reports a phantom result. `@dashframe/server` 440/440, including the new `delivers invalidate to a live subscriber after a mutation on another surface` (3671 ms on the post-rebase run).

**Behavioral QA.** The changed surface is subscription invalidation app-wide, and the E2E suite is green on this exact head. Six of the seven specs — `chart-editing`, `csv-to-chart`, `json-to-chart`, `dashboard`, `error-handling`, `visualize-intent` — contain **zero** `page.reload()` calls: they mutate and assert the UI updates in place, which is precisely the invalidation path. That is the regression signal that caught this bug the first time, and it is broader coverage than a manual boot would give.

**Clawpatch — two passes, 11 findings total, all triaged, none attributable to this PR.**

| Finding | Triage |
|---|---|
| `call` wrapper bypasses write invalidation (×3) | **False positive.** All cite `app.ts:455-493`, the *inner* `buildDashframeApp` seam; the emit lives at `:590`/`:625`/`:633` in the outer wrapper, outside that window. They describe the bug this PR fixes. |
| Headless serve persists plaintext credentials | **False positive.** There is no plaintext path — every vault-absent branch throws (`utils.ts:180`, `utils.ts:225`, `assistant-provider-configs.ts:150`, `app-artifacts.ts:1206`). The reviewer was reading the stale `vault` docblock, corrected in this PR. The real gap it gestured at — `dashframe serve` composing no vault at all — is filed as #254. |
| Loopback detection by string prefix (×4) | Real, pre-existing on `main`. Tracked as #232 / #243; fix in flight as #245. |
| `--insecure` not forwarded to the server factory (×2) | Real, pre-existing on `main`. Tracked as #244. |
| Concurrent `appendToDraft` loses commands | Real, pre-existing on `main`, latent (sole caller serializes). Filed as #253. |

> **Two notes on the gate itself.**
>
> `clawpatch review --since origin/main` returned `no features touched by diff` — a **false all-clear** — on the pre-rebase head. All four features owning `app.ts` had been reviewed in a run timestamped after the diff's base but before the emit commit, so it was skipped as already-reviewed. Every finding here came from forced feature-scoped re-runs. A "no features touched" result on a diff that demonstrably touches owned files is never a pass.
>
> The second pass re-raised four already-triaged findings under **new signature hashes**, so prior triage did not suppress them. Signature-keyed triage does not survive whatever perturbs the hash; treat the count as unreliable and read the titles.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores subscription invalidation after the WyStack dependency update.
- Bumps the `libs/wystack` submodule from `db1728c6` to `8eddcee`.
- Emits merged tracked and sub-tracker write sets from DashFrame’s outer `call` wrapper.
- Adds a WebSocket regression test covering cross-surface invalidation after an HTTP mutation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Adds guarded invalidation emission using the merged write set at the outer call seam. |
| apps/server/src/app.test.ts | Adds an end-to-end WebSocket test proving that an HTTP mutation invalidates a live subscription. |
| libs/wystack | Advances the pinned WyStack dependency to the server-fix revision described by the PR. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant S as WebSocket subscriber
  participant R as WyStack routes
  participant A as DashFrame call wrapper
  participant H as Mutation handler
  S->>R: subscribe(listDataSources)
  R->>A: call(getOrCreateDataSource)
  A->>H: run handler with tracked DB
  H-->>A: result + tablesWritten
  A->>A: merge __extraTablesWritten
  A->>R: emit(mergedTables)
  R-->>S: invalidate(subscriptionId)
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs(server): correct the vault option&#39;s..."](https://github.com/youhaowei/dashframe/commit/eb421c87a43d89ca1a12315f1dd9f64634bc3ce4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48073585)</sub>

**Context used:**

- Knowledge Base — [Server API (apps/server)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-api.md)

<!-- /greptile_comment -->