### PR TITLE
feat(data-frames): track origin and freshness on saved results

### DIFF
--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -203,6 +203,61 @@ describe("privacy floor — no raw sampleValues persist in artifact DB", () => {
     const stored = await readAnalysis(id);
     expect(stored).toBeNull();
   });
+
+  it("should persist data-frame origin and refresh metadata", async () => {
+    const id = crypto.randomUUID();
+    const sourceId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+    const lastRefreshedAt = Date.now();
+
+    await call("putDataFrameEntry", {
+      entry: {
+        ...makeDataFrameEntry(id),
+        sourceId,
+        definitionId,
+        lastRefreshedAt,
+      },
+    });
+
+    const result = (await call("getDataFrameEntry", { id })) as {
+      sourceId?: string;
+      definitionId?: string;
+      lastRefreshedAt?: number;
+    };
+    expect(result).toMatchObject({ sourceId, definitionId, lastRefreshedAt });
+  });
+
+  it("should update only lastRefreshedAt without clobbering origin metadata", async () => {
+    const id = crypto.randomUUID();
+    const sourceId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+    const lastRefreshedAt = Date.now();
+    const refreshedAt = lastRefreshedAt + 1_000;
+
+    await call("putDataFrameEntry", {
+      entry: {
+        ...makeDataFrameEntry(id),
+        sourceId,
+        definitionId,
+        lastRefreshedAt,
+      },
+    });
+    await call("updateDataFrameEntry", {
+      id,
+      updates: { lastRefreshedAt: refreshedAt },
+    });
+
+    const result = (await call("getDataFrameEntry", { id })) as {
+      sourceId?: string;
+      definitionId?: string;
+      lastRefreshedAt?: number;
+    };
+    expect(result).toMatchObject({
+      sourceId,
+      definitionId,
+      lastRefreshedAt: refreshedAt,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -66,9 +66,12 @@ type VisualizationRow = typeof visualizations.$inferSelect;
 type DataFrameEntry = DataFrameJSON & {
   name: string;
   insightId?: UUID;
+  sourceId?: UUID;
+  definitionId?: UUID;
   rowCount?: number;
   columnCount?: number;
   analysis?: DataFrameAnalysis;
+  lastRefreshedAt?: number;
 };
 
 type DataTableArrayKind = "fields" | "metrics";
@@ -76,6 +79,10 @@ type DataTableArrayItem = { id: string };
 
 function dateFromEpoch(value: unknown): Date | undefined {
   return typeof value === "number" ? new Date(value) : undefined;
+}
+
+function nullableDateFromEpoch(value: number | undefined): Date | null {
+  return value === undefined ? null : new Date(value);
 }
 
 function withDefaultCountMetric(
@@ -303,9 +310,12 @@ function rowToDataFrame(row: DataFrameRow): DataFrameEntry {
     createdAt: tsToMillis(row.createdAt),
     name: row.name,
     insightId: row.insightId ?? undefined,
+    sourceId: row.sourceId ?? undefined,
+    definitionId: row.definitionId ?? undefined,
     rowCount: row.rowCount ?? undefined,
     columnCount: row.columnCount ?? undefined,
     analysis: (row.analysis as DataFrameAnalysis | null) ?? undefined,
+    lastRefreshedAt: row.lastRefreshedAt?.getTime() ?? undefined,
   };
 }
 
@@ -800,9 +810,12 @@ const putDataFrameEntry = wy.procedure
       createdAt: new Date(value.createdAt),
       name: value.name,
       insightId: value.insightId ?? null,
+      sourceId: value.sourceId ?? null,
+      definitionId: value.definitionId ?? null,
       rowCount: value.rowCount ?? null,
       columnCount: value.columnCount ?? null,
       analysis: safeAnalysis,
+      lastRefreshedAt: nullableDateFromEpoch(value.lastRefreshedAt),
     };
     const existing = (await ctx.db
       .from(dataFrames)
@@ -836,6 +849,10 @@ const updateDataFrameEntry = wy.procedure
         ...(patch.insightId !== undefined
           ? { insightId: patch.insightId }
           : {}),
+        ...(patch.sourceId !== undefined ? { sourceId: patch.sourceId } : {}),
+        ...(patch.definitionId !== undefined
+          ? { definitionId: patch.definitionId }
+          : {}),
         ...(patch.rowCount !== undefined ? { rowCount: patch.rowCount } : {}),
         ...(patch.columnCount !== undefined
           ? { columnCount: patch.columnCount }
@@ -846,6 +863,11 @@ const updateDataFrameEntry = wy.procedure
               analysis: patch.analysis
                 ? stripSampleValues(patch.analysis)
                 : null,
+            }
+          : {}),
+        ...(patch.lastRefreshedAt !== undefined
+          ? {
+              lastRefreshedAt: nullableDateFromEpoch(patch.lastRefreshedAt),
             }
           : {}),
       });

--- a/packages/app/src/app/data-frames/page.tsx
+++ b/packages/app/src/app/data-frames/page.tsx
@@ -1,8 +1,10 @@
 import { DataGrid } from "@/components/data-grid";
+import { useNow } from "@/hooks/useNow";
 import {
   removeDataFrame,
   type DataFrameEntry,
 } from "@/lib/data-access/data-frames";
+import { formatRelativeTime } from "@/lib/format-relative-time";
 import { api } from "@/wystack/api";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMutation, useQuery } from "@wystack/client";
@@ -20,14 +22,55 @@ import {
 import { ArrowUpDownIcon } from "@wystack/ui-react/icons";
 import { useMemo, useState } from "react";
 
+function resolveSourceName(
+  sourceId: string | undefined,
+  isLoadingDataSources: boolean,
+  dataSourceNameById: Map<string, string>,
+): string | null {
+  if (!sourceId) return null;
+  if (isLoadingDataSources) return "…";
+  return dataSourceNameById.get(sourceId) ?? "Unknown source";
+}
+
+function resolveDefinitionName(
+  definitionId: string | undefined,
+  isLoadingDataTables: boolean,
+  dataTableNameById: Map<string, string>,
+): string {
+  if (!definitionId) return "—";
+  if (isLoadingDataTables) return "…";
+  return dataTableNameById.get(definitionId) ?? "Unknown table";
+}
+
 export default function DataFramesPage() {
   const { data: dataFrames, isLoading } = useQuery(api.listDataFrames);
+  const { data: dataSources, isLoading: isLoadingDataSources } = useQuery(
+    api.listDataSources,
+  );
+  const { data: dataTables, isLoading: isLoadingDataTables } = useQuery(
+    api.listDataTables,
+    { args: {} },
+  );
   const { mutateAsync: updateDataFrameEntry } = useMutation(
     api.updateDataFrameEntry,
   );
 
   const [editingFrame, setEditingFrame] = useState<DataFrameEntry | null>(null);
   const [editedName, setEditedName] = useState("");
+
+  const now = useNow();
+
+  const dataSourceNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const source of dataSources ?? []) map.set(source.id, source.name);
+    return map;
+  }, [dataSources]);
+
+  const dataTableNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const table of dataTables ?? []) map.set(table.id, table.name);
+    return map;
+  }, [dataTables]);
 
   const columns = useMemo<ColumnDef<DataFrameEntry>[]>(
     () => [
@@ -53,9 +96,43 @@ export default function DataFramesPage() {
         id: "source",
         header: "Source",
         cell: ({ row }) => {
+          const { sourceId, insightId } = row.original;
+          const sourceName = resolveSourceName(
+            sourceId,
+            isLoadingDataSources,
+            dataSourceNameById,
+          );
           return (
             <span className="text-neutral-fg-subtle">
-              {row.original.insightId ? "From Insight" : "Direct Load"}
+              {sourceName ?? (insightId ? "From Insight" : "Direct Load")}
+            </span>
+          );
+        },
+      },
+      {
+        id: "definition",
+        header: "Definition",
+        cell: ({ row }) => {
+          const { definitionId } = row.original;
+          return (
+            <span className="text-neutral-fg-subtle">
+              {resolveDefinitionName(
+                definitionId,
+                isLoadingDataTables,
+                dataTableNameById,
+              )}
+            </span>
+          );
+        },
+      },
+      {
+        id: "lastRefreshedAt",
+        header: "Last Refreshed",
+        cell: ({ row }) => {
+          const { lastRefreshedAt } = row.original;
+          return (
+            <span className="text-neutral-fg-subtle">
+              {lastRefreshedAt ? formatRelativeTime(now, lastRefreshedAt) : "—"}
             </span>
           );
         },
@@ -105,7 +182,13 @@ export default function DataFramesPage() {
         ),
       },
     ],
-    [],
+    [
+      dataSourceNameById,
+      dataTableNameById,
+      now,
+      isLoadingDataSources,
+      isLoadingDataTables,
+    ],
   );
 
   const handleEdit = (entry: DataFrameEntry) => {

--- a/packages/app/src/hooks/useNow.ts
+++ b/packages/app/src/hooks/useNow.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from "react";
+
+// Ticks once a minute on the client so relative-time strings refresh without
+// calling Date.now() during render. `getSnapshot` must return a cached value
+// between notifications — returning a fresh Date.now() on every call breaks
+// useSyncExternalStore's Object.is comparison and forces a re-render loop.
+let currentNowSnapshot = Date.now();
+const subscribeNow = (notify: () => void) => {
+  currentNowSnapshot = Date.now();
+  notify();
+  const id = setInterval(() => {
+    currentNowSnapshot = Date.now();
+    notify();
+  }, 60_000);
+  return () => clearInterval(id);
+};
+const getNowSnapshot = () => currentNowSnapshot;
+const getNowServerSnapshot = () => 0;
+
+/** Client clock that ticks once a minute, safe to read during render for relative-time formatting. */
+export function useNow(): number {
+  return useSyncExternalStore(
+    subscribeNow,
+    getNowSnapshot,
+    getNowServerSnapshot,
+  );
+}

--- a/packages/app/src/lib/data-access/data-frames.ts
+++ b/packages/app/src/lib/data-access/data-frames.ts
@@ -15,9 +15,12 @@ import { getWyStackClient } from "../../wystack/client";
 export type DataFrameEntry = DataFrameJSON & {
   name: string;
   insightId?: UUID;
+  sourceId?: UUID;
+  definitionId?: UUID;
   rowCount?: number;
   columnCount?: number;
   analysis?: DataFrameAnalysis;
+  lastRefreshedAt?: number;
 };
 
 async function deleteArrowDataBestEffort(key: string): Promise<void> {
@@ -33,11 +36,17 @@ export async function addDataFrameEntry(
   metadata: {
     name: string;
     insightId?: UUID;
+    sourceId?: UUID;
+    definitionId?: UUID;
     rowCount?: number;
     columnCount?: number;
   },
 ): Promise<UUID> {
-  const entry: DataFrameEntry = { ...dataFrame.toJSON(), ...metadata };
+  const entry: DataFrameEntry = {
+    ...dataFrame.toJSON(),
+    ...metadata,
+    lastRefreshedAt: Date.now(),
+  };
   await getWyStackClient().mutate(api.putDataFrameEntry, { entry });
   return dataFrame.id;
 }
@@ -52,7 +61,12 @@ export async function updateDataFrameEntry(
 export async function replaceDataFrame(
   id: UUID,
   newDataFrame: DataFrame,
-  metadata?: { rowCount?: number; columnCount?: number },
+  metadata?: {
+    rowCount?: number;
+    columnCount?: number;
+    sourceId?: UUID;
+    definitionId?: UUID;
+  },
 ): Promise<void> {
   const oldEntity = await getDataFrameEntry(id);
   const serialization = newDataFrame.toJSON();
@@ -61,8 +75,11 @@ export async function replaceDataFrame(
     fieldIds: serialization.fieldIds,
     primaryKey: serialization.primaryKey,
     createdAt: serialization.createdAt,
+    sourceId: metadata?.sourceId,
+    definitionId: metadata?.definitionId,
     rowCount: metadata?.rowCount,
     columnCount: metadata?.columnCount,
+    lastRefreshedAt: Date.now(),
   });
   if (oldEntity?.storage?.type === "indexeddb") {
     await deleteArrowDataBestEffort(oldEntity.storage.key);

--- a/packages/app/src/lib/format-relative-time.ts
+++ b/packages/app/src/lib/format-relative-time.ts
@@ -1,0 +1,18 @@
+/** Format `timestamp` (epoch ms) relative to `now` (epoch ms) as a short "Nd/h/m ago" string. */
+export function formatRelativeTime(now: number, timestamp: number): string {
+  const diff = now - timestamp;
+  // `now` is 0 on the server snapshot (useSyncExternalStore's SSR fallback,
+  // before the client clock hydrates) — every timestamp then reads as
+  // "in the future", which would otherwise fall through every branch below
+  // to "just now" and produce a hydration mismatch once the client clock
+  // ticks in. Render a neutral placeholder instead until `now` is real.
+  if (diff < 0) return "—";
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return "just now";
+}

--- a/packages/app/src/lib/local-csv-handler.ts
+++ b/packages/app/src/lib/local-csv-handler.ts
@@ -106,6 +106,8 @@ export async function handleLocalCSVUpload(
       await replaceDataFrame(overrideTable.dataFrameId, dataFrame, {
         rowCount,
         columnCount,
+        sourceId: dataSource.id,
+        definitionId: dataTableId,
       });
       dataFrameId = overrideTable.dataFrameId;
     } else {
@@ -114,6 +116,8 @@ export async function handleLocalCSVUpload(
         name: tableName,
         rowCount,
         columnCount,
+        sourceId: dataSource.id,
+        definitionId: dataTableId,
       });
       dataFrameId = dataFrame.id;
     }
@@ -140,6 +144,8 @@ export async function handleLocalCSVUpload(
       name: tableName,
       rowCount,
       columnCount,
+      sourceId: dataSource.id,
+      definitionId: dataTableId,
     });
     dataFrameId = dataFrame.id;
 
@@ -202,6 +208,8 @@ export async function handleFileConnectorResult(
       await replaceDataFrame(overrideTable.dataFrameId, dataFrame, {
         rowCount,
         columnCount,
+        sourceId: dataSource.id,
+        definitionId: dataTableId,
       });
       dataFrameId = overrideTable.dataFrameId;
     } else {
@@ -209,6 +217,8 @@ export async function handleFileConnectorResult(
         name: tableName,
         rowCount,
         columnCount,
+        sourceId: dataSource.id,
+        definitionId: dataTableId,
       });
       dataFrameId = dataFrame.id;
     }
@@ -234,6 +244,8 @@ export async function handleFileConnectorResult(
       name: tableName,
       rowCount,
       columnCount,
+      sourceId: dataSource.id,
+      definitionId: dataTableId,
     });
     dataFrameId = dataFrame.id;
 

--- a/packages/app/src/lib/remote-table-materialization.test.ts
+++ b/packages/app/src/lib/remote-table-materialization.test.ts
@@ -42,6 +42,7 @@ import {
 
 const TABLE_ID = "11111111-1111-4111-8111-111111111111" as UUID;
 const FRAME_ID = "22222222-2222-4222-8222-222222222222" as UUID;
+const SOURCE_ID = "33333333-3333-4333-8333-333333333333" as UUID;
 
 function field(sensitivity?: Field["sensitivity"]): Field {
   return {
@@ -66,7 +67,11 @@ function result(fields: Field[]) {
 describe("materializeRemoteTable", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getDataTable.mockResolvedValue({ id: TABLE_ID, fields: [] });
+    getDataTable.mockResolvedValue({
+      id: TABLE_ID,
+      dataSourceId: SOURCE_ID,
+      fields: [],
+    });
     getDataFrameEntry.mockResolvedValue(undefined);
     addDataFrameEntry.mockResolvedValue(FRAME_ID);
     updateDataTable.mockResolvedValue(undefined);
@@ -130,6 +135,13 @@ describe("materializeRemoteTable", () => {
       expect.any(Uint8Array),
       expect.any(Array),
     );
+    expect(addDataFrameEntry).toHaveBeenCalledWith(expect.anything(), {
+      name: "Leads",
+      rowCount: 1,
+      columnCount: 1,
+      sourceId: SOURCE_ID,
+      definitionId: TABLE_ID,
+    });
   });
 
   it("removes metadata and IndexedDB bytes when table linking fails", async () => {

--- a/packages/app/src/lib/remote-table-materialization.ts
+++ b/packages/app/src/lib/remote-table-materialization.ts
@@ -136,6 +136,8 @@ export async function materializeRemoteTable(
       name,
       rowCount: result.rowCount,
       columnCount,
+      sourceId: existing?.dataSourceId,
+      definitionId: table.id as UUID,
     });
     metadataAdded = true;
 

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -128,9 +128,12 @@ export const dataFrames = pgTable(
     primaryKey: jsonb("primary_key"),
     name: text("name").notNull(),
     insightId: uuid("insight_id"),
+    sourceId: uuid("source_id"),
+    definitionId: uuid("definition_id"),
     rowCount: integer("row_count"),
     columnCount: integer("column_count"),
     analysis: jsonb("analysis"),
+    lastRefreshedAt: timestamp("last_refreshed_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -345,9 +348,12 @@ export const dataFramesDraft = pgTable(
     primaryKey: jsonb("primary_key"),
     name: text("name"),
     insightId: uuid("insight_id"),
+    sourceId: uuid("source_id"),
+    definitionId: uuid("definition_id"),
     rowCount: integer("row_count"),
     columnCount: integer("column_count"),
     analysis: jsonb("analysis"),
+    lastRefreshedAt: timestamp("last_refreshed_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }),
     updatedAt: timestamp("updated_at", { withTimezone: true }),
     // Draft control columns.


### PR DESCRIPTION
## Summary
- Every saved DataFrame result now stores which DataSource and DataTable/definition it came from, plus when it was last refreshed — persisted through restart.
- `packages/server-core/src/schema.ts`: adds `sourceId`, `definitionId`, `lastRefreshedAt` columns to `dataFrames` and `dataFramesDraft`.
- `apps/server/src/functions/app-artifacts.ts`: `putDataFrameEntry`/`updateDataFrameEntry`/row mapping read and write the new fields.
- `packages/app/src/lib/data-access/data-frames.ts`: `addDataFrameEntry`/`replaceDataFrame` stamp `lastRefreshedAt` on every write and thread `sourceId`/`definitionId` through from callers.
- `packages/app/src/lib/local-csv-handler.ts` and `packages/app/src/lib/remote-table-materialization.ts`: pass `sourceId`/`definitionId` at every DataFrame creation/replacement site (CSV upload, file connector, remote materialization).
- `packages/app/src/app/data-frames/page.tsx`: Data Frames table gains **Source**, **Definition**, and **Last Refreshed** columns. Last Refreshed uses a once-a-minute client clock (`packages/app/src/hooks/useNow.ts`) and a hydration-safe relative-time formatter (`packages/app/src/lib/format-relative-time.ts`).

No schema migration file is needed — this repo syncs nullable columns automatically at startup (`syncSchema`'s add-nullable-columns-if-not-exists path), consistent with prior schema-only additions in this file's history.

## Test plan
- [x] `bun check` — all 79 tasks pass (typecheck, lint, tests) across the monorepo
- [x] New server tests: persisting origin/refresh metadata on `putDataFrameEntry`, and that `updateDataFrameEntry` can update `lastRefreshedAt` without clobbering `sourceId`/`definitionId`
- [x] Updated `materializeRemoteTable` test asserts `sourceId`/`definitionId` are passed through from the existing DataTable's `dataSourceId`
- [x] Manually verified in the running app (`apps/web` dev server via portless) — visually confirmed the Data Frames table renders Source ("Local Files"), Definition ("sample"), and Last Refreshed ("2h ago") for an existing local-CSV-backed frame

## Screenshots
Verified visually in a live browser session (Source/Definition/Last Refreshed columns rendering correctly), but no image-hosting step was available in this run to attach the screenshot file to this PR body — screenshot is owed as an attachment; happy to add it via a follow-up comment if the reviewer wants the image inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR persists origin and refresh metadata for saved DataFrame results and exposes it in the shared Data Frames page.
- Adds nullable source, definition, and refresh timestamp columns to canonical and draft DataFrame schemas.
- Threads provenance through local-file and remote-table materialization writes.
- Resolves source and definition names in the Data Frames grid and refreshes relative timestamps once per minute.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the reviewed changes and available prior-thread context.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/lib/data-access/data-frames.ts | Stamps refresh time on writes and carries optional source and definition identifiers while preserving omitted metadata during replacement. |
| packages/app/src/lib/local-csv-handler.ts | Supplies source and table-definition provenance for all local CSV and file-connector creation and replacement paths. |
| packages/app/src/lib/remote-table-materialization.ts | Associates newly materialized remote results with the existing DataTable and its DataSource. |
| apps/server/src/functions/app-artifacts.ts | Maps the new metadata fields between RPC DataFrame entries and timestamp/UUID database columns. |
| packages/server-core/src/schema.ts | Adds matching nullable, default-less metadata columns to canonical and draft DataFrame tables, allowing startup schema synchronization. |
| packages/app/src/app/data-frames/page.tsx | Adds resolved Source, Definition, and relative Last Refreshed columns to the shared Data Frames grid. |
| packages/app/src/hooks/useNow.ts | Implements a cached external-store clock with interval cleanup for minute-level relative-time updates. |
| packages/app/src/lib/format-relative-time.ts | Formats elapsed time in compact units and renders a neutral placeholder before a usable client clock is available. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant I as Import or materialization flow
  participant A as DataFrame data access
  participant S as Server RPC
  participant D as Project database
  participant U as Data Frames page
  I->>A: Save result with sourceId and definitionId
  A->>A: Stamp lastRefreshedAt
  A->>S: put/update DataFrame entry
  S->>D: Persist metadata
  U->>S: List DataFrames, sources, and tables
  S-->>U: Persisted result metadata
  U->>U: Resolve names and format relative time
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into task-721/result..."](https://github.com/youhaowei/dashframe/commit/52ce57ceee8d9ab306954c1faf5949e12341770b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50370507)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [App shell (`packages/app`)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/app-shell.md)
- Knowledge Base — [Server API (apps/server)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-api.md)
- Knowledge Base — [Server Core: Project Persistence](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-core.md)
</details>

<!-- /greptile_comment -->