### PR TITLE
chore(app): nav label for drafts surface — approved copy

### DIFF
--- a/e2e/web/tests/draft-review.spec.ts
+++ b/e2e/web/tests/draft-review.spec.ts
@@ -271,7 +271,7 @@ test.describe("draft review", () => {
     // invalidate it over the live subscription — no navigation, no reload.
     await seedDraft();
 
-    await expect(page.getByRole("link", { name: /Review 1/ })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Drafts 1/ })).toBeVisible();
     await expect(page.getByRole("link", { name: /5 changes/ })).toBeVisible();
   });
 

--- a/packages/app/src/app/drafts/page.tsx
+++ b/packages/app/src/app/drafts/page.tsx
@@ -38,7 +38,7 @@ export default function DraftsPage() {
   return (
     <main className="h-full overflow-y-auto bg-surface-base p-[var(--surface-inset)]">
       <section className="mx-auto min-h-full max-w-4xl rounded-[var(--surface-radius)] bg-neutral-bg/90 px-6 py-8 shadow-[var(--surface-shadow)] saturate-[1.2]">
-        <h1 className="text-xl font-semibold text-neutral-fg">Review</h1>
+        <h1 className="text-xl font-semibold text-neutral-fg">Drafts</h1>
 
         {isLoading ? (
           <div className="flex min-h-40 items-center justify-center">

--- a/packages/app/src/components/navigation.tsx
+++ b/packages/app/src/components/navigation.tsx
@@ -55,9 +55,9 @@ type NavItem = {
 
 const navItems: NavItem[] = [
   {
-    name: "Review",
+    name: "Drafts",
     href: "/drafts",
-    description: "Review",
+    description: "Drafts",
     icon: FileIcon,
   },
   {
@@ -159,7 +159,7 @@ function SidebarContent({
                   variant="soft"
                   color="secondary"
                   className="ml-auto min-w-5 justify-center text-[10px]"
-                  // A bare digit next to "Review" reads as "Review 3" to a
+                  // A bare digit next to "Drafts" reads as "Drafts 3" to a
                   // screen reader, which says nothing about what the 3 counts.
                   aria-label={
                     pendingDraftCount === 1


### PR DESCRIPTION
## Summary

- The owner approved the drafts-surface nav label as **"Drafts"** on 2026-08-05, replacing the shipped placeholder ("Review") from #274.
- Updated `packages/app/src/components/navigation.tsx`: the nav item `name`/`description` and the badge's aria-label explanatory comment.
- Updated `e2e/web/tests/draft-review.spec.ts` to match the new accessible name on the nav link.
- Left the draft detail page heading "Review changes" untouched — that copy was a separate, already-approved judged graft and is explicitly out of scope for this change.

## Test plan

- [x] `bun run check` — typecheck + lint + unit tests green across all packages
- [x] `bunx playwright test tests/draft-review.spec.ts --project=chromium` — 4/4 passing, including the updated nav-badge assertion
- [x] Confirmed no other source location carries the old "Review" nav-label string
- [x] No `TASK-\d+` references, no submodule pointer movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the drafts surface’s “Review” copy with the approved “Drafts” label across the shared application shell and updates the matching end-to-end assertion.

- Renames the drafts navigation item and description.
- Renames the drafts page heading.
- Updates the navigation badge accessibility test to expect the new accessible name.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app/src/components/navigation.tsx | Renames the shared navigation label and description from “Review” to “Drafts” while preserving the badge accessibility behavior. |
| packages/app/src/app/drafts/page.tsx | Renames the drafts page heading from “Review” to “Drafts.” |
| e2e/web/tests/draft-review.spec.ts | Updates the live draft-count assertion to use the navigation link’s new accessible name. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(app): rename drafts list page head..."](https://github.com/youhaowei/dashframe/commit/19ebce90d2aab89df5047b92fbf96db577790100) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50554360)</sub>

**Context used:**

- Knowledge Base — [App shell (`packages/app`)](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/app-shell.md)

<!-- /greptile_comment -->