### PR TITLE
feat(server): commitBatch endpoint with service-draft-only permission

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -30,6 +30,7 @@ import {
   type DashframeServer,
 } from "./app";
 import type { ProjectInfoResult } from "./functions";
+import { cmd } from "./functions/commands";
 import { LOCAL_USER_ID } from "./permissions";
 
 function bearer(token: string): { Authorization: string } {
@@ -343,6 +344,113 @@ describe("createDashframeServer", () => {
       expect((await res.json()) as { data: ProjectInfoResult }).toMatchObject({
         data: { name: "Keyed Co, no token" },
       });
+    });
+
+    it("keyed token-less loopback: commands 200, but issuing an access credential still 403s", async () => {
+      // Delta-review regression: a keyed loopback serve with no
+      // authToken/authRef has `hasPrimaryAuth === false`, so main's gate
+      // (above) keeps the accessCredentials resolver OUT of the chain —
+      // `credentialResolvers` ends up empty, same as the fully-unkeyed case.
+      // That means THIS config also hits the loopback-synthesis branch in
+      // `createDashframeServer` (see app.ts), and the synthesized principal
+      // must not double as the operator: `commands.commit` only requires
+      // `principal.kind === "user"` (satisfied — commands succeed below),
+      // but `accessCredentials.manage` additionally requires
+      // `principal.userId === LOCAL_USER_ID` specifically, which the
+      // synthesized `LOOPBACK_ANON_USER_ID` principal is NOT — so minting a
+      // credential over this unauthenticated bind must still 403, even
+      // though a key is configured and issuing credentials is otherwise
+      // reachable in principle.
+      project = await openProject({
+        dir: join(root, "proj"),
+        name: "Keyed Co, no token, commands",
+      });
+      const { vault, accessCredentials } = makeSecretServices(
+        join(root, "access-credentials"),
+      );
+      server = await createDashframeServer({
+        db: project.db,
+        vault,
+        accessCredentials,
+        // No `authToken`/`authRef` — a keyed loopback serve.
+      });
+
+      const sourceId = crypto.randomUUID();
+      const commandRes = await fetch(`${server.url}/api/createDataSource`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "csv",
+            name: "Keyed loopback",
+          }).args,
+        ),
+      });
+      expect(commandRes.status).toBe(200);
+
+      const issueRes = await fetch(`${server.url}/api/issueAccessCredential`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Should never mint" }),
+      });
+      expect(issueRes.status).toBe(403);
+    });
+
+    it("runs commands on the token-less loopback config (no authToken/authRef/accessCredentials configured)", async () => {
+      // Pins the fix for the loopback-becomes-read-only regression: before,
+      // an absent principal denied every `.authorize(commands.commit)`
+      // procedure (all 31 commands, publishDraft, discardDraft,
+      // commitBatch), even though `index.ts`'s own help text documents this
+      // exact config ("--project ... no --token ...") as the safe default —
+      // pre-existing behavior let every request through as the local
+      // operator. `createDashframeServer` must synthesize that principal
+      // when no auth mechanism is configured at all.
+      project = await openProject({ dir: join(root, "proj") });
+      server = await createDashframeServer({ db: project.db });
+
+      const sourceId = crypto.randomUUID();
+      // No Authorization header at all.
+      const res = await fetch(`${server.url}/api/createDataSource`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "csv",
+            name: "Loopback",
+          }).args,
+        ),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: { id: string } };
+      expect(body.data.id).toBe(sourceId);
+
+      // An arbitrary bearer token must not be interpreted as a service
+      // credential in this mode — there is no `accessCredentials` resolver
+      // configured to authenticate it, so the synthesized loopback resolver
+      // is the only one in play and every request (token or not) resolves
+      // to the SAME local-user principal. A service principal is simply
+      // unreachable in a config with no accessCredentials configured.
+      const otherSourceId = crypto.randomUUID();
+      const withRandomToken = await fetch(
+        `${server.url}/api/createDataSource`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...bearer("some-random-value-nobody-configured"),
+          },
+          body: JSON.stringify(
+            cmd("CreateDataSource", {
+              id: otherSourceId,
+              type: "csv",
+              name: "Loopback 2",
+            }).args,
+          ),
+        },
+      );
+      expect(withRandomToken.status).toBe(200);
     });
 
     it("issues, authenticates, and revokes a workspace access credential", async () => {

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -692,7 +692,10 @@ describe("write → subscription invalidation", () => {
 
   it("delivers invalidate to a live subscriber after a mutation on another surface", async () => {
     project = await openProject({ dir: join(root, "proj") });
-    server = await createDashframeServer({ db: project.db });
+    server = await createDashframeServer({
+      db: project.db,
+      authToken: "renderer-token",
+    });
 
     const ws = new WebSocket(`${server.url.replace(/^http/, "ws")}/api/ws`);
     const subscriptionId = "sub-invalidate-1";
@@ -703,7 +706,8 @@ describe("write → subscription invalidation", () => {
         10_000,
       );
       ws.onerror = () => reject(new Error("WebSocket failed"));
-      ws.onopen = () => ws.send(JSON.stringify({ type: "auth", token: null }));
+      ws.onopen = () =>
+        ws.send(JSON.stringify({ type: "auth", token: "renderer-token" }));
       ws.onmessage = (event) => {
         const msg = JSON.parse(String(event.data)) as {
           type?: string;
@@ -726,7 +730,10 @@ describe("write → subscription invalidation", () => {
         if (msg.type === "subscribed" && msg.id === subscriptionId) {
           void fetch(`${server!.url}/api/getOrCreateDataSource`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              "Content-Type": "application/json",
+              ...bearer("renderer-token"),
+            },
             body: JSON.stringify({
               id: crypto.randomUUID(),
               type: "csv",
@@ -785,7 +792,10 @@ describe("onWrite hook", () => {
   ): Promise<Response> {
     return fetch(`${url}/api/${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...bearer("renderer-token"),
+      },
       body: JSON.stringify(body),
     });
   }
@@ -795,6 +805,7 @@ describe("onWrite hook", () => {
     project = await openProject({ dir: join(root, "proj") });
     server = await createDashframeServer({
       db: project.db,
+      authToken: "renderer-token",
       onWrite: () => {
         onWriteCalls.push(Date.now());
       },
@@ -814,6 +825,7 @@ describe("onWrite hook", () => {
     project = await openProject({ dir: join(root, "proj") });
     server = await createDashframeServer({
       db: project.db,
+      authToken: "renderer-token",
       onWrite: () => {
         callCount++;
       },
@@ -839,6 +851,7 @@ describe("onWrite hook", () => {
     project = await openProject({ dir: join(root, "proj") });
     server = await createDashframeServer({
       db: project.db,
+      authToken: "renderer-token",
       onWrite: () => {
         callCount++;
       },
@@ -859,6 +872,7 @@ describe("onWrite hook", () => {
     project = await openProject({ dir: join(root, "proj") });
     server = await createDashframeServer({
       db: project.db,
+      authToken: "renderer-token",
       onWrite: () => {
         callCount++;
       },
@@ -866,6 +880,7 @@ describe("onWrite hook", () => {
 
     const res = await fetch(
       `${server.url}/api/projectInfo?args=${encodeURIComponent("{}")}`,
+      { headers: bearer("renderer-token") },
     );
     expect(res.status).toBe(200);
     expect(callCount).toBe(0);
@@ -874,7 +889,10 @@ describe("onWrite hook", () => {
   it("should work without onWrite (backward-compatible — omitting it changes nothing)", async () => {
     // No onWrite configured — server should start and mutations should succeed.
     project = await openProject({ dir: join(root, "proj") });
-    server = await createDashframeServer({ db: project.db });
+    server = await createDashframeServer({
+      db: project.db,
+      authToken: "renderer-token",
+    });
 
     const res = await postMutation(server.url, "getOrCreateDataSource", {
       id: crypto.randomUUID(),
@@ -893,6 +911,7 @@ describe("onWrite hook", () => {
     const sourceId = crypto.randomUUID();
     server = await createDashframeServer({
       db: project.db,
+      authToken: "renderer-token",
       onWrite: () => {
         throw new Error("snapshot scheduler exploded");
       },

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -453,6 +453,43 @@ describe("createDashframeServer", () => {
       expect(withRandomToken.status).toBe(200);
     });
 
+    it("token-less loopback synthesizes a non-operator principal — commands 200, minting an access credential still 403s", async () => {
+      // Delta-review finding: the loopback synthesis must NOT reuse
+      // `LOCAL_USER_ID` (the operator's own identity). `commands.commit`
+      // only requires `principal.kind === "user"`, so a distinct synthetic
+      // id keeps every command writable (first assertion below) — but
+      // `accessCredentials.manage` additionally requires
+      // `principal.userId === LOCAL_USER_ID` specifically, so an
+      // unauthenticated loopback request must NOT be able to mint a durable,
+      // off-host-usable API credential (second assertion). Reusing
+      // `LOCAL_USER_ID` for the synthesized principal would pass both checks
+      // and silently let any local process on the loopback bind mint
+      // credentials nobody typed a token for.
+      project = await openProject({ dir: join(root, "proj") });
+      server = await createDashframeServer({ db: project.db });
+
+      const sourceId = crypto.randomUUID();
+      const commandRes = await fetch(`${server.url}/api/createDataSource`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "csv",
+            name: "Loopback anon",
+          }).args,
+        ),
+      });
+      expect(commandRes.status).toBe(200);
+
+      const issueRes = await fetch(`${server.url}/api/issueAccessCredential`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Should never mint" }),
+      });
+      expect(issueRes.status).toBe(403);
+    });
+
     it("issues, authenticates, and revokes a workspace access credential", async () => {
       project = await openProject({
         dir: join(root, "proj"),

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -563,10 +563,27 @@ export async function createDashframeServer(
       createAccessCredentialResolver(opts.accessCredentials),
     );
   }
-  const resolveContext =
-    credentialResolvers.length > 0
-      ? combineResolvers(...credentialResolvers)
-      : undefined;
+  // No auth mechanism configured at all (no authToken, no authRef, no
+  // accessCredentials) — this is the documented token-less loopback config
+  // (`dashframe serve` with no `--token`; see index.ts's help text: "The
+  // default bind is loopback-only and safe to run without a token").
+  // `assertBindAuthorized` above already confirmed this combination is only
+  // reachable on a loopback bind (or an explicit `insecure: true` opt-out),
+  // so trusting every request as the local operator is the SAME trust model
+  // this config always had — pre-`commands.commit`, no procedure but
+  // `accessCredentials.manage` carried an `.authorize` check, so a missing
+  // principal never blocked anything. Now that every command procedure does,
+  // an absent principal denies every one of them: this loopback config would
+  // silently become read-only (previewDiff still works — its permission is
+  // open — but every command, `commitBatch`, `publishDraft`, and
+  // `discardDraft` would 403). Synthesize the local user principal for every
+  // request so the trust model is unchanged.
+  if (credentialResolvers.length === 0) {
+    credentialResolvers.push(async () => ({
+      principal: { kind: "user", userId },
+    }));
+  }
+  const resolveContext = combineResolvers(...credentialResolvers);
 
   // Wrap the WyStack app to inject the vault into every handler context and
   // to fire `opts.onWrite` after every successful mutation.

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -66,7 +66,11 @@ import {
 } from "./draft-controller";
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { functions } from "./functions";
-import { expectedPermissionIds, LOCAL_USER_ID } from "./permissions";
+import {
+  expectedPermissionIds,
+  LOCAL_USER_ID,
+  LOOPBACK_ANON_USER_ID,
+} from "./permissions";
 import { wy } from "./wystack";
 
 type CorsOrigin =
@@ -563,24 +567,36 @@ export async function createDashframeServer(
       createAccessCredentialResolver(opts.accessCredentials),
     );
   }
-  // No auth mechanism configured at all (no authToken, no authRef, no
-  // accessCredentials) — this is the documented token-less loopback config
-  // (`dashframe serve` with no `--token`; see index.ts's help text: "The
-  // default bind is loopback-only and safe to run without a token").
-  // `assertBindAuthorized` above already confirmed this combination is only
-  // reachable on a loopback bind (or an explicit `insecure: true` opt-out),
-  // so trusting every request as the local operator is the SAME trust model
-  // this config always had — pre-`commands.commit`, no procedure but
-  // `accessCredentials.manage` carried an `.authorize` check, so a missing
-  // principal never blocked anything. Now that every command procedure does,
-  // an absent principal denies every one of them: this loopback config would
-  // silently become read-only (previewDiff still works — its permission is
-  // open — but every command, `commitBatch`, `publishDraft`, and
-  // `discardDraft` would 403). Synthesize the local user principal for every
-  // request so the trust model is unchanged.
+  // `credentialResolvers` is empty here in two cases: no auth mechanism
+  // configured at all (no authToken, no authRef, no accessCredentials — the
+  // documented token-less loopback config; `dashframe serve` with no
+  // `--token`, see index.ts's help text: "The default bind is loopback-only
+  // and safe to run without a token"), OR `accessCredentials` IS configured
+  // but `hasPrimaryAuth` is false (a keyed loopback serve with no
+  // `--token`/`authRef` — the block above deliberately keeps that resolver
+  // out of the chain). Both are "no request carries an authenticated
+  // identity" configs and get the same treatment. `assertBindAuthorized`
+  // above already confirmed either combination is only reachable on a
+  // loopback bind (or an explicit `insecure: true` opt-out).
+  // Pre-`commands.commit`, no procedure but `accessCredentials.manage`
+  // carried an `.authorize` check, so a missing principal never blocked
+  // anything on this config. Now that every command procedure does, an
+  // absent principal denies every one of them: this loopback config would
+  // silently become read-only (`commands.preview` is still open to any
+  // well-formed principal — but `evaluate()` denies before it ever calls
+  // `check` when there is no principal at all, so even `previewDiff` would
+  // 403 without this — and every command, `commitBatch`, `publishDraft`, and
+  // `discardDraft` would too). Synthesize a principal for every request so
+  // the loopback config stays writable.
+  //
+  // Deliberately NOT `LOCAL_USER_ID` (the operator's own identity) — see
+  // `LOOPBACK_ANON_USER_ID`'s doc comment in permissions.ts for why using the
+  // operator id here would let any unauthenticated loopback request mint a
+  // durable, off-host-usable API credential via `accessCredentials.manage`.
+  // `commands.commit` only needs `kind === "user"`, which this satisfies.
   if (credentialResolvers.length === 0) {
     credentialResolvers.push(async () => ({
-      principal: { kind: "user", userId },
+      principal: { kind: "user", userId: LOOPBACK_ANON_USER_ID },
     }));
   }
   const resolveContext = combineResolvers(...credentialResolvers);

--- a/apps/server/src/assistant-host.test.ts
+++ b/apps/server/src/assistant-host.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { buildDashframeApp, createDraftController } from "./app";
 import { createDashframeAssistantHost } from "./assistant-host";
+import { cmd } from "./functions/commands";
+import { LOCAL_USER_ID } from "./permissions";
 
 const usage = {
   input: 0,
@@ -120,7 +122,11 @@ describe("DashFrame AssistantHost integration", () => {
 
   it("binds the single host port through a full run lifecycle", async () => {
     const dashboardId = crypto.randomUUID() as UUID;
-    const host = createDashframeAssistantHost({ app, draftController });
+    const host = createDashframeAssistantHost({
+      app,
+      draftController,
+      principal: { kind: "user", userId: LOCAL_USER_ID },
+    });
     const firstMutations: string[] = [];
     const toolErrors: boolean[] = [];
 
@@ -186,5 +192,25 @@ describe("DashFrame AssistantHost integration", () => {
       {},
     );
     expect(canonical).toBeNull();
+  });
+
+  it("forwards a service principal into draft append dispatch", async () => {
+    const host = createDashframeAssistantHost({
+      app,
+      draftController,
+      principal: { kind: "service", credentialId: "credential-1" },
+    });
+    const draftId = await host.open();
+    const dashboardId = crypto.randomUUID();
+
+    await host.append(
+      draftId,
+      [cmd("CreateDashboard", { id: dashboardId, name: "Service draft" })],
+      {},
+    );
+
+    expect(await draftController.getDraftLog(draftId)).toEqual([
+      expect.objectContaining({ path: "createDashboardCmd" }),
+    ]);
   });
 });

--- a/apps/server/src/assistant-host.ts
+++ b/apps/server/src/assistant-host.ts
@@ -1,4 +1,5 @@
 import type { AssistantCommand, AssistantHost } from "@dashframe/assistant";
+import type { Principal } from "@wystack/identity";
 import type { WyStackApp } from "@wystack/server";
 
 import { createAssistantReadHost } from "./assistant-read-host";
@@ -18,6 +19,7 @@ export interface DashframeAssistantHostOptions {
    */
   app: WyStackApp;
   draftController: DraftController;
+  principal?: Principal;
   readSourceFile?: (file: string) => Promise<string>;
 }
 
@@ -37,12 +39,25 @@ export function createDashframeAssistantHost(
   return {
     open: () => options.draftController.openDraft(),
     append: (draftId, batch, context) =>
-      options.draftController.appendToDraft(draftId, batch, context),
+      options.draftController.appendToDraft(draftId, batch, {
+        ...context,
+        ...(options.principal !== undefined
+          ? { principal: options.principal }
+          : {}),
+      }),
     discard: async (draftId) => {
       // Route through the registered command so discard runs the full
       // lifecycle (credential release, persistence scheduling), not just the
       // controller's in-memory drop.
-      await options.app.call("discardDraft", { draftId });
+      await options.app.call(
+        "discardDraft",
+        { draftId },
+        {
+          ...(options.principal !== undefined
+            ? { principal: options.principal }
+            : {}),
+        },
+      );
     },
     buildCommand,
     reader: (draftId) =>

--- a/apps/server/src/assistant-read-host.test.ts
+++ b/apps/server/src/assistant-read-host.test.ts
@@ -30,6 +30,7 @@ import { neighbors } from "@dashframe/assistant";
 import { buildDashframeApp, createDraftController } from "./app";
 import { createAssistantReadHost } from "./assistant-read-host";
 import { cmd } from "./functions/commands";
+import { LOCAL_USER_ID } from "./permissions";
 
 describe("assistant read host (resolver over the real server seam)", () => {
   let dir: string;
@@ -40,7 +41,20 @@ describe("assistant read host (resolver over the real server seam)", () => {
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-read-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
-    app = await buildDashframeApp({ db });
+    const baseApp = await buildDashframeApp({ db });
+    app = {
+      ...baseApp,
+      call: (path, args, context) =>
+        baseApp.call(path, args, {
+          ...(context ?? {}),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        }),
+      runHandler: (path, args, tracked, context) =>
+        baseApp.runHandler(path, args, tracked, {
+          ...(context ?? {}),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        }),
+    };
     controller = createDraftController(app, db);
   });
 

--- a/apps/server/src/assistant-run-route.ts
+++ b/apps/server/src/assistant-run-route.ts
@@ -7,6 +7,7 @@ import {
   type CreateAssistantRunOptions,
 } from "@dashframe/assistant";
 import { schema, type ArtifactDb } from "@dashframe/server-core";
+import { isPrincipal } from "@wystack/identity";
 import type { SecretVault } from "@wystack/secret-vault";
 import type { WyStackApp } from "@wystack/server";
 import { eq } from "drizzle-orm";
@@ -315,8 +316,9 @@ export async function handleAssistantRunRequest(
   c: Context,
   options: AssistantRunRouteOptions,
 ): Promise<Response> {
+  let resolved: Record<string, unknown> | undefined;
   try {
-    await options.resolveContext?.(c.req.raw);
+    resolved = await options.resolveContext?.(c.req.raw);
   } catch (error) {
     return c.json({ error: errorMessage(error) }, 401);
   }
@@ -360,6 +362,9 @@ export async function handleAssistantRunRequest(
   const host = createDashframeAssistantHost({
     app: options.app,
     draftController: options.draftController,
+    principal: isPrincipal(resolved?.principal)
+      ? resolved.principal
+      : undefined,
   });
 
   // Abort the provider run when the client goes away — either the fetch is

--- a/apps/server/src/credential-release.test.ts
+++ b/apps/server/src/credential-release.test.ts
@@ -60,6 +60,7 @@ import {
   commandFunctions,
   CREDENTIAL_COMMAND_FIELDS,
 } from "./functions/commands";
+import { LOCAL_USER_ID } from "./permissions";
 
 const { dataSources } = schema;
 
@@ -92,7 +93,9 @@ async function makeHarness(opts?: {
 
   // Mirror createDashframeServer's serverContext seam (without a socket): the
   // draft RPC handlers read draftController / artifactDb from the call context.
-  const serverContext: Record<string, unknown> = {};
+  const serverContext: Record<string, unknown> = {
+    principal: { kind: "user", userId: LOCAL_USER_ID },
+  };
   const app: WyStackApp = {
     ...baseApp,
     async call(path, args, ctx) {

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -38,6 +38,7 @@ import {
 } from "./app";
 import { computeLogSignature } from "./draft-log-signature";
 import { cmd } from "./functions/commands";
+import { LOCAL_USER_ID } from "./permissions";
 
 const { insights, dataSources, projectMeta } = schema;
 
@@ -62,7 +63,20 @@ describe("DraftController (persisted draft overlay)", () => {
   /** Open the full stack (db + app with the draft seam + controller) at a path. */
   async function openStack(path: string) {
     const openedDb = await openArtifactDb({ path });
-    const builtApp = await buildDashframeApp({ db: openedDb });
+    const baseApp = await buildDashframeApp({ db: openedDb });
+    const builtApp = {
+      ...baseApp,
+      call: (path, args, context) =>
+        baseApp.call(path, args, {
+          ...(context ?? {}),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        }),
+      runHandler: (path, args, tracked, context) =>
+        baseApp.runHandler(path, args, tracked, {
+          ...(context ?? {}),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        }),
+    } satisfies typeof baseApp;
     return {
       db: openedDb,
       app: builtApp,

--- a/apps/server/src/draft-controller.test.ts
+++ b/apps/server/src/draft-controller.test.ts
@@ -114,6 +114,43 @@ describe("DraftController (persisted draft overlay)", () => {
     expect(await controller.getDraftLog(draftId)).toHaveLength(1);
   });
 
+  it("rejects a nested lifecycle command in an appendToDraft batch before dispatching anything", async () => {
+    // `commands.commit`'s `.authorize` check treats `ctx.draftId != null` as
+    // "this is a draft-append step" and passes. Without a vocabulary
+    // allowlist, a nested `publishDraft` (or `discardDraft`/`commitBatch`)
+    // would read that SAME marker, pass authorization, and then run its
+    // OWN transaction against its OWN args — letting a draft-append-only
+    // caller (e.g. a service principal) publish a completely different
+    // draft for real. `appendToDraft` must reject before dispatching a
+    // single command in the batch.
+    const draftId = await controller.openDraft();
+    const otherDraftId = await controller.openDraft();
+    const targetSourceId = id();
+    await appendCmds(
+      otherDraftId,
+      cmd("CreateDataSource", {
+        id: targetSourceId,
+        type: "csv",
+        name: "Target draft",
+      }),
+    );
+
+    await expect(
+      controller.appendToDraft(draftId, [
+        { path: "publishDraft", args: { draftId: otherDraftId } } as Command,
+      ]),
+    ).rejects.toThrow(/publishDraft/);
+
+    // Neither draft was touched by the rejected append.
+    expect(await controller.getDraftLog(draftId)).toHaveLength(0);
+    expect(await controller.getDraftLog(otherDraftId)).toHaveLength(1);
+    expect(
+      (await db.select().from(dataSources)).some(
+        (row) => row.id === targetSourceId,
+      ),
+    ).toBe(false);
+  });
+
   it("enforces expectedCommandCount inside the publish transaction", async () => {
     const draftId = await controller.openDraft();
     await appendCmds(

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -83,6 +83,7 @@ import { eq, getTableName, sql } from "drizzle-orm";
 
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { computeLogSignature } from "./draft-log-signature";
+import { assertKnownCommandPaths } from "./functions/commands";
 
 /**
  * The closed set of `<table>__draft` shadows a draft can touch. Discard
@@ -763,6 +764,17 @@ export function createDraftController(
     },
 
     async appendToDraft(draftId, batch, context = {}) {
+      // Reject any non-vocabulary path (e.g. a nested `publishDraft`) BEFORE
+      // a single command runs. Every command below dispatches with `draftId`
+      // in context, and `commands.commit`'s `.authorize` check treats
+      // `ctx.draftId != null` as "this is a draft-append step" — a lifecycle
+      // procedure (publishDraft/discardDraft/commitBatch) nested in the batch
+      // would read that SAME marker and pass, then run its own real
+      // transaction using its OWN args (e.g. a different, unrelated draftId
+      // to publish for real) — a service principal that can only ever draft
+      // would escalate to a real canonical publish. See
+      // `assertKnownCommandPaths` in functions/commands.ts.
+      assertKnownCommandPaths(batch, "appendToDraft");
       // Route writes through the draft overlay by passing a BASE DrizzleTracker plus a
       // `draftId` in context, so `app.runHandler`'s `withDraftSeam` builds the
       // per-table FALL-THROUGH draft handle (draftable tables → `<table>__draft`,

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -812,6 +812,15 @@ export function createDraftController(
           const captured = captureCredentials
             ? await captureCredentials(cmd)
             : { command: cmd, rollback: async () => {} };
+          // Defense in depth: `assertKnownCommandPaths(batch, ...)` above
+          // already rejected any out-of-vocabulary path in the caller-supplied
+          // batch before this loop started. Re-check the CAPTURED command too
+          // — `captureCredentials` rewrites `args` (plaintext → vault ref) and
+          // is trusted to leave `path` alone, but a future capture
+          // implementation that also normalizes/reroutes `path` should not be
+          // able to smuggle a lifecycle path past the pre-dispatch gate by
+          // producing it only after the batch-level check already passed.
+          assertKnownCommandPaths([captured.command], "appendToDraft");
           captureRollbacks.push(captured.rollback);
           const value = await app.runHandler(
             captured.command.path,
@@ -900,6 +909,15 @@ export function createDraftController(
           );
         }
         assertPublishLogHasNoLateBound(log);
+        // Defense in depth: every command in the log was already vetted by
+        // `assertKnownCommandPaths` at `appendToDraft` time, so this should
+        // never find anything — but replay reads the log fresh from storage
+        // inside this transaction, not the in-memory batch that was
+        // originally validated. Re-checking here means a hypothetical path
+        // that reaches the table some other way (a direct write, a future
+        // seam that skips `appendToDraft`) still can't replay a lifecycle
+        // command onto canonical state.
+        assertKnownCommandPaths(log, "publishDraft replay");
         validatePublishLog?.(log);
         if (options.blockOnConflict === true) {
           const conflictReport = await detectConflictReport(

--- a/apps/server/src/functions/command-authorization.test.ts
+++ b/apps/server/src/functions/command-authorization.test.ts
@@ -1,0 +1,113 @@
+import { openArtifactDb } from "@dashframe/server-core";
+import type { Principal } from "@wystack/identity";
+import type { WyStackApp } from "@wystack/server";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { functions } from "../functions";
+import { wy } from "../wystack";
+
+const servicePrincipal: Principal = {
+  kind: "service",
+  credentialId: "credential-1",
+};
+
+const id = "00000000-0000-4000-8000-000000000001";
+const relatedId = "00000000-0000-4000-8000-000000000002";
+
+const commandCalls = [
+  ["getOrCreateDataSource", { id, type: "csv", name: "Source" }],
+  ["createDataSource", { id, type: "csv", name: "Source" }],
+  ["setDataSourceConfig", { id }],
+  [
+    "createDataTable",
+    { id, dataSourceId: relatedId, name: "Table", table: "table.csv" },
+  ],
+  ["setDataTableSchema", { id, sourceSchema: {} }],
+  ["refreshDataTableCmd", { id, dataFrameId: relatedId }],
+  ["addField", { nodeId: id, field: {} }],
+  ["updateField", { nodeId: id, fieldId: relatedId, updates: {} }],
+  ["removeField", { nodeId: id, fieldId: relatedId }],
+  ["addMetric", { nodeId: id, metric: {} }],
+  ["updateMetric", { nodeId: id, metricId: relatedId, updates: {} }],
+  ["removeMetric", { nodeId: id, metricId: relatedId }],
+  [
+    "createInsightCmd",
+    {
+      id,
+      name: "Insight",
+      source: { sourceType: "dataTable", sourceId: relatedId },
+    },
+  ],
+  [
+    "setInsightSource",
+    { id, source: { sourceType: "dataTable", sourceId: relatedId } },
+  ],
+  ["selectFields", { id, fieldIds: [] }],
+  ["setInsightFilter", { id, filters: [] }],
+  ["setInsightSort", { id, sorts: [] }],
+  ["addJoin", { id, join: {} }],
+  ["updateJoin", { id, joinIndex: 0, updates: {} }],
+  ["removeJoin", { id, joinIndex: 0 }],
+  [
+    "createVisualizationCmd",
+    {
+      id,
+      name: "Visualization",
+      insightId: relatedId,
+      visualizationType: "bar",
+      spec: {},
+    },
+  ],
+  ["setChartType", { id, visualizationType: "line" }],
+  ["setChartEncoding", { id, encoding: {} }],
+  ["createDashboardCmd", { id, name: "Dashboard" }],
+  ["addDashboardItemCmd", { dashboardId: id, item: {} }],
+  [
+    "updateDashboardItemCmd",
+    { dashboardId: id, itemId: relatedId, updates: {} },
+  ],
+  ["setDashboardLayout", { dashboardId: id, items: [] }],
+  ["removeDashboardItemCmd", { dashboardId: id, itemId: relatedId }],
+  [
+    "fanOutDashboardItemsCmd",
+    {
+      dashboardId: id,
+      sourceItemId: relatedId,
+      field: "region",
+      placements: [],
+    },
+  ],
+  ["renameNode", { id, name: "Renamed" }],
+  ["deleteNode", { id }],
+] as const;
+
+describe("command procedure authorization", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-command-auth-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await wy.build({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects a service principal on all 31 direct command procedures", async () => {
+    expect(commandCalls).toHaveLength(31);
+
+    for (const [path, args] of commandCalls) {
+      await expect(
+        app.call(path, args, { principal: servicePrincipal }),
+        path,
+      ).rejects.toMatchObject({ name: "PermissionDeniedError" });
+    }
+  });
+});

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -32,6 +32,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { functions } from "../functions";
+import { LOCAL_USER_ID } from "../permissions";
 import { wy } from "../wystack";
 import {
   cmd,
@@ -81,7 +82,13 @@ describe("command vocabulary", () => {
   // passes ctx.vault to handlers. Credential-bearing commands require it (the
   // server fails closed without a vault); credential-free batches ignore it.
   async function commit(...commands: ReturnType<typeof cmd>[]) {
-    return applyCommands(app, commands, { mode: "commit", context: { vault } });
+    return applyCommands(app, commands, {
+      mode: "commit",
+      context: {
+        vault,
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      },
+    });
   }
 
   // Assertion reads go through the raw Drizzle handle and filter in JS — the
@@ -828,7 +835,13 @@ describe("command vocabulary", () => {
       const result = await applyCommands(
         app,
         [cmd("CreateDataSource", { id: sourceId, type: "csv", name: "S" })],
-        { mode: "preview" },
+        {
+          mode: "preview",
+          context: {
+            principal: { kind: "service", credentialId: "credential-1" },
+            mode: "preview",
+          },
+        },
       );
       expect(result.mode).toBe("preview");
       // It WOULD have written the data_sources table — pin the table name so a

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -98,6 +98,7 @@ import { isSecretRef, type SecretRef } from "@wystack/secret-vault";
 import type { Command } from "@wystack/server";
 
 import type { DashframeFunctionContext } from "../app-context";
+import { permissions } from "../permissions";
 import { wy } from "../wystack";
 import {
   type InsightSource,
@@ -288,6 +289,7 @@ async function wouldCreateCycle(
  */
 const getOrCreateDataSource = wy.procedure
   .input({ id: uuid, type: text, name: text })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, type, name }): Promise<{ id: string }> => {
     const existing = (await ctx.db
       .from(dataSources)
@@ -322,6 +324,7 @@ const createDataSource = wy.procedure
     /** Artifact provenance carried by the emitter (agent vs user). */
     createdBy: jsonb.optional(),
   })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (
       ctx,
@@ -406,6 +409,7 @@ const setDataSourceConfig = wy.procedure
     connectionString: text.optional(),
     extra: jsonb.optional(),
   })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (
       ctx,
@@ -522,6 +526,7 @@ const createDataTable = wy.procedure
     metrics: jsonb.optional(),
     dataFrameId: uuid.optional(),
   })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, args): Promise<{ id: string }> => {
     const [row] = (await ctx.db.into(dataTables).insert({
       id: args.id,
@@ -554,6 +559,7 @@ async function requireDataTable(
 /** SetDataTableSchema — replaces the discovered source schema slice. */
 const setDataTableSchema = wy.procedure
   .input({ id: uuid, sourceSchema: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, sourceSchema }): Promise<{ ok: true }> => {
     await requireDataTable(ctx, id);
     await ctx.db
@@ -566,6 +572,7 @@ const setDataTableSchema = wy.procedure
 /** RefreshDataTable — points the table at a new DataFrame and stamps the fetch. */
 const refreshDataTable = wy.procedure
   .input({ id: uuid, dataFrameId: uuid })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, dataFrameId }): Promise<{ ok: true }> => {
     await requireDataTable(ctx, id);
     await ctx.db
@@ -595,6 +602,7 @@ const createInsight = wy.procedure
     selectedFields: jsonb.optional(),
     metrics: jsonb.optional(),
   })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, args): Promise<{ id: string }> => {
     const parsedSource = insightSourceSchema.safeParse(args.source);
     if (!parsedSource.success) {
@@ -642,6 +650,7 @@ const createInsight = wy.procedure
  */
 const setInsightSource = wy.procedure
   .input({ id: uuid, source: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, source: rawSource }): Promise<{ ok: true }> => {
     const parsedSource = insightSourceSchema.safeParse(rawSource);
     if (!parsedSource.success) {
@@ -691,6 +700,7 @@ const setInsightSource = wy.procedure
  */
 const selectFields = wy.procedure
   .input({ id: uuid, fieldIds: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, fieldIds }): Promise<{ ok: true }> => {
     const { definition } = await requireInsightDefinition(ctx, id);
     const next = requireDefinitionShape("SelectFields", {
@@ -713,6 +723,7 @@ const selectFields = wy.procedure
  */
 const setInsightFilter = wy.procedure
   .input({ id: uuid, filters: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, filters }): Promise<{ ok: true }> => {
     const { definition } = await requireInsightDefinition(ctx, id);
     const next = requireDefinitionShape("SetInsightFilter", {
@@ -732,6 +743,7 @@ const setInsightFilter = wy.procedure
  */
 const setInsightSort = wy.procedure
   .input({ id: uuid, sorts: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, sorts }): Promise<{ ok: true }> => {
     const { definition } = await requireInsightDefinition(ctx, id);
     const next = requireDefinitionShape("SetInsightSort", {
@@ -815,6 +827,7 @@ function requireJoinShape(value: unknown): InsightJoinConfig {
 /** AddJoin — append an inline join to an Insight. */
 const addJoin = wy.procedure
   .input({ id: uuid, join: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, join }): Promise<{ ok: true }> => {
     const validated = requireJoinShape(join);
     // The rightTableId has no stored FK (joins live in jsonb), so verify it
@@ -847,6 +860,7 @@ const addJoin = wy.procedure
 /** UpdateJoin — edit a join's keys/type at the given array index. */
 const updateJoin = wy.procedure
   .input({ id: uuid, joinIndex: jsonb, updates: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, joinIndex, updates }): Promise<{ ok: true }> => {
     if (!isRecord(updates) || Object.keys(updates).length === 0) {
       throw new Error("updates are required for UpdateJoin");
@@ -879,6 +893,7 @@ const updateJoin = wy.procedure
 /** RemoveJoin — drop the join at the given array index. */
 const removeJoin = wy.procedure
   .input({ id: uuid, joinIndex: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, joinIndex }): Promise<{ ok: true }> => {
     if (
       typeof joinIndex !== "number" ||
@@ -1136,6 +1151,7 @@ function applyCollectionOp(
 
 const addField = wy.procedure
   .input({ nodeId: uuid, field: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { nodeId, field }): Promise<FieldMetricResult> => {
     const kind = await patchDataTableCollection(ctx, nodeId, "fields", {
       mode: "add",
@@ -1146,6 +1162,7 @@ const addField = wy.procedure
 
 const updateField = wy.procedure
   .input({ nodeId: uuid, fieldId: uuid, updates: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (ctx, { nodeId, fieldId, updates }): Promise<FieldMetricResult> => {
       if (!isRecord(updates) || Object.keys(updates).length === 0) {
@@ -1162,6 +1179,7 @@ const updateField = wy.procedure
 
 const removeField = wy.procedure
   .input({ nodeId: uuid, fieldId: uuid })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { nodeId, fieldId }): Promise<FieldMetricResult> => {
     const kind = await patchDataTableCollection(ctx, nodeId, "fields", {
       mode: "remove",
@@ -1172,6 +1190,7 @@ const removeField = wy.procedure
 
 const addMetric = wy.procedure
   .input({ nodeId: uuid, metric: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { nodeId, metric }): Promise<FieldMetricResult> => {
     const kind = await patchDataTableCollection(ctx, nodeId, "metrics", {
       mode: "add",
@@ -1187,6 +1206,7 @@ const addMetric = wy.procedure
 
 const updateMetric = wy.procedure
   .input({ nodeId: uuid, metricId: uuid, updates: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (ctx, { nodeId, metricId, updates }): Promise<FieldMetricResult> => {
       if (!isRecord(updates) || Object.keys(updates).length === 0) {
@@ -1203,6 +1223,7 @@ const updateMetric = wy.procedure
 
 const removeMetric = wy.procedure
   .input({ nodeId: uuid, metricId: uuid })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { nodeId, metricId }): Promise<FieldMetricResult> => {
     const kind = await patchDataTableCollection(ctx, nodeId, "metrics", {
       mode: "remove",
@@ -1241,6 +1262,7 @@ const createVisualization = wy.procedure
     spec: jsonb,
     encoding: jsonb.optional(),
   })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, args): Promise<{ id: string }> => {
     const [row] = (await ctx.db.into(visualizations).insert({
       id: args.id,
@@ -1269,6 +1291,7 @@ async function requireVisualization(
  */
 const setChartType = wy.procedure
   .input({ id: uuid, visualizationType: text })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, visualizationType }): Promise<{ ok: true }> => {
     await requireVisualization(ctx, id);
     await ctx.db
@@ -1285,6 +1308,7 @@ const setChartType = wy.procedure
  */
 const setChartEncoding = wy.procedure
   .input({ id: uuid, encoding: jsonb, spec: jsonb.optional() })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, encoding, spec }): Promise<{ ok: true }> => {
     await requireVisualization(ctx, id);
     const patch: Partial<VisualizationRow> = {
@@ -1416,6 +1440,7 @@ function sanitizeDashboardItemUpdates(
  */
 const createDashboard = wy.procedure
   .input({ id: uuid, name: text, description: text.optional() })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, name, description }): Promise<{ id: string }> => {
     const [row] = (await ctx.db.into(dashboards).insert({
       id,
@@ -1437,6 +1462,7 @@ const createDashboard = wy.procedure
  */
 const addDashboardItem = wy.procedure
   .input({ dashboardId: uuid, item: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (ctx, { dashboardId, item: rawItem }): Promise<{ ok: true }> => {
       const item = requireDashboardItem(rawItem);
@@ -1461,6 +1487,7 @@ const addDashboardItem = wy.procedure
  */
 const updateDashboardItem = wy.procedure
   .input({ dashboardId: uuid, itemId: uuid, updates: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (ctx, { dashboardId, itemId, updates }): Promise<{ ok: true }> => {
       if (!isRecord(updates) || Object.keys(updates).length === 0) {
@@ -1503,6 +1530,7 @@ const updateDashboardItem = wy.procedure
  */
 const setDashboardLayout = wy.procedure
   .input({ dashboardId: uuid, items: jsonb })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { dashboardId, items }): Promise<{ ok: true }> => {
     // Guard existence first — a missing dashboard would silently do nothing.
     await requireDashboardItems(ctx, dashboardId);
@@ -1524,6 +1552,7 @@ const setDashboardLayout = wy.procedure
  */
 const removeDashboardItem = wy.procedure
   .input({ dashboardId: uuid, itemId: uuid })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { dashboardId, itemId }): Promise<{ ok: true }> => {
     const items = await requireDashboardItems(ctx, dashboardId);
     if (!items.some((it) => it.id === itemId)) {
@@ -1562,6 +1591,7 @@ const fanOutDashboardItems = wy.procedure
     field: text,
     placements: jsonb,
   })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (
       ctx,
@@ -1705,6 +1735,7 @@ export interface RenameNodeResult {
  */
 const renameNode = wy.procedure
   .input({ id: uuid, name: text })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, name }): Promise<RenameNodeResult> => {
     // Probe order (dataTables → dataSources → insights) is load-bearing: the
     // preview builder reads `renamed` to learn which artifact this rename hit
@@ -2042,6 +2073,7 @@ function assertVaultPresentForCredentialDelete(
  */
 const deleteNode = wy.procedure
   .input({ id: uuid })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id }): Promise<DeleteNodeResult> => {
     // --- Visualization -------------------------------------------------------
     // No owned children. Reference boundary: Dashboards that contain this

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -2280,6 +2280,64 @@ export const commandFunctions = {
   deleteNode,
 };
 
+/**
+ * The registry paths the pure command vocabulary dispatches under (the keys
+ * of `commandFunctions`). Lifecycle procedures — `publishDraft`,
+ * `discardDraft`, `commitBatch`, `previewDiff`, `draftPublishReview`, etc. —
+ * are never members of this set.
+ *
+ * This is a security boundary, not a convenience lookup. Every one of those
+ * lifecycle procedures runs `.authorize(permissions.commands.commit)`, whose
+ * check trusts CONTEXT markers it did not itself verify — `ctx.mode ===
+ * "preview"`, `ctx.draftId != null`, `ctx.__publishReplay === true` — because
+ * those markers are supposed to mean "this dispatch is a nested step of an
+ * already-authorized outer batch." But `applyCommands`/`runHandler` dispatch
+ * ANY registry path with no allowlist of their own. Nest `publishDraft` (or
+ * `commitBatch`) itself inside a batch and its `.authorize` check reads the
+ * OUTER batch's markers and passes — a service principal that can only ever
+ * preview or draft-append escalates to a real canonical publish, because the
+ * nested procedure's OWN transaction is outside the reach of the outer
+ * preview's rollback (or is simply a second, real commit).
+ *
+ * The fix is not a smarter authorize check (context markers can't distinguish
+ * "I am the outer call" from "I am nested inside one" — they're the same
+ * bag). It's dispatch discipline: every surface that runs a caller-supplied
+ * batch (`previewDiff`, `commitBatch`, `DraftController.appendToDraft`) MUST
+ * reject any command whose path falls outside this vocabulary BEFORE
+ * dispatching a single command — see `assertKnownCommandPaths`.
+ */
+const KNOWN_COMMAND_PATHS: ReadonlySet<string> = new Set(
+  Object.keys(commandFunctions),
+);
+
+export function isKnownCommandPath(
+  path: string,
+): path is keyof typeof commandFunctions {
+  return KNOWN_COMMAND_PATHS.has(path);
+}
+
+/**
+ * Reject a caller-supplied batch containing any path outside the pure
+ * command vocabulary — see `KNOWN_COMMAND_PATHS` for why this matters. Call
+ * this BEFORE dispatching a single command from the batch; a bad path later
+ * in the batch must not let earlier commands run first. `surface` names the
+ * calling procedure/method for the error message.
+ */
+export function assertKnownCommandPaths(
+  commands: readonly Command[],
+  surface: string,
+): void {
+  for (const command of commands) {
+    if (!isKnownCommandPath(command.path)) {
+      throw new Error(
+        `${surface}: "${command.path}" is not a DashFrame command — ` +
+          "lifecycle procedures (publishDraft, discardDraft, commitBatch, " +
+          "previewDiff, etc.) cannot be nested inside a batch",
+      );
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Typed command builders — the VOCABULARY face
 // ---------------------------------------------------------------------------

--- a/apps/server/src/functions/commit-batch.test.ts
+++ b/apps/server/src/functions/commit-batch.test.ts
@@ -197,6 +197,74 @@ describe("commitBatch and draft-only API credentials", () => {
     expect(await project!.db.select().from(schema.dataSources)).toHaveLength(0);
   });
 
+  it("rejects a nested lifecycle command inside a previewDiff/commitBatch batch (preview-nested-publish escape)", async () => {
+    // Regression for the merge-gate finding: previewDiff carries no
+    // vocabulary allowlist of its own, and its dispatch merges `mode:
+    // "preview"` into the handler context. `publishDraft`'s
+    // `.authorize(commands.commit)` check treats `ctx.mode === "preview"` as
+    // "this is a nested preview step" and passes — but `publishDraft`'s
+    // handler opens its OWN transaction that the preview's rollback can
+    // never reach. Nesting it inside a batch let a service principal (who
+    // can only ever preview or draft-append) publish a draft for real. The
+    // fix rejects any non-vocabulary path before a single command in the
+    // batch dispatches — see `assertKnownCommandPaths` in
+    // `functions/commands.ts`.
+    const seedApp = await buildDashframeApp({ db: project!.db });
+    const controller = createDraftController(seedApp, project!.db);
+    const targetSourceId = crypto.randomUUID();
+    const draftId = await controller.openDraft();
+    // `commands.commit`'s `.authorize` short-circuits to deny on an absent
+    // principal REGARDLESS of the draftId marker (`evaluate` requires a
+    // well-formed `Principal` before it will even call the permission's
+    // `check`) — a real append always carries the caller's identity, so
+    // attribute this seed append to a principal like every other caller
+    // does.
+    await controller.appendToDraft(
+      draftId,
+      [
+        cmd("CreateDataSource", {
+          id: targetSourceId,
+          type: "csv",
+          name: "Must stay a draft",
+        }),
+      ],
+      { principal: { kind: "user", userId: "seed-user" } },
+    );
+
+    server = await createDashframeServer({
+      db: project!.db,
+      accessCredentials,
+      authToken: USER_TOKEN,
+    });
+
+    const nestedPublish = { path: "publishDraft", args: { draftId } };
+
+    const previewArgs = encodeURIComponent(
+      JSON.stringify({ commands: [nestedPublish] }),
+    );
+    const previewResponse = await fetch(
+      `${server.url}/api/previewDiff?args=${previewArgs}`,
+      { headers: bearer(serviceToken) },
+    );
+    expect(previewResponse.status).not.toBe(200);
+
+    const commitResponse = await post(
+      server,
+      "commitBatch",
+      { commands: [nestedPublish] },
+      USER_TOKEN,
+    );
+    expect(commitResponse.status).not.toBe(200);
+
+    // The draft never published — no canonical write from either attempt.
+    expect(
+      (await project!.db.select().from(schema.dataSources)).some(
+        (row) => row.id === targetSourceId,
+      ),
+    ).toBe(false);
+    expect(await controller.getDraftLog(draftId)).toHaveLength(1);
+  });
+
   it("allows service draft append, denies its publish/discard, and lets a user finish", async () => {
     const seedApp = await buildDashframeApp({ db: project!.db });
     const controller = createDraftController(seedApp, project!.db);

--- a/apps/server/src/functions/commit-batch.test.ts
+++ b/apps/server/src/functions/commit-batch.test.ts
@@ -1,0 +1,288 @@
+import {
+  ApiAccessCredentials,
+  openProject,
+  schema,
+  type ProjectHandle,
+} from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+} from "@wystack/secret-vault";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildDashframeApp,
+  createDashframeServer,
+  createDraftController,
+  type DashframeServer,
+} from "../app";
+import { cmd } from "./commands";
+
+const USER_TOKEN = "renderer-token";
+
+function bearer(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}
+
+function makeAccessCredentials(rootDir: string): ApiAccessCredentials {
+  const registry = new SecretRegistry();
+  registry.register("test", new TestBackend(), { fallback: true });
+  registry.setClassDefault("serve-token", "test");
+  return new ApiAccessCredentials(
+    new SecretVault(registry, new InMemoryMappingStore()),
+    rootDir,
+  );
+}
+
+async function post(
+  server: DashframeServer,
+  path: string,
+  body: unknown,
+  token: string,
+): Promise<Response> {
+  return fetch(`${server.url}/api/${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...bearer(token),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("commitBatch and draft-only API credentials", () => {
+  let root: string;
+  let project: ProjectHandle | null;
+  let server: DashframeServer | null;
+  let serviceToken: string;
+  let accessCredentials: ApiAccessCredentials;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-commit-batch-"));
+    project = await openProject({ dir: join(root, "project") });
+    accessCredentials = makeAccessCredentials(join(root, "credentials"));
+    ({ token: serviceToken } = await accessCredentials.issue("Test service"));
+    server = null;
+  });
+
+  afterEach(async () => {
+    server?.stop();
+    await project?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("denies service commits, commits a user batch atomically, and reports writes", async () => {
+    const onWriteCalls: number[] = [];
+    server = await createDashframeServer({
+      db: project!.db,
+      accessCredentials,
+      authToken: USER_TOKEN,
+      onWrite: () => onWriteCalls.push(Date.now()),
+    });
+
+    const sourceId = crypto.randomUUID();
+    const tableId = crypto.randomUUID();
+    const commands = [
+      cmd("CreateDataSource", {
+        id: sourceId,
+        type: "csv",
+        name: "Committed source",
+      }),
+      cmd("CreateDataTable", {
+        id: tableId,
+        dataSourceId: sourceId,
+        name: "Committed table",
+        table: "committed.csv",
+      }),
+    ];
+
+    const denied = await post(
+      server,
+      "commitBatch",
+      { commands },
+      serviceToken,
+    );
+    expect(denied.status).toBe(403);
+    expect(await project!.db.select().from(schema.dataSources)).toHaveLength(0);
+
+    const committed = await post(
+      server,
+      "commitBatch",
+      { commands },
+      USER_TOKEN,
+    );
+    expect(committed.status).toBe(200);
+    const payload = (await committed.json()) as {
+      data: {
+        mode: string;
+        commands: unknown[];
+        results: unknown[];
+        tablesWritten: string[];
+        __extraTablesWritten?: unknown;
+      };
+    };
+    expect(payload.data).toMatchObject({
+      mode: "commit",
+      commands,
+    });
+    expect(payload.data.results).toHaveLength(2);
+    expect(payload.data.tablesWritten).toEqual(
+      expect.arrayContaining(["data_sources", "data_tables"]),
+    );
+    expect(payload.data.__extraTablesWritten).toBeUndefined();
+    expect(onWriteCalls).toHaveLength(1);
+
+    expect(await project!.db.select().from(schema.dataSources)).toHaveLength(1);
+    expect(await project!.db.select().from(schema.dataTables)).toHaveLength(1);
+
+    const rollbackSourceId = crypto.randomUUID();
+    const failed = await post(
+      server,
+      "commitBatch",
+      {
+        commands: [
+          cmd("CreateDataSource", {
+            id: rollbackSourceId,
+            type: "csv",
+            name: "Must roll back",
+          }),
+          cmd("DeleteNode", { id: crypto.randomUUID() }),
+        ],
+      },
+      USER_TOKEN,
+    );
+    expect(failed.status).toBe(500);
+    expect(
+      (await project!.db.select().from(schema.dataSources)).some(
+        (row) => row.id === rollbackSourceId,
+      ),
+    ).toBe(false);
+  });
+
+  it("allows a service principal to preview the same command surface", async () => {
+    server = await createDashframeServer({
+      db: project!.db,
+      accessCredentials,
+      authToken: USER_TOKEN,
+    });
+    const sourceId = crypto.randomUUID();
+    const args = encodeURIComponent(
+      JSON.stringify({
+        commands: [
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "csv",
+            name: "Preview only",
+          }),
+        ],
+      }),
+    );
+
+    const response = await fetch(`${server.url}/api/previewDiff?args=${args}`, {
+      headers: bearer(serviceToken),
+    });
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      data: { mode: string; directNodes: Array<{ nodeId: string }> };
+    };
+    expect(payload.data.mode).toBe("preview");
+    expect(payload.data.directNodes).toEqual([
+      expect.objectContaining({ nodeId: sourceId }),
+    ]);
+    expect(await project!.db.select().from(schema.dataSources)).toHaveLength(0);
+  });
+
+  it("allows service draft append, denies its publish/discard, and lets a user finish", async () => {
+    const seedApp = await buildDashframeApp({ db: project!.db });
+    const controller = createDraftController(seedApp, project!.db);
+    const servicePrincipal = {
+      kind: "service" as const,
+      credentialId: "seed-service",
+    };
+
+    const publishDraftId = await controller.openDraft();
+    const publishedSourceId = crypto.randomUUID();
+    await controller.appendToDraft(
+      publishDraftId,
+      [
+        cmd("CreateDataSource", {
+          id: publishedSourceId,
+          type: "csv",
+          name: "Draft source",
+        }),
+      ],
+      { principal: servicePrincipal },
+    );
+
+    server = await createDashframeServer({
+      db: project!.db,
+      accessCredentials,
+      authToken: USER_TOKEN,
+    });
+
+    const reviewArgs = encodeURIComponent(
+      JSON.stringify({ draftId: publishDraftId }),
+    );
+    const review = await fetch(
+      `${server.url}/api/draftPublishReview?args=${reviewArgs}`,
+      { headers: bearer(serviceToken) },
+    );
+    expect(review.status).toBe(200);
+
+    expect(
+      (
+        await post(
+          server,
+          "publishDraft",
+          { draftId: publishDraftId },
+          serviceToken,
+        )
+      ).status,
+    ).toBe(403);
+    expect(
+      (
+        await post(
+          server,
+          "publishDraft",
+          { draftId: publishDraftId },
+          USER_TOKEN,
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (await project!.db.select().from(schema.dataSources)).some(
+        (row) => row.id === publishedSourceId,
+      ),
+    ).toBe(true);
+
+    const discardDraftId = await controller.openDraft();
+    await controller.appendToDraft(discardDraftId, [], {
+      principal: servicePrincipal,
+    });
+    expect(
+      (
+        await post(
+          server,
+          "discardDraft",
+          { draftId: discardDraftId },
+          serviceToken,
+        )
+      ).status,
+    ).toBe(403);
+    expect(
+      (
+        await post(
+          server,
+          "discardDraft",
+          { draftId: discardDraftId },
+          USER_TOKEN,
+        )
+      ).status,
+    ).toBe(200);
+  });
+});

--- a/apps/server/src/functions/commit-batch.test.ts
+++ b/apps/server/src/functions/commit-batch.test.ts
@@ -246,7 +246,13 @@ describe("commitBatch and draft-only API credentials", () => {
       `${server.url}/api/previewDiff?args=${previewArgs}`,
       { headers: bearer(serviceToken) },
     );
-    expect(previewResponse.status).not.toBe(200);
+    // `assertKnownCommandPaths` throws a plain Error (not a permission
+    // denial — the batch is rejected before dispatch ever gets a chance to
+    // authorize anything), which the router's generic catch-all answers 500.
+    expect(previewResponse.status).toBe(500);
+    const previewBody = (await previewResponse.json()) as { error: string };
+    expect(previewBody.error).toContain("publishDraft");
+    expect(previewBody.error).toContain("is not a DashFrame command");
 
     const commitResponse = await post(
       server,
@@ -254,7 +260,10 @@ describe("commitBatch and draft-only API credentials", () => {
       { commands: [nestedPublish] },
       USER_TOKEN,
     );
-    expect(commitResponse.status).not.toBe(200);
+    expect(commitResponse.status).toBe(500);
+    const commitBody = (await commitResponse.json()) as { error: string };
+    expect(commitBody.error).toContain("publishDraft");
+    expect(commitBody.error).toContain("is not a DashFrame command");
 
     // The draft never published — no canonical write from either attempt.
     expect(

--- a/apps/server/src/functions/draft-lifecycle.test.ts
+++ b/apps/server/src/functions/draft-lifecycle.test.ts
@@ -60,10 +60,12 @@ import {
 } from "../app";
 import { captureCommandCredentials } from "../credential-release";
 import type { Functions } from "../functions";
+import { LOCAL_USER_ID } from "../permissions";
 import { cmd } from "./commands";
 
 /** Mirrors packages/app/src/wystack/api.ts's module-scope api object. */
 const api: ApiFromFunctions<Functions> = createApi<Functions>();
+const USER_TOKEN = "renderer-token";
 
 const { dataSources } = schema;
 
@@ -82,7 +84,10 @@ function makeTestVault(): SecretVault {
 function post(url: string, path: string, body: unknown): Promise<Response> {
   return fetch(`${url}/api/${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${USER_TOKEN}`,
+    },
     body: JSON.stringify(body),
   });
 }
@@ -90,7 +95,31 @@ function post(url: string, path: string, body: unknown): Promise<Response> {
 /** GET /api/:path?args=<json> — for WyStack query endpoints. */
 function get(url: string, path: string, args: unknown): Promise<Response> {
   const params = new URLSearchParams({ args: JSON.stringify(args) });
-  return fetch(`${url}/api/${path}?${params.toString()}`, { method: "GET" });
+  return fetch(`${url}/api/${path}?${params.toString()}`, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${USER_TOKEN}` },
+  });
+}
+
+async function buildUserApp(opts: Parameters<typeof buildDashframeApp>[0]) {
+  const baseApp = await buildDashframeApp(opts);
+  return {
+    ...baseApp,
+    call: (path, args, context) =>
+      baseApp.call(path, args, {
+        ...(context ?? {}),
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      }),
+    runHandler: (path, args, tracked, context) =>
+      baseApp.runHandler(path, args, tracked, {
+        ...(context ?? {}),
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      }),
+  } satisfies typeof baseApp;
+}
+
+function createUserServer(opts: Parameters<typeof createDashframeServer>[0]) {
+  return createDashframeServer({ ...opts, authToken: USER_TOKEN });
 }
 
 async function postOk<T>(url: string, path: string, body: unknown): Promise<T> {
@@ -141,7 +170,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
    * Returns the draftId to pass to the HTTP RPCs.
    */
   async function seedDraft(db: ArtifactDb): Promise<string> {
-    const seedApp = await buildDashframeApp({ db });
+    const seedApp = await buildUserApp({ db });
     const seedController = createDraftController(seedApp, db);
 
     // Seed a DataSource into canonical first (publishDraft writes to the
@@ -168,7 +197,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
   }
 
   async function seedCanonicalSource(db: ArtifactDb, name: string) {
-    const seedApp = await buildDashframeApp({ db });
+    const seedApp = await buildUserApp({ db });
     const seedController = createDraftController(seedApp, db);
     const sourceId = crypto.randomUUID();
     const seedDraftId = await seedController.openDraft();
@@ -189,7 +218,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const draftId = await seedDraft(project.db as ArtifactDb);
 
-    server = await createDashframeServer({
+    server = await createUserServer({
       db: project.db,
       onWrite: () => onWriteCalls.push(Date.now()),
     });
@@ -214,14 +243,14 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "empty") });
 
     // Open a draft with no commands — no writes means no onWrite.
-    const seedApp = await buildDashframeApp({ db: project.db as ArtifactDb });
+    const seedApp = await buildUserApp({ db: project.db as ArtifactDb });
     const seedController = createDraftController(
       seedApp,
       project.db as ArtifactDb,
     );
     const emptyDraftId = await seedController.openDraft();
 
-    server = await createDashframeServer({
+    server = await createUserServer({
       db: project.db,
       onWrite: () => onWriteCalls.push(Date.now()),
     });
@@ -247,7 +276,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const draftId = await seedDraft(project.db as ArtifactDb);
 
-    server = await createDashframeServer({
+    server = await createUserServer({
       db: project.db,
       onWrite: () => onWriteCalls.push(Date.now()),
     });
@@ -267,7 +296,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const draftId = await seedDraft(project.db as ArtifactDb);
 
-    server = await createDashframeServer({ db: project.db });
+    server = await createUserServer({ db: project.db });
 
     const res = await post(server.url, "publishDraft", { draftId });
     expect(res.status).toBe(200);
@@ -303,7 +332,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
       .set({ name: "Canonical rename" })
       .where(eq(dataSources.id, sourceId));
 
-    server = await createDashframeServer({ db });
+    server = await createUserServer({ db });
 
     const res = await post(server.url, "publishDraft", { draftId });
     expect(res.status).toBe(400);
@@ -357,7 +386,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
       .set({ name: "Disjoint canonical rename" })
       .where(eq(dataSources.id, canonicalSourceId));
 
-    server = await createDashframeServer({ db });
+    server = await createUserServer({ db });
 
     await postOk<{ tablesWritten: string[] }>(server.url, "publishDraft", {
       draftId,
@@ -389,7 +418,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     // the signal).
     await db.delete(dataSources).where(eq(dataSources.id, sourceId));
 
-    server = await createDashframeServer({ db });
+    server = await createUserServer({ db });
 
     const res = await post(server.url, "publishDraft", { draftId });
     expect(res.status).toBe(400);
@@ -434,7 +463,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     // so the publish must proceed.
     await db.delete(dataSources).where(eq(dataSources.id, deletedSourceId));
 
-    server = await createDashframeServer({ db });
+    server = await createUserServer({ db });
 
     await postOk<{ tablesWritten: string[] }>(server.url, "publishDraft", {
       draftId,
@@ -456,7 +485,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const draftId = await seedDraft(project.db as ArtifactDb);
 
-    server = await createDashframeServer({ db: project.db });
+    server = await createUserServer({ db: project.db });
 
     const res = await post(server.url, "publishDraft", {
       draftId,
@@ -494,9 +523,12 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const draftId = await seedDraft(project.db as ArtifactDb);
 
-    server = await createDashframeServer({ db: project.db });
+    server = await createUserServer({ db: project.db });
 
-    const client = createClient({ url: server.url });
+    const client = createClient({
+      url: server.url,
+      getToken: async () => USER_TOKEN,
+    });
 
     let caught: Error | undefined;
     try {
@@ -555,7 +587,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
 
     // Seed a canonical, credentialed DataSource via a real controller (so the
     // capture-before-log seam mints a real vault ref, not plaintext).
-    const seedApp = await buildDashframeApp({ db, vault });
+    const seedApp = await buildUserApp({ db, vault });
     const seedController = createDraftController(seedApp, db, {
       captureCredentials: (c) => captureCommandCredentials(c, vault, db),
     });
@@ -582,7 +614,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     // command to it.
     const draftId = await seedController.openDraft();
 
-    server = await createDashframeServer({
+    server = await createUserServer({
       db: project.db,
       vault,
       flushSnapshot: async () => {},
@@ -623,7 +655,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const db = project.db as ArtifactDb;
 
-    const seedApp = await buildDashframeApp({ db, vault });
+    const seedApp = await buildUserApp({ db, vault });
     const seedController = createDraftController(seedApp, db, {
       captureCredentials: (c) => captureCommandCredentials(c, vault, db),
     });
@@ -631,7 +663,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     // Open the draft the RPC will discard.
     const draftId = await seedController.openDraft();
 
-    server = await createDashframeServer({
+    server = await createUserServer({
       db: project.db,
       vault,
       flushSnapshot: async () => {},
@@ -669,7 +701,7 @@ describe("draft lifecycle RPCs (publishDraft, discardDraft, getDraftLog)", () =>
     project = await openProject({ dir: join(root, "proj") });
     const draftId = await seedDraft(project.db as ArtifactDb);
 
-    server = await createDashframeServer({ db: project.db });
+    server = await createUserServer({ db: project.db });
 
     // getDraftLog is a WyStack query → GET /api/getDraftLog?args=<json>
     const commands = await getOk<{ path: string; args: unknown }[]>(

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -36,6 +36,7 @@ import {
   DraftPublishConflictError,
   type DraftController,
 } from "../draft-controller";
+import { permissions } from "../permissions";
 import { wy } from "../wystack";
 import { PUBLISH_REPLAY_CONTEXT_KEY } from "./utils";
 
@@ -141,6 +142,7 @@ const publishDraft = wy.procedure
     expectedCommandCount: text.optional(),
     expectedLogSignature: text.optional(),
   })
+  .authorize(permissions.commands.commit)
   .mutation(
     async (
       ctx,
@@ -210,7 +212,12 @@ const publishDraft = wy.procedure
       try {
         result = await draftController.publishDraft(
           draftId,
-          { [PUBLISH_REPLAY_CONTEXT_KEY]: true },
+          {
+            [PUBLISH_REPLAY_CONTEXT_KEY]: true,
+            ...(ctx.principal !== undefined
+              ? { principal: ctx.principal }
+              : {}),
+          },
           {
             expectedCommandCount: expected,
             expectedLogSignature,
@@ -283,6 +290,7 @@ const publishDraft = wy.procedure
  */
 const discardDraft = wy.procedure
   .input({ draftId: text })
+  .authorize(permissions.commands.commit)
   .mutation(async (ctx, { draftId }): Promise<void> => {
     const draftController = ctx.draftController as DraftController | undefined;
     if (!draftController) {

--- a/apps/server/src/functions/drafts.test.ts
+++ b/apps/server/src/functions/drafts.test.ts
@@ -15,14 +15,18 @@ import {
   type DashframeServer,
 } from "../app";
 import { functions } from "../functions";
+import { LOCAL_USER_ID } from "../permissions";
 import { wy } from "../wystack";
 import { cmd } from "./commands";
 import type { DraftPublishReview } from "./drafts";
 
 const { dataSources } = schema;
+const USER_TOKEN = "renderer-token";
 
 async function getJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${USER_TOKEN}` },
+  });
   expect(response.status).toBe(200);
   return (await response.json()) as T;
 }
@@ -30,7 +34,10 @@ async function getJson<T>(url: string): Promise<T> {
 async function postJson<T>(url: string, body: unknown): Promise<T> {
   const response = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${USER_TOKEN}`,
+    },
     body: JSON.stringify(body),
   });
   expect(response.status).toBe(200);
@@ -55,7 +62,20 @@ describe("draft publish functions", () => {
   });
 
   async function controller() {
-    const app = await buildDashframeApp({ db });
+    const baseApp = await buildDashframeApp({ db });
+    const app = {
+      ...baseApp,
+      call: (path, args, context) =>
+        baseApp.call(path, args, {
+          ...(context ?? {}),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        }),
+      runHandler: (path, args, tracked, context) =>
+        baseApp.runHandler(path, args, tracked, {
+          ...(context ?? {}),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        }),
+    } satisfies typeof baseApp;
     return createDraftController(app, db);
   }
 
@@ -74,6 +94,7 @@ describe("draft publish functions", () => {
 
     server = await createDashframeServer({
       db,
+      authToken: USER_TOKEN,
       onWrite: () => onWriteCalls.push(Date.now()),
     });
 
@@ -134,7 +155,7 @@ describe("draft publish functions", () => {
       }),
     ]);
 
-    server = await createDashframeServer({ db });
+    server = await createDashframeServer({ db, authToken: USER_TOKEN });
 
     const review = await getJson<{ data: DraftPublishReview }>(
       `${server.url}/api/draftPublishReview?args=${encodeURIComponent(
@@ -147,7 +168,10 @@ describe("draft publish functions", () => {
     // the same failure mode a stale client would trigger after a real drift.
     const res = await fetch(`${server.url}/api/publishDraft`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${USER_TOKEN}`,
+      },
       body: JSON.stringify({
         draftId,
         expectedLogSignature: "0".repeat(64),
@@ -188,7 +212,11 @@ describe("draft publish functions", () => {
     const { result } = await app.call(
       "draftPublishReview",
       { draftId },
-      { wyStackApp: app, artifactDb: db },
+      {
+        wyStackApp: app,
+        artifactDb: db,
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      },
     );
     const review = result as DraftPublishReview;
 
@@ -218,6 +246,7 @@ describe("draft publish functions", () => {
           wyStackApp: app,
           artifactDb: db,
           draftController: createDraftController(app, db),
+          principal: { kind: "user", userId: LOCAL_USER_ID },
         },
       ),
     ).rejects.toThrow(/late-bound operands/);
@@ -234,7 +263,7 @@ describe("draft publish functions", () => {
         name: "Throwaway",
       }),
     ]);
-    server = await createDashframeServer({ db });
+    server = await createDashframeServer({ db, authToken: USER_TOKEN });
 
     await postJson(`${server.url}/api/discardDraft`, { draftId });
 

--- a/apps/server/src/functions/drafts.ts
+++ b/apps/server/src/functions/drafts.ts
@@ -44,6 +44,7 @@ interface DraftFunctionContext {
   wyStackApp?: unknown;
   artifactDb?: unknown;
   vault?: unknown;
+  principal?: unknown;
 }
 
 function asDraftFunctionContext(ctx: unknown): DraftFunctionContext {
@@ -81,7 +82,12 @@ function summarizeCommands(
 
 function handlerContext(ctx: unknown): Record<string, unknown> {
   const draftCtx = asDraftFunctionContext(ctx);
-  return draftCtx.vault !== undefined ? { vault: draftCtx.vault } : {};
+  return {
+    ...(draftCtx.vault !== undefined ? { vault: draftCtx.vault } : {}),
+    ...(draftCtx.principal !== undefined
+      ? { principal: draftCtx.principal }
+      : {}),
+  };
 }
 
 const draftPublishReview = wy.procedure

--- a/apps/server/src/functions/preview-diff.test.ts
+++ b/apps/server/src/functions/preview-diff.test.ts
@@ -78,8 +78,21 @@ describe("PreviewDiff builder", () => {
   // resolve under preview instead of failing closed (server contract: storing a
   // credential requires a vault).
   async function preview(...commands: ReturnType<typeof cmd>[]) {
-    return buildPreviewDiff(app, db, commands, { vault });
+    return buildPreviewDiff(app, db, commands, {
+      vault,
+      principal: { kind: "service", credentialId: "credential-1" },
+    });
   }
+
+  const userContext = {
+    principal: { kind: "user" as const, userId: "local-user" },
+  };
+  const servicePreviewContext = {
+    principal: {
+      kind: "service" as const,
+      credentialId: "credential-1",
+    },
+  };
 
   // --- direct seeding helpers (no vocabulary commands for these yet) ---------
 
@@ -1119,7 +1132,12 @@ describe("PreviewDiff builder", () => {
       ] as ReturnType<typeof cmd>[];
 
       // 1. Preview — capture the diff.
-      const diff = await buildPreviewDiff(app, db, batch);
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        batch,
+        servicePreviewContext,
+      );
 
       // Basic shape assertions.
       // After the rename, existingSource is no longer noop — it gets renamed.
@@ -1152,7 +1170,10 @@ describe("PreviewDiff builder", () => {
       });
 
       // 2. Commit the same batch against the same DB (preview rolled it back).
-      await applyCommands(app, batch, { mode: "commit" });
+      await applyCommands(app, batch, {
+        mode: "commit",
+        context: userContext,
+      });
 
       // 3. Equivalence: read committed rows and compare to proposedDefinition.
       const sources = await db.select().from(dataSources);
@@ -1232,7 +1253,12 @@ describe("PreviewDiff builder", () => {
       ] as ReturnType<typeof cmd>[];
 
       // 1. Preview — what kind does the preview think the rename targets?
-      const diff = await buildPreviewDiff(app, db, batch);
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        batch,
+        servicePreviewContext,
+      );
 
       // The rename node for collidingId must resolve to "dataTable" (same as
       // the renameNode handler which probes dataTables before dataSources).
@@ -1243,7 +1269,10 @@ describe("PreviewDiff builder", () => {
       expect(renameNode!.kind).toBe("dataTable");
 
       // 2. Commit the same batch.
-      await applyCommands(app, batch, { mode: "commit" });
+      await applyCommands(app, batch, {
+        mode: "commit",
+        context: userContext,
+      });
 
       // 3. Equivalence: the renameNode handler must have renamed the dataTable,
       //    not the dataSource — confirming preview matches publish.
@@ -1290,7 +1319,12 @@ describe("PreviewDiff builder", () => {
 
       // 1. Preview — the rename must attach to the dataTable kind (handler order),
       //    NOT the canonical dataSource.
-      const diff = await buildPreviewDiff(app, db, batch);
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        batch,
+        servicePreviewContext,
+      );
       const renameTable = diff.directNodes.find(
         (n) => n.nodeId === collidingId && n.kind === "dataTable",
       );
@@ -1313,7 +1347,10 @@ describe("PreviewDiff builder", () => {
 
       // 2. Commit the same batch — confirm the handler renamed the in-batch
       //    dataTable and left the canonical dataSource untouched.
-      await applyCommands(app, batch, { mode: "commit" });
+      await applyCommands(app, batch, {
+        mode: "commit",
+        context: userContext,
+      });
       const tables = await db.select().from(dataTables);
       const sources = await db.select().from(dataSources);
       expect(tables.find((r) => r.id === collidingId)?.name).toBe(
@@ -1331,7 +1368,7 @@ describe("PreviewDiff builder", () => {
 
   describe("contract: empty batch and idempotent re-preview", () => {
     it("empty batch produces all-empty diff without throwing", async () => {
-      const diff = await buildPreviewDiff(app, db, []);
+      const diff = await buildPreviewDiff(app, db, [], servicePreviewContext);
 
       expect(diff.mode).toBe("preview");
       expect(diff.directNodes).toEqual([]);
@@ -1348,8 +1385,18 @@ describe("PreviewDiff builder", () => {
         cmd("RenameNode", { id: sourceId, name: "Renamed" }),
       ] as ReturnType<typeof cmd>[];
 
-      const diff1 = await buildPreviewDiff(app, db, batch);
-      const diff2 = await buildPreviewDiff(app, db, batch);
+      const diff1 = await buildPreviewDiff(
+        app,
+        db,
+        batch,
+        servicePreviewContext,
+      );
+      const diff2 = await buildPreviewDiff(
+        app,
+        db,
+        batch,
+        servicePreviewContext,
+      );
 
       // Deep equality — idempotent re-preview produces identical metadata.
       expect(diff2.directNodes).toEqual(diff1.directNodes);
@@ -1442,9 +1489,12 @@ describe("PreviewDiff builder", () => {
       // A command that will definitely fail: RenameNode on a non-existent id
       // (no canonical row, not created in the batch).
       const nonExistentId = id();
-      const diff = await buildPreviewDiff(app, db, [
-        cmd("RenameNode", { id: nonExistentId, name: "Will Fail" }),
-      ]);
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        [cmd("RenameNode", { id: nonExistentId, name: "Will Fail" })],
+        servicePreviewContext,
+      );
 
       expect(diff.mode).toBe("preview");
       expect(diff.error).toBeDefined();
@@ -1462,17 +1512,26 @@ describe("PreviewDiff builder", () => {
       const tableId = id();
       const nonExistentId = id();
 
-      const diff = await buildPreviewDiff(app, db, [
-        cmd("CreateDataSource", { id: sourceId, type: "csv", name: "Src" }),
-        cmd("CreateDataTable", {
-          id: tableId,
-          dataSourceId: sourceId,
-          name: "Tbl",
-          table: "t.csv",
-        }),
-        // Fails: RenameNode on an id that doesn't exist in canonical or batch.
-        cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
-      ]);
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        [
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "csv",
+            name: "Src",
+          }),
+          cmd("CreateDataTable", {
+            id: tableId,
+            dataSourceId: sourceId,
+            name: "Tbl",
+            table: "t.csv",
+          }),
+          // Fails: RenameNode on an id that doesn't exist in canonical or batch.
+          cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
+        ],
+        servicePreviewContext,
+      );
 
       // Did not throw — returned a renderable diff.
       expect(diff.mode).toBe("preview");
@@ -1558,9 +1617,12 @@ describe("PreviewDiff builder", () => {
       // is empty so the guarded prefix re-run is skipped entirely, and the function
       // must still return a well-formed PreviewDiff.
       const nonExistentId = id();
-      const diffPromise = buildPreviewDiff(app, db, [
-        cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
-      ]);
+      const diffPromise = buildPreviewDiff(
+        app,
+        db,
+        [cmd("RenameNode", { id: nonExistentId, name: "Fail" })],
+        servicePreviewContext,
+      );
 
       // The contract: always resolves (never rejects).
       await expect(diffPromise).resolves.toBeDefined();
@@ -1578,10 +1640,15 @@ describe("PreviewDiff builder", () => {
       // failureIndex=1, not from the full-batch run. We assert that the slot is
       // coherent: commandIndex points to the failing command AND message is non-empty.
       const nonExistentId = id();
-      const diff = await buildPreviewDiff(app, db, [
-        cmd("CreateDataSource", { id: id(), type: "csv", name: "OK" }),
-        cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
-      ]);
+      const diff = await buildPreviewDiff(
+        app,
+        db,
+        [
+          cmd("CreateDataSource", { id: id(), type: "csv", name: "OK" }),
+          cmd("RenameNode", { id: nonExistentId, name: "Fail" }),
+        ],
+        servicePreviewContext,
+      );
 
       expect(diff.error).toBeDefined();
       expect(diff.error!.commandIndex).toBe(1);

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -61,6 +61,7 @@ import { jsonb } from "@wystack/db";
 import type { Command, CommandResult } from "@wystack/server";
 import { applyCommands, type WyStackApp } from "@wystack/server";
 
+import { permissions } from "../permissions";
 import { wy } from "../wystack";
 import { commandFunctions } from "./commands";
 
@@ -1188,6 +1189,7 @@ const previewDiff = wy.procedure
     // in the applyCommands context.
     const handlerContext: Record<string, unknown> = {};
     if (ctx.vault !== undefined) handlerContext.vault = ctx.vault;
+    if (ctx.principal !== undefined) handlerContext.principal = ctx.principal;
     return buildPreviewDiff(
       wyStackApp,
       artifactDb,
@@ -1196,6 +1198,46 @@ const previewDiff = wy.procedure
     );
   });
 
+const commitBatch = wy.procedure
+  .input({ commands: jsonb })
+  .authorize(permissions.commands.commit)
+  .mutation(async (ctx, { commands }) => {
+    const wyStackApp = ctx.wyStackApp as WyStackApp | undefined;
+    const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
+    if (!wyStackApp || !artifactDb) {
+      throw new Error(
+        "commitBatch: wyStackApp/artifactDb not in handler context — " +
+          "ensure createDashframeServer injects them via staticContext",
+      );
+    }
+    if (!Array.isArray(commands)) {
+      throw new Error("commitBatch: commands must be an array");
+    }
+
+    const handlerContext: Record<string, unknown> = {};
+    if (ctx.vault !== undefined) handlerContext.vault = ctx.vault;
+    if (ctx.principal !== undefined) handlerContext.principal = ctx.principal;
+
+    const result = await applyCommands(wyStackApp, commands as Command[], {
+      mode: "commit",
+      context: handlerContext,
+    });
+
+    if (result.tablesWritten.size > 0) {
+      ctx.onWrite?.();
+    }
+
+    const tablesWritten = [...result.tablesWritten];
+    return {
+      mode: result.mode,
+      commands: result.commands,
+      results: result.results,
+      tablesWritten,
+      __extraTablesWritten: tablesWritten,
+    };
+  });
+
 export const previewDiffFunctions = {
   previewDiff,
+  commitBatch,
 };

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -63,7 +63,7 @@ import { applyCommands, type WyStackApp } from "@wystack/server";
 
 import { permissions } from "../permissions";
 import { wy } from "../wystack";
-import { commandFunctions } from "./commands";
+import { assertKnownCommandPaths, commandFunctions } from "./commands";
 
 const {
   dataSources,
@@ -1169,6 +1169,7 @@ function dashboardVisRefs(layout: unknown): string[] {
  */
 const previewDiff = wy.procedure
   .input({ commands: jsonb })
+  .authorize(permissions.commands.preview)
   .query(async (ctx, { commands }): Promise<PreviewDiff> => {
     const wyStackApp = ctx.wyStackApp as WyStackApp | undefined;
     const artifactDb = ctx.artifactDb as ArtifactDb | undefined;
@@ -1184,6 +1185,14 @@ const previewDiff = wy.procedure
     if (!Array.isArray(commands)) {
       throw new Error("previewDiff: commands must be an array");
     }
+    // Reject any non-vocabulary path (e.g. a nested `publishDraft`) BEFORE
+    // dispatch. Preview execute-then-rolls-back the vocabulary commands it
+    // knows about; a lifecycle procedure dispatched from inside the batch
+    // would run its OWN transaction outside that rollback's reach, and its
+    // `.authorize(commands.commit)` check would read `mode: "preview"` off
+    // THIS request and pass — a service principal (who can only preview)
+    // would escalate to a real publish. See `assertKnownCommandPaths`.
+    assertKnownCommandPaths(commands as Command[], "previewDiff");
     // Pass through vault and per-request auth context to buildPreviewDiff.
     // Strip runtime-only keys (db, wyStackApp, artifactDb) that don't belong
     // in the applyCommands context.
@@ -1213,6 +1222,9 @@ const commitBatch = wy.procedure
     if (!Array.isArray(commands)) {
       throw new Error("commitBatch: commands must be an array");
     }
+    // Same nested-dispatch hazard as previewDiff — reject non-vocabulary
+    // paths before a single command runs. See `assertKnownCommandPaths`.
+    assertKnownCommandPaths(commands as Command[], "commitBatch");
 
     const handlerContext: Record<string, unknown> = {};
     if (ctx.vault !== undefined) handlerContext.vault = ctx.vault;

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { functions } from "../functions";
+import { LOCAL_USER_ID } from "../permissions";
 import { wy } from "../wystack";
 import { cmd } from "./commands";
 import { buildPreviewDiff } from "./preview-diff";
@@ -47,6 +48,25 @@ function makeTestVault(): { vault: SecretVault; backend: TestBackend } {
   registry.setClassDefault("connector-key", "test");
   const vault = new SecretVault(registry, new InMemoryMappingStore());
   return { vault, backend };
+}
+
+async function buildUserApp(
+  db: Awaited<ReturnType<typeof openArtifactDb>>,
+): Promise<WyStackApp> {
+  const rawApp = await wy.build({ db, functions });
+  return {
+    ...rawApp,
+    call: (path, args, context) =>
+      rawApp.call(path, args, {
+        ...(context ?? {}),
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      }),
+    runHandler: (path, args, tracked, context) =>
+      rawApp.runHandler(path, args, tracked, {
+        ...(context ?? {}),
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      }),
+  };
 }
 
 /** Read the raw config jsonb from the artifact DB for a given data-source id. */
@@ -71,19 +91,24 @@ describe("vault control-plane — store→ref + has→presence", () => {
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault, backend } = makeTestVault());
     // Inject vault via static context — mirrors createDashframeServer's seam.
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     // Wrap to inject vault into every call context, matching app.ts behaviour.
     // Static context (vault) spreads LAST so it cannot be shadowed by a caller-
     // supplied ctx — same ordering as the production createDashframeServer seam.
     app = {
       ...rawApp,
       async call(path, args, ctx) {
-        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
+        return rawApp.call(path, args, {
+          ...(ctx ?? {}),
+          vault,
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        });
       },
       async runHandler(path, args, tracked, ctx) {
         return rawApp.runHandler(path, args, tracked, {
           ...(ctx ?? {}),
           vault,
+          principal: { kind: "user", userId: LOCAL_USER_ID },
         });
       },
     };
@@ -337,14 +362,14 @@ describe("vault control-plane — store→ref + has→presence", () => {
 describe("vault control-plane — fail-closed when no vault is injected", () => {
   let dir: string;
   let db: Awaited<ReturnType<typeof openArtifactDb>>;
-  // No vault wrapper: wy.build's app is used directly, so ctx.vault is
-  // undefined for every handler — exactly a server runtime that injected no vault.
+  // No vault wrapper: the app receives only the test user principal, so
+  // ctx.vault is undefined — exactly a server runtime that injected no vault.
   let app: WyStackApp;
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-vault-failclosed-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
-    app = await wy.build({ db, functions });
+    app = await buildUserApp(db);
   });
 
   afterEach(async () => {
@@ -475,7 +500,7 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-factory-novault-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     // No vault wrapper — ctx.vault is undefined
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
 
     // Create a notion DataSource row (no vault needed for a credential-free create)
     const id = crypto.randomUUID();
@@ -491,7 +516,7 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-factory-noref-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     const { vault } = makeTestVault();
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     const vaultApp: WyStackApp = {
       ...rawApp,
       async call(path, args, ctx) {
@@ -526,7 +551,7 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
   it("queryNotionDatabase throws when no vault is injected", async () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-factory-q-novault-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
 
     const id = crypto.randomUUID();
     await rawApp.call("createDataSource", { id, type: "notion", name: "Src" });
@@ -546,7 +571,7 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-factory-q-kind-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     const { vault } = makeTestVault();
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     const vaultApp: WyStackApp = {
       ...rawApp,
       async call(path, args, ctx) {
@@ -611,7 +636,7 @@ describe("vault lifecycle — delete releases SecretRefs (removeDataSource)", ()
     dir = mkdtempSync(join(tmpdir(), "dashframe-vault-rm-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault, backend } = makeTestVault());
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     app = {
       ...rawApp,
       async call(path, args, ctx) {
@@ -716,7 +741,7 @@ describe("vault lifecycle — delete releases SecretRefs (DeleteNode)", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-vault-del-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault } = makeTestVault());
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     // flushSnapshot is required by the fail-closed credential-release gate: refs are
     // only released after a confirmed durable snapshot. Wire a no-op for tests
     // exercising the direct canonical path (no actual snapshot needed here).
@@ -904,7 +929,7 @@ describe("vault lifecycle — preview mode skips vault store", () => {
     // No vault wrapper on the raw app: buildPreviewDiff threads the vault through
     // the `context` arg it passes to applyCommands, so the handlers receive it
     // via ctx — the same path as the production seam.
-    app = await wy.build({ db, functions });
+    app = await buildUserApp(db);
   });
 
   afterEach(async () => {
@@ -974,7 +999,7 @@ describe("vault lifecycle — preview mode skips vault store", () => {
     const setupDb = await openArtifactDb({
       path: join(setupDir, "artifacts.db"),
     });
-    const rawSetupApp = await wy.build({ db: setupDb, functions });
+    const rawSetupApp = await buildUserApp(setupDb);
     const setupApp: WyStackApp = {
       ...rawSetupApp,
       async call(path, args, ctx) {
@@ -1039,7 +1064,7 @@ describe("vault lifecycle — preview mode skips vault store", () => {
     const commitDb = await openArtifactDb({
       path: join(commitDir, "artifacts.db"),
     });
-    const rawApp = await wy.build({ db: commitDb, functions });
+    const rawApp = await buildUserApp(commitDb);
     const commitApp: WyStackApp = {
       ...rawApp,
       async call(path, args, ctx) {
@@ -1126,7 +1151,7 @@ describe("vault lifecycle — preview mode skips vault delete", () => {
       return realDelete(...args);
     };
 
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     // commitApp threads the vault via a wrapper (commit-mode call path).
     commitApp = wrapWithVault(rawApp);
     // previewApp runs DeleteNode through buildPreviewDiff, which threads the
@@ -1304,7 +1329,7 @@ describe("vault lifecycle: clear releases prior SecretRef (AC1)", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-vault-clear-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault } = makeTestVault());
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     // flushSnapshot is required by the fail-closed credential-release gate: refs are
     // only released after a confirmed durable snapshot. Wire a no-op for tests
     // exercising the direct canonical path (no actual snapshot needed here).
@@ -1444,7 +1469,7 @@ describe("vault lifecycle: rotate releases prior SecretRef (AC2)", () => {
     dir = mkdtempSync(join(tmpdir(), "dashframe-vault-rotate-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault } = makeTestVault());
-    const rawApp = await wy.build({ db, functions });
+    const rawApp = await buildUserApp(db);
     // flushSnapshot is required by the fail-closed credential-release gate: refs are
     // only released after a confirmed durable snapshot. Wire a no-op for tests
     // exercising the direct canonical path (no actual snapshot needed here).
@@ -1519,7 +1544,7 @@ describe("vault lifecycle: vault-absent clear is a no-op (AC3)", () => {
     const dir = mkdtempSync(join(tmpdir(), "dashframe-vault-ac3-"));
     const db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     // No vault injected — this is a vault-absent server.
-    const app = await wy.build({ db, functions });
+    const app = await buildUserApp(db);
 
     try {
       // Arrange: create a source with no credential (allowed without vault).

--- a/apps/server/src/permissions.test.ts
+++ b/apps/server/src/permissions.test.ts
@@ -18,9 +18,11 @@ describe("permissions", () => {
       "accessCredentials.manage",
     );
     expect(permissions.commands.commit.id).toBe("commands.commit");
+    expect(permissions.commands.preview.id).toBe("commands.preview");
     expect(expectedPermissionIds).toEqual([
       "accessCredentials.manage",
       "commands.commit",
+      "commands.preview",
     ]);
   });
 
@@ -96,6 +98,27 @@ describe("permissions", () => {
     });
     await expect(
       evaluate(service.principal, permissions.commands.commit, service),
+    ).resolves.toBe(false);
+  });
+
+  it("allows preview for any well-formed principal, service or user", async () => {
+    const service = context({
+      kind: "service",
+      credentialId: "credential-1",
+    });
+    const user = context({ kind: "user", userId: LOCAL_USER_ID });
+
+    for (const ctx of [service, user]) {
+      await expect(
+        evaluate(ctx.principal, permissions.commands.preview, ctx),
+      ).resolves.toBe(true);
+    }
+  });
+
+  it("still denies preview with no principal at all — `evaluate` requires a well-formed Principal before it calls any permission's `check`, so 'preview is open' cannot mean 'no identity required'", async () => {
+    const anonymous = context(undefined);
+    await expect(
+      evaluate(anonymous.principal, permissions.commands.preview, anonymous),
     ).resolves.toBe(false);
   });
 });

--- a/apps/server/src/permissions.test.ts
+++ b/apps/server/src/permissions.test.ts
@@ -17,7 +17,11 @@ describe("permissions", () => {
     expect(permissions.accessCredentials.manage.id).toBe(
       "accessCredentials.manage",
     );
-    expect(expectedPermissionIds).toEqual(["accessCredentials.manage"]);
+    expect(permissions.commands.commit.id).toBe("commands.commit");
+    expect(expectedPermissionIds).toEqual([
+      "accessCredentials.manage",
+      "commands.commit",
+    ]);
   });
 
   it("grants access credential management to the local user principal", async () => {
@@ -53,5 +57,45 @@ describe("permissions", () => {
         evaluate(ctx.principal, permissions.accessCredentials.manage, ctx),
       ).resolves.toBe(false);
     }
+  });
+
+  it("allows command execution for previews, drafts, publish replay, and users", async () => {
+    const service = context({
+      kind: "service",
+      credentialId: "credential-1",
+    });
+    const user = context({ kind: "user", userId: LOCAL_USER_ID });
+
+    await expect(
+      evaluate(service.principal, permissions.commands.commit, {
+        ...service,
+        mode: "preview",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      evaluate(service.principal, permissions.commands.commit, {
+        ...service,
+        draftId: "draft-1",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      evaluate(user.principal, permissions.commands.commit, {
+        ...user,
+        __publishReplay: true,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      evaluate(user.principal, permissions.commands.commit, user),
+    ).resolves.toBe(true);
+  });
+
+  it("denies direct canonical command execution to service principals", async () => {
+    const service = context({
+      kind: "service",
+      credentialId: "credential-1",
+    });
+    await expect(
+      evaluate(service.principal, permissions.commands.commit, service),
+    ).resolves.toBe(false);
   });
 });

--- a/apps/server/src/permissions.ts
+++ b/apps/server/src/permissions.ts
@@ -25,6 +25,18 @@ export const permissions = definePermissions<AppContext>()({
         ctx.__publishReplay === true ||
         (isPrincipal(ctx.principal) && ctx.principal.kind === "user"),
     },
+    preview: {
+      description:
+        "Preview a command batch (execute-then-rollback; canonical state is never touched). " +
+        "Open to any WELL-FORMED principal, service or user — declared explicitly so " +
+        "`previewDiff` carries the same `.authorize(...)` shape as every other " +
+        "command-dispatching procedure, rather than relying on the absence of a check to " +
+        "mean 'open'. This does not waive the identity requirement: `evaluate()` denies " +
+        "before it ever calls `check` when there is no well-formed `Principal` at all " +
+        "(see @wystack/permissions), so a request still needs SOME resolved principal — " +
+        "which is what makes the no-auth-configured loopback fix in app.ts load-bearing.",
+      check: () => true,
+    },
   },
 });
 
@@ -32,4 +44,5 @@ export const permissions = definePermissions<AppContext>()({
 export const expectedPermissionIds = [
   "accessCredentials.manage",
   "commands.commit",
+  "commands.preview",
 ] as const;

--- a/apps/server/src/permissions.ts
+++ b/apps/server/src/permissions.ts
@@ -15,7 +15,21 @@ export const permissions = definePermissions<AppContext>()({
         ctx.principal.userId === LOCAL_USER_ID,
     },
   },
+  commands: {
+    commit: {
+      description:
+        "Commit or replay commands against canonical state (preview and draft-append stay open to any principal)",
+      check: (ctx) =>
+        ctx.mode === "preview" ||
+        ctx.draftId != null ||
+        ctx.__publishReplay === true ||
+        (isPrincipal(ctx.principal) && ctx.principal.kind === "user"),
+    },
+  },
 });
 
 /** Boot-time snapshot guarding the public permission identifiers. */
-export const expectedPermissionIds = ["accessCredentials.manage"] as const;
+export const expectedPermissionIds = [
+  "accessCredentials.manage",
+  "commands.commit",
+] as const;

--- a/apps/server/src/permissions.ts
+++ b/apps/server/src/permissions.ts
@@ -5,6 +5,24 @@ import type { AppContext } from "./app-context";
 
 export const LOCAL_USER_ID = "local-user";
 
+/**
+ * The synthesized principal for the token-less loopback config (see
+ * `createDashframeServer` in app.ts) — deliberately NOT `LOCAL_USER_ID`.
+ *
+ * `commands.commit` only requires `principal.kind === "user"`, so this
+ * identity is enough to keep that loopback config writable. But
+ * `accessCredentials.manage` additionally requires
+ * `principal.userId === LOCAL_USER_ID` specifically — that's the operator's
+ * own identity, meant to gate minting durable, off-host-usable API
+ * credentials behind an authenticated bind. If the loopback synthesis used
+ * `LOCAL_USER_ID` too, every unauthenticated request on a token-less server
+ * would silently double as the operator for that check, and could mint a
+ * credential usable from anywhere. `loopback-anonymous` is a real,
+ * well-formed `user` principal (satisfies `commands.commit`) but is never
+ * equal to `LOCAL_USER_ID` (still denied by `accessCredentials.manage`).
+ */
+export const LOOPBACK_ANON_USER_ID = "loopback-anonymous";
+
 export const permissions = definePermissions<AppContext>()({
   accessCredentials: {
     manage: {

--- a/packages/app/src/wystack/runtime.ts
+++ b/packages/app/src/wystack/runtime.ts
@@ -52,6 +52,20 @@ export function createWyStackRuntime(
   const instance = createWyStack<Functions>({
     url: runtimeConfig.url,
     getToken: token ? () => token : undefined,
+    // The DashFrame server always configures a `resolveContext` now — even
+    // the token-less loopback config synthesizes a local-user principal (see
+    // apps/server/src/app.ts) so command procedures have someone to
+    // authorize. Per the WS contract in @wystack/server's routes.ts, "when
+    // resolveContext is configured, the client must send `{type:'auth',
+    // token}` as the first frame" — unconditionally, regardless of whether
+    // the token is real. `requiresAuth` otherwise defaults to
+    // `getToken !== undefined`, which is false in the no-token config, so the
+    // client would never send that frame and the server's WS session would
+    // sit unauthenticated forever: subscribe frames get ignored, so live
+    // queries (e.g. the visualization list after creating a chart) never
+    // receive invalidation pushes. Force it on so a null token still
+    // completes the handshake against our synthetic resolver.
+    requiresAuth: true,
   });
   setWyStackClient(instance.client);
   return { Provider: instance.Provider };


### PR DESCRIPTION
## Summary

- Adds a `commitBatch` procedure that applies a command batch for real against canonical state (`mode: "commit"`), alongside the existing `previewDiff` (preview) and draft-append paths.
- Adds `commands.commit`, a permission gating direct canonical writes: preview execution, draft-append, and publish-replay stay open to any principal, but a bare commit — and draft publish/discard — now require a user principal. API-credentialed (service) requests can only draft, never commit ("service-draft-only").
- `.authorize(permissions.commands.commit)` is wired onto all 31 direct command procedures in `commands.ts`, plus `publishDraft` and `discardDraft` in `draft-lifecycle.ts`.
- `principal` is threaded through the draft-append, publish-replay, and draft-review handler contexts (`draft-lifecycle.ts`, `drafts.ts`) and into the assistant host's draft append/discard calls (`assistant-host.ts`, `assistant-run-route.ts`) so the authorization check has what it needs at every call site.

## Test plan

- [x] `bun check` at the repo root — typecheck, lint, and full test suite across every workspace (79/79 tasks green on the first run: 468/468 `apps/server` tests passing). A later rerun hit one unrelated flake (`apps/desktop/src/main-bundle.test.ts` timing out under load); confirmed unrelated by running it standalone, where it passes (2/2).
- [x] New `apps/server/src/functions/command-authorization.test.ts` — asserts all 31 direct command procedures reject a service principal.
- [x] New `apps/server/src/functions/commit-batch.test.ts` — end-to-end over HTTP: service `commitBatch` denied (403, no rows written), user `commitBatch` applies atomically and reports `tablesWritten`/fires `onWrite` once, a failing batch in the same request rolls back cleanly, a service principal can still preview the same command surface, and a service principal can append to a draft but is denied publish/discard (a user can finish both).
- [x] Updated `permissions.test.ts` covering the new `commands.commit` check directly (preview/draft/replay/user allow, bare service-principal commit denies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds atomic command-batch commits and restricts direct canonical writes and draft lifecycle transitions to user principals.
- Introduces commitBatch alongside previewDiff and validates batch paths against the command vocabulary.
- Adds commands.commit and commands.preview permissions across command and draft lifecycle procedures.
- Threads authenticated principals through assistant and draft execution contexts.
- Preserves writable token-less loopback operation through a constrained synthetic user principal.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because service-authenticated assistant abort and failure cleanup still cannot discard unsurfaced drafts.

The assistant host forwards the service principal into discardDraft, whose commands.commit authorization rejects it; the assistant lifecycle then swallows that cleanup failure, leaving the persisted draft behind.

**Files Needing Attention:** apps/server/src/assistant-host.ts, apps/server/src/functions/draft-lifecycle.ts, apps/server/src/permissions.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/functions/preview-diff.ts | Adds the authorized atomic commitBatch endpoint and pre-dispatch command-vocabulary validation. |
| apps/server/src/permissions.ts | Defines the service-draft-only permission policy and the restricted loopback synthetic identity. |
| apps/server/src/functions/draft-lifecycle.ts | Applies user-only commit authorization to publish and discard lifecycle transitions. |
| apps/server/src/assistant-host.ts | Propagates request principals through assistant draft append and discard calls. |
| apps/server/src/draft-controller.ts | Rejects non-command lifecycle paths before draft dispatch and again before canonical replay. |
| apps/server/src/app.ts | Synthesizes a non-operator user principal when no request-authentication resolver is configured. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into task-716/commit..."](https://github.com/youhaowei/dashframe/commit/cedc7c55c6fd53c1daa9f8abb48a7f6a9294dfd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50370471)</sub>

**Context used:**

- Knowledge Base — [Server API (apps/server)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-api.md)
- Knowledge Base — [Server Core: Project Persistence](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-core.md)

<!-- /greptile_comment -->