### PR TITLE
fix(ci): fail E2E job when e2e/web is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,24 +102,12 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Skip if e2e/web absent
-        id: guard
-        run: |
-          if [ -d e2e/web ]; then
-            echo "present=true" >>"$GITHUB_OUTPUT"
-          else
-            echo "present=false" >>"$GITHUB_OUTPUT"
-            echo "e2e/web not present yet — no tests to run"
-          fi
-
       - name: Setup Bun
-        if: steps.guard.outputs.present == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.5"
 
       - name: Install dependencies
-        if: steps.guard.outputs.present == 'true'
         run: bun install --frozen-lockfile
 
       # The web E2E target runs a production `vite build`, which resolves
@@ -128,19 +116,16 @@ jobs:
       # consume wystack *source* via the `bun` condition, so they don't need
       # this — but the bundler build does.)
       - name: Build WyStack submodule
-        if: steps.guard.outputs.present == 'true'
         run: bun run build:wystack
 
       - name: Install Playwright browsers
-        if: steps.guard.outputs.present == 'true'
         run: cd e2e/web && bun playwright install --with-deps chromium chromium-headless-shell
 
       - name: Run E2E tests
-        if: steps.guard.outputs.present == 'true'
         run: cd e2e/web && bun run test:e2e:ci
 
       - name: Upload test results
-        if: always() && steps.guard.outputs.present == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report


### PR DESCRIPTION
Make the CI E2E job fail loudly when `e2e/web` is missing, instead of silently skipping every step and reporting green.

## Changes

- Delete the `Skip if e2e/web absent` guard step from the `e2e` job in `.github/workflows/ci.yml`, along with the five `if: steps.guard.outputs.present == 'true'` clauses that consumed it. Nothing else in the workflow (jobs, `on:`, `concurrency:`, `needs:` graph) is touched, and nothing outside the job ever read the guard output.

A required check that goes green while the test suite it exists to run is absent is the hazard this closes: previously, deleting or breaking the `e2e/web` checkout would have produced a passing "E2E Tests" check with zero tests executed.

Failure model if `e2e/web` ever goes missing: the job fails at `Install dependencies` (`bun install --frozen-lockfile` against a lockfile still listing `@dashframe/web-e2e`, since root `workspaces` includes `e2e/*`) — before reaching `cd e2e/web`. Still loud, just earlier than the `cd` step.

## Screenshots

No UI change.

## Verification

- CI evidence that the guard was a no-op on the live tree: run 31202877906 on `main` (head `3fbfaced`), job "E2E Tests" — every previously gated step reports conclusion `success`, not `skipped` (Setup Bun, Install dependencies, Build WyStack submodule, Install Playwright browsers, Run E2E tests, Upload test results). The guard evaluated true on every current revision, so this diff cannot change behavior on any revision that has `e2e/web`.
- Cold-read review of the branch diff: CLEAN. YAML parses (`yaml.safe_load`); the required-context display string `name: E2E Tests` is unchanged; the artifact upload keeps `if: always()` (with `if-no-files-found: warn`, so a missing path cannot mask an earlier red).

Tracked internally as TASK-770.
