### PR TITLE
fix(scripts): repair the submodule pushed-ness probe; guard worktree creation

### DIFF
--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -102,6 +102,90 @@ init_unpopulated_submodules() {
   done
 }
 
+# assert_submodule_pins_pushed <rev>
+# Refuse to provision a worktree whose submodule pins point at commits no
+# submodule remote has.
+#
+# The trap this closes: an arm worktree is created from a rev whose
+# libs/wystack pin is a local-only commit, an agent builds on it, and the
+# submodule change later lands upstream as a SQUASH — which publishes the
+# content under a brand-new sha and leaves the pinned commit reachable from
+# nothing on the remote. From then on the arm's submodule gitdir is the only
+# copy, teardown correctly refuses to destroy it, and the worktree is stuck
+# until a human adjudicates. Blocking at creation costs one ls-remote per
+# submodule and avoids that situation entirely.
+#
+# Per AGENTS.md a submodule change lands in its own repo FIRST, so a
+# legitimate in-flight pin is always on a pushed branch and passes here. A
+# pin that fails is a local-only commit — push it or reset the submodule.
+#
+# Deliberately NOT fatal when no remote answers: this guard prevents an
+# awkward situation, it is not the data-loss guard (remove-worktree.sh is),
+# and failing closed here would make offline worktree creation impossible.
+# It warns loudly on stderr instead.
+assert_submodule_pins_pushed() {
+  _aspp_rev="$1"
+  [ -f "$repo_root/.gitmodules" ] || return 0
+  for _aspp_sub in $(git config --file "$repo_root/.gitmodules" --get-regexp 'submodule\..*\.path' 2>/dev/null | awk '{print $2}'); do
+    # An unpopulated submodule has no local object store and nothing at risk:
+    # the new worktree clones it fresh from the remote, so a pin the remote
+    # does not have fails loudly at checkout rather than silently here.
+    [ -e "$repo_root/$_aspp_sub/.git" ] || continue
+    _aspp_pin=$(git -C "$repo_root" rev-parse --verify --quiet "$_aspp_rev:$_aspp_sub" 2>/dev/null || echo "")
+    [ -n "$_aspp_pin" ] || continue
+    # A pin whose object is absent locally cannot be judged here at all — and
+    # is not a local-only commit by definition, since nothing local holds it.
+    git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_pin" 2>/dev/null || continue
+
+    _aspp_tips=""
+    _aspp_reached=false
+    for _aspp_remote in $(git -C "$repo_root/$_aspp_sub" remote); do
+      _aspp_refs=$(git -C "$repo_root/$_aspp_sub" ls-remote --heads --tags "$_aspp_remote" 2>/dev/null) || continue
+      _aspp_reached=true
+      # A tip sha whose object was never fetched cannot exclude anything, and
+      # dropping it silently would read the whole upstream history as
+      # unpushed — the same false-refusal bug remove-worktree.sh carried.
+      # Fetch once when something is missing; a failed fetch merely leaves the
+      # tip list shorter, which errs toward complaining rather than toward
+      # vouching for a pin no remote actually has.
+      _aspp_missing=false
+      for _aspp_sha in $(printf '%s\n' "$_aspp_refs" | awk '{print $1}'); do
+        git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_sha" 2>/dev/null || _aspp_missing=true
+      done
+      if [ "$_aspp_missing" = true ]; then
+        git -C "$repo_root/$_aspp_sub" fetch --quiet "$_aspp_remote" >/dev/null 2>&1 || true
+      fi
+      for _aspp_sha in $(printf '%s\n' "$_aspp_refs" | awk '{print $1}'); do
+        if git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_sha" 2>/dev/null; then
+          _aspp_tips="$_aspp_tips $_aspp_sha"
+        fi
+      done
+    done
+
+    if [ "$_aspp_reached" = false ]; then
+      echo "WARNING [ensure-worktree]: could not reach any remote of submodule '$_aspp_sub' — its pin was not verified as pushed." >&2
+      continue
+    fi
+
+    # shellcheck disable=SC2086
+    _aspp_unpushed=$(git -C "$repo_root/$_aspp_sub" log --oneline "$_aspp_pin" --not $_aspp_tips -- 2>/dev/null || echo "")
+    if [ -n "$_aspp_unpushed" ]; then
+      echo "ERROR [ensure-worktree]: '$_aspp_rev' pins submodule '$_aspp_sub' at $(printf '%.12s' "$_aspp_pin"), which no remote of that submodule has." >&2
+      printf '%s\n' "$_aspp_unpushed" | sed -n '1,5p' | sed 's/^/    /' >&2
+      echo "  Building on an unpushed submodule commit is how work gets orphaned: if that change" >&2
+      echo "  later lands upstream as a squash, the pinned sha becomes reachable from nothing and" >&2
+      echo "  this worktree's submodule gitdir is its only copy." >&2
+      echo "  Fix it first, in $repo_root/$_aspp_sub:" >&2
+      echo "    push it   — land the submodule change in its own repo (AGENTS.md), then bump the pin; or" >&2
+      echo "    reset it  — point '$_aspp_rev' back at a commit the submodule remote has." >&2
+      # The create paths call this after mktemp'ing the worktree-add log; the
+      # reuse path never sets it. Clean it up rather than leak a temp file.
+      if [ -n "${_wt_log:-}" ]; then rm -f "$_wt_log"; fi
+      exit 1
+    fi
+  done
+}
+
 # ── 1. Require a branch argument ────────────────────────────────────────────
 branch="${1:-}"
 if [ -z "$branch" ]; then
@@ -181,6 +265,9 @@ if [ -d "$worktree_path" ]; then
     exit 1
   fi
   assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
+  # Reuse path: the pin that matters is the one this worktree already records,
+  # and init_unpopulated_submodules below is about to check it out.
+  assert_submodule_pins_pushed "$(git -C "$worktree_path" rev-parse HEAD)"
   init_unpopulated_submodules "$worktree_path"
   echo "$worktree_path"
   exit 0
@@ -198,6 +285,7 @@ mkdir -p "$worktree_base"
 _wt_log=$(mktemp)
 _wt_rc=0
 if git show-ref --verify --quiet "refs/heads/$branch"; then
+  assert_submodule_pins_pushed "$branch"
   git worktree add "$worktree_path" "$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
 else
   # Check whether the branch exists on origin. `git ls-remote --exit-code`
@@ -219,6 +307,7 @@ else
       echo "ERROR [ensure-worktree]: branch '$branch' exists on origin but 'git fetch origin $branch' failed — not falling back to a possibly stale local ref." >&2
       exit 1
     fi
+    assert_submodule_pins_pushed "origin/$branch"
     git worktree add "$worktree_path" -b "$branch" "origin/$branch" >"$_wt_log" 2>&1 || _wt_rc=$?
   elif [ "$_ls_remote_rc" -ne 2 ]; then
     echo "ERROR [ensure-worktree]: could not determine whether branch '$branch' exists on origin (git ls-remote exited $_ls_remote_rc)." >&2
@@ -243,6 +332,7 @@ else
       echo "ERROR [ensure-worktree]: branch '$branch' not found locally or on origin, and 'origin/main' is unavailable to branch from." >&2
       exit 1
     fi
+    assert_submodule_pins_pushed "origin/main"
     git worktree add --no-track -b "$branch" "$worktree_path" origin/main >"$_wt_log" 2>&1 || _wt_rc=$?
   fi
 fi

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -106,14 +106,24 @@ init_unpopulated_submodules() {
 # Refuse to provision a worktree whose submodule pins point at commits no
 # submodule remote has.
 #
-# The trap this closes: an arm worktree is created from a rev whose
-# libs/wystack pin is a local-only commit, an agent builds on it, and the
-# submodule change later lands upstream as a SQUASH — which publishes the
-# content under a brand-new sha and leaves the pinned commit reachable from
-# nothing on the remote. From then on the arm's submodule gitdir is the only
-# copy, teardown correctly refuses to destroy it, and the worktree is stuck
-# until a human adjudicates. Blocking at creation costs one ls-remote per
-# submodule and avoids that situation entirely.
+# The trap this closes: a worktree is created from a rev whose libs/wystack
+# pin is a local-only commit, an agent builds on it, and the submodule change
+# later lands upstream as a SQUASH — which publishes the content under a
+# brand-new sha and leaves the pinned commit reachable from nothing on the
+# remote. From then on that worktree's submodule gitdir is the only copy,
+# teardown correctly refuses to destroy it, and the worktree is stuck until a
+# human adjudicates. Blocking at creation costs one ls-remote per submodule
+# and avoids that situation.
+#
+# SCOPE — this catches pins whose commit lives in THIS checkout's submodule
+# object store, which is the case that matters here because section 3 only
+# runs in the main checkout and its pins come from main or a local branch.
+# It does NOT catch a pin whose commit was authored inside a SIBLING
+# worktree: submodule gitdirs are per-worktree, so such a commit is absent
+# from this store entirely and is skipped below. That case is not silent —
+# `git submodule update` fails at checkout with "not our ref" — it is just
+# not caught here. Probing sibling worktrees' gitdirs would close it and is
+# left as follow-up.
 #
 # Per AGENTS.md a submodule change lands in its own repo FIRST, so a
 # legitimate in-flight pin is always on a pushed branch and passes here. A
@@ -133,8 +143,9 @@ assert_submodule_pins_pushed() {
     [ -e "$repo_root/$_aspp_sub/.git" ] || continue
     _aspp_pin=$(git -C "$repo_root" rev-parse --verify --quiet "$_aspp_rev:$_aspp_sub" 2>/dev/null || echo "")
     [ -n "$_aspp_pin" ] || continue
-    # A pin whose object is absent locally cannot be judged here at all — and
-    # is not a local-only commit by definition, since nothing local holds it.
+    # A pin whose object this store does not hold cannot be judged here. It
+    # may still be local to a sibling worktree's submodule gitdir — see SCOPE
+    # in the docblock — so this is a known gap, not a proof of pushed-ness.
     git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_pin" 2>/dev/null || continue
 
     _aspp_tips=""
@@ -147,13 +158,16 @@ assert_submodule_pins_pushed() {
       # unpushed — the same false-refusal bug remove-worktree.sh carried.
       # Fetch once when something is missing; a failed fetch merely leaves the
       # tip list shorter, which errs toward complaining rather than toward
-      # vouching for a pin no remote actually has.
+      # vouching for a pin no remote actually has. --tags is required: the
+      # default refspec auto-follows a tag only when its object is reachable
+      # from fetched branch history, so a tag sitting on no branch — exactly
+      # the tip most likely to be missing — would never arrive.
       _aspp_missing=false
       for _aspp_sha in $(printf '%s\n' "$_aspp_refs" | awk '{print $1}'); do
         git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_sha" 2>/dev/null || _aspp_missing=true
       done
       if [ "$_aspp_missing" = true ]; then
-        git -C "$repo_root/$_aspp_sub" fetch --quiet "$_aspp_remote" >/dev/null 2>&1 || true
+        git -C "$repo_root/$_aspp_sub" fetch --quiet --tags "$_aspp_remote" >/dev/null 2>&1 || true
       fi
       for _aspp_sha in $(printf '%s\n' "$_aspp_refs" | awk '{print $1}'); do
         if git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_sha" 2>/dev/null; then
@@ -167,8 +181,15 @@ assert_submodule_pins_pushed() {
       continue
     fi
 
+    # A failing `git log` must not read as "pushed": that is the one way this
+    # guard could fail open. Warn and move on instead of vouching for the pin.
+    _aspp_rc=0
     # shellcheck disable=SC2086
-    _aspp_unpushed=$(git -C "$repo_root/$_aspp_sub" log --oneline "$_aspp_pin" --not $_aspp_tips -- 2>/dev/null || echo "")
+    _aspp_unpushed=$(git -C "$repo_root/$_aspp_sub" log --oneline "$_aspp_pin" --not $_aspp_tips -- 2>/dev/null) || _aspp_rc=$?
+    if [ "$_aspp_rc" -ne 0 ]; then
+      echo "WARNING [ensure-worktree]: could not test the pin of submodule '$_aspp_sub' (git log exited $_aspp_rc) — not verified as pushed." >&2
+      continue
+    fi
     if [ -n "$_aspp_unpushed" ]; then
       echo "ERROR [ensure-worktree]: '$_aspp_rev' pins submodule '$_aspp_sub' at $(printf '%.12s' "$_aspp_pin"), which no remote of that submodule has." >&2
       printf '%s\n' "$_aspp_unpushed" | sed -n '1,5p' | sed 's/^/    /' >&2
@@ -265,9 +286,13 @@ if [ -d "$worktree_path" ]; then
     exit 1
   fi
   assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
-  # Reuse path: the pin that matters is the one this worktree already records,
-  # and init_unpopulated_submodules below is about to check it out.
-  assert_submodule_pins_pushed "$(git -C "$worktree_path" rev-parse HEAD)"
+  # Deliberately NOT guarded: this worktree already exists, so there is no
+  # creation to refuse — a block here would only withhold the path to a
+  # worktree that is already on disk, and since remove-worktree.sh rightly
+  # refuses to destroy unpushed submodule work, the worktree could then be
+  # neither entered nor torn down through the sanctioned tooling. The
+  # early-return path for a caller already inside a worktree is unguarded for
+  # the same reason.
   init_unpopulated_submodules "$worktree_path"
   echo "$worktree_path"
   exit 0

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -115,15 +115,12 @@ init_unpopulated_submodules() {
 # human adjudicates. Blocking at creation costs one ls-remote per submodule
 # and avoids that situation.
 #
-# SCOPE — this catches pins whose commit lives in THIS checkout's submodule
-# object store, which is the case that matters here because section 3 only
-# runs in the main checkout and its pins come from main or a local branch.
-# It does NOT catch a pin whose commit was authored inside a SIBLING
-# worktree: submodule gitdirs are per-worktree, so such a commit is absent
-# from this store entirely and is skipped below. That case is not silent —
-# `git submodule update` fails at checkout with "not our ref" — it is just
-# not caught here. Probing sibling worktrees' gitdirs would close it and is
-# left as follow-up.
+# Submodule gitdirs are PER-WORKTREE, so a pin authored inside a sibling
+# worktree is absent from this checkout's submodule object store even though
+# it exists on the machine. Such a pin is therefore judged the same way as
+# any other: fetch every head and tag the remote advertises, and if the
+# commit still is not here, no remote has it — refuse. Skipping it for being
+# locally unknown would miss the very case this guard exists for.
 #
 # Per AGENTS.md a submodule change lands in its own repo FIRST, so a
 # legitimate in-flight pin is always on a pushed branch and passes here. A
@@ -143,10 +140,6 @@ assert_submodule_pins_pushed() {
     [ -e "$repo_root/$_aspp_sub/.git" ] || continue
     _aspp_pin=$(git -C "$repo_root" rev-parse --verify --quiet "$_aspp_rev:$_aspp_sub" 2>/dev/null || echo "")
     [ -n "$_aspp_pin" ] || continue
-    # A pin whose object this store does not hold cannot be judged here. It
-    # may still be local to a sibling worktree's submodule gitdir — see SCOPE
-    # in the docblock — so this is a known gap, not a proof of pushed-ness.
-    git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_pin" 2>/dev/null || continue
 
     _aspp_tips=""
     _aspp_reached=false
@@ -162,7 +155,12 @@ assert_submodule_pins_pushed() {
       # default refspec auto-follows a tag only when its object is reachable
       # from fetched branch history, so a tag sitting on no branch — exactly
       # the tip most likely to be missing — would never arrive.
+      # The pin itself counts as a missing object worth fetching for: it may
+      # have been authored in a sibling worktree's submodule gitdir (those are
+      # per-worktree) and pushed from there, in which case this store has
+      # never seen it but the remote has.
       _aspp_missing=false
+      git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_pin" 2>/dev/null || _aspp_missing=true
       for _aspp_sha in $(printf '%s\n' "$_aspp_refs" | awk '{print $1}'); do
         git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_sha" 2>/dev/null || _aspp_missing=true
       done
@@ -179,6 +177,21 @@ assert_submodule_pins_pushed() {
     if [ "$_aspp_reached" = false ]; then
       echo "WARNING [ensure-worktree]: could not reach any remote of submodule '$_aspp_sub' — its pin was not verified as pushed." >&2
       continue
+    fi
+
+    # The pin is still absent after fetching every head and tag a reachable
+    # remote advertises. It is therefore reachable from nothing on that
+    # remote — typically a commit authored in a sibling worktree's submodule
+    # gitdir and never pushed. Refuse: `git worktree add` would succeed and
+    # `git submodule update` would then die with "not our ref", leaving a
+    # half-created worktree and a misleading connectivity error.
+    if ! git -C "$repo_root/$_aspp_sub" cat-file -e "$_aspp_pin" 2>/dev/null; then
+      echo "ERROR [ensure-worktree]: '$_aspp_rev' pins submodule '$_aspp_sub' at $(printf '%.12s' "$_aspp_pin"), which no remote of that submodule has and this checkout does not hold." >&2
+      echo "  A submodule commit made inside another worktree lives in that worktree's own gitdir." >&2
+      echo "  Push it from there — land it in the submodule's own repo (AGENTS.md), then bump the pin —" >&2
+      echo "  or point '$_aspp_rev' back at a commit the submodule remote has." >&2
+      if [ -n "${_wt_log:-}" ]; then rm -f "$_wt_log"; fi
+      exit 1
     fi
 
     # A failing `git log` must not read as "pushed": that is the one way this

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -25,6 +25,13 @@
 # local formulation of this check had a counterexample — either destroying
 # work hidden behind a local tag or blocking work published only via a tag.
 #
+# ls-remote answers with the remote's tip SHAs, and a SHA whose object this
+# gitdir never fetched cannot exclude anything reachable from it. So when the
+# answer names an object that is missing locally, this script fetches once
+# from that remote before deciding. Without that fetch, a worktree parked
+# while its submodule's remote advanced reads the entire upstream history as
+# unpushed and becomes permanently un-removable.
+#
 # NOT protected: gitignored files. Like `git worktree remove` itself, the
 # status checks here never see ignored content — a hand-made .env or local
 # build artifact is removed with the worktree. A block would trip on
@@ -150,6 +157,7 @@ check_paused_ops "this worktree" "$wt_gitdir"
 check_submodule_refs() {
   local sub="$1"; shift
   local remotes remote remote_refs sha ref unpushed stashes reason reached=false
+  local missing_tip
   local pushed=()
 
   # In --throwaway mode the network probe is skipped entirely: the caller
@@ -179,10 +187,29 @@ check_submodule_refs() {
   for remote in $remotes; do
     if remote_refs=$("$@" ls-remote --heads --tags "$remote" 2>/dev/null); then
       reached=true
+      # Only objects that exist locally can be used as exclusions — a sha
+      # never fetched cannot be handed to `git log --not`. Dropping such a
+      # tip silently is NOT the conservative choice it looks like: everything
+      # reachable from it then reads as unpushed, so a worktree whose
+      # submodule gitdir predates the remote's current tip reports its whole
+      # upstream history as work to save and can never be removed. That is
+      # the false refusal. One fetch per remote repairs it, and only when a
+      # tip is actually missing, so an up-to-date gitdir pays nothing.
+      missing_tip=false
       while read -r sha ref; do
         [ -n "$sha" ] || continue
-        # Only objects that exist locally can be used as exclusions; a
-        # remote sha never fetched cannot be an ancestor of local refs.
+        "$@" cat-file -e "$sha" 2>/dev/null || missing_tip=true
+      done <<EOF
+$remote_refs
+EOF
+      # A failed fetch is deliberately not fatal: the exclusion set merely
+      # stays as small as it was, which blocks removal rather than allowing
+      # one. The "no remote answered at all" case below still exits.
+      if [ "$missing_tip" = true ]; then
+        "$@" fetch --quiet "$remote" >/dev/null 2>&1 || true
+      fi
+      while read -r sha ref; do
+        [ -n "$sha" ] || continue
         if "$@" cat-file -e "$sha" 2>/dev/null; then
           pushed+=("$sha")
         fi
@@ -213,13 +240,16 @@ EOF
   # Everything local — every ref plus HEAD, so notes, replace refs and other
   # namespaces are covered, minus refs/stash which has its own check with a
   # better message — against everything the remotes have. In the default
-  # mode the ONLY exclusion source is the fresh ls-remote answer above:
-  # local remote-tracking refs can be stale, and after an upstream
-  # force-push or branch delete a stale refs/remotes/* would vouch for
-  # commits whose last remaining copy is right here — the exact loss this
-  # guard exists to prevent. (A commit pushed long ago but since discarded
-  # upstream therefore blocks; that is fail-closed working as intended, and
-  # a fetch is the remedy when the block is stale-local-state instead.)
+  # mode the exclusion set is exactly the shas the fresh ls-remote above
+  # named: local remote-tracking refs are never consulted as exclusions,
+  # because after an upstream force-push or branch delete a stale
+  # refs/remotes/* would vouch for commits whose last remaining copy is
+  # right here — the exact loss this guard exists to prevent. (A commit
+  # pushed long ago but since discarded upstream therefore blocks; that is
+  # fail-closed working as intended.) The repair fetch above may refresh
+  # those refs/remotes/* as a side effect; that does not widen the set,
+  # since membership is decided by the ls-remote answer either way — the
+  # fetch only supplies the objects needed to honor it.
   # In --throwaway mode the remote-tracking refs and tags ARE the check:
   # the caller attests the worktree was created moments ago from fetched
   # state, so those refs are fresh and a fetched tag need not be reachable

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -205,8 +205,12 @@ EOF
       # A failed fetch is deliberately not fatal: the exclusion set merely
       # stays as small as it was, which blocks removal rather than allowing
       # one. The "no remote answered at all" case below still exits.
+      # --tags is required: the default refspec auto-follows a tag only when
+      # its object is reachable from fetched branch history, so a tag sitting
+      # on no branch — exactly the tip most likely to be missing here — would
+      # never arrive, and missing_tip would stay true on every future run.
       if [ "$missing_tip" = true ]; then
-        "$@" fetch --quiet "$remote" >/dev/null 2>&1 || true
+        "$@" fetch --quiet --tags "$remote" >/dev/null 2>&1 || true
       fi
       while read -r sha ref; do
         [ -n "$sha" ] || continue


### PR DESCRIPTION
Fixes a false refusal in `remove-worktree.sh` that made parked worktrees permanently un-removable, and adds the matching guard at creation time in `ensure-worktree.sh`.

## Changes

**`remove-worktree.sh` — the false-refusal bug.** The submodule pushed-ness probe asks `git ls-remote` for the remote's tip SHAs, then filters them through `cat-file -e` and uses the survivors as `git log --not` exclusions. Filtering is necessary — a SHA whose object is absent locally cannot be handed to `--not` — but dropping a tip is *not* the conservative act it looks like. With the tip gone from the exclusion set, everything reachable from it reads as "commits no remote has". Any worktree that sat while its submodule's remote advanced therefore reported its entire upstream history as unpushed work, and the guard refused forever.

The fix fetches once from a remote whose ls-remote answer names an object the gitdir is missing, then rebuilds the exclusion set. Safety is unchanged in the direction that matters: membership is still decided by the fresh ls-remote answer, so the exclusion set stays a subset of what the remote actually has, and a failed fetch just leaves it smaller — which blocks removal rather than allowing one. `--throwaway` is untouched and still never reaches the network.

**`ensure-worktree.sh` — the same check at the other end.** Refuses to provision a worktree whose submodule pins point at commits no submodule remote has. That is where the trap starts: an agent builds on a local-only submodule commit, the change later lands upstream as a squash under a new SHA, and the pinned commit survives only inside that worktree's gitdir. Submodule gitdirs are per-worktree, so a pin authored in a sibling worktree is judged by fetching every head and tag the remote advertises and refusing if the commit still is not present. Guard runs on the three creation paths only — never on reuse, where a block would withhold the path to a worktree already on disk that `remove-worktree.sh` also (correctly) refuses to delete. Not fatal when no remote answers, so offline provisioning still works.

## Screenshots

No UI change.

## Verification

No CI-wired tests — per the repo's convention for tooling scripts, each path was exercised by hand. Neither script has existing automated coverage; a suggested fixture-based regression harness is described in the review notes.

`remove-worktree.sh`, against a faithfully reproduced stale gitdir (worktree pinned at an older `libs/wystack` commit, the remote's current tip pruned out of its object store):

- **Before:** refuses, listing 5+ commits that are all on `wystack` `origin/main` — the false refusal.
- **After:** removes cleanly.
- **Genuine refusal preserved:** against a worktree holding two truly unpushed submodule commits, it still refuses and now lists exactly those two, with the 8 false positives gone.
- `--throwaway` verified to make no network call.

`ensure-worktree.sh`:

- Pin local-only to this checkout → refused, names the commit.
- Pin absent locally and on the remote (the sibling-worktree shape) → refused, no worktree left behind.
- Clean pin → worktree created; second invocation reuses it and returns the path.

Both scripts pass `sh -n` / `bash -n`; `shellcheck -s sh` is clean on `ensure-worktree.sh`, and `remove-worktree.sh` carries only its pre-existing SC2034. `bun run check:ticket-refs` passes.

## Review

**The canonical `/cross-review` gate did not run.** The change was produced in a subagent context, where the `Workflow` tool the skill needs is not exposed, so the skill could not be invoked at all. What ran instead is the gate AGENTS.md itself defines: a code-review pass, hand-run behavioral QA (above), and an independent second reviewer on a different model. Two models, not four families — treat this as a substitution, not the gate, and run `/cross-review` from a main-thread session before merging.

That pass found a HIGH (the creation guard also ran on the reuse path, which could lock an operator out of a healthy worktree through both scripts at once), a MEDIUM (per-worktree gitdir blind spot), and three LOWs (`--tags` missing from the repair fetches, a fail-open `git log`, an ls-remote on the hot path). The second reviewer independently reached the same MEDIUM and argued for closing it rather than documenting it. All are fixed in the follow-up commits; the reuse-path guard was removed rather than softened.

**Greptile's finding (unpopulated submodule bypasses the guard) is accepted as real but pre-existing and out of scope.** When a submodule is unpopulated in the main checkout there is no object store to judge the pin against, so the guard skips it and an unfetchable pin fails inside `init_unpopulated_submodules` after `git worktree add` — leaving a registered, partial worktree. That failure path is unchanged from `origin/main` (`init_unpopulated_submodules` already `exit 1`s there, added in #263); this diff narrows the window by refusing the populated case before creation rather than opening a new one. Closing it properly means making the post-creation failure clean up its own worktree, which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR repairs stale submodule-tip handling during guarded worktree removal and adds corresponding pushed-pin validation before new worktrees are created.
- Fetches missing advertised branch and tag tips before computing remote-reachable exclusions during removal.
- Validates populated submodule pins on all three worktree creation paths while leaving reuse unguarded.
- Preserves fail-closed removal behavior and offline worktree provisioning.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not appear safe to merge until the outstanding partial-worktree failure for unpopulated submodule pins is resolved.

An unpopulated submodule still bypasses the new validation, allowing worktree registration before submodule initialization fails; that failure exits without cleanup, leaving a registered worktree that subsequent invocations continue to treat as existing.

**Files Needing Attention:** scripts/ensure-worktree.sh
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ensure-worktree.sh | Adds remote-reachability validation for populated submodule pins before each worktree creation path. |
| scripts/remove-worktree.sh | Fetches missing advertised remote tips before using them as exclusions in the submodule pushed-work check. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/worktree-..."](https://github.com/youhaowei/dashframe/commit/6843d13489d2a11b8965b6f3a2d089e015a36fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50566866)</sub>

<!-- /greptile_comment -->