### PR TITLE
chore(deps): bump libs/wystack to 80cfac1; make AGENTS.md the canonical cross-agent operations file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,37 @@ ticket references.
 - Test: `bunx turbo test --filter='!@wystack/*'`
 - Build: `bunx turbo build --filter='!@wystack/*'`
 
+## Worktrees (all agents)
+
+Every agent that touches source files works in an isolated git worktree — never
+in the shared main checkout (`/Users/youhaowei/Projects/DashFrame`). Two agents
+in the same checkout revert each other's uncommitted work.
+
+**Bootstrap (first step in any feature-branch brief):**
+
+```sh
+worktree=$(scripts/ensure-worktree.sh <branch-name>)
+cd "$worktree"
+# all work happens here
+```
+
+`scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch-slug>`
+(forward-slashes and colons in the branch name become dashes, lowercase) if not
+already there, populates and heals submodule checkouts, and prints the path. If
+it fails, STOP — do not improvise another location.
+
+**Enforcement:** `.husky/pre-commit` blocks commits on a non-default branch in
+the main checkout. Bypass with `ALLOW_MAIN_CHECKOUT_COMMIT=1` only when you
+knowingly own that checkout — e.g. a cloud/VM agent working on its branch in
+the environment's single checkout, where isolation is provided by the VM
+itself. The hook still runs `lint-staged` (prettier) on staged files.
+
+**Teardown:** remove worktrees with `scripts/remove-worktree.sh <path>` — never
+`git worktree remove --force` or `rm -rf`. The guard refuses when removal would
+destroy uncommitted, unpushed, stashed, or mid-operation work, in the worktree
+or any of its submodules, and tells you what to do instead. A refusal means
+there is work to save, not a broken script.
+
 ## Git submodules (`libs/wystack`, `libs/stdui`)
 
 Two vendored dependencies are **git submodules**, each with its own GitHub repo:
@@ -130,6 +161,13 @@ The `@dashframe/*` packages consume their **built** output, so `bun run setup`
 (and CI) init the submodules and run `bun run build:wystack` before anything
 else. If imports from `@wystack/*` fail to resolve, the submodule is
 uninitialized or unbuilt — run `git submodule update --init --recursive && bun run build:wystack`.
+
+**Nothing syncs submodules automatically.** There is no post-checkout hook:
+switching branches never touches a submodule checkout, so a submodule parked on
+its own branch stays there. Only `scripts/ensure-worktree.sh` (which also heals
+half-initialized checkouts) and `bun run setup` populate them. Teardown goes through
+`scripts/remove-worktree.sh` (see **Worktrees** above). See `README.md` → the
+submodule workflow section for the full contract.
 
 **Changing submodule code is a two-repo change — never edit in place and commit
 only the pin.** The parent repo records a submodule as a pinned commit SHA; a
@@ -151,17 +189,10 @@ reviewed. The workflow:
 
 **Worktree isolation applies to submodules too.** Parallel agents that both touch
 `libs/wystack` need their **own** wystack worktree each — two agents sharing one
-submodule checkout revert each other exactly like the parent repo (`CLAUDE.md` →
-worktree isolation). Trust the submodule PR's own remote state as the source of
+submodule checkout revert each other exactly like the parent repo (**Worktrees** above). Trust the submodule PR's own remote state as the source of
 truth for what has landed.
 
-## Cursor Cloud specific instructions
-
-Dependency refresh (submodules + install + build of the vendored `@wystack/*`
-packages) is handled by the startup update script; see root `package.json`
-`setup` for the equivalent steps.
-
-### Running for browser/headless testing (recommended in the cloud VM)
+## Running for browser/headless testing
 
 The web app is **not** purely client-side — it needs the backend API, or data
 import fails with `404` on `/api/*` and a failed `/api/ws` WebSocket. Run two
@@ -180,13 +211,3 @@ processes:
 Root `bun run dev` launches the **Electron desktop** app (embeds the server
 in-process, auto-starts the renderer on 5173). It needs a display, so it is not
 suitable for the headless VM — prefer the web+server combo above.
-
-### Committing (pre-commit worktree guard)
-
-`.husky/pre-commit` refuses feature-branch commits made from the **main
-checkout** (it's meant to force human/local multi-agent work into isolated
-worktrees via `scripts/ensure-worktree.sh`, per `CLAUDE.md`). A Cursor Cloud
-agent works on its branch directly in the single main checkout, so that guard
-would block every commit. Commit with the documented bypass:
-`ALLOW_MAIN_CHECKOUT_COMMIT=1 git commit ...`. The hook still runs `lint-staged`
-(prettier) on staged files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,9 @@ itself. The hook still runs `lint-staged` (prettier) on staged files.
 `git worktree remove --force` or `rm -rf`. The guard refuses when removal would
 destroy uncommitted, unpushed, stashed, or mid-operation work, in the worktree
 or any of its submodules, and tells you what to do instead. A refusal means
-there is work to save, not a broken script.
+there is work to save, not a broken script. Gitignored files are the one
+exemption: the checks never see ignored content, so a hand-made `.env` or a
+local build artifact is removed with the worktree — copy those out yourself.
 
 ## Git submodules (`libs/wystack`, `libs/stdui`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # DashFrame
 
-## Operations — see [AGENTS.md](AGENTS.md)
+@AGENTS.md
 
-@AGENTS.md is the operational companion to this file: how to run the app (desktop and headless web+server), the lint/test/build commands, and the **local review gate**. That gate — code review + behavioral QA + a second review pass on a different model (Codex), run on the branch diff (`git diff origin/main...HEAD`) — is **mandatory before every push and before marking any PR ready**. The one exception is narrow — a change confined to documentation and other prose files skips QA and the second reviewer but still gets code review; anything executable (application source, scripts, CI workflows, manifests, build wiring) does not qualify, and neither does a comment-only edit inside a source file. CI only _confirms_ the gate; it does not replace it. Read AGENTS.md before pushing.
+## Operations
+
+AGENTS.md (imported above) is the operational companion to this file: how to run the app (desktop and headless web+server), the lint/test/build commands, and the **local review gate**. That gate — code review + behavioral QA + a second review pass on a different model (Codex), run on the branch diff (`git diff origin/main...HEAD`) — is **mandatory before every push and before marking any PR ready**. The one exception is narrow — a change confined to documentation and other prose files skips QA and the second reviewer but still gets code review; anything executable (application source, scripts, CI workflows, manifests, build wiring) does not qualify, and neither does a comment-only edit inside a source file. CI only _confirms_ the gate; it does not replace it. Read AGENTS.md before pushing.
 
 ## Design Context
 
@@ -12,19 +14,12 @@ Key facts: product register; `@wystack/ui-core` (core tokens/utils) + `@wystack/
 
 ## Worktree isolation (dispatched agents)
 
-Every dispatched agent that touches source files MUST work in an isolated git worktree — never in the shared main checkout (`/Users/youhaowei/Projects/DashFrame`). Two agents in the same checkout will revert each other's uncommitted work.
-
-**Bootstrap (first step in any feature-branch brief):**
-
-```sh
-worktree=$(scripts/ensure-worktree.sh <branch-name>)
-cd "$worktree"
-# all work happens here
-```
-
-`scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch-slug>` (forward-slashes and colons in the branch name become dashes, lowercase) if not already there and prints the path. If it fails, STOP — do not improvise another location.
-
-**Enforcement:** `.husky/pre-commit` blocks commits on a non-default branch in the main checkout. Bypass with `ALLOW_MAIN_CHECKOUT_COMMIT=1` only when you knowingly own that checkout.
+Every dispatched agent that touches source files MUST work in an isolated git
+worktree — never in the shared main checkout. Bootstrap, enforcement, and
+teardown are defined in `AGENTS.md` → **Worktrees**; the short version:
+`worktree=$(scripts/ensure-worktree.sh <branch>)` to start,
+`scripts/remove-worktree.sh <path>` to tear down, and never improvise around
+either script.
 
 ## Pull requests
 


### PR DESCRIPTION
## What changed

Two commits, deliberately together:

1. **7c04a8fe — submodule pointer bump**: `libs/wystack` 8eddcee → 80cfac1. Effective upstream delta:
   - wystack#104 — `feat(db)`: column projection + draft `orderBy`/`limit` on the tracked select path; both builders converted from mutate-and-return-this to copy-on-write (`_with`).
   - 80cfac1 — removes wystack's own AGENTS.md/CLAUDE.md (docs-only).
2. **77cf90f4 — instruction-file restructure**: AGENTS.md becomes the canonical cross-agent operations file (worktree lifecycle moved in from CLAUDE.md, Cursor-specific framing removed, browser/headless run recipe promoted to top level); CLAUDE.md shrinks to Claude-specific glue plus a standalone `@AGENTS.md` import.

## Review

Local gate: cross-family review (opus, gpt-5.6-sol, gemini, grok seats; 3 evidence agents; panel synthesis) ran `full` at effort low against the pointer bump. Verdict: **level low, no code changes required**.

- Copy-on-write builder change confirmed safe: every DashFrame call site consumes the tracked builder as a single linear chain; no caller relies on mutating semantics or holds a builder across statements.
- PK tiebreaker only applies when `.orderBy()` was already chained — no unconditional ordering change.
- A/B test run: `apps/server` suite passes at both pointers (461 tests; one load-induced flake at the new pointer in a test unrelated to #104, passes in isolation).
- Repo checks green: build, typecheck (52/52), lint (20/20); `@wystack/server` 267/267 in isolation (3 timeouts under parallel turbo are load flakiness).

Two low findings, neither a branch change: a pre-existing stale-comment defect on main (spun off as its own task), and a scope note that the docs commit postdated the fan-out review — acknowledged here: the panel spot-checked its content (referenced scripts exist, documented contract matches the shipped submodule workflow), and the commit was authored under direct owner steering.

## Deliberately left out

- No fix for the stale draft-seam dormancy comments (`app.ts:342`, `draft-controller.ts:46`) — pre-existing on main, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the `libs/wystack` submodule and makes `AGENTS.md` the canonical cross-agent operations guide.
- Advances WyStack to the revision adding tracked-select projection and draft ordering/limit support with copy-on-write builders.
- Moves shared worktree, submodule, and headless-browser procedures into `AGENTS.md`.
- Reduces `CLAUDE.md` to Claude-specific guidance and an `@AGENTS.md` import.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Consolidates shared operational instructions; referenced worktree, teardown, setup, and development commands match repository scripts. |
| CLAUDE.md | Imports the canonical operations guide and retains Claude-specific design, worktree, and pull-request guidance. |
| libs/wystack | Advances the vendored dependency; inspected DashFrame call patterns do not rely on the upstream builders’ former mutating semantics. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(agents): document the gitignored-fi..."](https://github.com/youhaowei/dashframe/commit/a3ebdb8b7a36684bb2d204e20ea89457d089d32e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50329542)</sub>

<!-- /greptile_comment -->