### PR TITLE
[codex] Consolidate engine column type mappings

### DIFF
--- a/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.test.tsx
@@ -42,9 +42,13 @@ vi.mock("@wystack/client", async (importOriginal) => {
   };
 });
 
-vi.mock("@dashframe/engine", () => ({
-  resolveEncodingToSql: vi.fn().mockReturnValue({}),
-}));
+vi.mock("@dashframe/engine", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dashframe/engine")>();
+  return {
+    ...actual,
+    resolveEncodingToSql: vi.fn().mockReturnValue({}),
+  };
+});
 
 // Chart is a heavy dependency — stub it out so tests focus on guard logic.
 vi.mock("@dashframe/visualization", () => ({

--- a/packages/engine-browser/src/__tests__/arrow.test.ts
+++ b/packages/engine-browser/src/__tests__/arrow.test.ts
@@ -1,0 +1,36 @@
+import { tableFromIPC } from "apache-arrow";
+import { describe, expect, it } from "vitest";
+
+import { createArrowIPCBufferFromRows } from "../arrow";
+
+describe("createArrowIPCBufferFromRows", () => {
+  it("maps every ColumnType through the shared exhaustive adapter contract", () => {
+    const ipc = createArrowIPCBufferFromRows(
+      [
+        {
+          number: 42,
+          boolean: true,
+          date: Date.UTC(2026, 7, 5),
+          string: "value",
+          unknown: "fallback",
+        },
+      ],
+      [
+        { name: "number", type: "number" },
+        { name: "boolean", type: "boolean" },
+        { name: "date", type: "date" },
+        { name: "string", type: "string" },
+        { name: "unknown", type: "unknown" },
+      ],
+    );
+
+    const table = tableFromIPC(ipc);
+    expect(table.schema.fields.map((field) => field.type.toString())).toEqual([
+      "Float64",
+      "Bool",
+      "Timestamp<MILLISECOND>",
+      "Utf8",
+      "Utf8",
+    ]);
+  });
+});

--- a/packages/engine-browser/src/arrow.ts
+++ b/packages/engine-browser/src/arrow.ts
@@ -1,4 +1,4 @@
-import type { ColumnType } from "@dashframe/engine";
+import { defineColumnTypeMap, type ColumnType } from "@dashframe/engine";
 import {
   Bool,
   Float64,
@@ -16,6 +16,15 @@ export type ArrowColumn = {
   type: ColumnType;
 };
 
+const ARROW_VECTOR_FACTORIES = defineColumnTypeMap({
+  number: (values: unknown[]) => vectorFromArray(values, new Float64()),
+  boolean: (values: unknown[]) => vectorFromArray(values, new Bool()),
+  date: (values: unknown[]) =>
+    vectorFromArray(values, new TimestampMillisecond()),
+  string: (values: unknown[]) => vectorFromArray(values, new Utf8()),
+  unknown: (values: unknown[]) => vectorFromArray(values, new Utf8()),
+});
+
 export function createArrowIPCBufferFromRows(
   rows: Record<string, unknown>[],
   columns: ArrowColumn[],
@@ -25,22 +34,7 @@ export function createArrowIPCBufferFromRows(
   for (const col of columns) {
     const values = rows.map((row) => row[col.name]);
 
-    switch (col.type) {
-      case "number":
-        arrowColumns[col.name] = vectorFromArray(values, new Float64());
-        break;
-      case "boolean":
-        arrowColumns[col.name] = vectorFromArray(values, new Bool());
-        break;
-      case "date":
-        arrowColumns[col.name] = vectorFromArray(
-          values,
-          new TimestampMillisecond(),
-        );
-        break;
-      default:
-        arrowColumns[col.name] = vectorFromArray(values, new Utf8());
-    }
+    arrowColumns[col.name] = ARROW_VECTOR_FACTORIES[col.type](values);
   }
 
   return tableToIPC(new Table(arrowColumns));

--- a/packages/engine-server/src/arrow-encode.ts
+++ b/packages/engine-server/src/arrow-encode.ts
@@ -8,7 +8,7 @@
  * (`getColumnsObjectJson`): BigInt → string, Date/timestamp → string — so the
  * encoder coerces to the Arrow physical type here.
  */
-import type { ColumnType } from "@dashframe/types";
+import { defineColumnTypeMap, type ColumnType } from "@dashframe/engine";
 import { DuckDBTypeId } from "@duckdb/node-api";
 import {
   Bool,
@@ -30,39 +30,48 @@ export interface ResultColumn {
   values: unknown[];
 }
 
+const DUCKDB_TYPE_IDS_BY_COLUMN_TYPE = defineColumnTypeMap({
+  boolean: [DuckDBTypeId.BOOLEAN],
+  number: [
+    DuckDBTypeId.TINYINT,
+    DuckDBTypeId.SMALLINT,
+    DuckDBTypeId.INTEGER,
+    DuckDBTypeId.BIGINT,
+    DuckDBTypeId.UTINYINT,
+    DuckDBTypeId.USMALLINT,
+    DuckDBTypeId.UINTEGER,
+    DuckDBTypeId.UBIGINT,
+    DuckDBTypeId.HUGEINT,
+    DuckDBTypeId.UHUGEINT,
+    DuckDBTypeId.FLOAT,
+    DuckDBTypeId.DOUBLE,
+    DuckDBTypeId.DECIMAL,
+  ],
+  date: [
+    DuckDBTypeId.DATE,
+    DuckDBTypeId.TIMESTAMP,
+    DuckDBTypeId.TIMESTAMP_S,
+    DuckDBTypeId.TIMESTAMP_MS,
+    DuckDBTypeId.TIMESTAMP_NS,
+    DuckDBTypeId.TIMESTAMP_TZ,
+  ],
+  string: [DuckDBTypeId.VARCHAR],
+  unknown: [],
+});
+
+const COLUMN_TYPE_BY_DUCKDB_TYPE_ID = new Map<number, ColumnType>(
+  Object.entries(DUCKDB_TYPE_IDS_BY_COLUMN_TYPE).flatMap(([columnType, ids]) =>
+    ids.map((id) => [id, columnType as ColumnType]),
+  ),
+);
+
 /** Map a DuckDB type id to DashFrame's normalized `ColumnType`. */
 export function duckdbTypeIdToColumnType(
   typeId: number | undefined,
 ): ColumnType {
-  switch (typeId) {
-    case DuckDBTypeId.BOOLEAN:
-      return "boolean";
-    case DuckDBTypeId.TINYINT:
-    case DuckDBTypeId.SMALLINT:
-    case DuckDBTypeId.INTEGER:
-    case DuckDBTypeId.BIGINT:
-    case DuckDBTypeId.UTINYINT:
-    case DuckDBTypeId.USMALLINT:
-    case DuckDBTypeId.UINTEGER:
-    case DuckDBTypeId.UBIGINT:
-    case DuckDBTypeId.HUGEINT:
-    case DuckDBTypeId.UHUGEINT:
-    case DuckDBTypeId.FLOAT:
-    case DuckDBTypeId.DOUBLE:
-    case DuckDBTypeId.DECIMAL:
-      return "number";
-    case DuckDBTypeId.DATE:
-    case DuckDBTypeId.TIMESTAMP:
-    case DuckDBTypeId.TIMESTAMP_S:
-    case DuckDBTypeId.TIMESTAMP_MS:
-    case DuckDBTypeId.TIMESTAMP_NS:
-    case DuckDBTypeId.TIMESTAMP_TZ:
-      return "date";
-    case DuckDBTypeId.VARCHAR:
-      return "string";
-    default:
-      return "unknown";
-  }
+  return typeId === undefined
+    ? "unknown"
+    : (COLUMN_TYPE_BY_DUCKDB_TYPE_ID.get(typeId) ?? "unknown");
 }
 
 /**

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -402,24 +402,64 @@ function nextStagingId(): number {
  * which map losslessly here. Int/Date are covered for robustness against
  * future producers; anything else degrades to VARCHAR via String().
  */
+type ArrowValueAppender = (appender: DuckDBAppender, value: unknown) => void;
+
+type ArrowTypeAdapter = {
+  duckdbType: string;
+  append: ArrowValueAppender;
+};
+
+const VARCHAR_ARROW_ADAPTER: ArrowTypeAdapter = {
+  duckdbType: "VARCHAR",
+  append: (appender, value) => appender.appendVarchar(String(value)),
+};
+
+/**
+ * One adapter table owns both sides of Arrow -> DuckDB conversion. Keeping the
+ * DDL type and Appender operation together prevents those formerly independent
+ * switches from accepting a type differently.
+ */
+const ARROW_TYPE_ADAPTERS: Partial<Record<ArrowType, ArrowTypeAdapter>> = {
+  [ArrowType.Bool]: {
+    duckdbType: "BOOLEAN",
+    append: (appender, value) => appender.appendBoolean(Boolean(value)),
+  },
+  [ArrowType.Int]: {
+    duckdbType: "BIGINT",
+    append: (appender, value) =>
+      appender.appendBigInt(
+        typeof value === "bigint" ? value : BigInt(Math.trunc(Number(value))),
+      ),
+  },
+  [ArrowType.Float]: {
+    duckdbType: "DOUBLE",
+    append: (appender, value) => appender.appendDouble(Number(value)),
+  },
+  [ArrowType.Timestamp]: {
+    duckdbType: "TIMESTAMP",
+    // Arrow JS yields epoch millis; DuckDB TIMESTAMP stores micros.
+    append: (appender, value) =>
+      appender.appendTimestamp(
+        new DuckDBTimestampValue(BigInt(Math.round(Number(value))) * 1000n),
+      ),
+  },
+  [ArrowType.Date]: {
+    duckdbType: "DATE",
+    append: (appender, value) =>
+      appender.appendDate(new DuckDBDateValue(arrowDateToDuckDBDays(value))),
+  },
+  [ArrowType.Utf8]: VARCHAR_ARROW_ADAPTER,
+  [ArrowType.LargeUtf8]: VARCHAR_ARROW_ADAPTER,
+};
+
+function arrowTypeAdapter(field: Field): ArrowTypeAdapter {
+  return (
+    ARROW_TYPE_ADAPTERS[field.type.typeId as ArrowType] ?? VARCHAR_ARROW_ADAPTER
+  );
+}
+
 function arrowFieldToDuckDBType(field: Field): string {
-  switch (field.type.typeId) {
-    case ArrowType.Bool:
-      return "BOOLEAN";
-    case ArrowType.Int:
-      return "BIGINT";
-    case ArrowType.Float:
-      return "DOUBLE";
-    case ArrowType.Timestamp:
-      return "TIMESTAMP";
-    case ArrowType.Date:
-      return "DATE";
-    case ArrowType.Utf8:
-    case ArrowType.LargeUtf8:
-      return "VARCHAR";
-    default:
-      return "VARCHAR";
-  }
+  return arrowTypeAdapter(field).duckdbType;
 }
 
 /**
@@ -446,31 +486,7 @@ function appendArrowValue(
     appender.appendNull();
     return;
   }
-  switch (field.type.typeId) {
-    case ArrowType.Bool:
-      appender.appendBoolean(Boolean(value));
-      break;
-    case ArrowType.Int:
-      appender.appendBigInt(
-        typeof value === "bigint" ? value : BigInt(Math.trunc(Number(value))),
-      );
-      break;
-    case ArrowType.Float:
-      appender.appendDouble(Number(value));
-      break;
-    case ArrowType.Timestamp:
-      // Arrow JS yields epoch millis; DuckDB TIMESTAMP stores micros.
-      appender.appendTimestamp(
-        new DuckDBTimestampValue(BigInt(Math.round(Number(value))) * 1000n),
-      );
-      break;
-    case ArrowType.Date:
-      appender.appendDate(new DuckDBDateValue(arrowDateToDuckDBDays(value)));
-      break;
-    default:
-      appender.appendVarchar(String(value));
-      break;
-  }
+  arrowTypeAdapter(field).append(appender, value);
 }
 
 /**

--- a/packages/engine/src/column-type-map.ts
+++ b/packages/engine/src/column-type-map.ts
@@ -1,0 +1,28 @@
+import type { ColumnType } from "@dashframe/types";
+
+/**
+ * Exhaustive map keyed by every normalized DashFrame column type.
+ *
+ * Runtime packages use this contract for their Arrow and DuckDB adapters so a
+ * new `ColumnType` cannot be added without TypeScript identifying every adapter
+ * that needs a mapping decision.
+ */
+export type ColumnTypeMap<Value> = { [Type in ColumnType]: Value };
+
+/** Preserve each entry's inferred value type while enforcing exhaustiveness. */
+export function defineColumnTypeMap<const Map extends ColumnTypeMap<unknown>>(
+  map: Map,
+): Map {
+  return map;
+}
+
+/** Infer a normalized column type from an already-typed primitive value. */
+export function inferPrimitiveColumnType(
+  value: boolean | number | string | null,
+  inferString: (value: string) => ColumnType = () => "string",
+): ColumnType {
+  if (value === null) return "unknown";
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "boolean";
+  return inferString(value);
+}

--- a/packages/engine/src/connector/utils.ts
+++ b/packages/engine/src/connector/utils.ts
@@ -5,6 +5,7 @@ import type {
   TableColumn,
   UUID,
 } from "@dashframe/types";
+import { defineColumnTypeMap } from "../column-type-map";
 
 export type ConnectorColumn = {
   name: string;
@@ -18,6 +19,8 @@ export type SystemFieldInput = {
   isIdentifier?: boolean;
   isReference?: boolean;
 };
+
+type PrimitiveValue = boolean | number | string;
 
 export function inferStringColumnType(value: string | undefined): ColumnType {
   if (!value?.length) return "unknown";
@@ -46,27 +49,29 @@ export function parseStringValueByType(
     return null;
   }
 
-  switch (type) {
-    case "number": {
-      const numeric = Number(raw);
-      return Number.isNaN(numeric) ? null : numeric;
-    }
-    case "boolean": {
-      const normalized = raw.toLowerCase().trim();
-      if (normalized === "true" || normalized === "1") return true;
-      if (normalized === "false" || normalized === "0") return false;
-      if (normalized === "yes" || normalized === "y") return true;
-      if (normalized === "no" || normalized === "n") return false;
-      return null;
-    }
-    case "date": {
-      const date = new Date(raw);
-      return Number.isNaN(date.getTime()) ? null : date;
-    }
-    default:
-      return raw;
-  }
+  return STRING_VALUE_PARSERS[type](raw);
 }
+
+const STRING_VALUE_PARSERS = defineColumnTypeMap({
+  number: (raw: string): unknown => {
+    const numeric = Number(raw);
+    return Number.isNaN(numeric) ? null : numeric;
+  },
+  boolean: (raw: string): unknown => {
+    const normalized = raw.toLowerCase().trim();
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+    if (normalized === "yes" || normalized === "y") return true;
+    if (normalized === "no" || normalized === "n") return false;
+    return null;
+  },
+  date: (raw: string): unknown => {
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? null : date;
+  },
+  string: (raw: string): unknown => raw,
+  unknown: (raw: string): unknown => raw,
+});
 
 export function parsePrimitiveBoolean(
   raw: boolean | number | string | null,
@@ -84,7 +89,7 @@ export function parsePrimitiveBoolean(
   return typeof raw === "number" && raw === 1;
 }
 
-function parsePrimitiveDate(raw: boolean | number | string): Date | null {
+function parsePrimitiveDate(raw: PrimitiveValue): Date | null {
   if (typeof raw === "number") {
     const timestamp = Math.abs(raw) < 1_000_000_000_000 ? raw * 1000 : raw;
     const date = new Date(timestamp);
@@ -105,22 +110,22 @@ export function parsePrimitiveValueByType(
     return null;
   }
 
-  switch (type) {
-    case "number": {
-      if (typeof raw === "number") {
-        return raw;
-      }
-      const numeric = Number(raw);
-      return Number.isNaN(numeric) ? null : numeric;
-    }
-    case "boolean":
-      return parsePrimitiveBoolean(raw);
-    case "date":
-      return parsePrimitiveDate(raw);
-    default:
-      return String(raw);
-  }
+  return PRIMITIVE_VALUE_PARSERS[type](raw);
 }
+
+const PRIMITIVE_VALUE_PARSERS = defineColumnTypeMap({
+  number: (raw: PrimitiveValue): unknown => {
+    if (typeof raw === "number") {
+      return raw;
+    }
+    const numeric = Number(raw);
+    return Number.isNaN(numeric) ? null : numeric;
+  },
+  boolean: (raw: PrimitiveValue): unknown => parsePrimitiveBoolean(raw),
+  date: (raw: PrimitiveValue): unknown => parsePrimitiveDate(raw),
+  string: (raw: PrimitiveValue): unknown => String(raw),
+  unknown: (raw: PrimitiveValue): unknown => String(raw),
+});
 
 export function detectPrimaryKeyColumn(
   columns: { name: string }[],

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -43,6 +43,12 @@ export type {
 
 export { isQueryPushDownCapable } from "./interfaces";
 
+export {
+  defineColumnTypeMap,
+  inferPrimitiveColumnType,
+  type ColumnTypeMap,
+} from "./column-type-map";
+
 // ============================================================================
 // Connector Pattern
 // ============================================================================

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -11,6 +11,7 @@ import {
   createSourceSchema,
   DataFrame as DataFrameClass,
   detectPrimaryKeyColumn,
+  inferPrimitiveColumnType,
   parsePrimitiveValueByType,
 } from "@dashframe/engine-browser";
 import {
@@ -43,22 +44,18 @@ export interface JSONConversionOptions extends FlattenOptions {
  * JSON values are already typed, so this is simpler than CSV type inference.
  */
 const inferType = (value: JsonPrimitive): ColumnType => {
-  if (value === null) return "unknown";
-  if (typeof value === "number") return "number";
-  if (typeof value === "boolean") return "boolean";
-  if (typeof value === "string") {
+  return inferPrimitiveColumnType(value, (stringValue) => {
     // Check if it's a date string
-    const date = Date.parse(value);
+    const date = Date.parse(stringValue);
     if (!Number.isNaN(date)) {
       // Additional check: ensure it looks like a date (has separators like - or /)
       // This avoids matching simple numeric strings
-      if (/[-/:]/.test(value) && value.length >= 8) {
+      if (/[-/:]/.test(stringValue) && stringValue.length >= 8) {
         return "date";
       }
     }
     return "string";
-  }
-  return "unknown";
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary

- add an exhaustive shared `ColumnType` mapping contract in `@dashframe/engine`
- consolidate Arrow, DuckDB, parser, appender, and JSON primitive mappings without changing behavior
- preserve the engine module's runtime exports in the visualization test mock

Notion source of truth: https://app.notion.com/p/Single-source-of-truth-for-ColumnType-ArrowType-DuckDBTypeId-mappings-3b4d48ccaf5481f292a6d948dd87ced6

## Verification

- `bun run check` — 83/83 tasks passed
- runtime Arrow encoding → native DuckDB registration → SQL type inspection passed
- focused visualization regression — 6/6 tests passed
- independent second review — no findings; targeted typechecks and 100 mapping tests passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes exhaustive `ColumnType` mappings while preserving existing parser and Arrow/DuckDB conversion behavior.

- Adds shared exhaustive mapping and primitive-inference helpers to `@dashframe/engine`.
- Replaces duplicated switches across browser Arrow encoding, server encoding/registration, connector parsing, and JSON inference.
- Adds full-column-type Arrow coverage and preserves real engine exports in the visualization test mock.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or compatibility failures identified.

The consolidated mappings preserve the prior conversion branches for all reachable ColumnType values, and the affected package boundaries remain compatible with their existing runtime targets.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/engine/src/column-type-map.ts | Adds a runtime-neutral exhaustive mapping helper and shared primitive type inference. |
| packages/engine/src/connector/utils.ts | Converts string and primitive parsing switches into exhaustive maps without changing behavior for reachable typed inputs. |
| packages/engine-browser/src/arrow.ts | Centralizes browser Arrow vector construction in an exhaustive ColumnType-keyed adapter. |
| packages/engine-server/src/arrow-encode.ts | Consolidates DuckDB type-ID normalization into a shared exhaustive mapping with equivalent fallback behavior. |
| packages/engine-server/src/native-engine.ts | Unifies Arrow-to-DuckDB DDL and appender behavior in one adapter table while preserving null and fallback handling. |
| packages/json/src/index.ts | Reuses shared primitive inference while retaining the existing date-string heuristic. |
| packages/app/src/components/visualizations/VisualizationPreview.test.tsx | Preserves the engine module’s real exports while overriding the single function required by the test. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  CT[ColumnType contract] --> BM[Browser Arrow mapping]
  CT --> SM[Server DuckDB type mapping]
  CT --> PM[Connector parser mappings]
  CT --> JM[JSON primitive inference]
  BM --> IPC[Arrow IPC]
  SM --> IPC
  IPC --> DB[DuckDB]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve engine exports in visualization..."](https://github.com/youhaowei/dashframe/commit/d5e2e28fb0e1709e60df70654eefce20348771a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50738076)</sub>

**Context used:**

- Knowledge Base — [Query Engine: SQL Generation, Selection, and Execution](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/engine.md)
- Knowledge Base — [Connectors: local files, Notion, Postgres, and REST](https://app.greptile.com/lumony/-/custom-context/knowledge-base/youhaowei/dashframe/-/docs/connectors.md)

<!-- /greptile_comment -->