### PR TITLE
docs(server): correct stale draft-seam dormancy comments — the seam is live

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -339,8 +339,10 @@ export function createFallThroughDraftDb(
  * `withDraft(draftId)` is a pure @wystack/db primitive that accepts any
  * caller-supplied id.
  *
- * CONSUMER CONSTRAINTS — the seam is dormant in this slice (no host injects a
- * draftId). The host that wires draftId into request context owns these:
+ * CONSUMER CONSTRAINTS — the seam is live: the assistant host
+ * (assistant-host.ts) wires draftId through `DraftController` for the
+ * `/assistant/run` route mounted below. Any host that injects a draftId owns
+ * these:
  *   - LOG SYNC. A write mutation reached via raw `app.call({draftId})` lands in
  *     `<table>__draft` but does NOT append to `draft_command_log`; since publish
  *     replays only the log, that write is visible in the overlay yet dropped on
@@ -351,8 +353,12 @@ export function createFallThroughDraftDb(
  *     (`where(eq("id", …))`). A command whose handler filters a shadow table by a
  *     non-PK column (e.g. delete `data_frames` by `insightId`) is not draftable
  *     as-is; such paths must be PK-addressed or blocked before drafting.
- *   - CREDENTIAL SIDE EFFECTS. See draft-controller.ts SECURITY BOUNDARY: a
- *     credentialed handler's `vault.store` is a real side effect even in a draft.
+ *   - CREDENTIAL SIDE EFFECTS. A credentialed handler's `vault.store` is a real
+ *     side effect even in a draft. Handled by the two seams in
+ *     credential-release.ts: capture-before-log rewrites plaintext to vault refs
+ *     inside `DraftController.appendToDraft`, and publish/discard release
+ *     superseded or minted refs via `releaseRefsAtTransition` (gated on
+ *     snapshot persistence).
  *   - AUTHORIZATION. draftId is caller-supplied; a multi-tenant host must
  *     authorize it against the caller (single-user desktop is exempt).
  */

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -43,10 +43,13 @@
  * land. NOTE the scope: this closes the at-rest-table channel, NOT a handler's
  * vault SIDE EFFECT — a credentialed command run inside a draft would still call
  * `vault.store` for real (not drafted, not swept on discard, re-run on publish).
- * The seam is dormant in this slice (no host injects a draftId), so this is not
- * yet live; the consumer that wires draftId into request context must enforce the
- * credential-side-effect boundary at THAT seam (deny-list credentialed paths in a
- * draft, or make vault.store draft-aware) before routing untrusted drafts.
+ * The seam is live — the assistant host (assistant-host.ts) wires draftId
+ * through this controller. The vault-side-effect channel is handled in
+ * credential-release.ts: `captureCommandCredentials` (host-injected into
+ * `appendToDraft`) stores plaintext to the vault and rewrites the logged command
+ * to refs before it runs, and `releaseRefsAtTransition` releases superseded or
+ * minted refs after publish/discard commits — see that file's header for the
+ * two-seam contract.
  */
 import {
   dashboards,


### PR DESCRIPTION
## What was stale

Two duplicated comment blocks claimed the draft seam is dormant ("no host injects a draftId") and instructed the reader to build a credential-side-effect guard before routing untrusted drafts:

- `apps/server/src/app.ts` (the `withDraftSeam` header)
- `apps/server/src/draft-controller.ts` (the SECURITY BOUNDARY note)

Both predate the assistant host. The seam is live today: `/assistant/run` is mounted with a real `DraftController` (app.ts:696), the assistant host calls `openDraft`/`appendToDraft`, and drafted writes land in `<table>__draft`. The guard the comments asked for already shipped as the two-seam contract in `credential-release.ts` — `captureCommandCredentials` (capture-before-log inside `appendToDraft`) plus `releaseRefsAtTransition` on publish/discard, gated on snapshot persistence.

## What changed

Comments only, no code. Both blocks now state the seam is live, name the host that wires it, and point at the shipped credential-release contract instead of prescribing a guard that would partly duplicate it.

## Review

Finding confirmed by the cross-family review panel that gated #264 (pre-existing on main, spun off here). Per owner's call, no separate cross-review round for this comments-only diff — hosted bots are the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects stale server comments to document that the assistant draft seam is active and that credential handling is enforced through capture-before-log and transition-time release.
- Updates `withDraftSeam` documentation to identify the live `/assistant/run` integration.
- Updates the draft-controller security-boundary note to describe the existing credential-release contract.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Updates the draft-seam comment to accurately describe the active assistant host and credential lifecycle. |
| apps/server/src/draft-controller.ts | Replaces the obsolete dormancy warning with documentation of the live capture and release safeguards. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/stale-draft..."](https://github.com/youhaowei/dashframe/commit/d982b46d7f35a5d6af137df58adbc76ec03320a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50331410)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Server API (apps/server)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-api.md)
- Knowledge Base — [Server Core: Project Persistence](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-core.md)
- Knowledge Base — [Assistant (packages/assistant)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/assistant.md)
</details>

<!-- /greptile_comment -->