### PR TITLE
fix(visualization): quote identifiers in color-domain query

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -750,6 +750,7 @@
       "name": "@dashframe/visualization",
       "version": "0.1.0",
       "dependencies": {
+        "@dashframe/engine": "workspace:*",
         "@dashframe/types": "workspace:*",
         "@dashframe/ui": "workspace:*",
         "@duckdb/duckdb-wasm": "1.32.0",

--- a/packages/visualization/package.json
+++ b/packages/visualization/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@dashframe/engine": "workspace:*",
     "@dashframe/types": "workspace:*",
     "@dashframe/ui": "workspace:*",
     "@wystack/ui-core": "workspace:*",

--- a/packages/visualization/src/renderers/vgplot-renderer.test.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupColorDomain } from "./vgplot-renderer";
+
+describe("setupColorDomain", () => {
+  it("quotes color-column and table identifiers in its distinct-values query", () => {
+    const query = vi.fn(() => Promise.resolve([]));
+    const api = {
+      context: {
+        coordinator: { query },
+      },
+    };
+
+    setupColorDomain(api, 'order "status"', 'sales order"archive');
+
+    expect(query).toHaveBeenCalledWith(
+      'SELECT DISTINCT "order ""status""" as val FROM "sales order""archive" ORDER BY "order ""status"""',
+      { type: "json" },
+    );
+  });
+});

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -27,6 +27,7 @@
  * ```
  */
 
+import { quoteIdentifier } from "@dashframe/engine";
 import type { ChartEncoding, VisualizationType } from "@dashframe/types";
 import type {
   ChartCleanup,
@@ -446,7 +447,7 @@ function buildAxisOptions(
  * Set up color domain for stacked bar charts (async).
  * Queries distinct values and sets them in alphabetical order for consistent colors.
  */
-function setupColorDomain(
+export function setupColorDomain(
   api: VgplotAPIExtended,
   colorColumn: string,
   tableName: string,
@@ -456,7 +457,7 @@ function setupColorDomain(
 
   coordinator
     .query(
-      `SELECT DISTINCT "${colorColumn}" as val FROM ${tableName} ORDER BY "${colorColumn}"`,
+      `SELECT DISTINCT ${quoteIdentifier(colorColumn)} as val FROM ${quoteIdentifier(tableName)} ORDER BY ${quoteIdentifier(colorColumn)}`,
       { type: "json" },
     )
     .then((result) => {

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -56,7 +56,12 @@ interface VgplotAPIExtended extends VgplotAPI {
       ) => Promise<unknown>;
     };
   };
-  colorDomain?: (domain: string[]) => void;
+  /**
+   * vgplot's `colorDomain` is a directive factory: it returns `(plot) => void`
+   * rather than applying anything itself. The caller must invoke the returned
+   * closure against a plot for the domain to take effect.
+   */
+  colorDomain?: (domain: string[]) => (plot: unknown) => void;
 }
 
 // ============================================================================
@@ -444,8 +449,13 @@ function buildAxisOptions(
 }
 
 /**
- * Set up color domain for stacked bar charts (async).
- * Queries distinct values and sets them in alphabetical order for consistent colors.
+ * Query the color domain for stacked bar charts (async).
+ *
+ * Queries distinct values for the color column and calls `api.colorDomain(domain)`,
+ * but the returned directive closure is discarded here — the plot is already built
+ * and mounted (see call site) by the time this async query resolves, so the sorted
+ * domain does not currently affect rendered colors. Making it apply requires
+ * restructuring render order and is tracked as separate follow-up work, not this fix.
  */
 export function setupColorDomain(
   api: VgplotAPIExtended,


### PR DESCRIPTION
Fixes a SQL-injection/identifier-quoting bug in the vgplot chart renderer's color-domain query: the color column name and table name were interpolated raw into a `SELECT DISTINCT ... FROM ...` string sent to the Mosaic coordinator, so a column or table name containing a double-quote (or any DuckDB-significant character) could break out of the intended identifier and inject arbitrary SQL.

Tracked internally as TASK-682.

## Changes

- `packages/visualization/src/renderers/vgplot-renderer.ts`: `setupColorDomain` now quotes both the color column and the table name with `quoteIdentifier` (from `@dashframe/engine`) before building the SQL string, and is exported so it's directly unit-testable.
- `packages/visualization/package.json` / `bun.lock`: adds `@dashframe/engine: workspace:*` as a dependency of `@dashframe/visualization` (acyclic — `engine` only depends on `types`).
- `packages/visualization/src/renderers/vgplot-renderer.test.ts`: new regression test asserting that a column/table name containing an embedded `"` is correctly `""`-doubled in the emitted SQL.
- Follow-up from review: corrected the local `colorDomain` type (it's a directive factory returning `(plot) => void`, not `void`) and reworded `setupColorDomain`'s doc comment, which previously claimed the color domain gets set in alphabetical order. It doesn't currently — `api.colorDomain(domain)`'s returned directive is discarded since the plot is already built and mounted by the time the async query resolves. Comments are code; this one misstated behavior. Making the domain actually apply requires a render-order change and is tracked as separate follow-up work, out of scope for this quoting fix.

**Out of scope, left alone deliberately:** the unquoted interpolations at `packages/engine/src/sql/insight-sql.ts:204,209` are intentional — vgplot's DSL parser re-extracts the column there and Mosaic quotes it downstream (documented at `insight-sql.ts:199-208`). Same for the Drizzle `getTableName()` call sites in `apps/server/src/draft-controller.ts` and the internally-generated temp-view names in `engine-browser/src/analyze.ts` — both are safe by construction (machine-generated, never user input) and not part of this fix's scope. The color-domain-doesn't-apply behavior noted above, the metric-as-color expression case, and a WHERE-clause quoting question in `insight-sql.ts:1044` are all tracked separately, not addressed here.

## Screenshots

No UI change.

## Verification

- `bunx turbo lint --filter='!@wystack/*'` — 19/19 tasks green.
- `bunx turbo test --filter='!@wystack/*'` — 38/38 tasks green (683 app tests including the new visualization regression test).
- `bunx turbo build --filter='!@wystack/*'` — 22/22 tasks green.
- `bun run check` — 85/85 tasks plus all four custom repo checks (ticket-refs, wystack-domain-nouns, apply-commands-boundary, packages) green.
- Reviewed independently in two rounds (an initial cold read plus a converge pass over the follow-up fix commit) before this PR was marked ready; both closed clean with no open findings.
