### PR TITLE
Resumable connector onboarding for Google Analytics

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@dashframe/assistant": "workspace:*",
+    "@dashframe/connector-ga4": "workspace:*",
     "@dashframe/connector-notion": "workspace:*",
     "@dashframe/connector-postgres": "workspace:*",
     "@dashframe/engine": "workspace:*",

--- a/apps/server/src/app-context.ts
+++ b/apps/server/src/app-context.ts
@@ -21,6 +21,17 @@ export interface AppContext {
   mode?: string;
   draftId?: string;
   __publishReplay?: boolean;
+  /**
+   * Marks the connector-setup sweep as the one the server runs during startup,
+   * which is allowed to recover in-flight rows immediately instead of waiting
+   * out the abandonment grace window.
+   *
+   * Context, not procedure input, and deliberately so: an input field would let
+   * any client send `graceMs: 0` and recover a session a live handler is still
+   * working on — exactly the race the grace window exists to close. Only the
+   * host process can set this.
+   */
+  __bootSweep?: boolean;
 }
 
 export type DashframeFunctionContext = FunctionContext<AppContext>;

--- a/apps/server/src/app-context.ts
+++ b/apps/server/src/app-context.ts
@@ -3,6 +3,7 @@ import type { Principal } from "@wystack/identity";
 import type { SecretVault } from "@wystack/secret-vault";
 import type { FunctionContext, WyStackApp } from "@wystack/server";
 
+import type { GoogleOAuthConfig } from "./connector-setup/oauth-provider";
 import type { DraftController } from "./draft-controller";
 
 /** Host capabilities and request identity available to every WyStack procedure. */
@@ -16,6 +17,7 @@ export interface AppContext {
   draftController?: DraftController;
   onWrite?: () => void;
   flushSnapshot?: () => Promise<void>;
+  googleOAuth?: GoogleOAuthConfig;
   mode?: string;
   draftId?: string;
   __publishReplay?: boolean;

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -59,6 +59,15 @@ import { type ArtifactDb } from "@dashframe/server-core";
 import type { AppContext } from "./app-context";
 import { handleAssistantRunRequest } from "./assistant-run-route";
 import { isLoopbackHost } from "./bind-host";
+import {
+  handleConnectorOAuthCallback,
+  handleConnectorResumeLanding,
+  handleConnectorSetupResume,
+} from "./connector-oauth-callback";
+import {
+  readOptionalGoogleOAuthConfig,
+  type GoogleOAuthConfig,
+} from "./connector-setup/oauth-provider";
 import { captureCommandCredentials } from "./credential-release";
 import {
   createDraftController,
@@ -208,6 +217,8 @@ export interface DashframeServerOptions {
    * debounced `onWrite` behaviour in that case (existing semantics).
    */
   flushSnapshot?: () => Promise<void>;
+  /** Google OAuth client settings used by resumable connector setup. */
+  googleOAuth?: GoogleOAuthConfig;
   /**
    * Secret vault for credential storage. The runtime composer (Electron main
    * or `dashframe serve`) registers a backend into a SecretRegistry, builds a
@@ -439,6 +450,7 @@ export async function buildDashframeApp(opts: {
   onWrite?: () => void;
   accessCredentials?: ApiAccessCredentials;
   getServerEndpoint?: () => string | undefined;
+  googleOAuth?: GoogleOAuthConfig;
 }): Promise<WyStackApp> {
   const rawApp = await wy.build({
     db: opts.db,
@@ -456,6 +468,7 @@ export async function buildDashframeApp(opts: {
       ? { accessCredentials: opts.accessCredentials }
       : {}),
     ...(vault != null ? { vault } : {}),
+    ...(opts.googleOAuth != null ? { googleOAuth: opts.googleOAuth } : {}),
   };
 
   // The draft seam wraps `call` itself (not just runHandler): `rawApp.call`
@@ -528,6 +541,7 @@ export async function createDashframeServer(
   // by the accessCredentials.manage check, a typed lie.
   const userId = LOCAL_USER_ID;
   const serverState: { endpoint?: string } = {};
+  const googleOAuth = opts.googleOAuth ?? readOptionalGoogleOAuthConfig();
 
   // Resolve the auth context builder: vault-backed ref takes priority over
   // plaintext token. Both produce the same (req) → context shape for WyStack.
@@ -609,6 +623,7 @@ export async function createDashframeServer(
     onWrite: opts.onWrite,
     accessCredentials: opts.accessCredentials,
     getServerEndpoint: () => serverState.endpoint,
+    googleOAuth,
   });
 
   // Inject server-level references needed by the previewDiff query handler
@@ -758,11 +773,35 @@ export async function createDashframeServer(
     }),
   );
 
+  // OAuth callback + resume are intentionally outside createRoutes: neither
+  // browser request carries a bearer token. The callback reaches project writes
+  // only through its state gates and the fixed internal principal in the
+  // delegated app.call.
+  honoApp.get("/api/connectors/oauth/callback", (c) =>
+    handleConnectorOAuthCallback(c, app),
+  );
+  honoApp.get("/api/connectors/setup/:sessionId/resume", (c) =>
+    handleConnectorSetupResume(c, app),
+  );
+  honoApp.get("/", (c) => handleConnectorResumeLanding(c, app));
+
   honoApp.route("/", createRoutes({ app, resolveContext }, upgradeWebSocket));
 
   const { port, server } = await listen(honoApp, hostname, requestedPort);
   injectWebSocket(server);
   serverState.endpoint = `http://${hostname}:${port}/api`;
+
+  try {
+    await app.call(
+      "sweepConnectorSetupSessions",
+      {},
+      { principal: { kind: "user", userId: LOCAL_USER_ID } },
+    );
+    await opts.flushSnapshot?.();
+  } catch (error) {
+    server.close();
+    throw error;
+  }
 
   return {
     url: `http://${hostname}:${port}`,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -532,6 +532,9 @@ export async function buildDashframeApp(opts: {
  * that would have owned it is the one that just died. It also has to waive it:
  * this pass is the only one scheduled, so a row left inside the window would
  * sit in flight indefinitely while the browser polled it to its own timeout.
+ *
+ * Must be called before the listener opens — see the call site. The waiver is
+ * only sound while no request can be in flight.
  */
 async function sweepConnectorSetupAtBoot(
   app: WyStackApp,
@@ -830,11 +833,17 @@ export async function createDashframeServer(
 
   honoApp.route("/", createRoutes({ app, resolveContext }, upgradeWebSocket));
 
+  // Before the listener opens, and that ordering is load-bearing: the sweep
+  // waives the in-flight grace window on the claim that no handler can own an
+  // `exchanging` / `verifying` row. That claim is only true while nothing can
+  // reach the callback route. Run it after `listen` and an OAuth callback
+  // arriving in the same moment could have its session reset underneath it,
+  // failing a connection that in fact succeeded.
+  await sweepConnectorSetupAtBoot(app, opts.flushSnapshot);
+
   const { port, server } = await listen(honoApp, hostname, requestedPort);
   injectWebSocket(server);
   serverState.endpoint = `http://${hostname}:${port}/api`;
-
-  await sweepConnectorSetupAtBoot(app, opts.flushSnapshot);
 
   return {
     url: `http://${hostname}:${port}`,

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -526,6 +526,12 @@ export async function buildDashframeApp(opts: {
  * boot over it takes the whole app down for a problem confined to one
  * background chore. The next sweep, or the callback gate itself, catches
  * whatever this pass missed.
+ *
+ * `__bootSweep` waives the in-flight grace window. This is the one caller that
+ * can prove no handler owns an `exchanging` / `verifying` row — the process
+ * that would have owned it is the one that just died. It also has to waive it:
+ * this pass is the only one scheduled, so a row left inside the window would
+ * sit in flight indefinitely while the browser polled it to its own timeout.
  */
 async function sweepConnectorSetupAtBoot(
   app: WyStackApp,
@@ -535,7 +541,10 @@ async function sweepConnectorSetupAtBoot(
     await app.call(
       "sweepConnectorSetupSessions",
       {},
-      { principal: { kind: "user", userId: LOCAL_USER_ID } },
+      {
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+        __bootSweep: true,
+      },
     );
     await flushSnapshot?.();
   } catch (error) {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -518,6 +518,35 @@ export async function buildDashframeApp(opts: {
   };
 }
 
+/**
+ * Run the connector-setup sweep once at boot, and never let it stop the server.
+ *
+ * Housekeeping, not a precondition: the sweep only expires and prunes stale
+ * connector-setup rows, and nothing else depends on it having run. Failing the
+ * boot over it takes the whole app down for a problem confined to one
+ * background chore. The next sweep, or the callback gate itself, catches
+ * whatever this pass missed.
+ */
+async function sweepConnectorSetupAtBoot(
+  app: WyStackApp,
+  flushSnapshot: (() => Promise<void>) | undefined,
+): Promise<void> {
+  try {
+    await app.call(
+      "sweepConnectorSetupSessions",
+      {},
+      { principal: { kind: "user", userId: LOCAL_USER_ID } },
+    );
+    await flushSnapshot?.();
+  } catch (error) {
+    console.warn(
+      `[dashframe] connector setup sweep skipped at boot: ${
+        error instanceof Error ? error.message : "unknown error"
+      }`,
+    );
+  }
+}
+
 export async function createDashframeServer(
   opts: DashframeServerOptions,
 ): Promise<DashframeServer> {
@@ -783,6 +812,11 @@ export async function createDashframeServer(
   honoApp.get("/api/connectors/setup/:sessionId/resume", (c) =>
     handleConnectorSetupResume(c, app),
   );
+  // This route owns the origin root. Hono matches first-registered-first, so a
+  // static UI route registered at "/" below would never be reached, and one
+  // registered above would silently swallow every resume link. Moving this line
+  // relative to createRoutes changes which handler wins, with no error either
+  // way — do it deliberately or not at all.
   honoApp.get("/", (c) => handleConnectorResumeLanding(c, app));
 
   honoApp.route("/", createRoutes({ app, resolveContext }, upgradeWebSocket));
@@ -791,17 +825,7 @@ export async function createDashframeServer(
   injectWebSocket(server);
   serverState.endpoint = `http://${hostname}:${port}/api`;
 
-  try {
-    await app.call(
-      "sweepConnectorSetupSessions",
-      {},
-      { principal: { kind: "user", userId: LOCAL_USER_ID } },
-    );
-    await opts.flushSnapshot?.();
-  } catch (error) {
-    server.close();
-    throw error;
-  }
+  await sweepConnectorSetupAtBoot(app, opts.flushSnapshot);
 
   return {
     url: `http://${hostname}:${port}`,

--- a/apps/server/src/connector-oauth-callback.test.ts
+++ b/apps/server/src/connector-oauth-callback.test.ts
@@ -114,8 +114,8 @@ describe("connector OAuth browser routes", () => {
     expect(response.headers.get("location")).toBe(authorizeUrl);
     expect(response.headers.get("referrer-policy")).toBe("no-referrer");
     expect(call).toHaveBeenCalledWith(
-      "getConnectorSetupSession",
-      { sessionId: "opaque-session", publicResume: true },
+      "reissueConnectorSetupResume",
+      { sessionId: "opaque-session" },
       { principal: { kind: "user", userId: LOCAL_USER_ID } },
     );
   });

--- a/apps/server/src/connector-oauth-callback.test.ts
+++ b/apps/server/src/connector-oauth-callback.test.ts
@@ -1,5 +1,6 @@
 import { openArtifactDb } from "@dashframe/server-core";
 import type { WyStackApp } from "@wystack/server";
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -142,5 +143,116 @@ describe("connector OAuth browser routes", () => {
       "[dashframe] connector OAuth callback rejected: state-mismatch",
     );
     warn.mockRestore();
+  });
+
+  // These routes are consumed by a browser, not by our own client, so the
+  // status is the entire machine-readable half of the response — the body is
+  // prose for a human. Asserting only bodies let every status here be changed
+  // to 200 with the suite still green.
+  describe("status codes each browser route commits to", () => {
+    // Typed against the real handler shape rather than cast through `never`:
+    // these tests stand in for mutants, so a handler signature change has to
+    // break them rather than slide past on a cast.
+    function route(
+      handler: (c: Context, app: WyStackApp) => Promise<Response>,
+      path: string,
+      result: unknown,
+    ) {
+      const call = vi.fn(async () => ({
+        result,
+        tablesRead: new Set<string>(),
+        tablesWritten: new Set<string>(),
+      }));
+      const hono = new Hono();
+      hono.get(path, (c) => handler(c, fakeApp(call)));
+      return hono;
+    }
+
+    it("answers a callback that has to restart authorization with 409", async () => {
+      const hono = route(
+        handleConnectorOAuthCallback,
+        "/api/connectors/oauth/callback",
+        { state: "awaiting-user-auth" },
+      );
+      const response = await hono.request(
+        "/api/connectors/oauth/callback?state=opaque&code=authorization-code",
+      );
+      // Not 200: the tab is showing "sign in again", so a cache or a monitor
+      // must not read this as a completed connection.
+      expect(response.status).toBe(409);
+    });
+
+    it("answers a callback for a dead session with 400", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const hono = route(
+        handleConnectorOAuthCallback,
+        "/api/connectors/oauth/callback",
+        { state: "expired" },
+      );
+      const response = await hono.request(
+        "/api/connectors/oauth/callback?state=opaque&code=authorization-code",
+      );
+      expect(response.status).toBe(400);
+      warn.mockRestore();
+    });
+
+    it("serves the resume DTO with 200 and an unavailable session with 404", async () => {
+      const ok = route(
+        handleConnectorSetupResume,
+        "/api/connectors/setup/:sessionId/resume",
+        { sessionId: "s", connectorId: "googleAnalytics", state: "expired" },
+      );
+      expect((await ok.request("/api/connectors/setup/s/resume")).status).toBe(
+        200,
+      );
+
+      const failing = new Hono();
+      failing.get("/api/connectors/setup/:sessionId/resume", (c) =>
+        handleConnectorSetupResume(
+          c,
+          fakeApp(
+            vi.fn(async () => {
+              throw new ConnectorSetupGateError("state-mismatch");
+            }),
+          ),
+        ),
+      );
+      const response = await failing.request("/api/connectors/setup/s/resume");
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({
+        error: "Connector setup session is unavailable",
+      });
+    });
+
+    it("answers the landing route with 410 when the session is past resuming", async () => {
+      const landing = route(handleConnectorResumeLanding, "/", {
+        sessionId: "s",
+        connectorId: "googleAnalytics",
+        state: "failed",
+      });
+      // 410, not 404: the session existed and is being reported as gone for
+      // good, which is what tells the user to start over rather than retry.
+      expect((await landing.request("/?resumeConnector=opaque")).status).toBe(
+        410,
+      );
+    });
+
+    it("answers the landing route with 200 when setup already finished", async () => {
+      const landing = route(handleConnectorResumeLanding, "/", {
+        sessionId: "s",
+        connectorId: "googleAnalytics",
+        state: "connected",
+      });
+      expect((await landing.request("/?resumeConnector=opaque")).status).toBe(
+        200,
+      );
+    });
+
+    it("answers the bare origin root with 404 rather than claiming a session", async () => {
+      const landing = route(handleConnectorResumeLanding, "/", {
+        state: "connected",
+      });
+      expect((await landing.request("/")).status).toBe(404);
+    });
   });
 });

--- a/apps/server/src/connector-oauth-callback.test.ts
+++ b/apps/server/src/connector-oauth-callback.test.ts
@@ -1,0 +1,146 @@
+import { openArtifactDb } from "@dashframe/server-core";
+import type { WyStackApp } from "@wystack/server";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { createDashframeServer } from "./app";
+import {
+  handleConnectorOAuthCallback,
+  handleConnectorResumeLanding,
+  handleConnectorSetupResume,
+} from "./connector-oauth-callback";
+import { ConnectorSetupGateError } from "./connector-setup/session-store";
+import { LOCAL_USER_ID } from "./permissions";
+
+function fakeApp(call: WyStackApp["call"]): WyStackApp {
+  return { call } as WyStackApp;
+}
+
+describe("connector OAuth browser routes", () => {
+  it("bypasses bearer resolution on the registered callback route", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dashframe-oauth-route-"));
+    const db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    let server: Awaited<ReturnType<typeof createDashframeServer>> | undefined;
+    try {
+      server = await createDashframeServer({
+        db,
+        authToken: "required-for-normal-api-routes",
+      });
+      const response = await fetch(
+        `${server.url}/api/connectors/oauth/callback?state=invalid`,
+      );
+      expect(response.status).toBe(400);
+    } finally {
+      server?.stop();
+      await db.$client.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires no bearer and delegates completion with the fixed local principal", async () => {
+    const call = vi.fn(async () => ({
+      result: { state: "connected" },
+      tablesRead: new Set<string>(),
+      tablesWritten: new Set<string>(),
+    }));
+    const hono = new Hono();
+    hono.get("/api/connectors/oauth/callback", (c) =>
+      handleConnectorOAuthCallback(c, fakeApp(call)),
+    );
+
+    const response = await hono.request(
+      "/api/connectors/oauth/callback?state=opaque&code=authorization-code",
+    );
+    expect(response.status).toBe(200);
+    expect(call).toHaveBeenCalledWith(
+      "completeConnectorOAuth",
+      {
+        state: "opaque",
+        code: "authorization-code",
+        oauthError: undefined,
+      },
+      { principal: { kind: "user", userId: LOCAL_USER_ID } },
+    );
+  });
+
+  it("returns only the minimal public resume DTO", async () => {
+    const result = {
+      sessionId: crypto.randomUUID(),
+      connectorId: "googleAnalytics",
+      state: "awaiting-user-auth",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      expiresAt: Date.now() + 60_000,
+    };
+    const call = vi.fn(async () => ({
+      result,
+      tablesRead: new Set<string>(),
+      tablesWritten: new Set<string>(),
+    }));
+    const hono = new Hono();
+    hono.get("/api/connectors/setup/:sessionId/resume", (c) =>
+      handleConnectorSetupResume(c, fakeApp(call)),
+    );
+    const response = await hono.request(
+      `/api/connectors/setup/${result.sessionId}/resume`,
+    );
+    await expect(response.json()).resolves.toEqual(result);
+  });
+
+  it("turns the standalone resume capability into a fresh authorization redirect", async () => {
+    const authorizeUrl =
+      "https://accounts.google.com/o/oauth2/v2/auth?state=fresh";
+    const call = vi.fn(async () => ({
+      result: {
+        sessionId: crypto.randomUUID(),
+        connectorId: "googleAnalytics",
+        state: "awaiting-user-auth",
+        authorizeUrl,
+        expiresAt: Date.now() + 60_000,
+      },
+      tablesRead: new Set<string>(),
+      tablesWritten: new Set<string>(),
+    }));
+    const hono = new Hono();
+    hono.get("/", (c) => handleConnectorResumeLanding(c, fakeApp(call)));
+
+    const response = await hono.request("/?resumeConnector=opaque-session", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(authorizeUrl);
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(call).toHaveBeenCalledWith(
+      "getConnectorSetupSession",
+      { sessionId: "opaque-session", publicResume: true },
+      { principal: { kind: "user", userId: LOCAL_USER_ID } },
+    );
+  });
+
+  it("renders a generic error and logs only a session-free gate code", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const call = vi.fn(async () => {
+      throw new ConnectorSetupGateError("state-mismatch");
+    });
+    const hono = new Hono();
+    hono.get("/api/connectors/oauth/callback", (c) =>
+      handleConnectorOAuthCallback(c, fakeApp(call)),
+    );
+    const secretState = `${crypto.randomUUID()}.secret-nonce`;
+    const response = await hono.request(
+      `/api/connectors/oauth/callback?state=${encodeURIComponent(secretState)}&code=secret-code`,
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(html).not.toContain(secretState);
+    expect(html).not.toContain("secret-code");
+    expect(warn).toHaveBeenCalledWith(
+      "[dashframe] connector OAuth callback rejected: state-mismatch",
+    );
+    warn.mockRestore();
+  });
+});

--- a/apps/server/src/connector-oauth-callback.ts
+++ b/apps/server/src/connector-oauth-callback.ts
@@ -1,0 +1,142 @@
+import type { WyStackApp } from "@wystack/server";
+import type { Context } from "hono";
+
+import type {
+  ConnectorSetupSessionDto,
+  PublicConnectorSetupResumeDto,
+} from "./functions/connector-setup";
+import { connectorSetupGateCode } from "./functions/connector-setup";
+import { LOCAL_USER_ID } from "./permissions";
+
+const INTERNAL_PRINCIPAL = {
+  kind: "user" as const,
+  userId: LOCAL_USER_ID,
+};
+
+function secureHtml(c: Context, title: string, message: string, status = 200) {
+  c.header("Cache-Control", "no-store");
+  c.header("Referrer-Policy", "no-referrer");
+  c.header(
+    "Content-Security-Policy",
+    "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'",
+  );
+  return c.html(
+    `<!doctype html><html><head><meta charset="utf-8"><meta name="referrer" content="no-referrer"><title>${title}</title><style>body{font:16px system-ui;max-width:36rem;margin:12vh auto;padding:0 1.5rem;color:#171717}h1{font-size:1.5rem}</style></head><body><h1>${title}</h1><p>${message}</p></body></html>`,
+    status as 200,
+  );
+}
+
+export async function handleConnectorOAuthCallback(
+  c: Context,
+  app: WyStackApp,
+) {
+  const state = c.req.query("state") ?? "";
+  const code = c.req.query("code");
+  const oauthError = c.req.query("error");
+  try {
+    const call = await app.call(
+      "completeConnectorOAuth",
+      { state, code, oauthError },
+      // Fixed server-owned identity. No callback query/header value can select
+      // or alter the principal used for the project mutation.
+      { principal: INTERNAL_PRINCIPAL },
+    );
+    const result = call.result as ConnectorSetupSessionDto;
+    if (result.state === "connected") {
+      return secureHtml(
+        c,
+        "Google Analytics connected",
+        "You can close this window and return to DashFrame.",
+      );
+    }
+    if (result.state === "awaiting-user-auth") {
+      return secureHtml(
+        c,
+        "Authorization needs to restart",
+        "Return to DashFrame and use the original resume link to sign in again.",
+        409,
+      );
+    }
+    if (result.state === "expired") {
+      console.warn(
+        "[dashframe] connector OAuth callback rejected: session-expired",
+      );
+    }
+    return secureHtml(
+      c,
+      "Connection could not be completed",
+      "Return to DashFrame to review the setup status.",
+      400,
+    );
+  } catch (error) {
+    // Never log the request URL, state, code, or session id.
+    console.warn(
+      `[dashframe] connector OAuth callback rejected: ${connectorSetupGateCode(error)}`,
+    );
+    return secureHtml(
+      c,
+      "Connection could not be completed",
+      "Return to DashFrame and start connector setup again.",
+      400,
+    );
+  }
+}
+
+export async function handleConnectorSetupResume(c: Context, app: WyStackApp) {
+  c.header("Cache-Control", "no-store");
+  c.header("Referrer-Policy", "no-referrer");
+  try {
+    const call = await app.call(
+      "getConnectorSetupSession",
+      { sessionId: c.req.param("sessionId"), publicResume: true },
+      { principal: INTERNAL_PRINCIPAL },
+    );
+    return c.json(call.result as PublicConnectorSetupResumeDto);
+  } catch {
+    return c.json({ error: "Connector setup session is unavailable" }, 404);
+  }
+}
+
+export async function handleConnectorResumeLanding(
+  c: Context,
+  app: WyStackApp,
+) {
+  const sessionId = c.req.query("resumeConnector");
+  if (!sessionId) {
+    return secureHtml(c, "DashFrame", "Open DashFrame to continue.", 404);
+  }
+
+  try {
+    const call = await app.call(
+      "getConnectorSetupSession",
+      { sessionId, publicResume: true },
+      { principal: INTERNAL_PRINCIPAL },
+    );
+    const result = call.result as PublicConnectorSetupResumeDto;
+    if (result.state === "awaiting-user-auth" && result.authorizeUrl) {
+      c.header("Cache-Control", "no-store");
+      c.header("Referrer-Policy", "no-referrer");
+      return c.redirect(result.authorizeUrl);
+    }
+    if (result.state === "connected") {
+      return secureHtml(
+        c,
+        "Google Analytics connected",
+        "This setup is already complete. You can close this window.",
+      );
+    }
+    return secureHtml(
+      c,
+      "Connector setup unavailable",
+      "Return to DashFrame and start connector setup again.",
+      410,
+    );
+  } catch {
+    return secureHtml(
+      c,
+      "Connector setup unavailable",
+      "Return to DashFrame and start connector setup again.",
+      404,
+    );
+  }
+}

--- a/apps/server/src/connector-oauth-callback.ts
+++ b/apps/server/src/connector-oauth-callback.ts
@@ -86,9 +86,12 @@ export async function handleConnectorSetupResume(c: Context, app: WyStackApp) {
   c.header("Cache-Control", "no-store");
   c.header("Referrer-Policy", "no-referrer");
   try {
+    // Resuming means handing back a working authorize URL, which rotates the
+    // state nonce. That is a write, so this calls the mutation rather than the
+    // read-only query.
     const call = await app.call(
-      "getConnectorSetupSession",
-      { sessionId: c.req.param("sessionId"), publicResume: true },
+      "reissueConnectorSetupResume",
+      { sessionId: c.req.param("sessionId") },
       { principal: INTERNAL_PRINCIPAL },
     );
     return c.json(call.result as PublicConnectorSetupResumeDto);
@@ -108,8 +111,8 @@ export async function handleConnectorResumeLanding(
 
   try {
     const call = await app.call(
-      "getConnectorSetupSession",
-      { sessionId, publicResume: true },
+      "reissueConnectorSetupResume",
+      { sessionId },
       { principal: INTERNAL_PRINCIPAL },
     );
     const result = call.result as PublicConnectorSetupResumeDto;

--- a/apps/server/src/connector-setup/oauth-provider.test.ts
+++ b/apps/server/src/connector-setup/oauth-provider.test.ts
@@ -96,4 +96,47 @@ describe("Google connector OAuth provider", () => {
       }),
     ).rejects.toMatchObject({ redirectUriMismatch: true });
   });
+
+  // The client secret is one server-wide credential. Serialising it into each
+  // connected source's vault bundle would multiply the places it must be
+  // rotated out of, and would let any single source's bundle disclose the
+  // secret for every source.
+  it("never serialises the client secret into the stored token bundle", async () => {
+    const clientSecret = "super-secret-value";
+    const descriptor = makeGa4OAuthDescriptor({
+      clientId: "client-id",
+      clientSecret,
+      now: () => 1_000_000,
+      fetch: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              access_token: "access-token",
+              refresh_token: "refresh-token",
+              expires_in: 3600,
+              scope: "https://www.googleapis.com/auth/analytics.readonly",
+            }),
+            { status: 200 },
+          ),
+      ) as unknown as typeof fetch,
+    });
+
+    const stored = await descriptor.exchangeCode({
+      code: "code",
+      codeVerifier: "v".repeat(64),
+      redirectUri: "http://127.0.0.1/callback",
+      state: "state",
+    });
+
+    expect(stored).not.toContain(clientSecret);
+    const bundle = JSON.parse(stored) as Record<string, unknown>;
+    expect(bundle).not.toHaveProperty("clientSecret");
+    // The non-secret fields the refresh path still depends on must survive.
+    expect(bundle).toMatchObject({
+      version: 1,
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      clientId: "client-id",
+    });
+  });
 });

--- a/apps/server/src/connector-setup/oauth-provider.test.ts
+++ b/apps/server/src/connector-setup/oauth-provider.test.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  makeGa4OAuthDescriptor,
+  oauthConnectorDescriptorFor,
+  readOptionalGoogleOAuthConfig,
+  resolveOAuthRedirectUri,
+} from "./oauth-provider";
+
+describe("Google connector OAuth provider", () => {
+  it("builds a PKCE S256 authorize URL without exposing the verifier", () => {
+    const descriptor = makeGa4OAuthDescriptor({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    const verifier = "v".repeat(64);
+    const url = new URL(
+      descriptor.buildAuthorizeUrl({
+        redirectUri: "http://127.0.0.1:4567/api/connectors/oauth/callback",
+        state: "opaque-state",
+        codeVerifier: verifier,
+      }),
+    );
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBe(
+      createHash("sha256").update(verifier).digest("base64url"),
+    );
+    expect(url.toString()).not.toContain(verifier);
+  });
+
+  it("resolves GA4 only through an OAuth entry in the server catalog", () => {
+    expect(
+      oauthConnectorDescriptorFor("googleAnalytics", {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+      }),
+    ).toMatchObject({ id: "googleAnalytics", authKind: "oauth" });
+    expect(() =>
+      oauthConnectorDescriptorFor("notion", {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+      }),
+    ).toThrow(/does not support OAuth setup/);
+  });
+
+  it("fails closed for a non-loopback endpoint without an override", () => {
+    expect(() =>
+      resolveOAuthRedirectUri("https://dashframe.example/api"),
+    ).toThrow(/DASHFRAME_OAUTH_REDIRECT_BASE/);
+    expect(
+      resolveOAuthRedirectUri(
+        // Loopback HTTP is the installed-app OAuth contract under test.
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols
+        "http://0.0.0.0:4000/api",
+        "https://dashframe.example/api",
+      ),
+    ).toBe("https://dashframe.example/api/connectors/oauth/callback");
+    expect(
+      resolveOAuthRedirectUri(
+        // Loopback HTTP is the installed-app OAuth contract under test.
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols
+        "http://0.0.0.0:4000/api",
+        "https://dashframe.example",
+      ),
+    ).toBe("https://dashframe.example/api/connectors/oauth/callback");
+  });
+
+  it("treats partial Google client configuration as an actionable startup error", () => {
+    expect(() =>
+      readOptionalGoogleOAuthConfig({ DASHFRAME_GOOGLE_CLIENT_ID: "id" }),
+    ).toThrow(/DASHFRAME_GOOGLE_CLIENT_SECRET is required/);
+  });
+
+  it("classifies a redirect mismatch without including the provider response", async () => {
+    const descriptor = makeGa4OAuthDescriptor({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      fetch: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: "redirect_uri_mismatch",
+              error_description: "secret provider detail",
+            }),
+            { status: 400 },
+          ),
+      ) as unknown as typeof fetch,
+    });
+    await expect(
+      descriptor.exchangeCode({
+        code: "code",
+        codeVerifier: "v".repeat(64),
+        redirectUri: "http://127.0.0.1/callback",
+        state: "state",
+      }),
+    ).rejects.toMatchObject({ redirectUriMismatch: true });
+  });
+});

--- a/apps/server/src/connector-setup/oauth-provider.ts
+++ b/apps/server/src/connector-setup/oauth-provider.ts
@@ -1,0 +1,231 @@
+import type { GoogleOAuthTokenBundle } from "@dashframe/connector-ga4";
+import { createHash } from "node:crypto";
+
+import { isLoopbackHost } from "../bind-host";
+import { getConnectorCatalogEntries } from "../functions/connector-catalog";
+
+export interface OAuthAuthorizeInput {
+  redirectUri: string;
+  state: string;
+  codeVerifier: string;
+}
+
+export interface OAuthExchangeInput extends OAuthAuthorizeInput {
+  code: string;
+}
+
+export interface OAuthConnectorDescriptor {
+  id: string;
+  authKind: "oauth";
+  scopes: string[];
+  buildAuthorizeUrl(input: OAuthAuthorizeInput): string;
+  exchangeCode(input: OAuthExchangeInput): Promise<string>;
+}
+
+export interface GoogleOAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectBase?: string;
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
+export class OAuthExchangeError extends Error {
+  constructor(
+    readonly code: string,
+    readonly redirectUriMismatch: boolean,
+  ) {
+    super("OAuth code exchange failed");
+  }
+}
+
+const GA4_SCOPES = ["https://www.googleapis.com/auth/analytics.readonly"];
+
+function requiredEnvironmentValue(
+  environment: NodeJS.ProcessEnv,
+  name: string,
+): string {
+  const value = environment[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for Google Analytics connector setup`);
+  }
+  return value;
+}
+
+export function readGoogleOAuthConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): GoogleOAuthConfig {
+  return {
+    clientId: requiredEnvironmentValue(
+      environment,
+      "DASHFRAME_GOOGLE_CLIENT_ID",
+    ),
+    clientSecret: requiredEnvironmentValue(
+      environment,
+      "DASHFRAME_GOOGLE_CLIENT_SECRET",
+    ),
+    redirectBase:
+      environment.DASHFRAME_OAUTH_REDIRECT_BASE?.trim() || undefined,
+  };
+}
+
+export function readOptionalGoogleOAuthConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): GoogleOAuthConfig | undefined {
+  const clientId = environment.DASHFRAME_GOOGLE_CLIENT_ID?.trim();
+  const clientSecret = environment.DASHFRAME_GOOGLE_CLIENT_SECRET?.trim();
+  if (!clientId && !clientSecret) return undefined;
+  return readGoogleOAuthConfig(environment);
+}
+
+function normalizedBase(value: string): string {
+  const url = new URL(value);
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      "DASHFRAME_OAUTH_REDIRECT_BASE must be an HTTP(S) base URL without credentials, query, or fragment",
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("OAuth redirect base must use HTTP or HTTPS");
+  }
+  return url.toString().replace(/\/$/u, "");
+}
+
+/** Resolve the callback from the current server endpoint on every issuance. */
+export function resolveOAuthRedirectUri(
+  serverEndpoint: string | undefined,
+  redirectBase?: string,
+): string {
+  if (!serverEndpoint) throw new Error("Server endpoint is not ready");
+  const endpoint = new URL(serverEndpoint);
+  const selectedBase = redirectBase
+    ? normalizedBase(redirectBase)
+    : normalizedBase(serverEndpoint);
+  if (!redirectBase && !isLoopbackHost(endpoint.hostname)) {
+    throw new Error(
+      "Google OAuth on a non-loopback server requires DASHFRAME_OAUTH_REDIRECT_BASE set to the registered callback base",
+    );
+  }
+  const callbackBase = selectedBase.endsWith("/api")
+    ? selectedBase
+    : `${selectedBase}/api`;
+  return `${callbackBase}/connectors/oauth/callback`;
+}
+
+export function connectorResumeLink(
+  serverEndpoint: string | undefined,
+  sessionId: string,
+): string {
+  if (!serverEndpoint) throw new Error("Server endpoint is not ready");
+  const url = new URL("/", serverEndpoint);
+  url.searchParams.set("resumeConnector", sessionId);
+  return url.toString();
+}
+
+function codeChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function isRedirectMismatch(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const error = (value as { error?: unknown }).error;
+  const description = (value as { error_description?: unknown })
+    .error_description;
+  return [error, description].some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      candidate.toLowerCase().includes("redirect_uri"),
+  );
+}
+
+export function makeGa4OAuthDescriptor(
+  config: GoogleOAuthConfig,
+): OAuthConnectorDescriptor {
+  const fetchImpl = config.fetch ?? fetch;
+  const now = config.now ?? Date.now;
+  return {
+    id: "googleAnalytics",
+    authKind: "oauth",
+    scopes: [...GA4_SCOPES],
+    buildAuthorizeUrl(input) {
+      const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+      url.searchParams.set("client_id", config.clientId);
+      url.searchParams.set("redirect_uri", input.redirectUri);
+      url.searchParams.set("response_type", "code");
+      url.searchParams.set("scope", GA4_SCOPES.join(" "));
+      url.searchParams.set("access_type", "offline");
+      url.searchParams.set("prompt", "consent");
+      url.searchParams.set("state", input.state);
+      url.searchParams.set("code_challenge", codeChallenge(input.codeVerifier));
+      url.searchParams.set("code_challenge_method", "S256");
+      return url.toString();
+    },
+    async exchangeCode(input) {
+      const body = new URLSearchParams({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        code: input.code,
+        code_verifier: input.codeVerifier,
+        grant_type: "authorization_code",
+        redirect_uri: input.redirectUri,
+      });
+      const response = await fetchImpl("https://oauth2.googleapis.com/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body,
+      });
+      const value = (await response.json().catch(() => null)) as unknown;
+      if (!response.ok) {
+        throw new OAuthExchangeError(
+          "exchange-rejected",
+          isRedirectMismatch(value),
+        );
+      }
+      if (value === null || typeof value !== "object") {
+        throw new OAuthExchangeError("invalid-token-response", false);
+      }
+      const token = value as {
+        access_token?: unknown;
+        refresh_token?: unknown;
+        expires_in?: unknown;
+        scope?: unknown;
+      };
+      if (
+        typeof token.access_token !== "string" ||
+        typeof token.refresh_token !== "string" ||
+        typeof token.expires_in !== "number" ||
+        typeof token.scope !== "string"
+      ) {
+        throw new OAuthExchangeError("invalid-token-response", false);
+      }
+      const grantedScopes = token.scope.split(/\s+/u).filter(Boolean);
+      if (!GA4_SCOPES.every((scope) => grantedScopes.includes(scope))) {
+        throw new OAuthExchangeError("missing-required-scope", false);
+      }
+      const bundle: GoogleOAuthTokenBundle = {
+        version: 1,
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token,
+        expiresAt: now() + token.expires_in * 1000,
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+        scopes: grantedScopes,
+      };
+      return JSON.stringify(bundle);
+    },
+  };
+}
+
+/** Maps catalog-advertised OAuth connectors to their provider implementation. */
+export function oauthConnectorDescriptorFor(
+  connectorId: string,
+  config: GoogleOAuthConfig,
+): OAuthConnectorDescriptor {
+  const catalogEntry = getConnectorCatalogEntries().find(
+    (entry) => entry.id === connectorId,
+  );
+  if (catalogEntry?.authKind !== "oauth" || connectorId !== "googleAnalytics") {
+    throw new Error(`Connector ${connectorId} does not support OAuth setup`);
+  }
+  return makeGa4OAuthDescriptor(config);
+}

--- a/apps/server/src/connector-setup/oauth-provider.ts
+++ b/apps/server/src/connector-setup/oauth-provider.ts
@@ -202,13 +202,19 @@ export function makeGa4OAuthDescriptor(
       if (!GA4_SCOPES.every((scope) => grantedScopes.includes(scope))) {
         throw new OAuthExchangeError("missing-required-scope", false);
       }
+      // The client secret is deliberately NOT part of the stored bundle. It is
+      // one server-wide credential, not per-source data: copying it into every
+      // connected source's vault entry would multiply the number of places it
+      // has to be rotated out of, and would let a single source's bundle leak
+      // the secret for every source. Refresh reads it from server config at
+      // call time instead. `clientId` stays — it is not secret, and it records
+      // which OAuth client actually minted this grant.
       const bundle: GoogleOAuthTokenBundle = {
         version: 1,
         accessToken: token.access_token,
         refreshToken: token.refresh_token,
         expiresAt: now() + token.expires_in * 1000,
         clientId: config.clientId,
-        clientSecret: config.clientSecret,
         scopes: grantedScopes,
       };
       return JSON.stringify(bundle);

--- a/apps/server/src/connector-setup/session-store.test.ts
+++ b/apps/server/src/connector-setup/session-store.test.ts
@@ -1,0 +1,255 @@
+import { openArtifactDb, schema } from "@dashframe/server-core";
+import { eq } from "drizzle-orm";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { functions } from "../functions";
+import { wy } from "../wystack";
+import {
+  CONNECTOR_SETUP_TERMINAL_RETENTION_MS,
+  ConnectorSetupGateError,
+  consumeCallback,
+  oauthStateFor,
+  publicResumeInfo,
+  startSession,
+  sweep,
+} from "./session-store";
+
+const { connectorSetupSessions, dataSources } = schema;
+
+describe("connector setup session store", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: Awaited<ReturnType<typeof wy.build>>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-connector-session-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    app = await wy.build({ db, functions });
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function pending(now = new Date("2026-08-05T12:00:00Z")) {
+    return startSession(app.createTracked(), {
+      connectorId: "googleAnalytics",
+      requestedName: "GA4",
+      scopes: ["analytics.readonly"],
+      now,
+    });
+  }
+
+  it("consumes a callback exactly once with a conditional database transition", async () => {
+    const issuance = await pending();
+    const state = oauthStateFor(issuance.stateNonce);
+
+    const attempts = await Promise.allSettled([
+      consumeCallback(
+        app.createTracked(),
+        state,
+        new Date("2026-08-05T12:01:00Z"),
+      ),
+      consumeCallback(
+        app.createTracked(),
+        state,
+        new Date("2026-08-05T12:01:00Z"),
+      ),
+    ]);
+
+    expect(
+      attempts.filter((attempt) => attempt.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      attempts.filter((attempt) => attempt.status === "rejected"),
+    ).toHaveLength(1);
+    const [row] = await db
+      .select()
+      .from(connectorSetupSessions)
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+    expect(row?.state).toBe("exchanging");
+  });
+
+  it("rejects a wrong nonce without changing the pending row", async () => {
+    const issuance = await pending();
+    await expect(
+      consumeCallback(
+        app.createTracked(),
+        oauthStateFor("w".repeat(43)),
+        new Date("2026-08-05T12:01:00Z"),
+      ),
+    ).rejects.toMatchObject({
+      code: "state-mismatch",
+    } satisfies Partial<ConnectorSetupGateError>);
+    const [row] = await db
+      .select()
+      .from(connectorSetupSessions)
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+    expect(row?.state).toBe("awaiting-user-auth");
+  });
+
+  it("rejects an unmatched state when no session exists", async () => {
+    await expect(
+      consumeCallback(
+        app.createTracked(),
+        oauthStateFor("w".repeat(43)),
+        new Date("2026-08-05T12:01:00Z"),
+      ),
+    ).rejects.toMatchObject({
+      code: "state-mismatch",
+    } satisfies Partial<ConnectorSetupGateError>);
+  });
+
+  it("rejects a matching state after the session has left the pending state", async () => {
+    const issuance = await pending();
+    await db
+      .update(connectorSetupSessions)
+      .set({ state: "failed" })
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+
+    await expect(
+      consumeCallback(
+        app.createTracked(),
+        oauthStateFor(issuance.stateNonce),
+        new Date("2026-08-05T12:01:00Z"),
+      ),
+    ).rejects.toMatchObject({
+      code: "session-not-awaiting",
+    } satisfies Partial<ConnectorSetupGateError>);
+  });
+
+  it("expires a matching callback before consuming it", async () => {
+    const issuance = await pending();
+    await expect(
+      consumeCallback(
+        app.createTracked(),
+        oauthStateFor(issuance.stateNonce),
+        new Date("2026-08-05T12:16:00Z"),
+      ),
+    ).rejects.toMatchObject({
+      code: "session-expired",
+    } satisfies Partial<ConnectorSetupGateError>);
+    const [row] = await db
+      .select()
+      .from(connectorSetupSessions)
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+    expect(row?.state).toBe("expired");
+  });
+
+  it("lazily expires an awaiting session and never issues a new authorize nonce", async () => {
+    const issuance = await pending();
+    const resumed = await publicResumeInfo(
+      app.createTracked(),
+      issuance.session.id,
+      new Date("2026-08-05T12:16:00Z"),
+    );
+    expect(resumed.session.state).toBe("expired");
+    expect("stateNonce" in resumed).toBe(false);
+  });
+
+  it("allows only one concurrent resume request to rotate the authorization state", async () => {
+    const issuance = await pending();
+    const attempts = await Promise.allSettled([
+      publicResumeInfo(app.createTracked(), issuance.session.id),
+      publicResumeInfo(app.createTracked(), issuance.session.id),
+    ]);
+
+    expect(
+      attempts.filter((attempt) => attempt.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      attempts.filter((attempt) => attempt.status === "rejected"),
+    ).toHaveLength(1);
+  });
+
+  it("expires an in-flight exchange instead of reissuing after its TTL", async () => {
+    const issuance = await pending();
+    await db
+      .update(connectorSetupSessions)
+      .set({ state: "exchanging" })
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+
+    const resumed = await publicResumeInfo(
+      app.createTracked(),
+      issuance.session.id,
+      new Date("2026-08-05T12:16:00Z"),
+      true,
+      true,
+    );
+
+    expect(resumed.session.state).toBe("expired");
+    expect("stateNonce" in resumed).toBe(false);
+  });
+
+  it("boot sweep recovers in-flight rows, expires stale rows, and deletes old terminals", async () => {
+    const now = new Date("2026-08-05T12:00:00Z");
+    const exchanging = await pending(new Date("2026-08-05T11:55:00Z"));
+    const verifying = await pending(new Date("2026-08-05T11:56:00Z"));
+    const stale = await pending(new Date("2026-08-05T11:40:00Z"));
+    const terminal = await pending(new Date("2026-08-03T00:00:00Z"));
+    await db
+      .update(connectorSetupSessions)
+      .set({ state: "exchanging" })
+      .where(eq(connectorSetupSessions.id, exchanging.session.id));
+    await db
+      .update(connectorSetupSessions)
+      .set({ state: "verifying" })
+      .where(eq(connectorSetupSessions.id, verifying.session.id));
+    await db
+      .update(connectorSetupSessions)
+      .set({
+        state: "connected",
+        updatedAt: new Date(
+          now.getTime() - CONNECTOR_SETUP_TERMINAL_RETENTION_MS - 1,
+        ),
+      })
+      .where(eq(connectorSetupSessions.id, terminal.session.id));
+
+    await expect(sweep(app.createTracked(), now)).resolves.toEqual({
+      recovered: 2,
+      expired: 1,
+      deleted: 1,
+    });
+    const rows = await db.select().from(connectorSetupSessions);
+    expect(rows.find((row) => row.id === exchanging.session.id)?.state).toBe(
+      "awaiting-user-auth",
+    );
+    expect(rows.find((row) => row.id === verifying.session.id)?.state).toBe(
+      "awaiting-user-auth",
+    );
+    expect(rows.find((row) => row.id === stale.session.id)?.state).toBe(
+      "expired",
+    );
+    expect(rows.some((row) => row.id === terminal.session.id)).toBe(false);
+  });
+
+  it("reconciles a verifying session whose planned source was already created", async () => {
+    const issuance = await pending();
+    const sourceId = crypto.randomUUID();
+    await db.insert(dataSources).values({
+      id: sourceId,
+      name: "GA4",
+      kind: "googleAnalytics",
+      storage: "live",
+      config: {},
+      createdBy: { kind: "user" },
+    });
+    await db
+      .update(connectorSetupSessions)
+      .set({ state: "verifying", dataSourceId: sourceId })
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+
+    await expect(
+      sweep(app.createTracked(), new Date("2026-08-05T12:01:00Z")),
+    ).resolves.toEqual({ recovered: 1, expired: 0, deleted: 0 });
+    const [row] = await db
+      .select()
+      .from(connectorSetupSessions)
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+    expect(row).toMatchObject({ state: "connected", dataSourceId: sourceId });
+  });
+});

--- a/apps/server/src/connector-setup/session-store.test.ts
+++ b/apps/server/src/connector-setup/session-store.test.ts
@@ -246,11 +246,17 @@ describe("connector setup session store", () => {
     const terminal = await pending(new Date("2026-08-03T00:00:00Z"));
     await db
       .update(connectorSetupSessions)
-      .set({ state: "exchanging" })
+      // updatedAt is set explicitly: the sweep only recovers rows that have
+      // sat untouched past CONNECTOR_SETUP_INFLIGHT_GRACE_MS, and the schema's
+      // $onUpdate would otherwise stamp these with the real clock.
+      .set({
+        state: "exchanging",
+        updatedAt: new Date("2026-08-05T11:55:00Z"),
+      })
       .where(eq(connectorSetupSessions.id, exchanging.session.id));
     await db
       .update(connectorSetupSessions)
-      .set({ state: "verifying" })
+      .set({ state: "verifying", updatedAt: new Date("2026-08-05T11:56:00Z") })
       .where(eq(connectorSetupSessions.id, verifying.session.id));
     await db
       .update(connectorSetupSessions)
@@ -280,6 +286,38 @@ describe("connector setup session store", () => {
     expect(rows.some((row) => row.id === terminal.session.id)).toBe(false);
   });
 
+  it("leaves a still-live in-flight session alone", async () => {
+    // sweepConnectorSetupSessions is an ordinary mutation any client can call,
+    // including during the seconds between markVerifying and markConnected.
+    // Recovering there would rotate the nonce and clear dataSourceId under a
+    // live handler, failing its compare-and-swap and reporting failure for a
+    // connection that actually succeeded.
+    const now = new Date("2026-08-05T12:00:00Z");
+    const issuance = await pending(new Date("2026-08-05T11:59:30Z"));
+    const sourceId = crypto.randomUUID();
+    await db
+      .update(connectorSetupSessions)
+      .set({
+        state: "verifying",
+        dataSourceId: sourceId,
+        updatedAt: new Date("2026-08-05T11:59:30Z"),
+      })
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+
+    await expect(sweep(app.createTracked(), now)).resolves.toEqual({
+      recovered: 0,
+      expired: 0,
+      deleted: 0,
+    });
+    const [row] = await db
+      .select()
+      .from(connectorSetupSessions)
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+    expect(row?.state).toBe("verifying");
+    expect(row?.dataSourceId).toBe(sourceId);
+    expect(row?.stateNonceHash).toBe(issuance.session.stateNonceHash);
+  });
+
   it("reconciles a verifying session whose planned source was already created", async () => {
     const issuance = await pending();
     const sourceId = crypto.randomUUID();
@@ -293,7 +331,11 @@ describe("connector setup session store", () => {
     });
     await db
       .update(connectorSetupSessions)
-      .set({ state: "verifying", dataSourceId: sourceId })
+      .set({
+        state: "verifying",
+        dataSourceId: sourceId,
+        updatedAt: new Date("2026-08-05T11:57:00Z"),
+      })
       .where(eq(connectorSetupSessions.id, issuance.session.id));
 
     await expect(
@@ -384,7 +426,11 @@ describe("connector setup session store", () => {
       });
       await db
         .update(connectorSetupSessions)
-        .set({ state: "verifying", dataSourceId: sourceId })
+        .set({
+          state: "verifying",
+          dataSourceId: sourceId,
+          updatedAt: new Date("2026-08-05T11:57:00Z"),
+        })
         .where(eq(connectorSetupSessions.id, issuance.session.id));
 
       const tracker = app.createTracked();
@@ -396,7 +442,7 @@ describe("connector setup session store", () => {
       expect([...tracker.tablesWritten]).toContain("connector_setup_sessions");
     });
 
-    it("records the session write on every mutating path", async () => {
+    it("records the session write on the reissue, callback, and failure paths", async () => {
       // Each write tags through the tracked builder at the point of the write,
       // rather than through a single end-of-function call gated on counters the
       // module computes for itself — a path that writes without incrementing

--- a/apps/server/src/connector-setup/session-store.test.ts
+++ b/apps/server/src/connector-setup/session-store.test.ts
@@ -252,4 +252,73 @@ describe("connector setup session store", () => {
       .where(eq(connectorSetupSessions.id, issuance.session.id));
     expect(row).toMatchObject({ state: "connected", dataSourceId: sourceId });
   });
+
+  // Reactive invalidation and snapshot freshness are driven entirely by a
+  // tracker's tablesRead / tablesWritten sets. A read or write this module
+  // performs without recording its table is invisible to them: subscribers keep
+  // serving state that has already changed, with nothing to mark it stale.
+  // These tests pin the recording itself, which no behavioural assertion above
+  // can catch — every one of them passes with tracking completely absent.
+  describe("reactive tracking", () => {
+    it("records the data_sources read that decides an in-flight recovery", async () => {
+      const issuance = await pending();
+      const sourceId = crypto.randomUUID();
+      await db.insert(dataSources).values({
+        id: sourceId,
+        name: "GA4",
+        kind: "googleAnalytics",
+        storage: "live",
+        config: {},
+        createdBy: { kind: "user" },
+      });
+      await db
+        .update(connectorSetupSessions)
+        .set({ state: "verifying", dataSourceId: sourceId })
+        .where(eq(connectorSetupSessions.id, issuance.session.id));
+
+      const tracker = app.createTracked();
+      await sweep(tracker, new Date("2026-08-05T12:01:00Z"));
+
+      // The sweep's outcome depends on this row's `kind`, so a later write to
+      // data_sources must invalidate anything derived from the sweep.
+      expect([...tracker.tablesRead]).toContain("data_sources");
+      expect([...tracker.tablesWritten]).toContain("connector_setup_sessions");
+    });
+
+    it("records the session write on every mutating path", async () => {
+      // Each write tags through the tracked builder at the point of the write,
+      // rather than through a single end-of-function call gated on counters the
+      // module computes for itself — a path that writes without incrementing
+      // one of those counters silently loses its tag.
+      const consumed = await pending();
+      const consumeTracker = app.createTracked();
+      await consumeCallback(
+        consumeTracker,
+        oauthStateFor(consumed.stateNonce),
+        new Date("2026-08-05T12:01:00Z"),
+      );
+      expect([...consumeTracker.tablesWritten]).toContain(
+        "connector_setup_sessions",
+      );
+
+      const resumed = await pending();
+      const resumeTracker = app.createTracked();
+      await publicResumeInfo(resumeTracker, resumed.session.id);
+      expect([...resumeTracker.tablesWritten]).toContain(
+        "connector_setup_sessions",
+      );
+
+      const stale = await pending(new Date("2026-08-05T11:40:00Z"));
+      const sweepTracker = app.createTracked();
+      await sweep(sweepTracker, new Date("2026-08-05T12:00:00Z"));
+      expect([...sweepTracker.tablesWritten]).toContain(
+        "connector_setup_sessions",
+      );
+      const [staleRow] = await db
+        .select()
+        .from(connectorSetupSessions)
+        .where(eq(connectorSetupSessions.id, stale.session.id));
+      expect(staleRow?.state).toBe("expired");
+    });
+  });
 });

--- a/apps/server/src/connector-setup/session-store.test.ts
+++ b/apps/server/src/connector-setup/session-store.test.ts
@@ -193,9 +193,22 @@ describe("connector setup session store", () => {
 
   it("allows only one concurrent resume request to rotate the authorization state", async () => {
     const issuance = await pending();
+    // Pin the clock. `pending()` mints the session against a fixed date, so
+    // letting publicResumeInfo default to the wall clock makes the session
+    // expired for all but a 15-minute window on one particular day — and the
+    // expiry branch returns normally for both callers, so the race this test
+    // exists to check never runs.
     const attempts = await Promise.allSettled([
-      publicResumeInfo(app.createTracked(), issuance.session.id),
-      publicResumeInfo(app.createTracked(), issuance.session.id),
+      publicResumeInfo(
+        app.createTracked(),
+        issuance.session.id,
+        new Date("2026-08-05T12:01:00Z"),
+      ),
+      publicResumeInfo(
+        app.createTracked(),
+        issuance.session.id,
+        new Date("2026-08-05T12:01:00Z"),
+      ),
     ]);
 
     expect(
@@ -401,7 +414,11 @@ describe("connector setup session store", () => {
 
       const resumed = await pending();
       const resumeTracker = app.createTracked();
-      await publicResumeInfo(resumeTracker, resumed.session.id);
+      await publicResumeInfo(
+        resumeTracker,
+        resumed.session.id,
+        new Date("2026-08-05T12:01:00Z"),
+      );
       expect([...resumeTracker.tablesWritten]).toContain(
         "connector_setup_sessions",
       );

--- a/apps/server/src/connector-setup/session-store.test.ts
+++ b/apps/server/src/connector-setup/session-store.test.ts
@@ -19,6 +19,46 @@ import {
 
 const { connectorSetupSessions, dataSources } = schema;
 
+/**
+ * Wrap a tracked database handle so every SELECT it lowers is recorded.
+ *
+ * The session store's handle is `Pick<DrizzleTracker, "from" | "into">`, which
+ * is small enough to stand in for — that is what makes it possible to assert
+ * what SQL a code path actually issues, rather than only what it returns.
+ * `toSql()` is captured at the moment a read executes, since clause methods
+ * return copies rather than mutating the builder.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- test double mirrors the builder's dynamic surface */
+function recordingDb(tracked: any): { db: any; selects: string[] } {
+  const selects: string[] = [];
+  const wrap = (builder: any): any =>
+    new Proxy(builder, {
+      get(target, prop) {
+        const value = Reflect.get(target, prop);
+        if (typeof value !== "function") return value;
+        return (...args: unknown[]) => {
+          if (prop === "first" || prop === "all") {
+            selects.push(target.toSql().sql);
+          }
+          const result = value.apply(target, args);
+          const isBuilder =
+            result !== null &&
+            typeof result === "object" &&
+            typeof (result as { where?: unknown }).where === "function";
+          return isBuilder ? wrap(result) : result;
+        };
+      },
+    });
+  return {
+    selects,
+    db: {
+      into: (table: unknown) => tracked.into(table),
+      from: (table: unknown) => wrap(tracked.from(table)),
+    },
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 describe("connector setup session store", () => {
   let dir: string;
   let db: Awaited<ReturnType<typeof openArtifactDb>>;
@@ -251,6 +291,64 @@ describe("connector setup session store", () => {
       .from(connectorSetupSessions)
       .where(eq(connectorSetupSessions.id, issuance.session.id));
     expect(row).toMatchObject({ state: "connected", dataSourceId: sourceId });
+  });
+
+  // The OAuth callback endpoint is unauthenticated: anyone who can reach the
+  // callback URL can drive it, and the same caller can inflate the number of
+  // live sessions. Resolving the presented nonce by reading the table therefore
+  // makes per-callback cost grow with session count — a denial-of-service lever.
+  describe("callback state lookup", () => {
+    it("resolves the presented nonce through the unique index, not a table read", async () => {
+      const issuance = await pending();
+      const { db: recorded, selects } = recordingDb(app.createTracked());
+
+      await consumeCallback(
+        recorded,
+        oauthStateFor(issuance.stateNonce),
+        new Date("2026-08-05T12:01:00Z"),
+      );
+
+      // Every SELECT on the callback path is constrained by the nonce hash.
+      // An unconstrained read of connector_setup_sessions is exactly the scan
+      // this graft removes, so its absence is the assertion.
+      expect(selects.length).toBeGreaterThan(0);
+      for (const sql of selects) {
+        expect(sql).toContain("state_nonce_hash");
+        expect(sql).toContain("where");
+      }
+    });
+
+    it("still resolves the right session, and rejects a wrong nonce, with many sessions present", async () => {
+      const target = await pending();
+      const others = await Promise.all(
+        Array.from({ length: 200 }, () => pending()),
+      );
+
+      const consumed = await consumeCallback(
+        app.createTracked(),
+        oauthStateFor(target.stateNonce),
+        new Date("2026-08-05T12:01:00Z"),
+      );
+      expect(consumed.id).toBe(target.session.id);
+
+      // A nonce that matches no stored hash is rejected, and the sessions that
+      // were not addressed are untouched.
+      await expect(
+        consumeCallback(
+          app.createTracked(),
+          oauthStateFor("w".repeat(43)),
+          new Date("2026-08-05T12:01:00Z"),
+        ),
+      ).rejects.toMatchObject({
+        code: "state-mismatch",
+      } satisfies Partial<ConnectorSetupGateError>);
+
+      const rows = await db.select().from(connectorSetupSessions);
+      const untouched = rows.filter(
+        (row) => row.state === "awaiting-user-auth",
+      );
+      expect(untouched).toHaveLength(others.length);
+    });
   });
 
   // Reactive invalidation and snapshot freshness are driven entirely by a

--- a/apps/server/src/connector-setup/session-store.test.ts
+++ b/apps/server/src/connector-setup/session-store.test.ts
@@ -8,9 +8,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { functions } from "../functions";
 import { wy } from "../wystack";
 import {
+  CONNECTOR_SETUP_INFLIGHT_GRACE_MS,
   CONNECTOR_SETUP_TERMINAL_RETENTION_MS,
   ConnectorSetupGateError,
   consumeCallback,
+  effectiveState,
+  markConnected,
+  markVerifying,
   oauthStateFor,
   publicResumeInfo,
   startSession,
@@ -74,6 +78,18 @@ describe("connector setup session store", () => {
     await db.$client.close();
     rmSync(dir, { recursive: true, force: true });
   });
+
+  // Derived, not hardcoded: these offsets only mean anything relative to the
+  // grace window, so retuning CONNECTOR_SETUP_INFLIGHT_GRACE_MS must move them
+  // too. Literals would leave the tests passing while asserting the wrong side
+  // of the boundary.
+  const SWEEP_NOW = new Date("2026-08-05T12:00:00Z");
+  const ABANDONED_AT = new Date(
+    SWEEP_NOW.getTime() - CONNECTOR_SETUP_INFLIGHT_GRACE_MS - 1_000,
+  );
+  const STILL_LIVE_AT = new Date(
+    SWEEP_NOW.getTime() - Math.floor(CONNECTOR_SETUP_INFLIGHT_GRACE_MS / 4),
+  );
 
   async function pending(now = new Date("2026-08-05T12:00:00Z")) {
     return startSession(app.createTracked(), {
@@ -238,10 +254,117 @@ describe("connector setup session store", () => {
     expect("stateNonce" in resumed).toBe(false);
   });
 
-  it("boot sweep recovers in-flight rows, expires stale rows, and deletes old terminals", async () => {
-    const now = new Date("2026-08-05T12:00:00Z");
-    const exchanging = await pending(new Date("2026-08-05T11:55:00Z"));
-    const verifying = await pending(new Date("2026-08-05T11:56:00Z"));
+  // Each of these closes a mutant that survived the suite: the boundary
+  // comparisons and the compare-and-swap preconditions could all be weakened
+  // without a single test going red.
+  describe("boundaries a reader must not get wrong", () => {
+    it("reports a session as expired at the instant its TTL elapses, not after", async () => {
+      const { session } = await pending();
+      const deadline = session.expiresAt;
+
+      expect(effectiveState(session, new Date(deadline.getTime() - 1))).toBe(
+        "awaiting-user-auth",
+      );
+      // Exactly at expiresAt the session is already gone. `<` instead of `<=`
+      // here would keep a session usable for one more millisecond than the
+      // callback gate allows, so a resume issued on this boundary would mint an
+      // authorize URL that consumeCallback then rejects as expired.
+      expect(effectiveState(session, deadline)).toBe("expired");
+      expect(effectiveState(session, new Date(deadline.getTime() + 1))).toBe(
+        "expired",
+      );
+    });
+
+    it("refuses a callback that arrives exactly on the expiry instant", async () => {
+      const issuance = await pending();
+      const deadline = issuance.session.expiresAt;
+
+      // The gate and effectiveState have to agree on which side of `expiresAt`
+      // is still usable. `<` here would accept a callback for a session the
+      // resume path already reports as expired, so a code exchange would run
+      // against a row no reader considers live.
+      await expect(
+        consumeCallback(
+          app.createTracked(),
+          oauthStateFor(issuance.stateNonce),
+          deadline,
+        ),
+      ).rejects.toMatchObject({ code: "session-expired" });
+      const [row] = await db
+        .select()
+        .from(connectorSetupSessions)
+        .where(eq(connectorSetupSessions.id, issuance.session.id));
+      expect(row?.state).toBe("expired");
+    });
+
+    it("accepts a callback one millisecond before the expiry instant", async () => {
+      const issuance = await pending();
+      await expect(
+        consumeCallback(
+          app.createTracked(),
+          oauthStateFor(issuance.stateNonce),
+          new Date(issuance.session.expiresAt.getTime() - 1),
+        ),
+      ).resolves.toMatchObject({ state: "exchanging" });
+    });
+
+    it("refuses to re-enter verification for a session already verifying", async () => {
+      const { session } = await pending();
+      const first = crypto.randomUUID();
+      await db
+        .update(connectorSetupSessions)
+        .set({ state: "exchanging" })
+        .where(eq(connectorSetupSessions.id, session.id));
+      await markVerifying(app.createTracked(), session.id, first, SWEEP_NOW);
+
+      // Only an `exchanging` row may enter verification. Dropping that term
+      // would let a retried exchange run a second verification probe, minting
+      // a second data source and overwriting the first id — orphaning a row
+      // nothing ever cleans up.
+      await expect(
+        markVerifying(
+          app.createTracked(),
+          session.id,
+          crypto.randomUUID(),
+          SWEEP_NOW,
+        ),
+      ).rejects.toThrow("Connector setup transition rejected");
+      const [row] = await db
+        .select()
+        .from(connectorSetupSessions)
+        .where(eq(connectorSetupSessions.id, session.id));
+      expect(row).toMatchObject({ state: "verifying", dataSourceId: first });
+    });
+
+    it("refuses to connect a session to a source it was not verifying", async () => {
+      const { session } = await pending();
+      const intended = crypto.randomUUID();
+      const other = crypto.randomUUID();
+      await db
+        .update(connectorSetupSessions)
+        .set({ state: "exchanging" })
+        .where(eq(connectorSetupSessions.id, session.id));
+      await markVerifying(app.createTracked(), session.id, intended, SWEEP_NOW);
+
+      // The dataSourceId term in the compare-and-swap is the only thing tying a
+      // connect to the source its own verification probe created. Without it a
+      // concurrent flow's id could be written into this session, pointing the
+      // user's finished connector at someone else's data source.
+      await expect(
+        markConnected(app.createTracked(), session.id, other, SWEEP_NOW),
+      ).rejects.toThrow("Connector setup transition rejected");
+      const [row] = await db
+        .select()
+        .from(connectorSetupSessions)
+        .where(eq(connectorSetupSessions.id, session.id));
+      expect(row).toMatchObject({ state: "verifying", dataSourceId: intended });
+    });
+  });
+
+  it("recovers abandoned in-flight rows, expires stale rows, and deletes old terminals", async () => {
+    const now = SWEEP_NOW;
+    const exchanging = await pending(ABANDONED_AT);
+    const verifying = await pending(ABANDONED_AT);
     const stale = await pending(new Date("2026-08-05T11:40:00Z"));
     const terminal = await pending(new Date("2026-08-03T00:00:00Z"));
     await db
@@ -251,12 +374,12 @@ describe("connector setup session store", () => {
       // $onUpdate would otherwise stamp these with the real clock.
       .set({
         state: "exchanging",
-        updatedAt: new Date("2026-08-05T11:55:00Z"),
+        updatedAt: ABANDONED_AT,
       })
       .where(eq(connectorSetupSessions.id, exchanging.session.id));
     await db
       .update(connectorSetupSessions)
-      .set({ state: "verifying", updatedAt: new Date("2026-08-05T11:56:00Z") })
+      .set({ state: "verifying", updatedAt: ABANDONED_AT })
       .where(eq(connectorSetupSessions.id, verifying.session.id));
     await db
       .update(connectorSetupSessions)
@@ -292,15 +415,15 @@ describe("connector setup session store", () => {
     // Recovering there would rotate the nonce and clear dataSourceId under a
     // live handler, failing its compare-and-swap and reporting failure for a
     // connection that actually succeeded.
-    const now = new Date("2026-08-05T12:00:00Z");
-    const issuance = await pending(new Date("2026-08-05T11:59:30Z"));
+    const now = SWEEP_NOW;
+    const issuance = await pending(STILL_LIVE_AT);
     const sourceId = crypto.randomUUID();
     await db
       .update(connectorSetupSessions)
       .set({
         state: "verifying",
         dataSourceId: sourceId,
-        updatedAt: new Date("2026-08-05T11:59:30Z"),
+        updatedAt: STILL_LIVE_AT,
       })
       .where(eq(connectorSetupSessions.id, issuance.session.id));
 
@@ -316,6 +439,28 @@ describe("connector setup session store", () => {
     expect(row?.state).toBe("verifying");
     expect(row?.dataSourceId).toBe(sourceId);
     expect(row?.stateNonceHash).toBe(issuance.session.stateNonceHash);
+  });
+
+  it("waives the grace window at boot so a fast restart strands nothing", async () => {
+    // The grace window assumes a live handler may own an in-flight row. After a
+    // crash that assumption is false, and honouring it here would be permanent:
+    // the boot pass is the only sweep scheduled, so a row younger than the
+    // window would sit in `verifying` forever while the browser polled it to
+    // its own 15-minute timeout and reported a failure for a live connection.
+    const issuance = await pending(STILL_LIVE_AT);
+    await db
+      .update(connectorSetupSessions)
+      .set({ state: "exchanging", updatedAt: STILL_LIVE_AT })
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+
+    await expect(
+      sweep(app.createTracked(), SWEEP_NOW, 0),
+    ).resolves.toMatchObject({ recovered: 1 });
+    const [row] = await db
+      .select()
+      .from(connectorSetupSessions)
+      .where(eq(connectorSetupSessions.id, issuance.session.id));
+    expect(row?.state).toBe("awaiting-user-auth");
   });
 
   it("reconciles a verifying session whose planned source was already created", async () => {
@@ -334,13 +479,15 @@ describe("connector setup session store", () => {
       .set({
         state: "verifying",
         dataSourceId: sourceId,
-        updatedAt: new Date("2026-08-05T11:57:00Z"),
+        updatedAt: ABANDONED_AT,
       })
       .where(eq(connectorSetupSessions.id, issuance.session.id));
 
-    await expect(
-      sweep(app.createTracked(), new Date("2026-08-05T12:01:00Z")),
-    ).resolves.toEqual({ recovered: 1, expired: 0, deleted: 0 });
+    await expect(sweep(app.createTracked(), SWEEP_NOW)).resolves.toEqual({
+      recovered: 1,
+      expired: 0,
+      deleted: 0,
+    });
     const [row] = await db
       .select()
       .from(connectorSetupSessions)
@@ -429,12 +576,12 @@ describe("connector setup session store", () => {
         .set({
           state: "verifying",
           dataSourceId: sourceId,
-          updatedAt: new Date("2026-08-05T11:57:00Z"),
+          updatedAt: ABANDONED_AT,
         })
         .where(eq(connectorSetupSessions.id, issuance.session.id));
 
       const tracker = app.createTracked();
-      await sweep(tracker, new Date("2026-08-05T12:01:00Z"));
+      await sweep(tracker, SWEEP_NOW);
 
       // The sweep's outcome depends on this row's `kind`, so a later write to
       // data_sources must invalidate anything derived from the sweep.
@@ -471,7 +618,7 @@ describe("connector setup session store", () => {
 
       const stale = await pending(new Date("2026-08-05T11:40:00Z"));
       const sweepTracker = app.createTracked();
-      await sweep(sweepTracker, new Date("2026-08-05T12:00:00Z"));
+      await sweep(sweepTracker, SWEEP_NOW);
       expect([...sweepTracker.tablesWritten]).toContain(
         "connector_setup_sessions",
       );

--- a/apps/server/src/connector-setup/session-store.ts
+++ b/apps/server/src/connector-setup/session-store.ts
@@ -1,0 +1,453 @@
+import { schema } from "@dashframe/server-core";
+import { eq as trackedEq, type DrizzleTracker } from "@wystack/db";
+import { and, getTableName, lt, eq as sqlEq } from "drizzle-orm";
+import {
+  createHash,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
+
+const { connectorSetupSessions, dataSources } = schema;
+
+export const CONNECTOR_SETUP_TTL_MS = 15 * 60 * 1000;
+export const CONNECTOR_SETUP_TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export type ConnectorSetupState =
+  | "awaiting-user-auth"
+  | "exchanging"
+  | "verifying"
+  | "connected"
+  | "failed"
+  | "expired";
+
+export type ConnectorSetupSessionRow =
+  typeof connectorSetupSessions.$inferSelect;
+
+export interface StartSessionInput {
+  connectorId: string;
+  requestedName: string;
+  scopes: string[];
+  now?: Date;
+}
+
+export interface SessionIssuance {
+  session: ConnectorSetupSessionRow;
+  stateNonce: string;
+}
+
+export class ConnectorSetupGateError extends Error {
+  constructor(
+    readonly code: string,
+    readonly session?: ConnectorSetupSessionRow,
+  ) {
+    super("Connector setup callback rejected");
+  }
+}
+
+function nonceHash(nonce: string): string {
+  return createHash("sha256").update(nonce).digest("hex");
+}
+
+function newStateNonce(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function newCodeVerifier(): string {
+  return randomBytes(64).toString("base64url");
+}
+
+function matchesStateNonce(nonce: string, expectedHex: string): boolean {
+  const actual = Buffer.from(nonceHash(nonce), "hex");
+  const expected = Buffer.from(expectedHex, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function trackWrite(db: DrizzleTracker): void {
+  db.tablesWritten.add(getTableName(connectorSetupSessions));
+}
+
+export function oauthStateFor(stateNonce: string): string {
+  return stateNonce;
+}
+
+export async function startSession(
+  db: DrizzleTracker,
+  input: StartSessionInput,
+): Promise<SessionIssuance> {
+  const now = input.now ?? new Date();
+  const stateNonce = newStateNonce();
+  const [session] = (await db.into(connectorSetupSessions).insert({
+    id: randomUUID(),
+    connectorId: input.connectorId,
+    requestedName: input.requestedName,
+    state: "awaiting-user-auth",
+    stateNonceHash: nonceHash(stateNonce),
+    codeVerifier: newCodeVerifier(),
+    scopes: input.scopes,
+    dataSourceId: null,
+    failureCode: null,
+    failureMessage: null,
+    expiresAt: new Date(now.getTime() + CONNECTOR_SETUP_TTL_MS),
+    createdAt: now,
+    updatedAt: now,
+  })) as ConnectorSetupSessionRow[];
+  if (!session) throw new Error("Connector setup session insert failed");
+  return { session, stateNonce };
+}
+
+/**
+ * Resolve a resume capability. Awaiting sessions rotate both PKCE and state so
+ * every resume issuance kills the previous authorize URL automatically.
+ */
+export async function publicResumeInfo(
+  db: DrizzleTracker,
+  sessionId: string,
+  now = new Date(),
+  reissue = true,
+  recoverExchange = false,
+): Promise<SessionIssuance | { session: ConnectorSetupSessionRow }> {
+  let row = (await db
+    .from(connectorSetupSessions)
+    .where(trackedEq("id", sessionId))
+    .first()) as ConnectorSetupSessionRow | undefined;
+  if (!row) throw new ConnectorSetupGateError("session-not-found");
+
+  if (
+    row.state === "awaiting-user-auth" &&
+    row.expiresAt.getTime() <= now.getTime()
+  ) {
+    const [expired] = await db.raw
+      .update(connectorSetupSessions)
+      .set({ state: "expired", updatedAt: now })
+      .where(
+        and(
+          sqlEq(connectorSetupSessions.id, row.id),
+          sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
+        ),
+      )
+      .returning();
+    if (expired) trackWrite(db);
+    return { session: (expired ?? row) as ConnectorSetupSessionRow };
+  }
+
+  if (recoverExchange && row.state === "exchanging") {
+    const isExpired = row.expiresAt.getTime() <= now.getTime();
+    const [recovered] = await db.raw
+      .update(connectorSetupSessions)
+      .set({
+        state: isExpired ? "expired" : "awaiting-user-auth",
+        updatedAt: now,
+      })
+      .where(
+        and(
+          sqlEq(connectorSetupSessions.id, row.id),
+          sqlEq(connectorSetupSessions.state, "exchanging"),
+        ),
+      )
+      .returning();
+    if (!recovered) throw new ConnectorSetupGateError("session-raced");
+    trackWrite(db);
+    row = recovered as ConnectorSetupSessionRow;
+    if (isExpired) return { session: row };
+  }
+
+  if (row.state !== "awaiting-user-auth" || !reissue) {
+    return { session: row };
+  }
+
+  const stateNonce = newStateNonce();
+  const [reissued] = await db.raw
+    .update(connectorSetupSessions)
+    .set({
+      stateNonceHash: nonceHash(stateNonce),
+      codeVerifier: newCodeVerifier(),
+      failureCode: null,
+      failureMessage: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, row.id),
+        sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
+        sqlEq(connectorSetupSessions.stateNonceHash, row.stateNonceHash),
+      ),
+    )
+    .returning();
+  if (!reissued) throw new ConnectorSetupGateError("session-raced");
+  trackWrite(db);
+  return { session: reissued as ConnectorSetupSessionRow, stateNonce };
+}
+
+/**
+ * Apply all callback gates and consume the pending state with one conditional
+ * database update. No process-local lock participates in the single-use guard.
+ */
+export async function consumeCallback(
+  db: DrizzleTracker,
+  state: string,
+  now = new Date(),
+): Promise<ConnectorSetupSessionRow> {
+  if (!/^[A-Za-z0-9_-]{43}$/u.test(state)) {
+    throw new ConnectorSetupGateError("state-mismatch");
+  }
+  // State carries only the nonce, never the session capability. Scan the small
+  // setup-session table and perform every digest comparison in constant time;
+  // only after that gate succeeds does the callback learn which session exists.
+  const rows = (await db
+    .from(connectorSetupSessions)
+    .all()) as ConnectorSetupSessionRow[];
+  let row: ConnectorSetupSessionRow | undefined;
+  for (const candidate of rows) {
+    if (matchesStateNonce(state, candidate.stateNonceHash)) row = candidate;
+  }
+  if (!row) {
+    throw new ConnectorSetupGateError("state-mismatch");
+  }
+  if (row.state !== "awaiting-user-auth") {
+    throw new ConnectorSetupGateError("session-not-awaiting");
+  }
+  if (row.expiresAt.getTime() <= now.getTime()) {
+    const expired = await db.raw
+      .update(connectorSetupSessions)
+      .set({ state: "expired", updatedAt: now })
+      .where(
+        and(
+          sqlEq(connectorSetupSessions.id, row.id),
+          sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
+        ),
+      )
+      .returning();
+    if (expired.length > 0) trackWrite(db);
+    const expiredRow = expired[0] as ConnectorSetupSessionRow | undefined;
+    throw new ConnectorSetupGateError("session-expired", expiredRow ?? row);
+  }
+
+  const consumed = await db.raw
+    .update(connectorSetupSessions)
+    .set({ state: "exchanging", updatedAt: now })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, row.id),
+        sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
+        sqlEq(connectorSetupSessions.stateNonceHash, row.stateNonceHash),
+      ),
+    )
+    .returning();
+  if (consumed.length !== 1) {
+    throw new ConnectorSetupGateError("session-consumed");
+  }
+  trackWrite(db);
+  return consumed[0] as ConnectorSetupSessionRow;
+}
+
+export async function markVerifying(
+  db: DrizzleTracker,
+  sessionId: string,
+  dataSourceId: string,
+  now = new Date(),
+): Promise<ConnectorSetupSessionRow> {
+  const rows = await db.raw
+    .update(connectorSetupSessions)
+    .set({ state: "verifying", dataSourceId, updatedAt: now })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, sessionId),
+        sqlEq(connectorSetupSessions.state, "exchanging"),
+      ),
+    )
+    .returning();
+  if (rows.length !== 1) throw new Error("Connector setup transition rejected");
+  trackWrite(db);
+  return rows[0] as ConnectorSetupSessionRow;
+}
+
+export async function markConnected(
+  db: DrizzleTracker,
+  sessionId: string,
+  dataSourceId: string,
+  now = new Date(),
+): Promise<ConnectorSetupSessionRow> {
+  const rows = await db.raw
+    .update(connectorSetupSessions)
+    .set({
+      state: "connected",
+      dataSourceId,
+      failureCode: null,
+      failureMessage: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, sessionId),
+        sqlEq(connectorSetupSessions.state, "verifying"),
+        sqlEq(connectorSetupSessions.dataSourceId, dataSourceId),
+      ),
+    )
+    .returning();
+  if (rows.length !== 1) throw new Error("Connector setup transition rejected");
+  trackWrite(db);
+  return rows[0] as ConnectorSetupSessionRow;
+}
+
+export async function markFailed(
+  db: DrizzleTracker,
+  sessionId: string,
+  failureCode: string,
+  failureMessage: string,
+  now = new Date(),
+  allowedStates: ConnectorSetupState[] = [
+    "awaiting-user-auth",
+    "exchanging",
+    "verifying",
+  ],
+): Promise<ConnectorSetupSessionRow> {
+  const row = (await db
+    .from(connectorSetupSessions)
+    .where(trackedEq("id", sessionId))
+    .first()) as ConnectorSetupSessionRow | undefined;
+  if (!row) throw new Error("Connector setup session not found");
+  if (["connected", "failed", "expired"].includes(row.state)) return row;
+  if (!allowedStates.includes(row.state as ConnectorSetupState)) return row;
+  const [failed] = await db.raw
+    .update(connectorSetupSessions)
+    .set({
+      state: "failed",
+      dataSourceId: null,
+      failureCode,
+      failureMessage,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, sessionId),
+        sqlEq(connectorSetupSessions.state, row.state),
+      ),
+    )
+    .returning();
+  if (failed) {
+    trackWrite(db);
+    return failed as ConnectorSetupSessionRow;
+  }
+  const raced = (await db
+    .from(connectorSetupSessions)
+    .where(trackedEq("id", sessionId))
+    .first()) as ConnectorSetupSessionRow | undefined;
+  if (!raced) throw new Error("Connector setup session not found");
+  return raced;
+}
+
+async function expireAwaiting(
+  db: DrizzleTracker,
+  row: ConnectorSetupSessionRow,
+  now: Date,
+): Promise<boolean> {
+  if (row.expiresAt.getTime() > now.getTime()) return false;
+  const updated = await db.raw
+    .update(connectorSetupSessions)
+    .set({ state: "expired", updatedAt: now })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, row.id),
+        sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
+      ),
+    )
+    .returning({ id: connectorSetupSessions.id });
+  return updated.length > 0;
+}
+
+async function recoverInFlight(
+  db: DrizzleTracker,
+  row: ConnectorSetupSessionRow,
+  now: Date,
+): Promise<"recovered" | "expired" | undefined> {
+  if (row.state !== "exchanging" && row.state !== "verifying") {
+    return undefined;
+  }
+  const isExpired = row.expiresAt.getTime() <= now.getTime();
+  if (row.state === "verifying" && row.dataSourceId) {
+    const [source] = await db.raw
+      .select({ kind: dataSources.kind })
+      .from(dataSources)
+      .where(sqlEq(dataSources.id, row.dataSourceId));
+    if (source?.kind === row.connectorId) {
+      const connected = await db.raw
+        .update(connectorSetupSessions)
+        .set({ state: "connected", updatedAt: now })
+        .where(
+          and(
+            sqlEq(connectorSetupSessions.id, row.id),
+            sqlEq(connectorSetupSessions.state, "verifying"),
+            sqlEq(connectorSetupSessions.dataSourceId, row.dataSourceId),
+          ),
+        )
+        .returning({ id: connectorSetupSessions.id });
+      if (connected.length > 0) return "recovered";
+      return undefined;
+    }
+  }
+  const updated = await db.raw
+    .update(connectorSetupSessions)
+    .set({
+      state: isExpired ? "expired" : "awaiting-user-auth",
+      stateNonceHash: nonceHash(newStateNonce()),
+      codeVerifier: newCodeVerifier(),
+      dataSourceId: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        sqlEq(connectorSetupSessions.id, row.id),
+        sqlEq(connectorSetupSessions.state, row.state),
+      ),
+    )
+    .returning({ id: connectorSetupSessions.id });
+  if (updated.length === 0) return undefined;
+  return isExpired ? "expired" : "recovered";
+}
+
+export async function sweep(
+  db: DrizzleTracker,
+  now = new Date(),
+): Promise<{ recovered: number; expired: number; deleted: number }> {
+  const rows = (await db
+    .from(connectorSetupSessions)
+    .all()) as ConnectorSetupSessionRow[];
+  let recovered = 0;
+  let expired = 0;
+  for (const row of rows) {
+    if (row.state === "awaiting-user-auth") {
+      if (await expireAwaiting(db, row, now)) expired += 1;
+      continue;
+    }
+    const outcome = await recoverInFlight(db, row, now);
+    if (outcome === "expired") expired += 1;
+    if (outcome === "recovered") recovered += 1;
+  }
+
+  const cutoff = new Date(
+    now.getTime() - CONNECTOR_SETUP_TERMINAL_RETENTION_MS,
+  );
+  const terminalIds = rows
+    .filter(
+      (row) =>
+        ["connected", "failed", "expired"].includes(row.state) &&
+        row.updatedAt.getTime() < cutoff.getTime(),
+    )
+    .map((row) => row.id);
+  let deleted = 0;
+  for (const id of terminalIds) {
+    const removed = await db.raw
+      .delete(connectorSetupSessions)
+      .where(
+        and(
+          sqlEq(connectorSetupSessions.id, id),
+          lt(connectorSetupSessions.updatedAt, cutoff),
+        ),
+      )
+      .returning({ id: connectorSetupSessions.id });
+    deleted += removed.length;
+  }
+  if (recovered + expired + deleted > 0) trackWrite(db);
+  return { recovered, expired, deleted };
+}

--- a/apps/server/src/connector-setup/session-store.ts
+++ b/apps/server/src/connector-setup/session-store.ts
@@ -21,6 +21,13 @@ export const CONNECTOR_SETUP_TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1000;
  * succeeded, leaving a resumable session that creates a second data source.
  *
  * The window only has to exceed a normal code exchange plus verification probe.
+ *
+ * The boot sweep passes 0 instead (see `sweep`'s `graceMs`): nothing can be
+ * mid-exchange in a process that has not finished starting, and honouring the
+ * grace there would strand every row younger than the window — no later pass is
+ * scheduled, so the browser would poll a `verifying` row that never reaches a
+ * terminal state until its own 15-minute timeout gives up on a connection that
+ * actually succeeded.
  */
 export const CONNECTOR_SETUP_INFLIGHT_GRACE_MS = 2 * 60 * 1000;
 
@@ -396,15 +403,13 @@ async function recoverInFlight(
   db: Db,
   row: ConnectorSetupSessionRow,
   now: Date,
+  graceMs: number,
 ): Promise<"recovered" | "expired" | undefined> {
   if (row.state !== "exchanging" && row.state !== "verifying") {
     return undefined;
   }
   // Still inside the grace window: assume a live handler owns this row.
-  if (
-    now.getTime() - row.updatedAt.getTime() <
-    CONNECTOR_SETUP_INFLIGHT_GRACE_MS
-  ) {
+  if (now.getTime() - row.updatedAt.getTime() < graceMs) {
     return undefined;
   }
   const isExpired = row.expiresAt.getTime() <= now.getTime();
@@ -447,9 +452,16 @@ async function recoverInFlight(
   return isExpired ? "expired" : "recovered";
 }
 
+/**
+ * @param graceMs how long an in-flight row must sit untouched before it counts
+ * as abandoned. Callers that can prove no handler is alive — the boot sweep —
+ * pass 0; every other caller must leave the default, since the on-demand sweep
+ * is an ordinary mutation that can land mid-exchange.
+ */
 export async function sweep(
   db: Db,
   now = new Date(),
+  graceMs = CONNECTOR_SETUP_INFLIGHT_GRACE_MS,
 ): Promise<{ recovered: number; expired: number; deleted: number }> {
   const rows = (await db
     .from(connectorSetupSessions)
@@ -461,7 +473,7 @@ export async function sweep(
       if (await expireAwaiting(db, row, now)) expired += 1;
       continue;
     }
-    const outcome = await recoverInFlight(db, row, now);
+    const outcome = await recoverInFlight(db, row, now, graceMs);
     if (outcome === "expired") expired += 1;
     if (outcome === "recovered") recovered += 1;
   }

--- a/apps/server/src/connector-setup/session-store.ts
+++ b/apps/server/src/connector-setup/session-store.ts
@@ -193,16 +193,29 @@ export async function consumeCallback(
   if (!/^[A-Za-z0-9_-]{43}$/u.test(state)) {
     throw new ConnectorSetupGateError("state-mismatch");
   }
-  // State carries only the nonce, never the session capability. Scan the small
-  // setup-session table and perform every digest comparison in constant time;
-  // only after that gate succeeds does the callback learn which session exists.
-  const rows = (await db
+  // State carries only the nonce, never the session capability. Hash the
+  // presented nonce and look it up through
+  // connector_setup_sessions_state_nonce_hash_idx, which is UNIQUE — so this
+  // resolves to at most one candidate row instead of reading the table.
+  //
+  // This endpoint is unauthenticated: anyone who can reach the callback URL can
+  // drive it. A full scan here therefore hands out a denial-of-service lever
+  // whose cost grows with the number of live setup sessions, which the same
+  // caller can inflate. The index makes the work per callback independent of
+  // how many sessions exist.
+  //
+  // The constant-time digest comparison stays, and still does the deciding: the
+  // index lookup narrows to a candidate, and `matchesStateNonce` is what
+  // accepts it. Only after that gate succeeds does the callback learn which
+  // session exists.
+  const candidate = (await db
     .from(connectorSetupSessions)
-    .all()) as ConnectorSetupSessionRow[];
-  let row: ConnectorSetupSessionRow | undefined;
-  for (const candidate of rows) {
-    if (matchesStateNonce(state, candidate.stateNonceHash)) row = candidate;
-  }
+    .where(eq("stateNonceHash", hashStateNonce(state)))
+    .first()) as ConnectorSetupSessionRow | undefined;
+  const row =
+    candidate && matchesStateNonce(state, candidate.stateNonceHash)
+      ? candidate
+      : undefined;
   if (!row) {
     throw new ConnectorSetupGateError("state-mismatch");
   }

--- a/apps/server/src/connector-setup/session-store.ts
+++ b/apps/server/src/connector-setup/session-store.ts
@@ -1,16 +1,28 @@
 import { schema } from "@dashframe/server-core";
 import { eq, lt, type DrizzleTracker } from "@wystack/db";
-import {
-  createHash,
-  randomBytes,
-  randomUUID,
-  timingSafeEqual,
-} from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 
 const { connectorSetupSessions, dataSources } = schema;
 
 export const CONNECTOR_SETUP_TTL_MS = 15 * 60 * 1000;
 export const CONNECTOR_SETUP_TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How long an `exchanging` / `verifying` row must sit untouched before the
+ * sweep is allowed to treat it as abandoned.
+ *
+ * The sweep infers "the process handling this crashed" from the state alone,
+ * which is only true of a row nobody is working on. At boot that holds for
+ * everything in flight, but `sweepConnectorSetupSessions` is an ordinary
+ * mutation any client may call at any moment — including the seconds between
+ * markVerifying and markConnected. Recovering a live session there rotates its
+ * nonce and clears its dataSourceId out from under the handler, which then
+ * fails its compare-and-swap and reports failure for a connection that in fact
+ * succeeded, leaving a resumable session that creates a second data source.
+ *
+ * The window only has to exceed a normal code exchange plus verification probe.
+ */
+export const CONNECTOR_SETUP_INFLIGHT_GRACE_MS = 2 * 60 * 1000;
 
 /**
  * The only database surface this module may touch.
@@ -68,12 +80,6 @@ function newStateNonce(): string {
 
 function newCodeVerifier(): string {
   return randomBytes(64).toString("base64url");
-}
-
-function matchesStateNonce(nonce: string, expectedHex: string): boolean {
-  const actual = Buffer.from(hashStateNonce(nonce), "hex");
-  const expected = Buffer.from(expectedHex, "hex");
-  return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
 /** Rows returned by a tracked `update()` / `delete()`, which lowers to RETURNING *. */
@@ -244,18 +250,16 @@ export async function consumeCallback(
   // caller can inflate. The index makes the work per callback independent of
   // how many sessions exist.
   //
-  // The constant-time digest comparison stays, and still does the deciding: the
-  // index lookup narrows to a candidate, and `matchesStateNonce` is what
-  // accepts it. Only after that gate succeeds does the callback learn which
-  // session exists.
-  const candidate = (await db
+  // The unique-index equality IS the match — there is no separate compare step
+  // after it, because there is nothing left to decide. Nothing secret is
+  // compared here either: the lookup key is a SHA-256 digest of the presented
+  // nonce, not the nonce, so an equality test on it leaks nothing about the
+  // nonce. Loosening this lookup to a prefix or a non-unique index would
+  // reintroduce a candidate set and would need a real gate added back.
+  const row = (await db
     .from(connectorSetupSessions)
     .where(eq("stateNonceHash", hashStateNonce(state)))
     .first()) as ConnectorSetupSessionRow | undefined;
-  const row =
-    candidate && matchesStateNonce(state, candidate.stateNonceHash)
-      ? candidate
-      : undefined;
   if (!row) {
     throw new ConnectorSetupGateError("state-mismatch");
   }
@@ -354,8 +358,11 @@ export async function markFailed(
       .from(connectorSetupSessions)
       .where([eq("id", sessionId), eq("state", row.state)])
       .update({
+        // dataSourceId is deliberately preserved. It is the only record of
+        // which source this attempt was working on, and a failed session that
+        // has forgotten it cannot be reconciled by anything but manual
+        // inspection. The state itself already says the attempt did not finish.
         state: "failed",
-        dataSourceId: null,
         failureCode,
         failureMessage,
         updatedAt: now,
@@ -391,6 +398,13 @@ async function recoverInFlight(
   now: Date,
 ): Promise<"recovered" | "expired" | undefined> {
   if (row.state !== "exchanging" && row.state !== "verifying") {
+    return undefined;
+  }
+  // Still inside the grace window: assume a live handler owns this row.
+  if (
+    now.getTime() - row.updatedAt.getTime() <
+    CONNECTOR_SETUP_INFLIGHT_GRACE_MS
+  ) {
     return undefined;
   }
   const isExpired = row.expiresAt.getTime() <= now.getTime();

--- a/apps/server/src/connector-setup/session-store.ts
+++ b/apps/server/src/connector-setup/session-store.ts
@@ -111,8 +111,48 @@ export async function startSession(
 }
 
 /**
+ * Read one session without touching it.
+ *
+ * Kept separate from `publicResumeInfo` because that function writes on three
+ * different paths (expiry, exchange recovery, reissue). A caller that only
+ * wants to look at a session must not go through it.
+ */
+export async function readSession(
+  db: Db,
+  sessionId: string,
+): Promise<ConnectorSetupSessionRow> {
+  const row = (await db
+    .from(connectorSetupSessions)
+    .where(eq("id", sessionId))
+    .first()) as ConnectorSetupSessionRow | undefined;
+  if (!row) throw new ConnectorSetupGateError("session-not-found");
+  return row;
+}
+
+/**
+ * The state a reader should be shown, derived rather than stored.
+ *
+ * An awaiting session past its TTL is expired in every sense a caller cares
+ * about, but persisting that is a write, and reads must not write. Deriving it
+ * here lets the read path report the truth while staying a pure query; the row
+ * itself is flipped by the reissue path, the callback gate, or the sweep.
+ */
+export function effectiveState(
+  row: ConnectorSetupSessionRow,
+  now = new Date(),
+): ConnectorSetupState {
+  return row.state === "awaiting-user-auth" &&
+    row.expiresAt.getTime() <= now.getTime()
+    ? "expired"
+    : (row.state as ConnectorSetupState);
+}
+
+/**
  * Resolve a resume capability. Awaiting sessions rotate both PKCE and state so
  * every resume issuance kills the previous authorize URL automatically.
+ *
+ * Writes on every path that is not an immediate return, so it may only be
+ * called from a mutation.
  */
 export async function publicResumeInfo(
   db: Db,

--- a/apps/server/src/connector-setup/session-store.ts
+++ b/apps/server/src/connector-setup/session-store.ts
@@ -1,6 +1,5 @@
 import { schema } from "@dashframe/server-core";
-import { eq as trackedEq, type DrizzleTracker } from "@wystack/db";
-import { and, getTableName, lt, eq as sqlEq } from "drizzle-orm";
+import { eq, lt, type DrizzleTracker } from "@wystack/db";
 import {
   createHash,
   randomBytes,
@@ -12,6 +11,20 @@ const { connectorSetupSessions, dataSources } = schema;
 
 export const CONNECTOR_SETUP_TTL_MS = 15 * 60 * 1000;
 export const CONNECTOR_SETUP_TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The only database surface this module may touch.
+ *
+ * Deliberately NOT `DrizzleTracker`: narrowing to `from` / `into` makes `raw`
+ * unreachable from here, so every read and write in this file goes through the
+ * tracked builder and self-records `tablesRead` / `tablesWritten`. That is a
+ * correctness requirement, not a style preference — reactive invalidation and
+ * snapshot freshness are driven entirely by those two sets, and an untracked
+ * write is invisible to them: subscribers keep serving a stale session state
+ * with nothing to indicate it went stale. Widening this type back to
+ * `DrizzleTracker` re-opens that hole silently, because `raw` compiles fine.
+ */
+type Db = Pick<DrizzleTracker, "from" | "into">;
 
 export type ConnectorSetupState =
   | "awaiting-user-auth"
@@ -45,7 +58,7 @@ export class ConnectorSetupGateError extends Error {
   }
 }
 
-function nonceHash(nonce: string): string {
+export function hashStateNonce(nonce: string): string {
   return createHash("sha256").update(nonce).digest("hex");
 }
 
@@ -58,13 +71,14 @@ function newCodeVerifier(): string {
 }
 
 function matchesStateNonce(nonce: string, expectedHex: string): boolean {
-  const actual = Buffer.from(nonceHash(nonce), "hex");
+  const actual = Buffer.from(hashStateNonce(nonce), "hex");
   const expected = Buffer.from(expectedHex, "hex");
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
-function trackWrite(db: DrizzleTracker): void {
-  db.tablesWritten.add(getTableName(connectorSetupSessions));
+/** Rows returned by a tracked `update()` / `delete()`, which lowers to RETURNING *. */
+function returnedRows(rows: unknown): ConnectorSetupSessionRow[] {
+  return rows as ConnectorSetupSessionRow[];
 }
 
 export function oauthStateFor(stateNonce: string): string {
@@ -72,7 +86,7 @@ export function oauthStateFor(stateNonce: string): string {
 }
 
 export async function startSession(
-  db: DrizzleTracker,
+  db: Db,
   input: StartSessionInput,
 ): Promise<SessionIssuance> {
   const now = input.now ?? new Date();
@@ -82,7 +96,7 @@ export async function startSession(
     connectorId: input.connectorId,
     requestedName: input.requestedName,
     state: "awaiting-user-auth",
-    stateNonceHash: nonceHash(stateNonce),
+    stateNonceHash: hashStateNonce(stateNonce),
     codeVerifier: newCodeVerifier(),
     scopes: input.scopes,
     dataSourceId: null,
@@ -101,7 +115,7 @@ export async function startSession(
  * every resume issuance kills the previous authorize URL automatically.
  */
 export async function publicResumeInfo(
-  db: DrizzleTracker,
+  db: Db,
   sessionId: string,
   now = new Date(),
   reissue = true,
@@ -109,7 +123,7 @@ export async function publicResumeInfo(
 ): Promise<SessionIssuance | { session: ConnectorSetupSessionRow }> {
   let row = (await db
     .from(connectorSetupSessions)
-    .where(trackedEq("id", sessionId))
+    .where(eq("id", sessionId))
     .first()) as ConnectorSetupSessionRow | undefined;
   if (!row) throw new ConnectorSetupGateError("session-not-found");
 
@@ -117,38 +131,28 @@ export async function publicResumeInfo(
     row.state === "awaiting-user-auth" &&
     row.expiresAt.getTime() <= now.getTime()
   ) {
-    const [expired] = await db.raw
-      .update(connectorSetupSessions)
-      .set({ state: "expired", updatedAt: now })
-      .where(
-        and(
-          sqlEq(connectorSetupSessions.id, row.id),
-          sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
-        ),
-      )
-      .returning();
-    if (expired) trackWrite(db);
-    return { session: (expired ?? row) as ConnectorSetupSessionRow };
+    const [expired] = returnedRows(
+      await db
+        .from(connectorSetupSessions)
+        .where([eq("id", row.id), eq("state", "awaiting-user-auth")])
+        .update({ state: "expired", updatedAt: now }),
+    );
+    return { session: expired ?? row };
   }
 
   if (recoverExchange && row.state === "exchanging") {
     const isExpired = row.expiresAt.getTime() <= now.getTime();
-    const [recovered] = await db.raw
-      .update(connectorSetupSessions)
-      .set({
-        state: isExpired ? "expired" : "awaiting-user-auth",
-        updatedAt: now,
-      })
-      .where(
-        and(
-          sqlEq(connectorSetupSessions.id, row.id),
-          sqlEq(connectorSetupSessions.state, "exchanging"),
-        ),
-      )
-      .returning();
+    const [recovered] = returnedRows(
+      await db
+        .from(connectorSetupSessions)
+        .where([eq("id", row.id), eq("state", "exchanging")])
+        .update({
+          state: isExpired ? "expired" : "awaiting-user-auth",
+          updatedAt: now,
+        }),
+    );
     if (!recovered) throw new ConnectorSetupGateError("session-raced");
-    trackWrite(db);
-    row = recovered as ConnectorSetupSessionRow;
+    row = recovered;
     if (isExpired) return { session: row };
   }
 
@@ -157,26 +161,24 @@ export async function publicResumeInfo(
   }
 
   const stateNonce = newStateNonce();
-  const [reissued] = await db.raw
-    .update(connectorSetupSessions)
-    .set({
-      stateNonceHash: nonceHash(stateNonce),
-      codeVerifier: newCodeVerifier(),
-      failureCode: null,
-      failureMessage: null,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, row.id),
-        sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
-        sqlEq(connectorSetupSessions.stateNonceHash, row.stateNonceHash),
-      ),
-    )
-    .returning();
+  const [reissued] = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([
+        eq("id", row.id),
+        eq("state", "awaiting-user-auth"),
+        eq("stateNonceHash", row.stateNonceHash),
+      ])
+      .update({
+        stateNonceHash: hashStateNonce(stateNonce),
+        codeVerifier: newCodeVerifier(),
+        failureCode: null,
+        failureMessage: null,
+        updatedAt: now,
+      }),
+  );
   if (!reissued) throw new ConnectorSetupGateError("session-raced");
-  trackWrite(db);
-  return { session: reissued as ConnectorSetupSessionRow, stateNonce };
+  return { session: reissued, stateNonce };
 }
 
 /**
@@ -184,7 +186,7 @@ export async function publicResumeInfo(
  * database update. No process-local lock participates in the single-use guard.
  */
 export async function consumeCallback(
-  db: DrizzleTracker,
+  db: Db,
   state: string,
   now = new Date(),
 ): Promise<ConnectorSetupSessionRow> {
@@ -208,90 +210,75 @@ export async function consumeCallback(
     throw new ConnectorSetupGateError("session-not-awaiting");
   }
   if (row.expiresAt.getTime() <= now.getTime()) {
-    const expired = await db.raw
-      .update(connectorSetupSessions)
-      .set({ state: "expired", updatedAt: now })
-      .where(
-        and(
-          sqlEq(connectorSetupSessions.id, row.id),
-          sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
-        ),
-      )
-      .returning();
-    if (expired.length > 0) trackWrite(db);
-    const expiredRow = expired[0] as ConnectorSetupSessionRow | undefined;
-    throw new ConnectorSetupGateError("session-expired", expiredRow ?? row);
+    const expired = returnedRows(
+      await db
+        .from(connectorSetupSessions)
+        .where([eq("id", row.id), eq("state", "awaiting-user-auth")])
+        .update({ state: "expired", updatedAt: now }),
+    );
+    throw new ConnectorSetupGateError("session-expired", expired[0] ?? row);
   }
 
-  const consumed = await db.raw
-    .update(connectorSetupSessions)
-    .set({ state: "exchanging", updatedAt: now })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, row.id),
-        sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
-        sqlEq(connectorSetupSessions.stateNonceHash, row.stateNonceHash),
-      ),
-    )
-    .returning();
+  const consumed = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([
+        eq("id", row.id),
+        eq("state", "awaiting-user-auth"),
+        eq("stateNonceHash", row.stateNonceHash),
+      ])
+      .update({ state: "exchanging", updatedAt: now }),
+  );
   if (consumed.length !== 1) {
     throw new ConnectorSetupGateError("session-consumed");
   }
-  trackWrite(db);
-  return consumed[0] as ConnectorSetupSessionRow;
+  return consumed[0]!;
 }
 
 export async function markVerifying(
-  db: DrizzleTracker,
+  db: Db,
   sessionId: string,
   dataSourceId: string,
   now = new Date(),
 ): Promise<ConnectorSetupSessionRow> {
-  const rows = await db.raw
-    .update(connectorSetupSessions)
-    .set({ state: "verifying", dataSourceId, updatedAt: now })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, sessionId),
-        sqlEq(connectorSetupSessions.state, "exchanging"),
-      ),
-    )
-    .returning();
+  const rows = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([eq("id", sessionId), eq("state", "exchanging")])
+      .update({ state: "verifying", dataSourceId, updatedAt: now }),
+  );
   if (rows.length !== 1) throw new Error("Connector setup transition rejected");
-  trackWrite(db);
-  return rows[0] as ConnectorSetupSessionRow;
+  return rows[0]!;
 }
 
 export async function markConnected(
-  db: DrizzleTracker,
+  db: Db,
   sessionId: string,
   dataSourceId: string,
   now = new Date(),
 ): Promise<ConnectorSetupSessionRow> {
-  const rows = await db.raw
-    .update(connectorSetupSessions)
-    .set({
-      state: "connected",
-      dataSourceId,
-      failureCode: null,
-      failureMessage: null,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, sessionId),
-        sqlEq(connectorSetupSessions.state, "verifying"),
-        sqlEq(connectorSetupSessions.dataSourceId, dataSourceId),
-      ),
-    )
-    .returning();
+  const rows = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([
+        eq("id", sessionId),
+        eq("state", "verifying"),
+        eq("dataSourceId", dataSourceId),
+      ])
+      .update({
+        state: "connected",
+        dataSourceId,
+        failureCode: null,
+        failureMessage: null,
+        updatedAt: now,
+      }),
+  );
   if (rows.length !== 1) throw new Error("Connector setup transition rejected");
-  trackWrite(db);
-  return rows[0] as ConnectorSetupSessionRow;
+  return rows[0]!;
 }
 
 export async function markFailed(
-  db: DrizzleTracker,
+  db: Db,
   sessionId: string,
   failureCode: string,
   failureMessage: string,
@@ -304,60 +291,49 @@ export async function markFailed(
 ): Promise<ConnectorSetupSessionRow> {
   const row = (await db
     .from(connectorSetupSessions)
-    .where(trackedEq("id", sessionId))
+    .where(eq("id", sessionId))
     .first()) as ConnectorSetupSessionRow | undefined;
   if (!row) throw new Error("Connector setup session not found");
   if (["connected", "failed", "expired"].includes(row.state)) return row;
   if (!allowedStates.includes(row.state as ConnectorSetupState)) return row;
-  const [failed] = await db.raw
-    .update(connectorSetupSessions)
-    .set({
-      state: "failed",
-      dataSourceId: null,
-      failureCode,
-      failureMessage,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, sessionId),
-        sqlEq(connectorSetupSessions.state, row.state),
-      ),
-    )
-    .returning();
-  if (failed) {
-    trackWrite(db);
-    return failed as ConnectorSetupSessionRow;
-  }
+  const [failed] = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([eq("id", sessionId), eq("state", row.state)])
+      .update({
+        state: "failed",
+        dataSourceId: null,
+        failureCode,
+        failureMessage,
+        updatedAt: now,
+      }),
+  );
+  if (failed) return failed;
   const raced = (await db
     .from(connectorSetupSessions)
-    .where(trackedEq("id", sessionId))
+    .where(eq("id", sessionId))
     .first()) as ConnectorSetupSessionRow | undefined;
   if (!raced) throw new Error("Connector setup session not found");
   return raced;
 }
 
 async function expireAwaiting(
-  db: DrizzleTracker,
+  db: Db,
   row: ConnectorSetupSessionRow,
   now: Date,
 ): Promise<boolean> {
   if (row.expiresAt.getTime() > now.getTime()) return false;
-  const updated = await db.raw
-    .update(connectorSetupSessions)
-    .set({ state: "expired", updatedAt: now })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, row.id),
-        sqlEq(connectorSetupSessions.state, "awaiting-user-auth"),
-      ),
-    )
-    .returning({ id: connectorSetupSessions.id });
+  const updated = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([eq("id", row.id), eq("state", "awaiting-user-auth")])
+      .update({ state: "expired", updatedAt: now }),
+  );
   return updated.length > 0;
 }
 
 async function recoverInFlight(
-  db: DrizzleTracker,
+  db: Db,
   row: ConnectorSetupSessionRow,
   now: Date,
 ): Promise<"recovered" | "expired" | undefined> {
@@ -366,48 +342,46 @@ async function recoverInFlight(
   }
   const isExpired = row.expiresAt.getTime() <= now.getTime();
   if (row.state === "verifying" && row.dataSourceId) {
-    const [source] = await db.raw
-      .select({ kind: dataSources.kind })
+    // Tracked read: this decides the recovery outcome, so the sweep's result
+    // depends on data_sources and must invalidate when data_sources changes.
+    const source = (await db
       .from(dataSources)
-      .where(sqlEq(dataSources.id, row.dataSourceId));
+      .select("kind")
+      .where(eq("id", row.dataSourceId))
+      .first()) as { kind: string } | undefined;
     if (source?.kind === row.connectorId) {
-      const connected = await db.raw
-        .update(connectorSetupSessions)
-        .set({ state: "connected", updatedAt: now })
-        .where(
-          and(
-            sqlEq(connectorSetupSessions.id, row.id),
-            sqlEq(connectorSetupSessions.state, "verifying"),
-            sqlEq(connectorSetupSessions.dataSourceId, row.dataSourceId),
-          ),
-        )
-        .returning({ id: connectorSetupSessions.id });
+      const connected = returnedRows(
+        await db
+          .from(connectorSetupSessions)
+          .where([
+            eq("id", row.id),
+            eq("state", "verifying"),
+            eq("dataSourceId", row.dataSourceId),
+          ])
+          .update({ state: "connected", updatedAt: now }),
+      );
       if (connected.length > 0) return "recovered";
       return undefined;
     }
   }
-  const updated = await db.raw
-    .update(connectorSetupSessions)
-    .set({
-      state: isExpired ? "expired" : "awaiting-user-auth",
-      stateNonceHash: nonceHash(newStateNonce()),
-      codeVerifier: newCodeVerifier(),
-      dataSourceId: null,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        sqlEq(connectorSetupSessions.id, row.id),
-        sqlEq(connectorSetupSessions.state, row.state),
-      ),
-    )
-    .returning({ id: connectorSetupSessions.id });
+  const updated = returnedRows(
+    await db
+      .from(connectorSetupSessions)
+      .where([eq("id", row.id), eq("state", row.state)])
+      .update({
+        state: isExpired ? "expired" : "awaiting-user-auth",
+        stateNonceHash: hashStateNonce(newStateNonce()),
+        codeVerifier: newCodeVerifier(),
+        dataSourceId: null,
+        updatedAt: now,
+      }),
+  );
   if (updated.length === 0) return undefined;
   return isExpired ? "expired" : "recovered";
 }
 
 export async function sweep(
-  db: DrizzleTracker,
+  db: Db,
   now = new Date(),
 ): Promise<{ recovered: number; expired: number; deleted: number }> {
   const rows = (await db
@@ -437,17 +411,13 @@ export async function sweep(
     .map((row) => row.id);
   let deleted = 0;
   for (const id of terminalIds) {
-    const removed = await db.raw
-      .delete(connectorSetupSessions)
-      .where(
-        and(
-          sqlEq(connectorSetupSessions.id, id),
-          lt(connectorSetupSessions.updatedAt, cutoff),
-        ),
-      )
-      .returning({ id: connectorSetupSessions.id });
+    const removed = returnedRows(
+      await db
+        .from(connectorSetupSessions)
+        .where([eq("id", id), lt("updatedAt", cutoff)])
+        .delete(),
+    );
     deleted += removed.length;
   }
-  if (recovered + expired + deleted > 0) trackWrite(db);
   return { recovered, expired, deleted };
 }

--- a/apps/server/src/functions.ts
+++ b/apps/server/src/functions.ts
@@ -15,6 +15,7 @@ import { appArtifactFunctions } from "./functions/app-artifacts";
 import { assistantProviderConfigFunctions } from "./functions/assistant-provider-configs";
 import { commandFunctions } from "./functions/commands";
 import { connectorCatalogFunctions } from "./functions/connector-catalog";
+import { connectorSetupFunctions } from "./functions/connector-setup";
 import { dashboardFunctions } from "./functions/dashboards";
 import { draftLifecycleFunctions } from "./functions/draft-lifecycle";
 import { draftFunctions } from "./functions/drafts";
@@ -63,6 +64,7 @@ export const functions = {
   ...assistantProviderConfigFunctions,
   ...commandFunctions,
   ...connectorCatalogFunctions,
+  ...connectorSetupFunctions,
   ...dashboardFunctions,
   ...draftLifecycleFunctions,
   ...draftFunctions,

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -1162,3 +1162,126 @@ describe("insight writes preserve `source` (Insight-on-Insight composition)", ()
     expect(rows[0]?.id).toBe(draftId);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GA4 token write-back — concurrent refresh must not orphan a vault ref
+// ---------------------------------------------------------------------------
+//
+// Writing a refreshed bundle is a read-modify-write: read the source's config,
+// store a new secret, write the config, then release the ref the read saw. Run
+// two of those interleaved and each computes "the old ref" from its own read,
+// so one minted ref ends up stored with no config pointing at it and nothing
+// that will ever release it. Nothing detects that later — the vault has no
+// listing operation, so an orphan is invisible by construction.
+//
+// The assertion that discriminates fixed from broken is that exactly one of the
+// two minted refs is still live. "One config write happened" would pass on the
+// broken code too.
+
+describe("GA4 refreshed-token write-back under concurrency", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let app: WyStackApp;
+  let vault: SecretVault;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-ga4-refresh-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    ({ vault } = makeTestVault());
+    app = await wy.build({ db, functions });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("leaves exactly one live credential ref when two refreshes race", async () => {
+    // An already-expired bundle, so both calls take the refresh path.
+    const expired = JSON.stringify({
+      version: 1,
+      clientId: "client-id",
+      accessToken: "stale-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 60_000,
+      scopes: ["https://www.googleapis.com/auth/analytics.readonly"],
+    });
+    const originalRef = await vault.store(expired, {
+      class: CREDENTIAL_CLASS.ConnectorKey,
+    });
+    const dataSourceId = crypto.randomUUID();
+    await db.insert(dataSources).values({
+      id: dataSourceId,
+      name: "GA4",
+      kind: "googleAnalytics",
+      storage: "live",
+      config: { apiKey: originalRef },
+      createdBy: { kind: "user" },
+    });
+
+    const minted: SecretRef[] = [];
+    const realStore = vault.store.bind(vault);
+    vi.spyOn(vault, "store").mockImplementation(async (plaintext, opts) => {
+      const ref = await realStore(plaintext, opts);
+      minted.push(ref);
+      return ref;
+    });
+
+    // Both calls interleave around the token endpoint: each has read the
+    // source's config before either has written one back.
+    let releaseToken: (() => void) | undefined;
+    const bothRefreshing = new Promise<void>((resolve) => {
+      let arrived = 0;
+      releaseToken = () => {
+        if (++arrived === 2) resolve();
+      };
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input instanceof Request ? input.url : input);
+        if (url.startsWith("https://oauth2.googleapis.com/token")) {
+          releaseToken?.();
+          await bothRefreshing;
+          return new Response(
+            JSON.stringify({
+              access_token: `fresh-${crypto.randomUUID()}`,
+              expires_in: 3600,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ accountSummaries: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    const context = {
+      vault,
+      googleOAuth: { clientId: "client-id", clientSecret: "client-secret" },
+      flushSnapshot: async () => {},
+    };
+    await Promise.all([
+      app.call("listGa4Properties", { dataSourceId }, context),
+      app.call("listGa4Properties", { dataSourceId }, context),
+    ]);
+
+    // Both refreshes minted a ref; only the one the config points at survives.
+    expect(minted).toHaveLength(2);
+    const [row] = await db
+      .select()
+      .from(dataSources)
+      .where(eq(dataSources.id, dataSourceId));
+    const live = (row?.config as { apiKey?: SecretRef }).apiKey;
+    expect(isSecretRef(live)).toBe(true);
+    expect(minted).toContain(live);
+    const survivors: SecretRef[] = [];
+    for (const ref of [originalRef, ...minted]) {
+      if (await vault.has(ref)) survivors.push(ref);
+    }
+    expect(survivors).toEqual([live]);
+  });
+});

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -1240,8 +1240,12 @@ describe("GA4 refreshed-token write-back under concurrency", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input instanceof Request ? input.url : input);
-        if (url.startsWith("https://oauth2.googleapis.com/token")) {
+        const url = new URL(
+          String(input instanceof Request ? input.url : input),
+        );
+        // Compared as a parsed origin rather than a substring, so a host that
+        // merely contains this one cannot match.
+        if (url.origin === "https://oauth2.googleapis.com") {
           releaseToken?.();
           await bothRefreshing;
           return new Response(

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1,3 +1,4 @@
+import { makeGa4Connector } from "@dashframe/connector-ga4";
 import { makeNotionConnector } from "@dashframe/connector-notion";
 import { makePostgresConnector } from "@dashframe/connector-postgres";
 // The canonical bound-resolver type — aliased for readability at the mint site.
@@ -1485,6 +1486,74 @@ const queryPostgresTable = wy.procedure
     },
   );
 
+// ============================================================================
+// GA4 connector factory + data plane — mirrors postgresConnectorFor.
+// ============================================================================
+
+async function ga4ConnectorFor(
+  ctx: DashframeFunctionContext,
+  dataSourceId: UUID,
+): Promise<ReturnType<typeof makeGa4Connector>> {
+  const vault = vaultFromCtx(ctx);
+  const row = (await ctx.db
+    .from(dataSources)
+    .where(eq("id", dataSourceId))
+    .first()) as DataSourceRow | undefined;
+  if (!row) throw new Error(`DataSource ${dataSourceId} not found`);
+  if (row.kind !== "googleAnalytics") {
+    throw new Error(
+      `DataSource ${dataSourceId} is not a Google Analytics source`,
+    );
+  }
+  const config = (row.config ?? {}) as DataSourceConfig;
+  const auth = mintBoundResolver(
+    vault,
+    config.apiKey,
+    `DataSource(${dataSourceId})`,
+  );
+  return makeGa4Connector(auth);
+}
+
+const listGa4Properties = wy.procedure
+  .input({ dataSourceId: uuid })
+  .mutation(
+    async (ctx, { dataSourceId }): Promise<{ id: string; title: string }[]> => {
+      const connector = await ga4ConnectorFor(ctx, dataSourceId);
+      const properties = await connector.connect();
+      return properties.map((property) => ({
+        id: property.id,
+        title: property.name,
+      }));
+    },
+  );
+
+const queryGa4Report = wy.procedure
+  .input({
+    dataSourceId: uuid,
+    propertyId: text,
+    tableId: uuid,
+    limit: int.optional(),
+  })
+  .mutation(
+    async (
+      ctx,
+      { dataSourceId, propertyId, tableId, limit },
+    ): Promise<PostgresQueryResult> => {
+      const connector = await ga4ConnectorFor(ctx, dataSourceId);
+      const pagination =
+        limit !== undefined && Number.isInteger(limit) && limit > 0
+          ? { pagination: { offset: 0, limit } }
+          : undefined;
+      const result = await connector.query(propertyId, tableId, pagination);
+      return {
+        arrowBuffer: result.arrowBuffer,
+        fieldIds: result.fieldIds,
+        fields: result.fields,
+        rowCount: result.rowCount,
+      };
+    },
+  );
+
 export const appArtifactFunctions = {
   listDataSources,
   getDataSource,
@@ -1523,4 +1592,7 @@ export const appArtifactFunctions = {
   // Postgres data-plane routes (auth-blind via bound resolver)
   listPostgresTables,
   queryPostgresTable,
+  // Google Analytics data-plane routes (auth-blind via bound resolver)
+  listGa4Properties,
+  queryGa4Report,
 };

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1545,6 +1545,11 @@ async function ga4ConnectorFor(
  * store-new → canonical-write → flush-snapshot → release-old. Releasing the old
  * ref before the new config is durable would leave a snapshot pointing at a
  * credential that no longer exists.
+ *
+ * Two simultaneous queries can both refresh and both mint a ref; the last
+ * config write wins and the other blob is orphaned. Wasteful, never dangling —
+ * no config ever points at the loser — and not worth a lock on a path that runs
+ * about once an hour per source.
  */
 async function persistGa4TokenBundle(
   ctx: DashframeFunctionContext,

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1,4 +1,7 @@
-import { makeGa4Connector } from "@dashframe/connector-ga4";
+import {
+  makeGa4Connector,
+  type GoogleOAuthTokenBundle,
+} from "@dashframe/connector-ga4";
 import { makeNotionConnector } from "@dashframe/connector-notion";
 import { makePostgresConnector } from "@dashframe/connector-postgres";
 // The canonical bound-resolver type — aliased for readability at the mint site.
@@ -42,6 +45,7 @@ import {
 import { tsToMillis } from "./timestamps";
 import {
   applyCredentialField,
+  flushThenReleaseRefs,
   isRecord,
   modeFromCtx,
   releaseCredentialRefs,
@@ -1524,7 +1528,60 @@ async function ga4ConnectorFor(
           },
         }
       : {}),
+    persistTokenBundle: (bundle) =>
+      persistGa4TokenBundle(ctx, dataSourceId, vault, bundle),
   });
+}
+
+/**
+ * Write a renewed GA4 token bundle back to the source's vault entry.
+ *
+ * Without this the connector holds a fresh access token only for the life of
+ * one request: the next call past the stored expiry refreshes again, spending a
+ * Google grant per request instead of per hour.
+ *
+ * The vault has no in-place rotate — `store` mints a new ref — so this follows
+ * the same ordering every other credential rotation here uses:
+ * store-new → canonical-write → flush-snapshot → release-old. Releasing the old
+ * ref before the new config is durable would leave a snapshot pointing at a
+ * credential that no longer exists.
+ */
+async function persistGa4TokenBundle(
+  ctx: DashframeFunctionContext,
+  dataSourceId: UUID,
+  vault: SecretVault | undefined,
+  bundle: GoogleOAuthTokenBundle,
+): Promise<void> {
+  // A preview executes and rolls back, but a vault write is outside that
+  // transaction and would survive the rollback pointing at a discarded config.
+  if (modeFromCtx(ctx) === "preview") return;
+  const current = (await ctx.db
+    .from(dataSources)
+    .where(eq("id", dataSourceId))
+    .first()) as DataSourceRow | undefined;
+  if (!current) return;
+  const config = { ...((current.config ?? {}) as DataSourceConfig) };
+  const superseded: SecretRef[] = [];
+  await applyCredentialField(
+    config,
+    "apiKey",
+    JSON.stringify(bundle),
+    vault,
+    `apiKey-${dataSourceId}`,
+    false,
+    false,
+    superseded,
+  );
+  await ctx.db
+    .from(dataSources)
+    .where(eq("id", dataSourceId))
+    .update({ config });
+  await flushThenReleaseRefs(
+    ctx.flushSnapshot,
+    superseded,
+    vault,
+    `ga4-refresh-${dataSourceId}`,
+  );
 }
 
 const listGa4Properties = wy.procedure

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1546,12 +1546,13 @@ async function ga4ConnectorFor(
  * ref before the new config is durable would leave a snapshot pointing at a
  * credential that no longer exists.
  *
- * Two simultaneous queries can both refresh and both mint a ref; the last
- * config write wins and the other blob is orphaned. Wasteful, never dangling —
- * no config ever points at the loser — and not worth a lock on a path that runs
- * about once an hour per source.
+ * Callers reach this through `persistGa4TokenBundle`, which serializes it per
+ * source. It must not be called directly: `superseded` is computed from the
+ * read a few lines below, so two interleaved runs would each supersede only
+ * what their own read saw and one of the minted refs would be stored and then
+ * never referenced or released.
  */
-async function persistGa4TokenBundle(
+async function persistGa4TokenBundleLocked(
   ctx: DashframeFunctionContext,
   dataSourceId: UUID,
   vault: SecretVault | undefined,
@@ -1587,6 +1588,65 @@ async function persistGa4TokenBundle(
     vault,
     `ga4-refresh-${dataSourceId}`,
   );
+}
+
+/**
+ * In-flight token write per data source, so the read-modify-write above runs
+ * one at a time.
+ *
+ * Keyed by source rather than global: refreshes for different sources share
+ * nothing, and a global lock would let one slow vault write stall every other
+ * source's queries.
+ */
+const ga4TokenWrites = new Map<UUID, Promise<void>>();
+
+/**
+ * Write a renewed GA4 token bundle back, serialized against other writes for
+ * the same source.
+ *
+ * Serializing makes the second writer re-read after the first has landed, so
+ * its `superseded` list contains the first writer's ref and
+ * `flushThenReleaseRefs` actually releases it. Without that, two simultaneous
+ * refreshes each mint a ref, the last config write wins, and the loser's blob
+ * stays in the vault forever with nothing pointing at it.
+ *
+ * This narrows the race to the write, not the refresh: two callers can still
+ * both hit Google, and if Google rotated the refresh token the second caller's
+ * bundle carries the pre-rotation one, so the surviving config can hold a dead
+ * refresh token. Tolerable, because Google's web-server flow does not rotate
+ * refresh tokens per call, and a bundle that does go stale costs one failed
+ * refresh before the next call re-reads and recovers. Coalescing the refresh
+ * itself has to happen above the connector boundary and is a separate change.
+ */
+async function persistGa4TokenBundle(
+  ctx: DashframeFunctionContext,
+  dataSourceId: UUID,
+  vault: SecretVault | undefined,
+  bundle: GoogleOAuthTokenBundle,
+): Promise<void> {
+  const previous = ga4TokenWrites.get(dataSourceId) ?? Promise.resolve();
+  // Chained on a tail that settles either way. A persist failure is non-fatal
+  // to the request that hit it (see `accessTokenFor`), so it must not reject
+  // every write queued behind it — that would turn one storage hiccup into a
+  // permanently broken refresh path for the source.
+  const settle = () =>
+    persistGa4TokenBundleLocked(ctx, dataSourceId, vault, bundle);
+  const result = previous.then(settle, settle);
+  // Drop the entry once this is the last write outstanding, or the map grows a
+  // permanent entry per source connected in the process's lifetime. Folded
+  // into the stored tail rather than chained separately so the cleanup runs
+  // before anything queued behind this write reads the map.
+  // Only clears its own entry: a writer that queued behind this one has
+  // already replaced the map value, and deleting that would let a third writer
+  // start from an empty chain and race the one still running.
+  const forget = () => {
+    if (ga4TokenWrites.get(dataSourceId) === tail) {
+      ga4TokenWrites.delete(dataSourceId);
+    }
+  };
+  const tail: Promise<void> = result.then(forget, forget);
+  ga4TokenWrites.set(dataSourceId, tail);
+  return result;
 }
 
 const listGa4Properties = wy.procedure

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1511,7 +1511,20 @@ async function ga4ConnectorFor(
     config.apiKey,
     `DataSource(${dataSourceId})`,
   );
-  return makeGa4Connector(auth);
+  // Client credentials come from server config on every call rather than from
+  // the stored bundle, so rotating the OAuth client is a config change instead
+  // of a re-write of every connected source's vault entry.
+  const oauthClient = ctx.googleOAuth;
+  return makeGa4Connector(auth, {
+    ...(oauthClient
+      ? {
+          oauthClient: {
+            clientId: oauthClient.clientId,
+            clientSecret: oauthClient.clientSecret,
+          },
+        }
+      : {}),
+  });
 }
 
 const listGa4Properties = wy.procedure

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1597,24 +1597,54 @@ const listGa4Properties = wy.procedure
     },
   );
 
-const queryGa4Report = wy.procedure
+/**
+ * Serializable result of a GA4 property read. Structurally identical to
+ * PostgresQueryResult today, and named separately on purpose: these two travel
+ * different code paths and one gaining a field should not silently change the
+ * other's contract.
+ */
+type Ga4QueryResult = {
+  arrowBuffer: string;
+  fieldIds: string[];
+  fields: Field[];
+  rowCount: number;
+};
+
+/**
+ * Read a GA4 property into a DataTable.
+ *
+ * Named for what it queries: a GA4 "table" is a property, not a saved report,
+ * and the old name promised a report selection that never existed.
+ *
+ * The property comes from the DataTable row rather than from a caller-supplied
+ * argument. The row records which property the table was created from, so
+ * taking a separate property id let the two disagree and wrote one property's
+ * data into another property's table.
+ */
+const queryGa4Property = wy.procedure
   .input({
     dataSourceId: uuid,
-    propertyId: text,
     tableId: uuid,
     limit: int.optional(),
   })
   .mutation(
-    async (
-      ctx,
-      { dataSourceId, propertyId, tableId, limit },
-    ): Promise<PostgresQueryResult> => {
+    async (ctx, { dataSourceId, tableId, limit }): Promise<Ga4QueryResult> => {
+      const table = (await ctx.db
+        .from(dataTables)
+        .where(eq("id", tableId))
+        .first()) as DataTableRow | undefined;
+      if (!table) throw new Error(`DataTable ${tableId} not found`);
+      if (table.dataSourceId !== dataSourceId) {
+        throw new Error(
+          `DataTable ${tableId} does not belong to DataSource ${dataSourceId}`,
+        );
+      }
       const connector = await ga4ConnectorFor(ctx, dataSourceId);
       const pagination =
         limit !== undefined && Number.isInteger(limit) && limit > 0
           ? { pagination: { offset: 0, limit } }
           : undefined;
-      const result = await connector.query(propertyId, tableId, pagination);
+      const result = await connector.query(table.table, tableId, pagination);
       return {
         arrowBuffer: result.arrowBuffer,
         fieldIds: result.fieldIds,
@@ -1664,5 +1694,5 @@ export const appArtifactFunctions = {
   queryPostgresTable,
   // Google Analytics data-plane routes (auth-blind via bound resolver)
   listGa4Properties,
-  queryGa4Report,
+  queryGa4Property,
 };

--- a/apps/server/src/functions/connector-catalog.test.ts
+++ b/apps/server/src/functions/connector-catalog.test.ts
@@ -1,7 +1,10 @@
 import { localFileConnector } from "@dashframe/connector-local";
 import { describe, expect, it } from "vitest";
 
-import { LOCAL_CATALOG_ENTRY } from "./connector-catalog";
+import {
+  getConnectorCatalogEntries,
+  LOCAL_CATALOG_ENTRY,
+} from "./connector-catalog";
 
 describe("LOCAL_CATALOG_ENTRY drift guard", () => {
   it("matches the real localFileConnector static metadata", () => {
@@ -18,5 +21,20 @@ describe("LOCAL_CATALOG_ENTRY drift guard", () => {
     expect(LOCAL_CATALOG_ENTRY.formFields).toEqual(
       localFileConnector.getFormFields(),
     );
+  });
+});
+
+describe("connector catalog OAuth metadata", () => {
+  it("advertises Google Analytics as an OAuth connector with no form fields", () => {
+    const entry = getConnectorCatalogEntries().find(
+      ({ id }) => id === "googleAnalytics",
+    );
+
+    expect(entry).toMatchObject({
+      id: "googleAnalytics",
+      sourceType: "remote-api",
+      authKind: "oauth",
+      formFields: [],
+    });
   });
 });

--- a/apps/server/src/functions/connector-catalog.ts
+++ b/apps/server/src/functions/connector-catalog.ts
@@ -1,3 +1,4 @@
+import { makeGa4Connector } from "@dashframe/connector-ga4";
 import { makeNotionConnector } from "@dashframe/connector-notion";
 import { makePostgresConnector } from "@dashframe/connector-postgres";
 import type { AnyConnector } from "@dashframe/engine";
@@ -17,9 +18,12 @@ const throwingResolver = () => {
 
 function toCatalogEntry(connector: AnyConnector): ConnectorCatalogEntry {
   const formFields = connector.getFormFields() as ConnectorFormField[];
-  const authKind = formFields.some((field) => field.type === "password")
-    ? "credential"
-    : "none";
+  let authKind: ConnectorCatalogEntry["authKind"] = "none";
+  if (connector.authKind === "oauth") {
+    authKind = "oauth";
+  } else if (formFields.some((field) => field.type === "password")) {
+    authKind = "credential";
+  }
 
   const entry: ConnectorCatalogEntry = {
     id: connector.id,
@@ -67,7 +71,7 @@ export const LOCAL_CATALOG_ENTRY: ConnectorCatalogEntry = Object.freeze({
 
 /**
  * Lazily builds and memoizes the catalog on first read rather than at module
- * load. The Notion/Postgres connector instances below exist purely to read
+ * load. The remote connector instances below exist purely to read
  * static metadata (id/name/description/icon/getFormFields()) — the exact same
  * pattern already used client-side in
  * packages/app/src/components/providers/ConnectorSetup.tsx — but constructing
@@ -89,11 +93,13 @@ function buildConnectorCatalog(): ConnectorCatalogEntry[] {
     throwingResolver,
     {},
   );
+  const ga4ConnectorForCatalog = makeGa4Connector(throwingResolver);
 
   return Object.freeze([
     LOCAL_CATALOG_ENTRY,
     toCatalogEntry(notionConnectorForCatalog),
     toCatalogEntry(postgresConnectorForCatalog),
+    toCatalogEntry(ga4ConnectorForCatalog),
   ]) as ConnectorCatalogEntry[];
 }
 

--- a/apps/server/src/functions/connector-setup.test.ts
+++ b/apps/server/src/functions/connector-setup.test.ts
@@ -329,6 +329,29 @@ describe("connector setup functions", () => {
       expect((await row(session.sessionId))?.state).toBe("awaiting-user-auth");
     });
 
+    it("exposes only the minimal public shape on the unauthenticated path", async () => {
+      const app = await makeApp(makeVault().vault);
+      const session = await start(app);
+
+      const reissued = await app.call(
+        "reissueConnectorSetupResume",
+        { sessionId: session.sessionId },
+        { principal: user },
+      );
+
+      // An exact key set, not a subset: this DTO is what the unauthenticated
+      // resume routes hand to the browser, so a field added to it must fail
+      // here rather than ship. Notably absent: codeVerifier, stateNonceHash,
+      // requestedName, dataSourceId, failureMessage.
+      expect(Object.keys(reissued.result as object).sort()).toEqual([
+        "authorizeUrl",
+        "connectorId",
+        "expiresAt",
+        "sessionId",
+        "state",
+      ]);
+    });
+
     it("rotates the capability only through the reissue mutation", async () => {
       const app = await makeApp(makeVault().vault);
       const session = await start(app);

--- a/apps/server/src/functions/connector-setup.test.ts
+++ b/apps/server/src/functions/connector-setup.test.ts
@@ -273,4 +273,79 @@ describe("connector setup functions", () => {
     expect(completed.result).toMatchObject({ state: "expired" });
     expect(flushSnapshot).toHaveBeenCalledTimes(2);
   });
+
+  // Reading a session and reissuing its resume capability are different
+  // operations with different consequences, so they are different procedures.
+  // These pin that the query really is side-effect free — a rotation hidden in
+  // it would kill an authorize URL the user is in the middle of using.
+  describe("read/reissue split", () => {
+    async function row(sessionId: string) {
+      const [found] = await db
+        .select()
+        .from(connectorSetupSessions)
+        .where(eq(connectorSetupSessions.id, sessionId));
+      return found;
+    }
+
+    it("reads a session without writing anything or minting a URL", async () => {
+      const app = await makeApp(makeVault().vault);
+      const session = await start(app);
+      const before = await row(session.sessionId);
+      flushSnapshot.mockClear();
+
+      const read = await app.call(
+        "getConnectorSetupSession",
+        { sessionId: session.sessionId },
+        { principal: user },
+      );
+
+      expect(read.tablesWritten.size).toBe(0);
+      expect(read.result).not.toHaveProperty("authorizeUrl");
+      expect(flushSnapshot).not.toHaveBeenCalled();
+      expect(await row(session.sessionId)).toEqual(before);
+    });
+
+    it("reports a lapsed session as expired without persisting the expiry", async () => {
+      const app = await makeApp(makeVault().vault);
+      const session = await start(app);
+      await db
+        .update(connectorSetupSessions)
+        .set({ expiresAt: new Date(0) })
+        .where(eq(connectorSetupSessions.id, session.sessionId));
+
+      const read = await app.call(
+        "getConnectorSetupSession",
+        { sessionId: session.sessionId, publicResume: true },
+        { principal: user },
+      );
+
+      expect(read.result).toMatchObject({ state: "expired" });
+      expect(read.tablesWritten.size).toBe(0);
+      // The stored state is still the pre-expiry one: only a mutation may
+      // advance it, and the sweep or the callback gate will.
+      expect((await row(session.sessionId))?.state).toBe("awaiting-user-auth");
+    });
+
+    it("rotates the capability only through the reissue mutation", async () => {
+      const app = await makeApp(makeVault().vault);
+      const session = await start(app);
+      const before = await row(session.sessionId);
+
+      const reissued = await app.call(
+        "reissueConnectorSetupResume",
+        { sessionId: session.sessionId },
+        { principal: user },
+      );
+      const after = await row(session.sessionId);
+
+      expect(reissued.tablesWritten).toContain("connector_setup_sessions");
+      expect(
+        (reissued.result as { authorizeUrl?: string }).authorizeUrl,
+      ).toContain("state=");
+      expect(after?.stateNonceHash).not.toBe(before?.stateNonceHash);
+      expect(after?.codeVerifier).not.toBe(before?.codeVerifier);
+      // The rotated nonce must be durable before the URL is usable.
+      expect(flushSnapshot).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/server/src/functions/connector-setup.test.ts
+++ b/apps/server/src/functions/connector-setup.test.ts
@@ -183,7 +183,7 @@ describe("connector setup functions", () => {
     expect(flushSnapshot).toHaveBeenCalledTimes(2);
   });
 
-  it("fails closed without a vault after a successful probe and leaves no source", async () => {
+  it("fails closed without a vault before spending the authorization code", async () => {
     const app = await makeApp();
     const session = await start(app);
     const state = new URL(session.authorizeUrl).searchParams.get("state");
@@ -193,11 +193,14 @@ describe("connector setup functions", () => {
       { principal: user },
     );
 
+    // Named for the actual cause. Reaching the create step first would report
+    // "create-failed", which reads as a database fault, after having already
+    // burned the single-use code on an exchange that could never be stored.
     expect(completed.result).toMatchObject({
       state: "failed",
-      failureCode: "create-failed",
+      failureCode: "no_vault",
     });
-    expect(probedBundles).toHaveLength(1);
+    expect(probedBundles).toHaveLength(0);
     expect(await db.select().from(dataSources)).toHaveLength(0);
     const [row] = await db.select().from(connectorSetupSessions);
     expect(row?.dataSourceId).toBeNull();

--- a/apps/server/src/functions/connector-setup.test.ts
+++ b/apps/server/src/functions/connector-setup.test.ts
@@ -1,0 +1,276 @@
+import { openArtifactDb, schema } from "@dashframe/server-core";
+import {
+  InMemoryMappingStore,
+  SecretRegistry,
+  SecretVault,
+  TestBackend,
+  isSecretRef,
+} from "@wystack/secret-vault";
+import type { WyStackApp } from "@wystack/server";
+import { eq } from "drizzle-orm";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const probedBundles: string[] = [];
+let probeStarted: (() => void) | undefined;
+let probeWait: Promise<void> | undefined;
+
+vi.mock("@dashframe/connector-ga4", () => ({
+  makeGa4Connector: (
+    auth: <T>(use: (plaintext: string) => Promise<T>) => Promise<T>,
+  ) => ({
+    id: "googleAnalytics",
+    name: "Google Analytics 4",
+    description: "Test GA4 connector",
+    sourceType: "remote-api",
+    icon: "<svg></svg>",
+    authKind: "oauth",
+    getFormFields: () => [],
+    connect: () =>
+      auth(async (plaintext) => {
+        probedBundles.push(plaintext);
+        probeStarted?.();
+        await probeWait;
+        return [{ id: "properties/123", name: "Example" }];
+      }),
+  }),
+}));
+
+import { buildDashframeApp } from "../app";
+import type { AppContext } from "../app-context";
+import type { GoogleOAuthConfig } from "../connector-setup/oauth-provider";
+import { LOCAL_USER_ID } from "../permissions";
+
+const { connectorSetupSessions, dataSources } = schema;
+
+function makeVault(): { vault: SecretVault; backend: TestBackend } {
+  const backend = new TestBackend();
+  const registry = new SecretRegistry();
+  registry.register("test", backend, { fallback: true });
+  registry.setClassDefault("connector-key", "test");
+  return {
+    vault: new SecretVault(registry, new InMemoryMappingStore()),
+    backend,
+  };
+}
+
+describe("connector setup functions", () => {
+  let dir: string;
+  let db: Awaited<ReturnType<typeof openArtifactDb>>;
+  let flushSnapshot: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    probedBundles.length = 0;
+    probeStarted = undefined;
+    probeWait = undefined;
+    dir = mkdtempSync(join(tmpdir(), "dashframe-connector-functions-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    flushSnapshot = vi.fn(async () => {});
+  });
+
+  afterEach(async () => {
+    await db.$client.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function oauthConfig(): GoogleOAuthConfig {
+    return {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      now: () => Date.parse("2026-08-05T12:00:00Z"),
+      fetch: vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              access_token: "access-token",
+              refresh_token: "refresh-token",
+              expires_in: 3600,
+              scope: "https://www.googleapis.com/auth/analytics.readonly",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ) as unknown as typeof fetch,
+    };
+  }
+
+  async function makeApp(
+    vault?: SecretVault,
+    googleOAuth: GoogleOAuthConfig | null = oauthConfig(),
+  ): Promise<WyStackApp> {
+    const base = await buildDashframeApp({
+      db,
+      vault,
+      ...(googleOAuth ? { googleOAuth } : {}),
+      getServerEndpoint: () => "http://127.0.0.1:4567/api",
+    });
+    const app: WyStackApp = {
+      ...base,
+      call: (path, args, context) =>
+        base.call(path, args, {
+          ...(context ?? {}),
+          wyStackApp: app,
+          flushSnapshot,
+        }),
+    };
+    return app;
+  }
+
+  const user = { kind: "user" as const, userId: LOCAL_USER_ID };
+  const service = {
+    kind: "service" as const,
+    credentialId: "credential-1",
+  };
+
+  async function start(
+    app: WyStackApp,
+    principal: NonNullable<AppContext["principal"]> = user,
+  ) {
+    const call = await app.call(
+      "startConnectorSetup",
+      { connectorId: "googleAnalytics", requestedName: "Website analytics" },
+      { principal },
+    );
+    return call.result as {
+      sessionId: string;
+      authorizeUrl: string;
+      state: string;
+    };
+  }
+
+  it("accepts user and service principals for API-initiated setup", async () => {
+    const app = await makeApp(makeVault().vault);
+    await expect(start(app, user)).resolves.toMatchObject({
+      state: "awaiting-user-auth",
+    });
+    await expect(start(app, service)).resolves.toMatchObject({
+      state: "awaiting-user-auth",
+    });
+    await expect(
+      app.call("startConnectorSetup", {
+        connectorId: "googleAnalytics",
+        requestedName: "No principal",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("probes plaintext first, creates canonically second, and stores only a ref", async () => {
+    const { vault } = makeVault();
+    const app = await makeApp(vault);
+    const session = await start(app);
+    const state = new URL(session.authorizeUrl).searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    const completed = await app.call(
+      "completeConnectorOAuth",
+      { state, code: "authorization-code" },
+      { principal: user },
+    );
+    expect(completed.result).toMatchObject({
+      state: "connected",
+      requestedName: "Website analytics",
+    });
+    expect(probedBundles).toHaveLength(1);
+
+    const [source] = await db.select().from(dataSources);
+    expect(source?.kind).toBe("googleAnalytics");
+    const ref = (source?.config as { apiKey?: unknown }).apiKey;
+    expect(isSecretRef(ref)).toBe(true);
+    await expect(
+      vault.withSecret(ref as never, async (value) => value),
+    ).resolves.toBe(probedBundles[0]);
+    expect(flushSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed without a vault after a successful probe and leaves no source", async () => {
+    const app = await makeApp();
+    const session = await start(app);
+    const state = new URL(session.authorizeUrl).searchParams.get("state");
+    const completed = await app.call(
+      "completeConnectorOAuth",
+      { state, code: "authorization-code" },
+      { principal: user },
+    );
+
+    expect(completed.result).toMatchObject({
+      state: "failed",
+      failureCode: "create-failed",
+    });
+    expect(probedBundles).toHaveLength(1);
+    expect(await db.select().from(dataSources)).toHaveLength(0);
+    const [row] = await db.select().from(connectorSetupSessions);
+    expect(row?.dataSourceId).toBeNull();
+  });
+
+  it("does not let cancellation interrupt an already-consumed callback", async () => {
+    const { vault } = makeVault();
+    const app = await makeApp(vault);
+    const session = await start(app);
+    const state = new URL(session.authorizeUrl).searchParams.get("state");
+    let releaseProbe = () => {};
+    probeWait = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    const enteredProbe = new Promise<void>((resolve) => {
+      probeStarted = resolve;
+    });
+
+    const completion = app.call(
+      "completeConnectorOAuth",
+      { state, code: "authorization-code" },
+      { principal: user },
+    );
+    await enteredProbe;
+    const cancellation = await app.call(
+      "cancelConnectorSetup",
+      { sessionId: session.sessionId },
+      { principal: user },
+    );
+    expect(cancellation.result).toMatchObject({ state: "verifying" });
+    releaseProbe();
+
+    await expect(completion).resolves.toMatchObject({
+      result: { state: "connected" },
+    });
+    expect(await db.select().from(dataSources)).toHaveLength(1);
+  });
+
+  it("marks provider configuration failures terminal after callback consumption", async () => {
+    const app = await makeApp(makeVault().vault);
+    const session = await start(app);
+    const state = new URL(session.authorizeUrl).searchParams.get("state");
+    const restartedWithoutGoogle = await makeApp(makeVault().vault, null);
+
+    const completed = await restartedWithoutGoogle.call(
+      "completeConnectorOAuth",
+      { state, code: "authorization-code" },
+      { principal: user },
+    );
+
+    expect(completed.result).toMatchObject({
+      state: "failed",
+      failureCode: "exchange-failed",
+      failureMessage: "Google authorization could not be completed.",
+    });
+  });
+
+  it("durably returns an expired callback through the procedure boundary", async () => {
+    const app = await makeApp(makeVault().vault);
+    const session = await start(app);
+    const state = new URL(session.authorizeUrl).searchParams.get("state");
+    await db
+      .update(connectorSetupSessions)
+      .set({ expiresAt: new Date(0) })
+      .where(eq(connectorSetupSessions.id, session.sessionId));
+
+    const completed = await app.call(
+      "completeConnectorOAuth",
+      { state, code: "authorization-code" },
+      { principal: user },
+    );
+
+    expect(completed.result).toMatchObject({ state: "expired" });
+    expect(flushSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/src/functions/connector-setup.ts
+++ b/apps/server/src/functions/connector-setup.ts
@@ -27,6 +27,7 @@ import {
 import { permissions } from "../permissions";
 import { wy } from "../wystack";
 import { COMMAND_PATHS } from "./commands";
+import { vaultFromCtx } from "./utils";
 
 export interface ConnectorSetupSessionDto {
   sessionId: string;
@@ -221,6 +222,21 @@ const completeConnectorOAuth = wy.procedure
         session.id,
         "authorization-rejected",
         "Google authorization was not completed.",
+      );
+      return fullDto(ctx, failed);
+    }
+
+    // Check for somewhere to put the credential before spending the
+    // authorization code. Without this the flow exchanges the code, probes
+    // Google, and only then fails at the create step — reporting
+    // "create-failed", which reads as a database problem, and burning a
+    // single-use code the user has to redo the whole consent screen to replace.
+    if (vaultFromCtx(ctx) == null) {
+      const failed = await markFailed(
+        ctx.db,
+        session.id,
+        "no_vault",
+        "This server has no credential vault, so the connection cannot be stored.",
       );
       return fullDto(ctx, failed);
     }

--- a/apps/server/src/functions/connector-setup.ts
+++ b/apps/server/src/functions/connector-setup.ts
@@ -253,7 +253,12 @@ const completeConnectorOAuth = wy.procedure
     try {
       // Probe against the plaintext bundle in process memory. No vault write or
       // DataSource exists until this authenticated read succeeds.
-      const probe = makeGa4Connector(async (use) => use(tokenBundle));
+      const probe = makeGa4Connector(async (use) => use(tokenBundle), {
+        oauthClient: {
+          clientId: googleOAuth(ctx).clientId,
+          clientSecret: googleOAuth(ctx).clientSecret,
+        },
+      });
       await probe.connect();
     } catch {
       const failed = await markFailed(

--- a/apps/server/src/functions/connector-setup.ts
+++ b/apps/server/src/functions/connector-setup.ts
@@ -1,0 +1,333 @@
+import { makeGa4Connector } from "@dashframe/connector-ga4";
+import { boolean, text, uuid } from "@wystack/db";
+
+import type { DashframeFunctionContext } from "../app-context";
+import {
+  OAuthExchangeError,
+  connectorResumeLink,
+  oauthConnectorDescriptorFor,
+  resolveOAuthRedirectUri,
+} from "../connector-setup/oauth-provider";
+import {
+  ConnectorSetupGateError,
+  consumeCallback,
+  markConnected,
+  markFailed,
+  markVerifying,
+  oauthStateFor,
+  publicResumeInfo,
+  startSession,
+  sweep,
+  type ConnectorSetupSessionRow,
+  type ConnectorSetupState,
+  type SessionIssuance,
+} from "../connector-setup/session-store";
+import { permissions } from "../permissions";
+import { wy } from "../wystack";
+import { COMMAND_PATHS } from "./commands";
+
+export interface ConnectorSetupSessionDto {
+  sessionId: string;
+  connectorId: string;
+  requestedName: string;
+  state: ConnectorSetupState;
+  authorizeUrl?: string;
+  resumeUrl: string;
+  dataSourceId?: string;
+  failureCode?: string;
+  failureMessage?: string;
+  expiresAt: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PublicConnectorSetupResumeDto {
+  sessionId: string;
+  connectorId: string;
+  state: "awaiting-user-auth" | "connected" | "failed" | "expired";
+  authorizeUrl?: string;
+  expiresAt: number;
+}
+
+function googleOAuth(ctx: DashframeFunctionContext) {
+  if (!ctx.googleOAuth) {
+    throw new Error("Google Analytics OAuth is not configured");
+  }
+  return ctx.googleOAuth;
+}
+
+function descriptorFor(ctx: DashframeFunctionContext, connectorId: string) {
+  return oauthConnectorDescriptorFor(connectorId, googleOAuth(ctx));
+}
+
+function redirectUriFor(ctx: DashframeFunctionContext): string {
+  return resolveOAuthRedirectUri(
+    ctx.getServerEndpoint(),
+    googleOAuth(ctx).redirectBase,
+  );
+}
+
+function authorizeUrlFor(
+  ctx: DashframeFunctionContext,
+  issuance: SessionIssuance,
+): string {
+  const descriptor = descriptorFor(ctx, issuance.session.connectorId);
+  return descriptor.buildAuthorizeUrl({
+    redirectUri: redirectUriFor(ctx),
+    state: oauthStateFor(issuance.stateNonce),
+    codeVerifier: issuance.session.codeVerifier,
+  });
+}
+
+function fullDto(
+  ctx: DashframeFunctionContext,
+  row: ConnectorSetupSessionRow,
+  authorizeUrl?: string,
+): ConnectorSetupSessionDto {
+  return {
+    sessionId: row.id,
+    connectorId: row.connectorId,
+    requestedName: row.requestedName,
+    state: row.state as ConnectorSetupState,
+    ...(authorizeUrl ? { authorizeUrl } : {}),
+    resumeUrl: connectorResumeLink(ctx.getServerEndpoint(), row.id),
+    ...(row.dataSourceId ? { dataSourceId: row.dataSourceId } : {}),
+    ...(row.failureCode ? { failureCode: row.failureCode } : {}),
+    ...(row.failureMessage ? { failureMessage: row.failureMessage } : {}),
+    expiresAt: row.expiresAt.getTime(),
+    createdAt: row.createdAt.getTime(),
+    updatedAt: row.updatedAt.getTime(),
+  };
+}
+
+function publicDto(
+  row: ConnectorSetupSessionRow,
+  authorizeUrl?: string,
+): PublicConnectorSetupResumeDto {
+  const state =
+    row.state === "connected" ||
+    row.state === "failed" ||
+    row.state === "expired"
+      ? row.state
+      : "awaiting-user-auth";
+  return {
+    sessionId: row.id,
+    connectorId: row.connectorId,
+    state,
+    ...(state === "awaiting-user-auth" && authorizeUrl ? { authorizeUrl } : {}),
+    expiresAt: row.expiresAt.getTime(),
+  };
+}
+
+async function requireDurableFlush(
+  ctx: DashframeFunctionContext,
+  label: string,
+): Promise<void> {
+  if (!ctx.flushSnapshot) {
+    throw new Error(`${label} requires durable project snapshots`);
+  }
+  await ctx.flushSnapshot();
+}
+
+async function consumeForCompletion(
+  ctx: DashframeFunctionContext,
+  state: string,
+): Promise<
+  { session: ConnectorSetupSessionRow } | { expired: ConnectorSetupSessionDto }
+> {
+  try {
+    return { session: await consumeCallback(ctx.db, state) };
+  } catch (error) {
+    if (
+      error instanceof ConnectorSetupGateError &&
+      error.code === "session-expired" &&
+      error.session
+    ) {
+      // The expiry update must leave the procedure normally so app.call can
+      // run its write/snapshot/invalidation hooks before the route reports a
+      // generic callback rejection.
+      await requireDurableFlush(ctx, "completeConnectorOAuth");
+      return { expired: fullDto(ctx, error.session) };
+    }
+    throw error;
+  }
+}
+
+const startConnectorSetup = wy.procedure
+  .authorize(permissions.connectors.setup)
+  .input({ connectorId: text, requestedName: text })
+  .mutation(async (ctx, input): Promise<ConnectorSetupSessionDto> => {
+    const descriptor = descriptorFor(ctx, input.connectorId);
+    const redirectUri = redirectUriFor(ctx);
+    const issuance = await startSession(ctx.db, {
+      connectorId: descriptor.id,
+      requestedName: input.requestedName.trim() || descriptor.id,
+      scopes: descriptor.scopes,
+    });
+    const authorizeUrl = descriptor.buildAuthorizeUrl({
+      redirectUri,
+      state: oauthStateFor(issuance.stateNonce),
+      codeVerifier: issuance.session.codeVerifier,
+    });
+    // A resume capability without its row is permanently dead. Do not return it
+    // until the snapshot containing the INSERT is durable.
+    await requireDurableFlush(ctx, "startConnectorSetup");
+    return fullDto(ctx, issuance.session, authorizeUrl);
+  });
+
+const getConnectorSetupSession = wy.procedure
+  .authorize(permissions.connectors.setup)
+  .input({ sessionId: uuid, publicResume: boolean.optional() })
+  .query(async (ctx, { sessionId, publicResume }) => {
+    const issuance = await publicResumeInfo(
+      ctx.db,
+      sessionId,
+      new Date(),
+      publicResume === true,
+    );
+    const authorizeUrl =
+      "stateNonce" in issuance ? authorizeUrlFor(ctx, issuance) : undefined;
+    if ("stateNonce" in issuance) {
+      await requireDurableFlush(ctx, "getConnectorSetupSession");
+    }
+    return publicResume
+      ? publicDto(issuance.session, authorizeUrl)
+      : fullDto(ctx, issuance.session, authorizeUrl);
+  });
+
+const completeConnectorOAuth = wy.procedure
+  .authorize(permissions.connectors.setup)
+  .input({ state: text, code: text.optional(), oauthError: text.optional() })
+  .mutation(async (ctx, { state, code, oauthError }) => {
+    const consumed = await consumeForCompletion(ctx, state);
+    if ("expired" in consumed) return consumed.expired;
+    const { session } = consumed;
+    if (oauthError || !code) {
+      const failed = await markFailed(
+        ctx.db,
+        session.id,
+        "authorization-rejected",
+        "Google authorization was not completed.",
+      );
+      return fullDto(ctx, failed);
+    }
+
+    let descriptor: ReturnType<typeof descriptorFor>;
+    let redirectUri: string;
+    let tokenBundle: string;
+    try {
+      descriptor = descriptorFor(ctx, session.connectorId);
+      redirectUri = redirectUriFor(ctx);
+      tokenBundle = await descriptor.exchangeCode({
+        code,
+        codeVerifier: session.codeVerifier,
+        redirectUri,
+        state,
+      });
+    } catch (error) {
+      if (error instanceof OAuthExchangeError && error.redirectUriMismatch) {
+        const issuance = await publicResumeInfo(
+          ctx.db,
+          session.id,
+          new Date(),
+          true,
+          true,
+        );
+        if (!("stateNonce" in issuance)) {
+          return fullDto(ctx, issuance.session);
+        }
+        await requireDurableFlush(ctx, "completeConnectorOAuth");
+        return fullDto(ctx, issuance.session, authorizeUrlFor(ctx, issuance));
+      }
+      const failed = await markFailed(
+        ctx.db,
+        session.id,
+        error instanceof OAuthExchangeError ? error.code : "exchange-failed",
+        "Google authorization could not be completed.",
+      );
+      return fullDto(ctx, failed);
+    }
+
+    const dataSourceId = crypto.randomUUID();
+    await markVerifying(ctx.db, session.id, dataSourceId);
+    try {
+      // Probe against the plaintext bundle in process memory. No vault write or
+      // DataSource exists until this authenticated read succeeds.
+      const probe = makeGa4Connector(async (use) => use(tokenBundle));
+      await probe.connect();
+    } catch {
+      const failed = await markFailed(
+        ctx.db,
+        session.id,
+        "probe-failed",
+        "Google Analytics could not be verified.",
+      );
+      return fullDto(ctx, failed);
+    }
+
+    const app = ctx.wyStackApp;
+    if (!app) throw new Error("Connector setup app context is unavailable");
+    try {
+      // Direct canonical command call only. Never pass mode: "preview": the
+      // plaintext token bundle must go straight to storeCredential and can
+      // never enter proposedDefinition or a draft command log.
+      await app.call(
+        COMMAND_PATHS.CreateDataSource,
+        {
+          id: dataSourceId,
+          type: session.connectorId,
+          name: session.requestedName,
+          apiKey: tokenBundle,
+        },
+        { principal: ctx.principal },
+      );
+    } catch {
+      const failed = await markFailed(
+        ctx.db,
+        session.id,
+        "create-failed",
+        "The verified connection could not be saved.",
+      );
+      return fullDto(ctx, failed);
+    }
+
+    const connected = await markConnected(ctx.db, session.id, dataSourceId);
+    await requireDurableFlush(ctx, "completeConnectorOAuth");
+    return fullDto(ctx, connected);
+  });
+
+const cancelConnectorSetup = wy.procedure
+  .authorize(permissions.connectors.setup)
+  .input({ sessionId: uuid })
+  .mutation(async (ctx, { sessionId }) =>
+    fullDto(
+      ctx,
+      await markFailed(
+        ctx.db,
+        sessionId,
+        "cancelled",
+        "Connector setup was cancelled.",
+        new Date(),
+        ["awaiting-user-auth"],
+      ),
+    ),
+  );
+
+const sweepConnectorSetupSessions = wy.procedure
+  .authorize(permissions.connectors.setup)
+  .input({})
+  .mutation(async (ctx) => sweep(ctx.db));
+
+export function connectorSetupGateCode(error: unknown): string {
+  return error instanceof ConnectorSetupGateError
+    ? error.code
+    : "callback-failed";
+}
+
+export const connectorSetupFunctions = {
+  startConnectorSetup,
+  getConnectorSetupSession,
+  completeConnectorOAuth,
+  cancelConnectorSetup,
+  sweepConnectorSetupSessions,
+};

--- a/apps/server/src/functions/connector-setup.ts
+++ b/apps/server/src/functions/connector-setup.ts
@@ -347,10 +347,19 @@ const cancelConnectorSetup = wy.procedure
     ),
   );
 
+// The grace window comes from context, never from input: a client-settable
+// `graceMs: 0` would let anyone recover a session whose handler is still
+// running, which is the exact race the window exists to close. Only the host
+// process can set __bootSweep, and only startup can honestly claim that no
+// handler is alive.
 const sweepConnectorSetupSessions = wy.procedure
   .authorize(permissions.connectors.setup)
   .input({})
-  .mutation(async (ctx) => sweep(ctx.db));
+  .mutation(async (ctx) =>
+    ctx.__bootSweep === true
+      ? sweep(ctx.db, new Date(), 0)
+      : sweep(ctx.db, new Date()),
+  );
 
 export function connectorSetupGateCode(error: unknown): string {
   return error instanceof ConnectorSetupGateError

--- a/apps/server/src/functions/connector-setup.ts
+++ b/apps/server/src/functions/connector-setup.ts
@@ -11,11 +11,13 @@ import {
 import {
   ConnectorSetupGateError,
   consumeCallback,
+  effectiveState,
   markConnected,
   markFailed,
   markVerifying,
   oauthStateFor,
   publicResumeInfo,
+  readSession,
   startSession,
   sweep,
   type ConnectorSetupSessionRow,
@@ -88,7 +90,7 @@ function fullDto(
     sessionId: row.id,
     connectorId: row.connectorId,
     requestedName: row.requestedName,
-    state: row.state as ConnectorSetupState,
+    state: effectiveState(row),
     ...(authorizeUrl ? { authorizeUrl } : {}),
     resumeUrl: connectorResumeLink(ctx.getServerEndpoint(), row.id),
     ...(row.dataSourceId ? { dataSourceId: row.dataSourceId } : {}),
@@ -104,11 +106,10 @@ function publicDto(
   row: ConnectorSetupSessionRow,
   authorizeUrl?: string,
 ): PublicConnectorSetupResumeDto {
+  const reported = effectiveState(row);
   const state =
-    row.state === "connected" ||
-    row.state === "failed" ||
-    row.state === "expired"
-      ? row.state
+    reported === "connected" || reported === "failed" || reported === "expired"
+      ? reported
       : "awaiting-user-auth";
   return {
     sessionId: row.id,
@@ -175,25 +176,37 @@ const startConnectorSetup = wy.procedure
     return fullDto(ctx, issuance.session, authorizeUrl);
   });
 
+// A query that reads and nothing else. It cannot hand back an authorize URL:
+// minting one rotates the state nonce and the PKCE verifier, which is a write,
+// and a write hidden inside a query is invisible to callers, retried by any
+// transport that assumes queries are safe, and silently invalidates a resume
+// link that someone else is mid-flight on. Ask for a fresh URL explicitly
+// through `reissueConnectorSetupResume`.
 const getConnectorSetupSession = wy.procedure
   .authorize(permissions.connectors.setup)
   .input({ sessionId: uuid, publicResume: boolean.optional() })
   .query(async (ctx, { sessionId, publicResume }) => {
-    const issuance = await publicResumeInfo(
-      ctx.db,
-      sessionId,
-      new Date(),
-      publicResume === true,
-    );
-    const authorizeUrl =
-      "stateNonce" in issuance ? authorizeUrlFor(ctx, issuance) : undefined;
-    if ("stateNonce" in issuance) {
-      await requireDurableFlush(ctx, "getConnectorSetupSession");
-    }
-    return publicResume
-      ? publicDto(issuance.session, authorizeUrl)
-      : fullDto(ctx, issuance.session, authorizeUrl);
+    const row = await readSession(ctx.db, sessionId);
+    return publicResume ? publicDto(row) : fullDto(ctx, row);
   });
+
+/** Rotate the resume capability and return a usable authorize URL. */
+const reissueConnectorSetupResume = wy.procedure
+  .authorize(permissions.connectors.setup)
+  .input({ sessionId: uuid })
+  .mutation(
+    async (ctx, { sessionId }): Promise<PublicConnectorSetupResumeDto> => {
+      const issuance = await publicResumeInfo(ctx.db, sessionId, new Date());
+      if (!("stateNonce" in issuance)) {
+        return publicDto(issuance.session);
+      }
+      const authorizeUrl = authorizeUrlFor(ctx, issuance);
+      // An authorize URL whose rotated nonce is not yet durable is dead on
+      // arrival: the callback would arrive to a row still holding the old hash.
+      await requireDurableFlush(ctx, "reissueConnectorSetupResume");
+      return publicDto(issuance.session, authorizeUrl);
+    },
+  );
 
 const completeConnectorOAuth = wy.procedure
   .authorize(permissions.connectors.setup)
@@ -332,6 +345,7 @@ export function connectorSetupGateCode(error: unknown): string {
 export const connectorSetupFunctions = {
   startConnectorSetup,
   getConnectorSetupSession,
+  reissueConnectorSetupResume,
   completeConnectorOAuth,
   cancelConnectorSetup,
   sweepConnectorSetupSessions,

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -295,12 +295,9 @@ describe("dashframe serve CLI", () => {
         expect(options.accessCredentials).toBe(services.accessCredentials);
         expect(options.authToken).toBe("plaintext-token");
 
-        // This vault is scoped to `serve-token` only (see
-        // `createStandaloneSecretServices`) — `connector-key` deliberately
-        // has no default here, so a copied/relocated project can never end
-        // up with a connector-credential ref this host-local vault can't
-        // resolve. Desktop keeps `connector-key` on a project-scoped
-        // DrizzleMappingStore for the same reason.
+        // Named access tokens and connector credentials share the composed,
+        // encrypted standalone vault. No other credential class is routed to
+        // it implicitly.
         await services.vault!.store("serve-token-secret", {
           class: CREDENTIAL_CLASS.ServeToken,
         });
@@ -313,9 +310,25 @@ describe("dashframe serve CLI", () => {
           ),
         ).toBeDefined();
 
+        // Connector credentials now DO have a class default here: OAuth
+        // connector onboarding stores its token bundle through this same
+        // standalone vault. Assistant-provider remains the fail-closed class.
+        const connectorRef = await services.vault!.store("connector-secret", {
+          class: CREDENTIAL_CLASS.ConnectorKey,
+        });
         await expect(
-          services.vault!.store("connector-secret", {
-            class: CREDENTIAL_CLASS.ConnectorKey,
+          services.vault!.withSecret(connectorRef, async (value) => value),
+        ).resolves.toBe("connector-secret");
+        expect(
+          await fs.readdir(path.join(dataDir, "access-credentials", "blobs")),
+        ).toHaveLength(2);
+
+        // The registry is still registered WITHOUT `fallback: true`, so a
+        // class with no explicit default must keep throwing rather than land
+        // in this host-local vault.
+        await expect(
+          services.vault!.store("assistant-provider-secret", {
+            class: CREDENTIAL_CLASS.AssistantProvider,
           }),
         ).rejects.toThrow(/no fallback default/);
       } finally {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -24,6 +24,7 @@ import {
   type DashframeServerOptions,
 } from "./app";
 import { isLoopbackHost } from "./bind-host";
+import { readOptionalGoogleOAuthConfig } from "./connector-setup/oauth-provider";
 import {
   ENCRYPTED_FILE_BACKEND_NAME,
   EncryptedFileSecretBackend,
@@ -355,17 +356,16 @@ export async function createStandaloneSecretServices(
     keyring,
   );
   // Permanent mapping identifier: NEVER change after secrets may exist under it.
-  // Scoped to `serve-token` only (the brief's named class), and registered
-  // WITHOUT `fallback: true` — `SecretRegistry#getForClass` resolves
-  // registry-wide fallback ahead of an absent class default, so `fallback:
-  // true` would silently route `connector-key` and `assistant-provider`
-  // writes here too. Desktop keeps those classes on a project-scoped
-  // DrizzleMappingStore so credential refs travel with the copiable project
-  // DB; a class with no explicit default here must keep throwing rather than
-  // land in this host-local vault.
+  // Registered WITHOUT `fallback: true`: only explicitly configured classes
+  // may land in this host-local encrypted store. Assistant-provider remains
+  // fail-closed because it has no class default here.
   registry.register(ENCRYPTED_FILE_BACKEND_NAME, backend);
   registry.setClassDefault(
     CREDENTIAL_CLASS.ServeToken,
+    ENCRYPTED_FILE_BACKEND_NAME,
+  );
+  registry.setClassDefault(
+    CREDENTIAL_CLASS.ConnectorKey,
     ENCRYPTED_FILE_BACKEND_NAME,
   );
 
@@ -397,6 +397,7 @@ export function createStandaloneServerOptions(
     // Durable counterpart: used by the pre-release gate before deleting a vault
     // ref so the snapshot that drops the ref is confirmed on disk first.
     flushSnapshot: () => project.flushSnapshot(),
+    googleOAuth: readOptionalGoogleOAuthConfig(),
   };
 }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -364,6 +364,19 @@ export async function createStandaloneSecretServices(
     CREDENTIAL_CLASS.ServeToken,
     ENCRYPTED_FILE_BACKEND_NAME,
   );
+  // OAuth connector onboarding stores its token bundle through this vault, so
+  // connector keys need a default here or `serve` cannot complete a connection
+  // at all.
+  //
+  // Know what that inherits. This vault's mappings live in a host-local
+  // mappings.json under dataDir while the ref itself lives in the project DB,
+  // so unlike desktop — which uses DrizzleMappingStore and keeps ref, blob, and
+  // mapping inside one transactional boundary — a project copied or restored
+  // away from this host holds refs that no longer resolve. That split is
+  // pre-existing: serve tokens already sit on it. This line widens which
+  // credential classes it covers; it does not create it. Moving the serve path
+  // onto DrizzleMappingStore is the real fix and needs a migration for the
+  // mappings already written here.
   registry.setClassDefault(
     CREDENTIAL_CLASS.ConnectorKey,
     ENCRYPTED_FILE_BACKEND_NAME,

--- a/apps/server/src/permissions.test.ts
+++ b/apps/server/src/permissions.test.ts
@@ -19,10 +19,12 @@ describe("permissions", () => {
     );
     expect(permissions.commands.commit.id).toBe("commands.commit");
     expect(permissions.commands.preview.id).toBe("commands.preview");
+    expect(permissions.connectors.setup.id).toBe("connectors.setup");
     expect(expectedPermissionIds).toEqual([
       "accessCredentials.manage",
       "commands.commit",
       "commands.preview",
+      "connectors.setup",
     ]);
   });
 
@@ -37,6 +39,25 @@ describe("permissions", () => {
     const ctx = context({ kind: "service", credentialId: "credential-1" });
     await expect(
       evaluate(ctx.principal, permissions.accessCredentials.manage, ctx),
+    ).resolves.toBe(false);
+  });
+
+  it("allows connector setup for user and service principals", async () => {
+    for (const principal of [
+      { kind: "user" as const, userId: LOCAL_USER_ID },
+      { kind: "service" as const, credentialId: "credential-1" },
+    ]) {
+      const ctx = context(principal);
+      await expect(
+        evaluate(ctx.principal, permissions.connectors.setup, ctx),
+      ).resolves.toBe(true);
+    }
+  });
+
+  it("denies connector setup without a valid principal", async () => {
+    const ctx = context(undefined);
+    await expect(
+      evaluate(ctx.principal, permissions.connectors.setup, ctx),
     ).resolves.toBe(false);
   });
 

--- a/apps/server/src/permissions.ts
+++ b/apps/server/src/permissions.ts
@@ -56,6 +56,14 @@ export const permissions = definePermissions<AppContext>()({
       check: () => true,
     },
   },
+  connectors: {
+    setup: {
+      description: "Set up connector credentials",
+      check: (ctx) =>
+        isPrincipal(ctx.principal) &&
+        (ctx.principal.kind === "user" || ctx.principal.kind === "service"),
+    },
+  },
 });
 
 /** Boot-time snapshot guarding the public permission identifiers. */
@@ -63,4 +71,5 @@ export const expectedPermissionIds = [
   "accessCredentials.manage",
   "commands.commit",
   "commands.preview",
+  "connectors.setup",
 ] as const;

--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,7 @@
       },
       "dependencies": {
         "@dashframe/assistant": "workspace:*",
+        "@dashframe/connector-ga4": "workspace:*",
         "@dashframe/connector-notion": "workspace:*",
         "@dashframe/connector-postgres": "workspace:*",
         "@dashframe/engine": "workspace:*",
@@ -423,6 +424,7 @@
       "name": "@dashframe/app",
       "version": "0.1.0",
       "dependencies": {
+        "@dashframe/connector-ga4": "workspace:*",
         "@dashframe/connector-local": "workspace:*",
         "@dashframe/connector-notion": "workspace:*",
         "@dashframe/connector-postgres": "workspace:*",
@@ -504,6 +506,20 @@
         "@types/bun": "^1.2.0",
         "typescript": "5.7.2",
         "vitest": "^4.1.6",
+      },
+    },
+    "packages/connector-ga4": {
+      "name": "@dashframe/connector-ga4",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dashframe/engine": "workspace:*",
+        "@dashframe/types": "workspace:*",
+        "apache-arrow": "^21.1.0",
+      },
+      "devDependencies": {
+        "@dashframe/eslint-config": "workspace:*",
+        "typescript": "5.7.2",
+        "vitest": "^4.0.16",
       },
     },
     "packages/connector-local": {
@@ -944,6 +960,8 @@
     "@dashframe/app": ["@dashframe/app@workspace:packages/app"],
 
     "@dashframe/assistant": ["@dashframe/assistant@workspace:packages/assistant"],
+
+    "@dashframe/connector-ga4": ["@dashframe/connector-ga4@workspace:packages/connector-ga4"],
 
     "@dashframe/connector-local": ["@dashframe/connector-local@workspace:packages/connector-local"],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dashframe/connector-ga4": "workspace:*",
     "@dashframe/connector-local": "workspace:*",
     "@dashframe/connector-notion": "workspace:*",
     "@dashframe/connector-postgres": "workspace:*",

--- a/packages/app/src/components/data-sources/AddConnectionPanel.test.tsx
+++ b/packages/app/src/components/data-sources/AddConnectionPanel.test.tsx
@@ -66,6 +66,7 @@ function renderPanel() {
     <AddConnectionPanel
       onFileSelect={vi.fn()}
       onConnect={vi.fn().mockResolvedValue(undefined)}
+      onOAuthConnect={vi.fn().mockResolvedValue(undefined)}
     />,
   );
 }

--- a/packages/app/src/components/data-sources/AddConnectionPanel.tsx
+++ b/packages/app/src/components/data-sources/AddConnectionPanel.tsx
@@ -32,6 +32,11 @@ export interface AddConnectionPanelProps {
     connector: RemoteApiConnector,
     credentials: Record<string, unknown>,
   ) => Promise<void>;
+  /** Called after an OAuth connector reaches the connected terminal state. */
+  onOAuthConnect: (
+    connector: RemoteApiConnector,
+    dataSourceId: string,
+  ) => Promise<void>;
 }
 
 /**
@@ -50,6 +55,7 @@ export function AddConnectionPanel({
   error,
   onFileSelect,
   onConnect,
+  onOAuthConnect,
 }: AddConnectionPanelProps) {
   const { data: catalog, isLoading, isError, refetch } = useConnectorCatalog();
 
@@ -100,6 +106,7 @@ export function AddConnectionPanel({
             connector={connector}
             onFileSelect={onFileSelect}
             onConnect={onConnect}
+            onOAuthConnect={onOAuthConnect}
           />
         ))}
       </div>

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -125,8 +125,8 @@ export function DataPickerContent({
   const { mutateAsync: listGa4PropertiesMutation } = useMutation(
     api.listGa4Properties,
   );
-  const { mutateAsync: queryGa4ReportMutation } = useMutation(
-    api.queryGa4Report,
+  const { mutateAsync: queryGa4PropertyMutation } = useMutation(
+    api.queryGa4Property,
   );
   const confirm = useConfirmDialogStore((state) => state.confirm);
 
@@ -363,9 +363,10 @@ export function DataPickerContent({
             tableId,
           });
         } else {
-          result = await queryGa4ReportMutation({
+          // The property is read from the DataTable row just created above,
+          // so it cannot drift from the resource the user picked.
+          result = await queryGa4PropertyMutation({
             dataSourceId: remoteResourceState.sourceId,
-            propertyId: resource.id,
             tableId,
           });
         }
@@ -419,7 +420,7 @@ export function DataPickerContent({
       addDataTable,
       onTableSelect,
       queryPostgresTableMutation,
-      queryGa4ReportMutation,
+      queryGa4PropertyMutation,
       confirm,
       remoteResourceState,
       removeDataTable,

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -122,6 +122,12 @@ export function DataPickerContent({
   const { mutateAsync: queryPostgresTableMutation } = useMutation(
     api.queryPostgresTable,
   );
+  const { mutateAsync: listGa4PropertiesMutation } = useMutation(
+    api.listGa4Properties,
+  );
+  const { mutateAsync: queryGa4ReportMutation } = useMutation(
+    api.queryGa4Report,
+  );
   const confirm = useConfirmDialogStore((state) => state.confirm);
 
   // Local state
@@ -313,6 +319,21 @@ export function DataPickerContent({
     ],
   );
 
+  const handleOAuthConnect = useCallback(
+    async (connector: RemoteApiConnector, dataSourceId: string) => {
+      if (connector.id !== "googleAnalytics") {
+        throw new Error(`${connector.name} OAuth onboarding is not supported`);
+      }
+      setError(null);
+      setRemoteResourceState({
+        connectorId: "googleAnalytics",
+        sourceId: dataSourceId,
+        resources: await listGa4PropertiesMutation({ dataSourceId }),
+      });
+    },
+    [listGa4PropertiesMutation],
+  );
+
   const handleRemoteResourceSelect = useCallback(
     async (resource: { id: string; title: string }) => {
       if (!remoteResourceState) return;
@@ -328,18 +349,26 @@ export function DataPickerContent({
             table: resource.id,
           })
         ).id;
-        const result =
-          remoteResourceState.connectorId === "notion"
-            ? await queryNotionDatabaseMutation({
-                dataSourceId: remoteResourceState.sourceId,
-                databaseId: resource.id,
-                tableId,
-              })
-            : await queryPostgresTableMutation({
-                dataSourceId: remoteResourceState.sourceId,
-                databaseId: resource.id,
-                tableId,
-              });
+        let result;
+        if (remoteResourceState.connectorId === "notion") {
+          result = await queryNotionDatabaseMutation({
+            dataSourceId: remoteResourceState.sourceId,
+            databaseId: resource.id,
+            tableId,
+          });
+        } else if (remoteResourceState.connectorId === "postgres") {
+          result = await queryPostgresTableMutation({
+            dataSourceId: remoteResourceState.sourceId,
+            databaseId: resource.id,
+            tableId,
+          });
+        } else {
+          result = await queryGa4ReportMutation({
+            dataSourceId: remoteResourceState.sourceId,
+            propertyId: resource.id,
+            tableId,
+          });
+        }
         const explicitlySensitive = result.fields.some(
           (field) => getFieldSensitivity(field) === "sensitive",
         );
@@ -390,6 +419,7 @@ export function DataPickerContent({
       addDataTable,
       onTableSelect,
       queryPostgresTableMutation,
+      queryGa4ReportMutation,
       confirm,
       remoteResourceState,
       removeDataTable,
@@ -449,6 +479,7 @@ export function DataPickerContent({
               error={error}
               onFileSelect={handleFileSelect}
               onConnect={handleConnect}
+              onOAuthConnect={handleOAuthConnect}
             />
           </SectionList>
         )}

--- a/packages/app/src/components/data-sources/renderers/ConnectorCard.tsx
+++ b/packages/app/src/components/data-sources/renderers/ConnectorCard.tsx
@@ -56,6 +56,16 @@ export function ConnectorCard({
   const fileConnector = isFileConnector
     ? (connector as FileSourceConnector)
     : null;
+  let connectButtonLabel = "Connect";
+  if (connector.authKind === "oauth") {
+    connectButtonLabel = "Sign in with Google";
+  }
+  if (isLoading) {
+    connectButtonLabel =
+      connector.authKind === "oauth"
+        ? "Waiting for Google..."
+        : "Connecting...";
+  }
 
   return (
     <Card className="overflow-hidden">
@@ -99,7 +109,7 @@ export function ConnectorCard({
         {/* Connect button for remote-api connectors */}
         {connector.sourceType === "remote-api" && (
           <Button
-            label={isLoading ? "Connecting..." : "Connect"}
+            label={connectButtonLabel}
             onClick={onConnect}
             disabled={isLoading}
             className="w-full"

--- a/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
+++ b/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
@@ -8,6 +8,7 @@ import {
   type FileSourceConnector,
   type RemoteApiConnector,
 } from "@dashframe/engine";
+import { useEffect, useRef } from "react";
 import { ConnectorCard } from "./ConnectorCard";
 import { FormFieldRenderer } from "./FormFieldRenderer";
 
@@ -38,8 +39,23 @@ interface ConnectorCardWithFormProps {
 const POLL_INTERVAL_MS = 2_000;
 const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
 
-function waitForPoll(): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, POLL_INTERVAL_MS));
+/**
+ * Ownership handle for an in-flight OAuth poll.
+ *
+ * The poll outlives the click that started it — up to POLL_TIMEOUT_MS — so the
+ * component needs a way to stop it on unmount. Without one the loop keeps
+ * querying the server for fifteen minutes after the card is gone and then calls
+ * onOAuthConnect on a tree that no longer exists.
+ */
+interface PollToken {
+  cancelled: boolean;
+  timer?: number;
+}
+
+function waitForPoll(token: PollToken): Promise<void> {
+  return new Promise((resolve) => {
+    token.timer = window.setTimeout(resolve, POLL_INTERVAL_MS);
+  });
 }
 
 function openAuthorizationWindow(): Window | null {
@@ -54,10 +70,35 @@ function openAuthorizationWindow(): Window | null {
   return authWindow;
 }
 
+/**
+ * Interpret one poll result. Returns true when the flow has reached a terminal
+ * state and the loop should stop; throws when that state is a failure.
+ */
+async function settleOAuthPoll(
+  current: { state: string; dataSourceId?: string; failureMessage?: string },
+  connector: RemoteApiConnector,
+  onOAuthConnect: ConnectorCardWithFormProps["onOAuthConnect"],
+): Promise<boolean> {
+  if (current.state === "connected") {
+    if (!current.dataSourceId) {
+      throw new Error("Connected source id is missing");
+    }
+    await onOAuthConnect(connector, current.dataSourceId);
+    return true;
+  }
+  if (current.state === "failed" || current.state === "expired") {
+    throw new Error(
+      current.failureMessage ?? "Google authorization did not complete",
+    );
+  }
+  return false;
+}
+
 async function pollOAuthCompletion(
   connector: RemoteApiConnector,
   sessionId: string,
   onOAuthConnect: ConnectorCardWithFormProps["onOAuthConnect"],
+  token: PollToken,
 ): Promise<void> {
   const client = getWyStackClient();
   for (
@@ -65,24 +106,15 @@ async function pollOAuthCompletion(
     elapsed < POLL_TIMEOUT_MS;
     elapsed += POLL_INTERVAL_MS
   ) {
-    await waitForPoll();
+    await waitForPoll(token);
+    if (token.cancelled) return;
     const current = await client.query(api.getConnectorSetupSession, {
       sessionId,
     });
-    if (current.state === "connected") {
-      const dataSourceId =
-        "dataSourceId" in current ? current.dataSourceId : undefined;
-      if (!dataSourceId) throw new Error("Connected source id is missing");
-      await onOAuthConnect(connector, dataSourceId);
-      return;
-    }
-    if (current.state === "failed" || current.state === "expired") {
-      const failureMessage =
-        "failureMessage" in current ? current.failureMessage : undefined;
-      throw new Error(
-        failureMessage ?? "Google authorization did not complete",
-      );
-    }
+    // Checked again after the round trip: the component can unmount while the
+    // query is in flight, and onOAuthConnect updates parent state.
+    if (token.cancelled) return;
+    if (await settleOAuthPoll(current, connector, onOAuthConnect)) return;
   }
   throw new Error("Google authorization timed out");
 }
@@ -90,6 +122,7 @@ async function pollOAuthCompletion(
 async function runOAuthSetup(
   connector: RemoteApiConnector,
   onOAuthConnect: ConnectorCardWithFormProps["onOAuthConnect"],
+  token: PollToken,
 ): Promise<void> {
   const client = getWyStackClient();
   const authWindow = openAuthorizationWindow();
@@ -116,7 +149,12 @@ async function runOAuthSetup(
     );
   }
   authWindow.location.replace(session.authorizeUrl);
-  await pollOAuthCompletion(connector, session.sessionId, onOAuthConnect);
+  await pollOAuthCompletion(
+    connector,
+    session.sessionId,
+    onOAuthConnect,
+    token,
+  );
 }
 
 /**
@@ -146,6 +184,15 @@ export function ConnectorCardWithForm({
   const { form, formFields, execute, isSubmitting, submitError } =
     useConnectorForm(connector);
 
+  const pollToken = useRef<PollToken>({ cancelled: false });
+  useEffect(() => {
+    const token = pollToken.current;
+    return () => {
+      token.cancelled = true;
+      if (token.timer !== undefined) window.clearTimeout(token.timer);
+    };
+  }, []);
+
   const handleFileSelect = (file: File) => {
     // Type guard with graceful recovery: if type mismatch occurs (e.g., bad data
     // from storage), log error and return instead of crashing the UI
@@ -170,7 +217,10 @@ export function ConnectorCardWithForm({
       return;
     }
     if (connector.authKind === "oauth") {
-      await execute(() => runOAuthSetup(connector, onOAuthConnect));
+      pollToken.current.cancelled = false;
+      await execute(() =>
+        runOAuthSetup(connector, onOAuthConnect, pollToken.current),
+      );
       return;
     }
 

--- a/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
+++ b/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
@@ -1,4 +1,6 @@
 import { useConnectorForm } from "@/hooks/useConnectorForm";
+import { api } from "@/wystack/api";
+import { getWyStackClient } from "@/wystack/client";
 import {
   isFileConnector,
   isRemoteApiConnector,
@@ -27,6 +29,94 @@ interface ConnectorCardWithFormProps {
     connector: RemoteApiConnector,
     credentials: Record<string, unknown>,
   ) => Promise<void>;
+  onOAuthConnect: (
+    connector: RemoteApiConnector,
+    dataSourceId: string,
+  ) => Promise<void>;
+}
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 15 * 60 * 1_000;
+
+function waitForPoll(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, POLL_INTERVAL_MS));
+}
+
+function openAuthorizationWindow(): Window | null {
+  // Open synchronously from the click so browser popup policy cannot discard
+  // the authorization window while the start call is in flight.
+  const authWindow = window.open("about:blank", "_blank");
+  if (!authWindow) return null;
+  authWindow.opener = null;
+  authWindow.document.head.innerHTML =
+    '<meta name="referrer" content="no-referrer">';
+  authWindow.document.body.textContent = "Preparing Google authorization…";
+  return authWindow;
+}
+
+async function pollOAuthCompletion(
+  connector: RemoteApiConnector,
+  sessionId: string,
+  onOAuthConnect: ConnectorCardWithFormProps["onOAuthConnect"],
+): Promise<void> {
+  const client = getWyStackClient();
+  for (
+    let elapsed = 0;
+    elapsed < POLL_TIMEOUT_MS;
+    elapsed += POLL_INTERVAL_MS
+  ) {
+    await waitForPoll();
+    const current = await client.query(api.getConnectorSetupSession, {
+      sessionId,
+    });
+    if (current.state === "connected") {
+      const dataSourceId =
+        "dataSourceId" in current ? current.dataSourceId : undefined;
+      if (!dataSourceId) throw new Error("Connected source id is missing");
+      await onOAuthConnect(connector, dataSourceId);
+      return;
+    }
+    if (current.state === "failed" || current.state === "expired") {
+      const failureMessage =
+        "failureMessage" in current ? current.failureMessage : undefined;
+      throw new Error(
+        failureMessage ?? "Google authorization did not complete",
+      );
+    }
+  }
+  throw new Error("Google authorization timed out");
+}
+
+async function runOAuthSetup(
+  connector: RemoteApiConnector,
+  onOAuthConnect: ConnectorCardWithFormProps["onOAuthConnect"],
+): Promise<void> {
+  const client = getWyStackClient();
+  const authWindow = openAuthorizationWindow();
+  let session: { sessionId: string; authorizeUrl?: string };
+  try {
+    session = await client.mutate(api.startConnectorSetup, {
+      connectorId: connector.id,
+      requestedName: connector.name,
+    });
+  } catch (error) {
+    authWindow?.close();
+    throw error;
+  }
+  if (!session.authorizeUrl) {
+    authWindow?.close();
+    throw new Error("Google authorization URL was not issued");
+  }
+  if (!authWindow) {
+    await client.mutate(api.cancelConnectorSetup, {
+      sessionId: session.sessionId,
+    });
+    throw new Error(
+      "Google sign-in was blocked. Allow popups for DashFrame and try again.",
+    );
+  }
+  authWindow.location.replace(session.authorizeUrl);
+  await pollOAuthCompletion(connector, session.sessionId, onOAuthConnect);
 }
 
 /**
@@ -50,6 +140,7 @@ export function ConnectorCardWithForm({
   connector,
   onFileSelect,
   onConnect,
+  onOAuthConnect,
 }: ConnectorCardWithFormProps) {
   // Hook called at component top level - safe!
   const { form, formFields, execute, isSubmitting, submitError } =
@@ -78,6 +169,11 @@ export function ConnectorCardWithForm({
       );
       return;
     }
+    if (connector.authKind === "oauth") {
+      await execute(() => runOAuthSetup(connector, onOAuthConnect));
+      return;
+    }
+
     // The renderer must NOT call connector.connect()/query() — those resolve the
     // credential and hit the remote API SERVER-SIDE (the renderer-registered
     // resolver throws by design). execute() validates the form and returns the

--- a/packages/app/src/components/providers/ConnectorSetup.tsx
+++ b/packages/app/src/components/providers/ConnectorSetup.tsx
@@ -1,5 +1,6 @@
 import { useConnectorCatalog } from "@/data/connector-catalog";
 import { hydrateConnectorRegistry } from "@/lib/connectors/registry";
+import { makeGa4Connector } from "@dashframe/connector-ga4";
 import { localFileConnector } from "@dashframe/connector-local";
 import { makeNotionConnector } from "@dashframe/connector-notion";
 import { makePostgresConnector } from "@dashframe/connector-postgres";
@@ -23,10 +24,18 @@ const postgresConnectorForRegistry = makePostgresConnector(() => {
   );
 }, {});
 
+const ga4ConnectorForRegistry = makeGa4Connector(() => {
+  throw new Error(
+    "[connector-registry] connect()/query() must not be called from the renderer — " +
+      "use the WyStack server mutations instead.",
+  );
+});
+
 const CONNECTOR_FACTORIES: Record<string, () => AnyConnector> = {
   local: () => localFileConnector,
   notion: () => notionConnectorForRegistry,
   postgres: () => postgresConnectorForRegistry,
+  googleAnalytics: () => ga4ConnectorForRegistry,
 };
 
 /**

--- a/packages/app/src/lib/connectors/registry.test.ts
+++ b/packages/app/src/lib/connectors/registry.test.ts
@@ -15,6 +15,7 @@
  * - Known connector kinds (local, notion) are resolvable after registration
  */
 
+import { makeGa4Connector } from "@dashframe/connector-ga4";
 import { localFileConnector } from "@dashframe/connector-local";
 import { makeNotionConnector } from "@dashframe/connector-notion";
 import type { AnyConnector } from "@dashframe/engine";
@@ -34,6 +35,9 @@ import {
 // Static-metadata connector for registry tests — resolver throws if called
 // (connect/query must never be invoked from the renderer)
 const notionConnector = makeNotionConnector(() => {
+  throw new Error("connect/query must not be called from the renderer");
+});
+const ga4Connector = makeGa4Connector(() => {
   throw new Error("connect/query must not be called from the renderer");
 });
 
@@ -280,6 +284,21 @@ describe("connector registry", () => {
       // Same id re-registration does not bump version (registerConnector contract)
       expect(getRegistryVersion()).toBe(v);
       expect(getConnectorById("local")).toBe(c2);
+    });
+
+    it("hydrates Google Analytics when the server catalog advertises it", () => {
+      hydrateConnectorRegistry(
+        [
+          {
+            ...makeCatalogEntry("googleAnalytics", "remote-api"),
+            authKind: "oauth",
+          },
+        ],
+        { googleAnalytics: () => ga4Connector },
+      );
+
+      expect(getConnectorById("googleAnalytics")).toBe(ga4Connector);
+      expect(getConnectorById("googleAnalytics")?.authKind).toBe("oauth");
     });
   });
 

--- a/packages/app/src/lib/remote-connector-onboarding.ts
+++ b/packages/app/src/lib/remote-connector-onboarding.ts
@@ -1,6 +1,9 @@
 import type { CreateDataSourceInput, UUID } from "@dashframe/types";
 
-export type SupportedRemoteConnectorId = "notion" | "postgres";
+export type SupportedRemoteConnectorId =
+  | "notion"
+  | "postgres"
+  | "googleAnalytics";
 
 export interface RemoteResource {
   id: string;
@@ -8,7 +11,7 @@ export interface RemoteResource {
 }
 
 interface ConnectRemoteSourceOptions {
-  connectorId: SupportedRemoteConnectorId;
+  connectorId: Exclude<SupportedRemoteConnectorId, "googleAnalytics">;
   connectorName: string;
   credentials: Record<string, unknown>;
   addSource: (input: CreateDataSourceInput) => Promise<UUID>;

--- a/packages/connector-ga4/package.json
+++ b/packages/connector-ga4/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dashframe/connector-ga4",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "tsc -w -p tsconfig.json --preserveWatchOutput",
+    "lint": "eslint src",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@dashframe/engine": "workspace:*",
+    "@dashframe/types": "workspace:*",
+    "apache-arrow": "^21.1.0"
+  },
+  "devDependencies": {
+    "@dashframe/eslint-config": "workspace:*",
+    "typescript": "5.7.2",
+    "vitest": "^4.0.16"
+  }
+}

--- a/packages/connector-ga4/src/connector.test.ts
+++ b/packages/connector-ga4/src/connector.test.ts
@@ -1,0 +1,136 @@
+import { tableFromIPC } from "apache-arrow";
+import { describe, expect, it, vi } from "vitest";
+
+import { makeGa4Connector, type GoogleOAuthTokenBundle } from "./connector";
+
+function resolver(bundle: GoogleOAuthTokenBundle) {
+  return async <T>(use: (plaintext: string) => Promise<T>) =>
+    use(JSON.stringify(bundle));
+}
+
+function bundle(overrides: Partial<GoogleOAuthTokenBundle> = {}) {
+  return {
+    version: 1 as const,
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresAt: Date.parse("2026-08-05T13:00:00Z"),
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    scopes: ["https://www.googleapis.com/auth/analytics.readonly"],
+    ...overrides,
+  };
+}
+
+describe("GA4 connector", () => {
+  it("lists every accessible property with a bearer header", async () => {
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        expect(new Headers(init?.headers).get("Authorization")).toBe(
+          "Bearer access-token",
+        );
+        return new Response(
+          JSON.stringify({
+            accountSummaries: [
+              {
+                propertySummaries: [
+                  { property: "properties/123", displayName: "Store" },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      },
+    );
+    const connector = makeGa4Connector(resolver(bundle()), {
+      fetch: fetchImpl as typeof fetch,
+      now: () => Date.parse("2026-08-05T12:00:00Z"),
+    });
+    await expect(connector.connect()).resolves.toEqual([
+      { id: "properties/123", name: "Store" },
+    ]);
+  });
+
+  it("refreshes an expired access token before the authenticated read", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "fresh-token" }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accountSummaries: [] }), { status: 200 }),
+      );
+    const connector = makeGa4Connector(
+      resolver(bundle({ expiresAt: Date.parse("2026-08-05T11:00:00Z") })),
+      {
+        fetch: fetchImpl as typeof fetch,
+        now: () => Date.parse("2026-08-05T12:00:00Z"),
+      },
+    );
+    await connector.connect();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(
+      new Headers(fetchImpl.mock.calls[1]?.[1]?.headers).get("Authorization"),
+    ).toBe("Bearer fresh-token");
+  });
+
+  it("runs the bounded default report and returns aligned Arrow data", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            dimensionHeaders: [{ name: "date" }],
+            metricHeaders: [{ name: "activeUsers", type: "TYPE_INTEGER" }],
+            rows: [
+              {
+                dimensionValues: [{ value: "20260804" }],
+                metricValues: [{ value: "42" }],
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    const connector = makeGa4Connector(resolver(bundle()), {
+      fetch: fetchImpl as typeof fetch,
+      now: () => Date.parse("2026-08-05T12:00:00Z"),
+    });
+    const result = await connector.query(
+      "properties/123",
+      crypto.randomUUID(),
+      { pagination: { offset: 0, limit: 25 } },
+    );
+    const arrow = tableFromIPC(Buffer.from(result.arrowBuffer, "base64"));
+    expect(result.rowCount).toBe(1);
+    expect(result.fields.map((field) => field.name)).toEqual([
+      "date",
+      "activeUsers",
+    ]);
+    expect(result.fields.map((field) => field.type)).toEqual([
+      "date",
+      "number",
+    ]);
+    expect(String(arrow.schema.fields[0]?.type)).toContain("Timestamp");
+    expect(arrow.numRows).toBe(1);
+    expect(
+      JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)),
+    ).toMatchObject({
+      offset: "0",
+      limit: "25",
+    });
+  });
+
+  it("rejects a property id that could alter the Google request path", async () => {
+    const connector = makeGa4Connector(resolver(bundle()), {
+      fetch: vi.fn() as typeof fetch,
+    });
+    await expect(
+      connector.query(
+        "properties/123:runReport?token=leak",
+        crypto.randomUUID(),
+      ),
+    ).rejects.toThrow(/Invalid GA4 property id/);
+  });
+});

--- a/packages/connector-ga4/src/connector.test.ts
+++ b/packages/connector-ga4/src/connector.test.ts
@@ -15,11 +15,13 @@ function bundle(overrides: Partial<GoogleOAuthTokenBundle> = {}) {
     refreshToken: "refresh-token",
     expiresAt: Date.parse("2026-08-05T13:00:00Z"),
     clientId: "client-id",
-    clientSecret: "client-secret",
     scopes: ["https://www.googleapis.com/auth/analytics.readonly"],
     ...overrides,
   };
 }
+
+/** Client credentials the host supplies at call time, never persisted. */
+const oauthClient = { clientId: "client-id", clientSecret: "client-secret" };
 
 describe("GA4 connector", () => {
   it("lists every accessible property with a bearer header", async () => {
@@ -67,6 +69,7 @@ describe("GA4 connector", () => {
       {
         fetch: fetchImpl as typeof fetch,
         now: () => Date.parse("2026-08-05T12:00:00Z"),
+        oauthClient,
       },
     );
     await connector.connect();
@@ -132,5 +135,72 @@ describe("GA4 connector", () => {
         crypto.randomUUID(),
       ),
     ).rejects.toThrow(/Invalid GA4 property id/);
+  });
+
+  // The client secret is server-wide config, not per-source data, so it reaches
+  // the refresh request from the host at call time rather than from the stored
+  // bundle. These pin that the wire request is still correctly authenticated,
+  // and that a missing or mismatched client fails closed instead of silently
+  // sending an unauthenticated refresh.
+  describe("token refresh client credentials", () => {
+    const expired = { expiresAt: Date.parse("2026-08-05T11:00:00Z") };
+    const now = () => Date.parse("2026-08-05T12:00:00Z");
+
+    it("sends the host-supplied client secret, which is absent from the bundle", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "fresh-token" }), {
+            status: 200,
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ accountSummaries: [] }), {
+            status: 200,
+          }),
+        );
+      const stored = bundle(expired);
+      expect(stored).not.toHaveProperty("clientSecret");
+
+      const connector = makeGa4Connector(resolver(stored), {
+        fetch: fetchImpl as typeof fetch,
+        now,
+        oauthClient,
+      });
+      await connector.connect();
+
+      const body = new URLSearchParams(
+        String(fetchImpl.mock.calls[0]?.[1]?.body),
+      );
+      expect(body.get("client_secret")).toBe(oauthClient.clientSecret);
+      expect(body.get("client_id")).toBe(oauthClient.clientId);
+      expect(body.get("grant_type")).toBe("refresh_token");
+    });
+
+    it("fails closed when the host has no OAuth client configured", async () => {
+      const fetchImpl = vi.fn();
+      const connector = makeGa4Connector(resolver(bundle(expired)), {
+        fetch: fetchImpl as unknown as typeof fetch,
+        now,
+      });
+      await expect(connector.connect()).rejects.toThrow(/not configured/);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("refuses to renew a grant minted by a different OAuth client", async () => {
+      const fetchImpl = vi.fn();
+      const connector = makeGa4Connector(
+        resolver(bundle({ ...expired, clientId: "retired-client" })),
+        {
+          fetch: fetchImpl as unknown as typeof fetch,
+          now,
+          oauthClient,
+        },
+      );
+      await expect(connector.connect()).rejects.toThrow(
+        /different OAuth client/,
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/connector-ga4/src/connector.test.ts
+++ b/packages/connector-ga4/src/connector.test.ts
@@ -187,6 +187,84 @@ describe("GA4 connector", () => {
       expect(fetchImpl).not.toHaveBeenCalled();
     });
 
+    it("persists the renewed bundle so the next call does not refresh again", async () => {
+      // A mutable store standing in for the vault entry: persist writes to it,
+      // and the resolver reads whatever is currently there.
+      let stored = JSON.stringify(bundle(expired));
+      const persistTokenBundle = vi.fn(async (next: GoogleOAuthTokenBundle) => {
+        stored = JSON.stringify(next);
+      });
+      const fetchImpl = vi.fn(async (url: string | URL) =>
+        String(url).includes("oauth2.googleapis.com")
+          ? new Response(
+              JSON.stringify({ access_token: "fresh-token", expires_in: 3600 }),
+              { status: 200 },
+            )
+          : new Response(JSON.stringify({ accountSummaries: [] }), {
+              status: 200,
+            }),
+      );
+      const connector = makeGa4Connector(
+        async <T>(use: (plaintext: string) => Promise<T>) => use(stored),
+        {
+          fetch: fetchImpl as unknown as typeof fetch,
+          now,
+          persistTokenBundle,
+          oauthClient,
+        },
+      );
+
+      await connector.connect();
+      expect(persistTokenBundle).toHaveBeenCalledTimes(1);
+      const saved = JSON.parse(stored) as GoogleOAuthTokenBundle;
+      expect(saved.accessToken).toBe("fresh-token");
+      expect(saved.expiresAt).toBe(now() + 3600_000);
+      // Google returned no new refresh token, so the existing grant is kept.
+      expect(saved.refreshToken).toBe("refresh-token");
+      expect(saved).not.toHaveProperty("clientSecret");
+
+      // The whole point: the second call is already inside the new expiry
+      // window, so it must not spend another refresh grant.
+      fetchImpl.mockClear();
+      await connector.connect();
+      expect(persistTokenBundle).toHaveBeenCalledTimes(1);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(String(fetchImpl.mock.calls[0]?.[0])).not.toContain(
+        "oauth2.googleapis.com",
+      );
+    });
+
+    it("still serves the request when the write-back fails", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "fresh-token" }), {
+            status: 200,
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ accountSummaries: [] }), {
+            status: 200,
+          }),
+        );
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const connector = makeGa4Connector(resolver(bundle(expired)), {
+        fetch: fetchImpl as typeof fetch,
+        now,
+        oauthClient,
+        persistTokenBundle: async () => {
+          throw new Error("vault unavailable");
+        },
+      });
+
+      // The token in hand is valid; only storing it failed.
+      await expect(connector.connect()).resolves.toEqual([]);
+      expect(
+        new Headers(fetchImpl.mock.calls[1]?.[1]?.headers).get("Authorization"),
+      ).toBe("Bearer fresh-token");
+      warn.mockRestore();
+    });
+
     it("refuses to renew a grant minted by a different OAuth client", async () => {
       const fetchImpl = vi.fn();
       const connector = makeGa4Connector(

--- a/packages/connector-ga4/src/connector.test.ts
+++ b/packages/connector-ga4/src/connector.test.ts
@@ -194,8 +194,13 @@ describe("GA4 connector", () => {
       const persistTokenBundle = vi.fn(async (next: GoogleOAuthTokenBundle) => {
         stored = JSON.stringify(next);
       });
+      // Matched on the parsed origin, not a substring: a substring test would
+      // also match a host that merely contains this one, which is the same
+      // mistake that makes real host checks exploitable.
+      const isTokenEndpoint = (url: string | URL) =>
+        new URL(String(url)).origin === "https://oauth2.googleapis.com";
       const fetchImpl = vi.fn(async (url: string | URL) =>
-        String(url).includes("oauth2.googleapis.com")
+        isTokenEndpoint(url)
           ? new Response(
               JSON.stringify({ access_token: "fresh-token", expires_in: 3600 }),
               { status: 200 },
@@ -229,8 +234,8 @@ describe("GA4 connector", () => {
       await connector.connect();
       expect(persistTokenBundle).toHaveBeenCalledTimes(1);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
-      expect(String(fetchImpl.mock.calls[0]?.[0])).not.toContain(
-        "oauth2.googleapis.com",
+      expect(new URL(String(fetchImpl.mock.calls[0]?.[0])).origin).not.toBe(
+        "https://oauth2.googleapis.com",
       );
     });
 

--- a/packages/connector-ga4/src/connector.ts
+++ b/packages/connector-ga4/src/connector.ts
@@ -1,0 +1,311 @@
+import type {
+  ConnectorQueryResult,
+  FormField,
+  QueryOptions,
+  RemoteDatabase,
+  SecretResolver,
+  UUID,
+  ValidationResult,
+} from "@dashframe/engine";
+import { RemoteApiConnector, createFieldsFromColumns } from "@dashframe/engine";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+
+export interface GoogleOAuthTokenBundle {
+  version: 1;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  clientId: string;
+  clientSecret?: string;
+  scopes: string[];
+}
+
+interface GoogleTokenResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+}
+
+interface AccountSummariesResponse {
+  accountSummaries?: Array<{
+    propertySummaries?: Array<{ property?: unknown; displayName?: unknown }>;
+  }>;
+  nextPageToken?: unknown;
+}
+
+interface RunReportResponse {
+  dimensionHeaders?: Array<{ name?: unknown }>;
+  metricHeaders?: Array<{ name?: unknown; type?: unknown }>;
+  rows?: Array<{
+    dimensionValues?: Array<{ value?: unknown }>;
+    metricValues?: Array<{ value?: unknown }>;
+  }>;
+}
+
+export interface Ga4ConnectorDependencies {
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
+function parseTokenBundle(raw: string): GoogleOAuthTokenBundle {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("[GA4Connector] Stored Google credential is malformed");
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    (parsed as { version?: unknown }).version !== 1 ||
+    typeof (parsed as { accessToken?: unknown }).accessToken !== "string" ||
+    typeof (parsed as { refreshToken?: unknown }).refreshToken !== "string" ||
+    typeof (parsed as { expiresAt?: unknown }).expiresAt !== "number" ||
+    typeof (parsed as { clientId?: unknown }).clientId !== "string" ||
+    !Array.isArray((parsed as { scopes?: unknown }).scopes)
+  ) {
+    throw new Error("[GA4Connector] Stored Google credential is incomplete");
+  }
+  const bundle = parsed as GoogleOAuthTokenBundle;
+  if (!bundle.scopes.every((scope) => typeof scope === "string")) {
+    throw new Error(
+      "[GA4Connector] Stored Google credential scopes are invalid",
+    );
+  }
+  return bundle;
+}
+
+async function refreshAccessToken(
+  bundle: GoogleOAuthTokenBundle,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  if (!bundle.refreshToken) {
+    throw new Error("[GA4Connector] Google authorization must be renewed");
+  }
+  const body = new URLSearchParams({
+    client_id: bundle.clientId,
+    refresh_token: bundle.refreshToken,
+    grant_type: "refresh_token",
+  });
+  if (bundle.clientSecret) body.set("client_secret", bundle.clientSecret);
+  const response = await fetchImpl("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `[GA4Connector] Google token refresh failed (${response.status})`,
+    );
+  }
+  const token = (await response.json()) as GoogleTokenResponse;
+  if (typeof token.access_token !== "string" || !token.access_token) {
+    throw new Error("[GA4Connector] Google token refresh returned no token");
+  }
+  return token.access_token;
+}
+
+async function accessTokenFor(
+  raw: string,
+  fetchImpl: typeof fetch,
+  now: () => number,
+): Promise<string> {
+  const bundle = parseTokenBundle(raw);
+  if (bundle.expiresAt > now() + 60_000) return bundle.accessToken;
+  return refreshAccessToken(bundle, fetchImpl);
+}
+
+async function fetchJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  accessToken: string,
+  init?: RequestInit,
+): Promise<unknown> {
+  const response = await fetchImpl(url, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `[GA4Connector] Google API request failed (${response.status})`,
+    );
+  }
+  return response.json();
+}
+
+function propertyResource(databaseId: string): string {
+  const value = databaseId.startsWith("properties/")
+    ? databaseId
+    : `properties/${databaseId}`;
+  if (!/^properties\/\d+$/u.test(value)) {
+    throw new Error("[GA4Connector] Invalid GA4 property id");
+  }
+  return value;
+}
+
+function propertiesFrom(body: AccountSummariesResponse): RemoteDatabase[] {
+  return (body.accountSummaries ?? []).flatMap((account) =>
+    (account.propertySummaries ?? []).flatMap((property) =>
+      typeof property.property === "string" &&
+      typeof property.displayName === "string"
+        ? [{ id: property.property, name: property.displayName }]
+        : [],
+    ),
+  );
+}
+
+async function listProperties(
+  fetchImpl: typeof fetch,
+  accessToken: string,
+): Promise<RemoteDatabase[]> {
+  const properties: RemoteDatabase[] = [];
+  let pageToken: string | undefined;
+  do {
+    const url = new URL(
+      "https://analyticsadmin.googleapis.com/v1beta/accountSummaries",
+    );
+    url.searchParams.set("pageSize", "200");
+    if (pageToken) url.searchParams.set("pageToken", pageToken);
+    const body = (await fetchJson(
+      fetchImpl,
+      url.toString(),
+      accessToken,
+    )) as AccountSummariesResponse;
+    properties.push(...propertiesFrom(body));
+    pageToken =
+      typeof body.nextPageToken === "string" && body.nextPageToken
+        ? body.nextPageToken
+        : undefined;
+  } while (pageToken);
+  return properties;
+}
+
+function dimensionValue(name: string, value: unknown): string | Date | null {
+  if (typeof value !== "string") return null;
+  if (name !== "date") return value;
+  if (!/^\d{8}$/u.test(value)) return null;
+  const date = new Date(
+    `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T00:00:00.000Z`,
+  );
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export class Ga4Connector extends RemoteApiConnector {
+  readonly id = "googleAnalytics";
+  override readonly authKind = "oauth" as const;
+  readonly name = "Google Analytics 4";
+  readonly description = "Connect a Google Analytics account.";
+  readonly icon = `<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#F9AB00" d="M18.7 2.2a3.1 3.1 0 0 0-3.1 3.1v13.4a3.1 3.1 0 1 0 6.2 0V5.3a3.1 3.1 0 0 0-3.1-3.1Z"/><path fill="#E37400" d="M10.9 8.4a3.1 3.1 0 0 0-3.1 3.1v7.2a3.1 3.1 0 1 0 6.2 0v-7.2a3.1 3.1 0 0 0-3.1-3.1Z"/><circle cx="3.1" cy="18.7" r="3.1" fill="#E37400"/></svg>`;
+
+  readonly #fetch: typeof fetch;
+  readonly #now: () => number;
+
+  constructor(
+    auth: SecretResolver,
+    dependencies: Ga4ConnectorDependencies = {},
+  ) {
+    super(auth);
+    this.#fetch = dependencies.fetch ?? fetch;
+    this.#now = dependencies.now ?? Date.now;
+  }
+
+  getFormFields(): FormField[] {
+    return [];
+  }
+
+  validate(): ValidationResult {
+    return { valid: true };
+  }
+
+  async connect(): Promise<RemoteDatabase[]> {
+    return this.auth(async (raw) => {
+      const token = await accessTokenFor(raw, this.#fetch, this.#now);
+      return listProperties(this.#fetch, token);
+    });
+  }
+
+  async query(
+    databaseId: string,
+    tableId: UUID,
+    options?: QueryOptions,
+  ): Promise<ConnectorQueryResult> {
+    const property = propertyResource(databaseId);
+    const offset = options?.pagination?.offset ?? 0;
+    const limit = options?.pagination?.limit ?? 10_000;
+    if (offset < 0 || limit <= 0) {
+      throw new Error("[GA4Connector] Invalid report pagination");
+    }
+
+    return this.auth(async (raw) => {
+      const token = await accessTokenFor(raw, this.#fetch, this.#now);
+      const response = (await fetchJson(
+        this.#fetch,
+        `https://analyticsdata.googleapis.com/v1beta/${property}:runReport`,
+        token,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            dateRanges: [{ startDate: "30daysAgo", endDate: "yesterday" }],
+            dimensions: [{ name: "date" }],
+            metrics: [{ name: "activeUsers" }],
+            offset: String(offset),
+            limit: String(limit),
+            orderBys: [{ dimension: { dimensionName: "date" } }],
+          }),
+        },
+      )) as RunReportResponse;
+
+      const dimensionNames = (response.dimensionHeaders ?? []).map((header) =>
+        typeof header.name === "string" ? header.name : "dimension",
+      );
+      const metricNames = (response.metricHeaders ?? []).map((header) =>
+        typeof header.name === "string" ? header.name : "metric",
+      );
+      const columns = [
+        ...dimensionNames.map((name) => ({
+          name,
+          type: name === "date" ? ("date" as const) : ("string" as const),
+        })),
+        ...metricNames.map((name) => ({ name, type: "number" as const })),
+      ];
+      const fields = createFieldsFromColumns(columns, tableId);
+      const arrays: Record<string, unknown[]> = Object.create(null) as Record<
+        string,
+        unknown[]
+      >;
+      for (const name of dimensionNames) arrays[name] = [];
+      for (const name of metricNames) arrays[name] = [];
+
+      for (const row of response.rows ?? []) {
+        dimensionNames.forEach((name, index) => {
+          const value = row.dimensionValues?.[index]?.value;
+          arrays[name]!.push(dimensionValue(name, value));
+        });
+        metricNames.forEach((name, index) => {
+          const value = row.metricValues?.[index]?.value;
+          const numeric = typeof value === "string" ? Number(value) : NaN;
+          arrays[name]!.push(Number.isFinite(numeric) ? numeric : null);
+        });
+      }
+
+      const arrow = tableFromArrays(arrays);
+      return {
+        arrowBuffer: Buffer.from(tableToIPC(arrow)).toString("base64"),
+        fieldIds: fields.map((field) => field.id),
+        fields,
+        rowCount: response.rows?.length ?? 0,
+      };
+    });
+  }
+}
+
+export function makeGa4Connector(
+  auth: SecretResolver,
+  dependencies?: Ga4ConnectorDependencies,
+): Ga4Connector {
+  return new Ga4Connector(auth, dependencies);
+}

--- a/packages/connector-ga4/src/connector.ts
+++ b/packages/connector-ga4/src/connector.ts
@@ -10,14 +10,31 @@ import type {
 import { RemoteApiConnector, createFieldsFromColumns } from "@dashframe/engine";
 import { tableFromArrays, tableToIPC } from "apache-arrow";
 
+/**
+ * The per-source credential persisted in the vault.
+ *
+ * Carries no client secret by design: that is one server-wide credential, not
+ * per-source data. Storing it here would copy it into every connected source's
+ * vault entry — multiplying the places it must be rotated out of, and letting
+ * any single source's bundle disclose the secret for all of them. `clientId` is
+ * not secret and stays, because it records which OAuth client minted the grant.
+ */
 export interface GoogleOAuthTokenBundle {
   version: 1;
   accessToken: string;
   refreshToken: string;
   expiresAt: number;
   clientId: string;
-  clientSecret?: string;
   scopes: string[];
+}
+
+/**
+ * Client credentials the host supplies at call time, read from server config
+ * and never persisted alongside a token bundle.
+ */
+export interface GoogleOAuthClientCredentials {
+  clientId: string;
+  clientSecret: string;
 }
 
 interface GoogleTokenResponse {
@@ -44,6 +61,13 @@ interface RunReportResponse {
 export interface Ga4ConnectorDependencies {
   fetch?: typeof fetch;
   now?: () => number;
+  /**
+   * OAuth client credentials for token refresh, read from server config by the
+   * host that constructs this connector. Optional because the catalog and
+   * client-registry construct a connector purely for its static metadata and
+   * never reach a network path; a refresh without it fails closed.
+   */
+  oauthClient?: GoogleOAuthClientCredentials;
 }
 
 function parseTokenBundle(raw: string): GoogleOAuthTokenBundle {
@@ -77,16 +101,33 @@ function parseTokenBundle(raw: string): GoogleOAuthTokenBundle {
 async function refreshAccessToken(
   bundle: GoogleOAuthTokenBundle,
   fetchImpl: typeof fetch,
+  oauthClient: GoogleOAuthClientCredentials | undefined,
 ): Promise<string> {
   if (!bundle.refreshToken) {
     throw new Error("[GA4Connector] Google authorization must be renewed");
   }
+  // Fail closed rather than attempting an unauthenticated refresh: Google
+  // rejects it anyway, and a clear message points at the missing server config.
+  if (!oauthClient) {
+    throw new Error(
+      "[GA4Connector] Google OAuth client credentials are not configured",
+    );
+  }
+  // A grant is bound to the client that minted it. If the server's configured
+  // client has been replaced, the stored refresh token cannot be renewed under
+  // the new one — say so instead of sending a mismatched pair and surfacing an
+  // opaque provider error.
+  if (bundle.clientId !== oauthClient.clientId) {
+    throw new Error(
+      "[GA4Connector] Google authorization was issued for a different OAuth client and must be renewed",
+    );
+  }
   const body = new URLSearchParams({
-    client_id: bundle.clientId,
+    client_id: oauthClient.clientId,
+    client_secret: oauthClient.clientSecret,
     refresh_token: bundle.refreshToken,
     grant_type: "refresh_token",
   });
-  if (bundle.clientSecret) body.set("client_secret", bundle.clientSecret);
   const response = await fetchImpl("https://oauth2.googleapis.com/token", {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -108,10 +149,11 @@ async function accessTokenFor(
   raw: string,
   fetchImpl: typeof fetch,
   now: () => number,
+  oauthClient: GoogleOAuthClientCredentials | undefined,
 ): Promise<string> {
   const bundle = parseTokenBundle(raw);
   if (bundle.expiresAt > now() + 60_000) return bundle.accessToken;
-  return refreshAccessToken(bundle, fetchImpl);
+  return refreshAccessToken(bundle, fetchImpl, oauthClient);
 }
 
 async function fetchJson(
@@ -203,6 +245,7 @@ export class Ga4Connector extends RemoteApiConnector {
 
   readonly #fetch: typeof fetch;
   readonly #now: () => number;
+  readonly #oauthClient: GoogleOAuthClientCredentials | undefined;
 
   constructor(
     auth: SecretResolver,
@@ -211,6 +254,7 @@ export class Ga4Connector extends RemoteApiConnector {
     super(auth);
     this.#fetch = dependencies.fetch ?? fetch;
     this.#now = dependencies.now ?? Date.now;
+    this.#oauthClient = dependencies.oauthClient;
   }
 
   getFormFields(): FormField[] {
@@ -223,7 +267,12 @@ export class Ga4Connector extends RemoteApiConnector {
 
   async connect(): Promise<RemoteDatabase[]> {
     return this.auth(async (raw) => {
-      const token = await accessTokenFor(raw, this.#fetch, this.#now);
+      const token = await accessTokenFor(
+        raw,
+        this.#fetch,
+        this.#now,
+        this.#oauthClient,
+      );
       return listProperties(this.#fetch, token);
     });
   }
@@ -241,7 +290,12 @@ export class Ga4Connector extends RemoteApiConnector {
     }
 
     return this.auth(async (raw) => {
-      const token = await accessTokenFor(raw, this.#fetch, this.#now);
+      const token = await accessTokenFor(
+        raw,
+        this.#fetch,
+        this.#now,
+        this.#oauthClient,
+      );
       const response = (await fetchJson(
         this.#fetch,
         `https://analyticsdata.googleapis.com/v1beta/${property}:runReport`,

--- a/packages/connector-ga4/src/connector.ts
+++ b/packages/connector-ga4/src/connector.ts
@@ -40,7 +40,20 @@ export interface GoogleOAuthClientCredentials {
 interface GoogleTokenResponse {
   access_token?: unknown;
   expires_in?: unknown;
+  refresh_token?: unknown;
 }
+
+/**
+ * Write the renewed bundle back to wherever the host keeps it.
+ *
+ * Optional, and a failure to persist must not fail the request the refresh was
+ * for: the freshly minted token is valid in memory either way. Without it the
+ * connector re-refreshes on every call past expiry, which spends a Google
+ * grant per request and eventually trips rate limits.
+ */
+export type PersistTokenBundle = (
+  bundle: GoogleOAuthTokenBundle,
+) => Promise<void>;
 
 interface AccountSummariesResponse {
   accountSummaries?: Array<{
@@ -68,6 +81,12 @@ export interface Ga4ConnectorDependencies {
    * never reach a network path; a refresh without it fails closed.
    */
   oauthClient?: GoogleOAuthClientCredentials;
+  /**
+   * Write-back for a renewed token bundle. Optional for the same reason as
+   * `oauthClient`; omitting it means every call past expiry burns a fresh
+   * refresh grant.
+   */
+  persistTokenBundle?: PersistTokenBundle;
 }
 
 function parseTokenBundle(raw: string): GoogleOAuthTokenBundle {
@@ -98,11 +117,14 @@ function parseTokenBundle(raw: string): GoogleOAuthTokenBundle {
   return bundle;
 }
 
+const DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
+
 async function refreshAccessToken(
   bundle: GoogleOAuthTokenBundle,
   fetchImpl: typeof fetch,
+  now: () => number,
   oauthClient: GoogleOAuthClientCredentials | undefined,
-): Promise<string> {
+): Promise<GoogleOAuthTokenBundle> {
   if (!bundle.refreshToken) {
     throw new Error("[GA4Connector] Google authorization must be renewed");
   }
@@ -142,7 +164,21 @@ async function refreshAccessToken(
   if (typeof token.access_token !== "string" || !token.access_token) {
     throw new Error("[GA4Connector] Google token refresh returned no token");
   }
-  return token.access_token;
+  const lifetime =
+    typeof token.expires_in === "number" && token.expires_in > 0
+      ? token.expires_in
+      : DEFAULT_TOKEN_LIFETIME_SECONDS;
+  return {
+    ...bundle,
+    accessToken: token.access_token,
+    // Google only returns a refresh token when it rotates one. Keep the
+    // existing one otherwise, or the source loses its grant on first refresh.
+    refreshToken:
+      typeof token.refresh_token === "string" && token.refresh_token
+        ? token.refresh_token
+        : bundle.refreshToken,
+    expiresAt: now() + lifetime * 1000,
+  };
 }
 
 async function accessTokenFor(
@@ -150,10 +186,31 @@ async function accessTokenFor(
   fetchImpl: typeof fetch,
   now: () => number,
   oauthClient: GoogleOAuthClientCredentials | undefined,
+  persist: PersistTokenBundle | undefined,
 ): Promise<string> {
   const bundle = parseTokenBundle(raw);
   if (bundle.expiresAt > now() + 60_000) return bundle.accessToken;
-  return refreshAccessToken(bundle, fetchImpl, oauthClient);
+  const refreshed = await refreshAccessToken(
+    bundle,
+    fetchImpl,
+    now,
+    oauthClient,
+  );
+  if (persist) {
+    try {
+      await persist(refreshed);
+    } catch (error) {
+      // The token in hand is valid; only the write-back failed. Losing the
+      // request over a storage problem is strictly worse than refreshing
+      // again next time. Never include the bundle in what is logged.
+      console.warn(
+        `[GA4Connector] refreshed credential could not be persisted: ${
+          error instanceof Error ? error.message : "unknown error"
+        }`,
+      );
+    }
+  }
+  return refreshed.accessToken;
 }
 
 async function fetchJson(
@@ -246,6 +303,7 @@ export class Ga4Connector extends RemoteApiConnector {
   readonly #fetch: typeof fetch;
   readonly #now: () => number;
   readonly #oauthClient: GoogleOAuthClientCredentials | undefined;
+  readonly #persistTokenBundle: PersistTokenBundle | undefined;
 
   constructor(
     auth: SecretResolver,
@@ -255,6 +313,7 @@ export class Ga4Connector extends RemoteApiConnector {
     this.#fetch = dependencies.fetch ?? fetch;
     this.#now = dependencies.now ?? Date.now;
     this.#oauthClient = dependencies.oauthClient;
+    this.#persistTokenBundle = dependencies.persistTokenBundle;
   }
 
   getFormFields(): FormField[] {
@@ -272,6 +331,7 @@ export class Ga4Connector extends RemoteApiConnector {
         this.#fetch,
         this.#now,
         this.#oauthClient,
+        this.#persistTokenBundle,
       );
       return listProperties(this.#fetch, token);
     });
@@ -295,6 +355,7 @@ export class Ga4Connector extends RemoteApiConnector {
         this.#fetch,
         this.#now,
         this.#oauthClient,
+        this.#persistTokenBundle,
       );
       const response = (await fetchJson(
         this.#fetch,

--- a/packages/connector-ga4/src/index.ts
+++ b/packages/connector-ga4/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  Ga4Connector,
+  makeGa4Connector,
+  type Ga4ConnectorDependencies,
+  type GoogleOAuthTokenBundle,
+} from "./connector.js";

--- a/packages/connector-ga4/src/index.ts
+++ b/packages/connector-ga4/src/index.ts
@@ -3,4 +3,5 @@ export {
   makeGa4Connector,
   type Ga4ConnectorDependencies,
   type GoogleOAuthTokenBundle,
+  type PersistTokenBundle,
 } from "./connector.js";

--- a/packages/connector-ga4/tsconfig.json
+++ b/packages/connector-ga4/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  }
+}

--- a/packages/engine/src/connector/base.ts
+++ b/packages/engine/src/connector/base.ts
@@ -41,6 +41,9 @@ export type SecretResolver = <T>(
  * State management is handled by React hooks, not the connector.
  */
 export abstract class BaseConnector {
+  /** Authentication interaction used by connector onboarding. */
+  readonly authKind: "form" | "oauth" = "form";
+
   /** Unique identifier for this connector */
   abstract readonly id: string;
 

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -54,6 +54,7 @@ export {
   PROJECT_META_ID,
   PROJECT_META_SINGLETON_KEY,
   assistantProviderConfigs,
+  connectorSetupSessions,
   dashboards,
   dashboardsDraft,
   dataFrames,

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -71,7 +71,7 @@ export const dataSources = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     name: text("name").notNull(),
-    kind: text("kind").notNull(), // 'csv' | 'json' | 'parquet' | 'notion' | 'postgres'
+    kind: text("kind").notNull(), // 'csv' | 'json' | 'parquet' | 'notion' | 'postgres' | 'googleAnalytics'
     storage: text("storage").notNull(), // 'parquet' | 'live'
     config: jsonb("config").notNull(),
     schema: jsonb("schema"),
@@ -269,6 +269,41 @@ export const assistantProviderConfigs = pgTable(
   (t) => [
     index("assistant_provider_configs_provider_id_idx").on(t.providerId),
     index("assistant_provider_configs_is_default_idx").on(t.isDefault),
+  ],
+);
+
+// connector_setup_sessions — resumable OAuth connector setup state.
+//
+// NOT drafted: setup is infrastructure state, not an artifact proposal. The
+// session deliberately owns no SecretRef; plaintext OAuth tokens exist only in
+// memory between exchange and the canonical CreateDataSource call.
+export const connectorSetupSessions = pgTable(
+  "connector_setup_sessions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    connectorId: text("connector_id").notNull(),
+    requestedName: text("requested_name").notNull(),
+    state: text("state").notNull(),
+    stateNonceHash: text("state_nonce_hash").notNull(),
+    codeVerifier: text("code_verifier").notNull(),
+    scopes: jsonb("scopes").notNull(),
+    dataSourceId: uuid("data_source_id"),
+    failureCode: text("failure_code"),
+    failureMessage: text("failure_message"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    uniqueIndex("connector_setup_sessions_state_nonce_hash_idx").on(
+      t.stateNonceHash,
+    ),
+    index("connector_setup_sessions_state_idx").on(t.state),
   ],
 );
 
@@ -500,6 +535,7 @@ export const schema = {
   // Credential infrastructure — NOT drafted (security boundary)
   secretMappings,
   assistantProviderConfigs,
+  connectorSetupSessions,
   // Draft metadata — base version for conflict detection
   draftMetadata,
   // Draft shadow tables (artifact overlay)

--- a/packages/types/src/connectors.ts
+++ b/packages/types/src/connectors.ts
@@ -1,6 +1,6 @@
 import type { UseRetryableQueryResult } from "./repository-base";
 
-export type ConnectorAuthKind = "none" | "credential";
+export type ConnectorAuthKind = "none" | "credential" | "oauth";
 
 export type ConnectorFormFieldType =
   | "text"


### PR DESCRIPTION
## What this does

Adds resumable Google Analytics connector onboarding. Starting a connection now creates a server-side setup session that survives the browser tab: the OAuth handshake is tracked through an explicit state machine (`awaiting-user-auth` → `exchanging` → `verifying` → `connected` / `failed` / `expired`), each transition is a compare-and-swap, and a session that gets interrupted can be picked up again from its resume link instead of starting over.

Base content comes from the Codex arm of the face-off. Everything below is a change made on top of it, each as its own commit with its own test.

## What was changed on top of the base

**Every session write goes through the tracked query builder.** Direct SQL writes bypassed the reactive layer, so subscribers kept serving stale sessions after a transition. The database handle is now typed narrowly enough that the untracked escape hatch is not reachable from this file at all. Two tracking bugs went with it: recovery read a table without recording the read, and the sweep decided whether to report a write from its own counters rather than from what it actually wrote.

**The callback nonce is resolved through its unique index.** It previously scanned every session row and compared in a loop — on an endpoint that takes no authentication, where the scan's timing is itself a signal. It is now a single indexed lookup on a hash of the presented value.

**The OAuth client secret is no longer written into per-source credential bundles.** It is read from server config at refresh time, so rotating the OAuth client is a config change rather than a rewrite of every connected source's stored credential.

**Reading a setup session no longer writes.** `getConnectorSetupSession` was declared a query but issued a write when asked for public resume info. It is now a read-only query plus an explicit reissue mutation, and the resume landing path calls the mutation.

**A refreshed GA4 access token is persisted.** It was being refreshed and then dropped, so every request past the stored expiry spent a fresh Google grant.

**Cleanup, in one commit:** setup now fails explicitly when no vault is configured instead of proceeding without one; the connector card's status poll is cancellable (the popup hardening from the base is kept); a failed sweep at boot logs and continues rather than taking the server down with it; and `queryGa4Report` is renamed `queryGa4Property` — it queries a property, never a saved report — with a dedicated result type and the table selection actually honored.

**Review and QA fixes**, covering the sweep's in-flight grace window, the boot pass's need to waive it, and the token write-back race described below.

## Known gaps, not addressed here

- **`resumeUrl` has no consumer.** It is computed and returned, but nothing in the app renders it, so the resume path is reachable only by holding the URL directly — while the callback page tells the user to "use the original resume link". QA rates this blocking for a feature headlined "resumable". Wiring up the UI entry point is deliberately left out of a landing PR.
- **An interrupted exchange only recovers on restart.** The boot sweep recovers sessions stranded by a crash. A session orphaned without a restart stays in flight until its own timeout. Closing that means letting the resume path recover a live exchange, which reopens the race the grace window exists to close, so it needs its own design pass.
- **Concurrent GA4 refreshes can still both call Google.** The write-back is now serialized per data source, which is what was orphaning credentials in the vault. The duplicate refresh itself is not coalesced; the residual is documented at the call site.
- **Two smaller GA4 issues found in passing**, both pre-existing: a zero-row report builds a type-mismatched Arrow buffer, and property listing pages without a cap or a repeat-token guard.
- **Credential mapping storage** was reviewed and accepted as-is with an explanatory comment, but without the portability test the reviewer asked for. Tracked separately.

## Test evidence

`bun run check` (typecheck + lint + tests, 83 tasks) passes clean. Server suite 615 tests, app suite 681.

The new tests were checked against the bugs they describe rather than only against the fixed code — the credential-orphan test was confirmed to fail with the serialization removed, and the added boundary and status-code tests close mutants that a mutation run showed surviving the previous suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds durable, resumable Google Analytics OAuth onboarding with tracked session transitions, recovery, credential handling, and GA4 token refresh support.

- Introduces connector setup sessions, callback/resume routes, and a compare-and-swap OAuth state machine.
- Adds GA4 OAuth configuration, credential-vault integration, token refresh persistence, and connector query support.
- Adds boot-time session recovery, extensive server and UI tests, and onboarding status polling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a duplicate server startup can run the zero-grace sweep against a callback actively owned by another server instance.

The startup sweep executes before listener binding and assumes no live callback handler exists, while the recovery code immediately rewrites every in-flight row when grace is zero; another server using the same project can therefore invalidate an active callback before its own bind attempt fails.

**Files Needing Attention:** apps/server/src/app.ts, apps/server/src/connector-setup/session-store.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/app.ts | Registers OAuth browser routes and runs startup recovery before binding, but the zero-grace sweep can interfere with another live server instance. |
| apps/server/src/connector-setup/session-store.ts | Implements conditional session transitions, nonce lookup, expiration, and in-flight recovery with a configurable grace window. |
| apps/server/src/functions/connector-setup.ts | Implements setup, resume, callback exchange, verification, data-source creation, and session lifecycle procedures. |
| apps/server/src/connector-oauth-callback.ts | Adds unauthenticated browser callback and resume handlers using fixed internal identity and generic responses. |
| packages/connector-ga4/src/connector.ts | Adds GA4 OAuth credential refresh, serialized token write-back, property listing, and property query behavior. |
| packages/app/src/components/providers/ConnectorSetup.tsx | Adds client-side setup-session orchestration and polling for resumable connector onboarding. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant S1 as Existing server
  participant DB as Project database
  participant G as Google callback
  participant S2 as Second server startup
  G->>S1: OAuth callback
  S1->>DB: awaiting-user-auth → exchanging → verifying
  S1->>G: Probe and create data source
  S2->>DB: "Boot sweep with graceMs=0"
  S2->>DB: Reset verifying → awaiting-user-auth
  S2->>S2: Attempt listener bind
  S1->>DB: markConnected CAS
  DB-->>S1: Transition rejected
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fserver%2Fsrc%2Fapp.ts%3A842-844%0A**Boot%20sweep%20lacks%20exclusive%20ownership**%0A%0AIf%20a%20second%20DashFrame%20server%20starts%20against%20the%20same%20project%20while%20the%20first%20is%20processing%20an%20OAuth%20callback%2C%20it%20runs%20the%20zero-grace%20sweep%20before%20attempting%20to%20bind%20its%20listener.%20The%20sweep%20can%20reset%20the%20first%20server's%20%60exchanging%60%20or%20%60verifying%60%20session%2C%20causing%20its%20final%20transition%20to%20fail%20and%20leaving%20a%20failed%20connection%20or%20orphaned%20data%20source.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youhaowei%2Fdashframe&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22youhaowei%2Fdashframe%22%20on%20the%20existing%20branch%20%22task-723%2Fonboarding%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22task-723%2Fonboarding%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fserver%2Fsrc%2Fapp.ts%3A842-844%0A**Boot%20sweep%20lacks%20exclusive%20ownership**%0A%0AIf%20a%20second%20DashFrame%20server%20starts%20against%20the%20same%20project%20while%20the%20first%20is%20processing%20an%20OAuth%20callback%2C%20it%20runs%20the%20zero-grace%20sweep%20before%20attempting%20to%20bind%20its%20listener.%20The%20sweep%20can%20reset%20the%20first%20server's%20%60exchanging%60%20or%20%60verifying%60%20session%2C%20causing%20its%20final%20transition%20to%20fail%20and%20leaving%20a%20failed%20connection%20or%20orphaned%20data%20source.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=youhaowei%2Fdashframe&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fserver%2Fsrc%2Fapp.ts%3A842-844%0A**Boot%20sweep%20lacks%20exclusive%20ownership**%0A%0AIf%20a%20second%20DashFrame%20server%20starts%20against%20the%20same%20project%20while%20the%20first%20is%20processing%20an%20OAuth%20callback%2C%20it%20runs%20the%20zero-grace%20sweep%20before%20attempting%20to%20bind%20its%20listener.%20The%20sweep%20can%20reset%20the%20first%20server's%20%60exchanging%60%20or%20%60verifying%60%20session%2C%20causing%20its%20final%20transition%20to%20fail%20and%20leaving%20a%20failed%20connection%20or%20orphaned%20data%20source.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/server/src/app.ts:842-844
**Boot sweep lacks exclusive ownership**

If a second DashFrame server starts against the same project while the first is processing an OAuth callback, it runs the zero-grace sweep before attempting to bind its listener. The sweep can reset the first server's `exchanging` or `verifying` session, causing its final transition to fail and leaving a failed connection or orphaned data source.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(server): run the boot sweep before t..."](https://github.com/youhaowei/dashframe/commit/33c97b71dbd9776a55a0ac1fdada10e9573f39b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50434551)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server API (apps/server)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/server-api.md)

<!-- /greptile_comment -->