### PR TITLE
fix(app): truthful preview-diff details, drawer dismiss, linear display names

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,6 +20,10 @@
       "bun": "./src/functions.ts",
       "default": "./src/functions.ts"
     },
+    "./dashboard-item-updates": {
+      "bun": "./src/functions/dashboard-item-updates.ts",
+      "default": "./src/functions/dashboard-item-updates.ts"
+    },
     "./assistant-read-host": {
       "bun": "./src/assistant-read-host.ts",
       "default": "./src/assistant-read-host.ts"

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -128,6 +128,7 @@ export {
 import type { DashframeFunctionContext } from "../app-context";
 import { permissions } from "../permissions";
 import { wy } from "../wystack";
+import { sanitizeDashboardItemUpdates } from "./dashboard-item-updates";
 import {
   type InsightSource,
   insightSourceSchema,
@@ -1491,36 +1492,6 @@ function requireDashboardItem(value: unknown): DashboardItem {
   // `overrides` is passed through as-is — it is written by the fan-out primitive
   // which controls the shape; the per-field filter pin is validated there.
   return value as unknown as DashboardItem;
-}
-
-/**
- * Filter raw `updates` to the recognized DashboardItem fields with the correct
- * primitive types, dropping anything malformed. Mirrors sanitizeDashboardUpdates in
- * dashboards.ts so the raw command path cannot write `{ x: "left", width: null }`
- * into layout coordinates that consumers assume are numeric.
- */
-function sanitizeDashboardItemUpdates(
-  updates: Record<string, unknown>,
-): Partial<Omit<DashboardItem, "id" | "type">> {
-  const next: Partial<Omit<DashboardItem, "id" | "type">> = {};
-  if (typeof updates.visualizationId === "string") {
-    next.visualizationId = updates.visualizationId;
-  }
-  if (typeof updates.content === "string") next.content = updates.content;
-  if (typeof updates.x === "number") next.x = updates.x;
-  if (typeof updates.y === "number") next.y = updates.y;
-  if (typeof updates.width === "number") next.width = updates.width;
-  if (typeof updates.height === "number") next.height = updates.height;
-  // `overrides` is passed through as-is — callers use this to update or clear
-  // a panel's filter/sort/limit bag. The shape is opaque jsonb; downstream
-  // rendering validates filters at query time, not at the write boundary.
-  // An explicit `undefined` means "not updating overrides" (the key was absent
-  // in the updates object); `null` is not in the type so omit check mirrors
-  // the other field guards.
-  if ("overrides" in updates) {
-    next.overrides = updates.overrides as DashboardItemOverrides | undefined;
-  }
-  return next;
 }
 
 /**

--- a/apps/server/src/functions/dashboard-item-updates.ts
+++ b/apps/server/src/functions/dashboard-item-updates.ts
@@ -1,0 +1,33 @@
+import type { DashboardItem, DashboardItemOverrides } from "@dashframe/types";
+
+/**
+ * Filter raw `updates` to the recognized DashboardItem fields with the correct
+ * primitive types, dropping anything malformed. Mirrors sanitizeDashboardUpdates in
+ * dashboards.ts so the raw command path cannot write `{ x: "left", width: null }`
+ * into layout coordinates that consumers assume are numeric. Shared with the
+ * preview-diff renderer so the consent surface never claims a change that
+ * publication would drop.
+ */
+export function sanitizeDashboardItemUpdates(
+  updates: Record<string, unknown>,
+): Partial<Omit<DashboardItem, "id" | "type">> {
+  const next: Partial<Omit<DashboardItem, "id" | "type">> = {};
+  if (typeof updates.visualizationId === "string") {
+    next.visualizationId = updates.visualizationId;
+  }
+  if (typeof updates.content === "string") next.content = updates.content;
+  if (typeof updates.x === "number") next.x = updates.x;
+  if (typeof updates.y === "number") next.y = updates.y;
+  if (typeof updates.width === "number") next.width = updates.width;
+  if (typeof updates.height === "number") next.height = updates.height;
+  // `overrides` is passed through as-is — callers use this to update or clear
+  // a panel's filter/sort/limit bag. The shape is opaque jsonb; downstream
+  // rendering validates filters at query time, not at the write boundary.
+  // An explicit `undefined` means "not updating overrides" (the key was absent
+  // in the updates object); `null` is not in the type so omit check mirrors
+  // the other field guards.
+  if ("overrides" in updates) {
+    next.overrides = updates.overrides as DashboardItemOverrides | undefined;
+  }
+  return next;
+}

--- a/packages/app/src/app/data-sources/page.tsx
+++ b/packages/app/src/app/data-sources/page.tsx
@@ -309,6 +309,7 @@ export default function DataSourcesPage() {
       <CreateVisualizationModal
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
+        title="Add Data Source"
       />
     </div>
   );

--- a/packages/app/src/components/navigation.test.tsx
+++ b/packages/app/src/components/navigation.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLocation } = vi.hoisted(() => ({
+  mockLocation: { pathname: "/data-sources" },
+}));
 
 vi.mock("@/components/access-credentials/AccessCredentialsDialog", () => ({
   AccessCredentialsDialog: () => null,
@@ -38,7 +42,10 @@ vi.mock("@tanstack/react-router", () => ({
       {children}
     </a>
   ),
-  useLocation: () => "/data-sources",
+  useLocation: ({
+    select,
+  }: { select?: (location: { pathname: string }) => unknown } = {}) =>
+    select ? select(mockLocation) : mockLocation,
   useNavigate: () => vi.fn(),
 }));
 vi.mock("@wystack/ui-react", () => ({
@@ -103,6 +110,10 @@ vi.mock("@wystack/ui-react/icons", () => ({
 import { Navigation } from "./navigation";
 
 describe("Navigation", () => {
+  beforeEach(() => {
+    mockLocation.pathname = "/data-sources";
+  });
+
   it("closes the mobile drawer when the active route is tapped", () => {
     render(<Navigation />);
 
@@ -114,6 +125,18 @@ describe("Navigation", () => {
         name: "Data Sources",
       }),
     );
+    expect(screen.queryByTestId("mobile-drawer")).toBeNull();
+  });
+
+  it("closes the mobile drawer when the pathname changes", () => {
+    const { rerender } = render(<Navigation />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(screen.getByTestId("mobile-drawer")).toBeDefined();
+
+    mockLocation.pathname = "/insights";
+    rerender(<Navigation />);
+
     expect(screen.queryByTestId("mobile-drawer")).toBeNull();
   });
 });

--- a/packages/app/src/components/navigation.test.tsx
+++ b/packages/app/src/components/navigation.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/access-credentials/AccessCredentialsDialog", () => ({
+  AccessCredentialsDialog: () => null,
+}));
+vi.mock("@/components/theme-toggle", () => ({ ThemeToggle: () => null }));
+vi.mock("@/data", () => ({
+  useAccessCapabilities: () => ({ data: { canManageCredentials: false } }),
+}));
+vi.mock("@/lib/data-access/data-frames", () => ({ clearAllData: vi.fn() }));
+vi.mock("@/lib/perf", () => ({ PerfHud: () => null }));
+vi.mock("@/lib/stores", () => ({
+  useToastStore: () => ({ showError: vi.fn(), showSuccess: vi.fn() }),
+}));
+vi.mock("@/lib/stores/assistant-store", () => ({
+  useAssistantStore: (
+    select: (state: { setSetupOpen: () => void }) => unknown,
+  ) => select({ setSetupOpen: vi.fn() }),
+}));
+vi.mock("@/lib/stores/shell-store", () => ({
+  useShellStore: (select: (state: { leftNavOpen: boolean }) => unknown) =>
+    select({ leftNavOpen: true }),
+}));
+vi.mock("@/wystack/api", () => ({ api: { listDrafts: {} } }));
+vi.mock("@wystack/client", () => ({ useQuery: () => ({ data: [] }) }));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ to, onClick, children, ...props }: React.ComponentProps<"a">) => (
+    <a
+      href={to}
+      onClick={(event) => {
+        event.preventDefault();
+        onClick?.(event);
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  useLocation: () => "/data-sources",
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("@wystack/ui-react", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  Button: ({
+    label,
+    children,
+    onClick,
+  }: {
+    label?: string;
+    children?: React.ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{label ?? children}</button>,
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="mobile-drawer">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Dock: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+  DropdownMenuTrigger: ({ render: trigger }: { render: React.ReactNode }) => (
+    <>{trigger}</>
+  ),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+vi.mock("@wystack/ui-react/icons", () => ({
+  ChartIcon: () => null,
+  CloseIcon: () => null,
+  DashboardIcon: () => null,
+  DatabaseIcon: () => null,
+  DeleteIcon: () => null,
+  FileIcon: () => null,
+  GithubIcon: () => null,
+  GridIcon: () => null,
+  MenuIcon: () => null,
+  SettingsIcon: () => null,
+  SparklesIcon: () => null,
+}));
+
+import { Navigation } from "./navigation";
+
+describe("Navigation", () => {
+  it("closes the mobile drawer when the active route is tapped", () => {
+    render(<Navigation />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(screen.getByTestId("mobile-drawer")).toBeDefined();
+
+    fireEvent.click(
+      within(screen.getByTestId("mobile-drawer")).getByRole("link", {
+        name: "Data Sources",
+      }),
+    );
+    expect(screen.queryByTestId("mobile-drawer")).toBeNull();
+  });
+});

--- a/packages/app/src/components/navigation.tsx
+++ b/packages/app/src/components/navigation.tsx
@@ -39,7 +39,7 @@ import {
   SettingsIcon,
   SparklesIcon,
 } from "@wystack/ui-react/icons";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 import {
   DESKTOP_NAV_BREAKPOINT_CLASS,
@@ -223,6 +223,7 @@ function SidebarContent({
 
 export function Navigation() {
   const navigate = useNavigate();
+  const pathname = useLocation({ select: (location) => location.pathname });
   const [isOpen, setIsOpen] = useState(false);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [showAccessCredentials, setShowAccessCredentials] = useState(false);
@@ -235,6 +236,9 @@ export function Navigation() {
   const leftNavOpen = useShellStore((s) => s.leftNavOpen);
 
   const { showError, showSuccess } = useToastStore();
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- route changes must dismiss the modal drawer.
+  useEffect(() => setIsOpen(false), [pathname]);
 
   const handleClearAllData = async () => {
     try {
@@ -293,7 +297,10 @@ export function Navigation() {
 
       {/* Mobile Sidebar Dialog */}
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent className="max-w-xs gap-0 border-0 p-0">
+        <DialogContent
+          className="max-w-xs gap-0 border-0 p-0"
+          showCloseButton={false}
+        >
           <div className="flex h-screen flex-col">
             <div className="flex items-center justify-between border-b border-neutral-border/60 p-4">
               <span className="text-sm font-semibold">Menu</span>

--- a/packages/app/src/components/navigation.tsx
+++ b/packages/app/src/components/navigation.tsx
@@ -90,6 +90,7 @@ interface SidebarContentProps {
   onClearData?: () => void;
   onAssistantProviders?: () => void;
   onAccessCredentials?: () => void;
+  onNavigate?: () => void;
   /**
    * Extra rows for the footer, below Settings/Open source — dev tooling like
    * the perf HUD. Supplied only by the desktop nav so the mobile dialog doesn't
@@ -103,6 +104,7 @@ function SidebarContent({
   onClearData,
   onAssistantProviders,
   onAccessCredentials,
+  onNavigate,
   footerSlot,
   pendingDraftCount,
 }: SidebarContentProps) {
@@ -138,6 +140,7 @@ function SidebarContent({
             <Link
               key={item.name}
               to={item.href as never}
+              onClick={onNavigate}
               className={cn(
                 "group flex items-center gap-3 rounded-lg px-2.5 py-2 transition-colors",
                 isActive
@@ -315,6 +318,7 @@ export function Navigation() {
             <div className="flex-1 overflow-y-auto">
               <SidebarContent
                 pendingDraftCount={drafts.length}
+                onNavigate={() => setIsOpen(false)}
                 onClearData={() => setShowClearConfirm(true)}
                 onAssistantProviders={() => setAssistantSetupOpen(true)}
                 onAccessCredentials={

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -160,6 +160,43 @@ describe("PreviewDiffRenderer", () => {
         ),
       ).toBeDefined();
     });
+
+    it("does not attribute a merged nested update to the wrong target", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("dt-merged-nested-update"),
+        before: {
+          fields: [
+            {
+              id: "3c4708a7-a85d-457e-b69d-3226b0a1cfd5",
+              name: "revenue",
+            },
+          ],
+          metrics: [
+            {
+              id: "fdd13f3e-b880-4524-a829-6515aeb7ccc7",
+              name: "Revenue",
+            },
+          ],
+        },
+        proposedDefinition: {
+          nodeId: "dt-merged-nested-update",
+          fieldId: "3c4708a7-a85d-457e-b69d-3226b0a1cfd5",
+          metricId: "fdd13f3e-b880-4524-a829-6515aeb7ccc7",
+          updates: { name: "Total revenue" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.queryByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "name: revenue → Total revenue",
+        ),
+      ).toBeNull();
+      expect(screen.queryByText("Total revenue")).toBeNull();
+    });
   });
 
   describe("pending indicator — compute===undefined for active insight node", () => {

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -13,6 +13,7 @@
  * 7. Empty state when no direct nodes and no error.
  */
 
+import { fieldIdToColumnAlias } from "@dashframe/engine";
 import type {
   PreviewCompute,
   PreviewDiff,
@@ -220,13 +221,32 @@ describe("PreviewDiffRenderer", () => {
       ).toBeNull();
     });
 
+    it("renders a resolved join update from its positional index", () => {
+      const node: PreviewDirectNode = {
+        ...insightNode("join-update", "update"),
+        before: { joins: [{ name: "Orders users", type: "inner" }] },
+        proposedDefinition: { joinIndex: 0, updates: { type: "left" } },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "type: inner → left",
+        ),
+      ).toBeDefined();
+    });
+
     it("keeps unresolvable merged targets in the ambiguous label", () => {
+      const fieldId = "3c4708a7-a85d-457e-b69d-3226b0a1cfd5";
       const node: PreviewDirectNode = {
         ...dataTableNode("partially-resolved-merged-update"),
-        before: { fields: [{ id: "f1" }] },
+        before: { fields: [{ id: fieldId }] },
         proposedDefinition: {
           nodeId: "partially-resolved-merged-update",
-          fieldId: "f1",
+          fieldId,
           joinIndex: 0,
           updates: { name: "Renamed field" },
         },
@@ -239,7 +259,7 @@ describe("PreviewDiffRenderer", () => {
           (_, element) =>
             element?.tagName === "LI" &&
             element.textContent ===
-              "one of: field f1, join #0 — name: — → Renamed field",
+              "one of: field 3c4708a7…, join #0 — name: — → Renamed field",
         ),
       ).toBeDefined();
       expect(
@@ -270,11 +290,22 @@ describe("PreviewDiffRenderer", () => {
     it("expands dashboard item updates into per-key detail rows", () => {
       const node: PreviewDirectNode = {
         ...dataTableNode("dashboard-item"),
-        before: { items: [] },
+        before: {
+          layout: [
+            {
+              id: "item-1",
+              type: "markdown",
+              x: 1,
+              y: 2,
+              width: 3,
+              height: 2,
+            },
+          ],
+        },
         proposedDefinition: {
           nodeId: "dashboard-item",
           itemId: "item-1",
-          updates: { w: 4, h: 2 },
+          updates: { width: 4, height: 2, unsupported: true },
         },
       };
 
@@ -283,16 +314,40 @@ describe("PreviewDiffRenderer", () => {
       expect(
         screen.getByText(
           (_, element) =>
-            element?.tagName === "LI" && element.textContent === "w: — → 4",
+            element?.tagName === "LI" && element.textContent === "width: 3 → 4",
         ),
       ).toBeDefined();
       expect(
+        screen.queryByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "height: 2 → 2",
+        ),
+      ).toBeNull();
+      expect(screen.queryByText(/unsupported:/)).toBeNull();
+      expect(screen.queryByText(/updates:/)).toBeNull();
+    });
+
+    it("redacts secret references in detail rows", () => {
+      const oldSecretRef = "secret:3c4708a7-a85d-457e-b69d-3226b0a1cfd5";
+      const newSecretRef = "secret:fdd13f3e-b880-4524-a829-6515aeb7ccc7";
+      const node: PreviewDirectNode = {
+        ...dataTableNode("secret-config"),
+        before: { apiKey: oldSecretRef },
+        proposedDefinition: { apiKey: newSecretRef },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
         screen.getByText(
           (_, element) =>
-            element?.tagName === "LI" && element.textContent === "h: — → 2",
+            element?.tagName === "LI" &&
+            element.textContent === "apiKey: •••••• → ••••••",
         ),
       ).toBeDefined();
-      expect(screen.queryByText(/updates:/)).toBeNull();
+      expect(screen.queryByText(oldSecretRef)).toBeNull();
+      expect(screen.queryByText(newSecretRef)).toBeNull();
     });
 
     it("expands an unresolvable field update into per-key detail rows", () => {
@@ -337,6 +392,34 @@ describe("PreviewDiffRenderer", () => {
       expect(screen.queryByText(/source:/)).toBeNull();
     });
 
+    it("normalizes chart operands to their stored visualization shape", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("chart-type"),
+        before: { chartType: "barY", options: { spec: { mark: "bar" } } },
+        proposedDefinition: {
+          visualizationType: "line",
+          spec: { mark: "line" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "chartType: barY → line",
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === 'spec: {"mark":"bar"} → {"mark":"line"}',
+        ),
+      ).toBeDefined();
+    });
+
     it("renders changed source objects without comparing them to baseTableId", () => {
       const node: PreviewDirectNode = {
         ...insightNode("changed-source", "update"),
@@ -377,6 +460,21 @@ describe("PreviewDiffRenderer", () => {
       render(<PreviewDiffRenderer diff={makeDiff([node])} />);
 
       expect(screen.queryByText(/filters:/)).toBeNull();
+    });
+
+    it("does not render detail rows for a create node", () => {
+      const node: PreviewDirectNode = {
+        ...insightNode("new-insight", "create"),
+        proposedDefinition: {
+          baseTableId: "table-1",
+          selectedFields: ["field-1"],
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(screen.queryByText(/baseTableId:/)).toBeNull();
+      expect(screen.queryByText(/selectedFields:/)).toBeNull();
     });
   });
 
@@ -436,22 +534,26 @@ describe("PreviewDiffRenderer", () => {
     });
 
     it("renders head rows when compute is filled with head data", () => {
+      const regionFieldId = "fdd13f3e-b880-4524-a829-6515aeb7ccc7";
+      const revenueFieldId = "3c4708a7-a85d-457e-b69d-3226b0a1cfd5";
+      const regionAlias = fieldIdToColumnAlias(regionFieldId);
+      const revenueAlias = fieldIdToColumnAlias(revenueFieldId);
       const compute: PreviewCompute = {
         rowCountBefore: null,
         rowCountAfter: 3,
         head: [
           {
-            field_fdd13f3e_b880_4524_a829_6515aeb7ccc7: "Alice",
-            field_3c4708a7_a85d_457e_b69d_3226b0a1cfd5: 100,
+            [regionAlias]: "Alice",
+            [revenueAlias]: 100,
           },
           {
-            field_fdd13f3e_b880_4524_a829_6515aeb7ccc7: "Bob",
-            field_3c4708a7_a85d_457e_b69d_3226b0a1cfd5: 200,
+            [regionAlias]: "Bob",
+            [revenueAlias]: 200,
           },
         ],
         columnLabels: {
-          field_fdd13f3e_b880_4524_a829_6515aeb7ccc7: "region",
-          field_3c4708a7_a85d_457e_b69d_3226b0a1cfd5: "Revenue (USD)",
+          [regionAlias]: "region",
+          [revenueAlias]: "Revenue (USD)",
         },
       };
       const diff = makeDiff([insightNode("ins-head", "create", compute)]);
@@ -461,9 +563,7 @@ describe("PreviewDiffRenderer", () => {
       // Column headers.
       expect(screen.getByText("region")).toBeDefined();
       expect(screen.getByText("Revenue (USD)")).toBeDefined();
-      expect(
-        screen.queryByText("field_fdd13f3e_b880_4524_a829_6515aeb7ccc7"),
-      ).toBeNull();
+      expect(screen.queryByText(regionAlias)).toBeNull();
       // Row values.
       expect(screen.getByText("Alice")).toBeDefined();
       expect(screen.getByText("Bob")).toBeDefined();

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -182,7 +182,7 @@ describe("PreviewDiffRenderer", () => {
           nodeId: "dt-merged-nested-update",
           fieldId: "3c4708a7-a85d-457e-b69d-3226b0a1cfd5",
           metricId: "fdd13f3e-b880-4524-a829-6515aeb7ccc7",
-          updates: { name: "Total revenue" },
+          updates: { name: "Total revenue", format: "currency" },
         },
       };
 
@@ -193,7 +193,15 @@ describe("PreviewDiffRenderer", () => {
           (_, element) =>
             element?.tagName === "LI" &&
             element.textContent ===
-              'applies to: field revenue, metric Revenue: — → {"name":"Total revenue"}',
+              "one of: field revenue, metric Revenue — name: — → Total revenue",
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent ===
+              "one of: field revenue, metric Revenue — format: — → currency",
         ),
       ).toBeDefined();
       expect(
@@ -208,6 +216,37 @@ describe("PreviewDiffRenderer", () => {
           (_, element) =>
             element?.tagName === "LI" &&
             element.textContent === "name: Revenue → Total revenue",
+        ),
+      ).toBeNull();
+    });
+
+    it("keeps unresolvable merged targets in the ambiguous label", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("partially-resolved-merged-update"),
+        before: { fields: [{ id: "f1" }] },
+        proposedDefinition: {
+          nodeId: "partially-resolved-merged-update",
+          fieldId: "f1",
+          joinIndex: 0,
+          updates: { name: "Renamed field" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent ===
+              "one of: field f1, join #0 — name: — → Renamed field",
+        ),
+      ).toBeDefined();
+      expect(
+        screen.queryByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "name: — → Renamed field",
         ),
       ).toBeNull();
     });

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -131,6 +131,35 @@ describe("PreviewDiffRenderer", () => {
       expect(screen.getByText("Data Table")).toBeDefined();
       expect(screen.queryByText(/Computing/)).toBeNull();
     });
+
+    it("renders the actual field change from the node's before slice", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("dt-field"),
+        before: {
+          fields: [
+            {
+              id: "3c4708a7-a85d-457e-b69d-3226b0a1cfd5",
+              name: "revenue",
+            },
+          ],
+        },
+        proposedDefinition: {
+          nodeId: "dt-field",
+          fieldId: "3c4708a7-a85d-457e-b69d-3226b0a1cfd5",
+          updates: { name: "Revenue (USD)" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "name: revenue → Revenue (USD)",
+        ),
+      ).toBeDefined();
+    });
   });
 
   describe("pending indicator — compute===undefined for active insight node", () => {
@@ -193,17 +222,30 @@ describe("PreviewDiffRenderer", () => {
         rowCountBefore: null,
         rowCountAfter: 3,
         head: [
-          { name: "Alice", score: 100 },
-          { name: "Bob", score: 200 },
+          {
+            field_fdd13f3e_b880_4524_a829_6515aeb7ccc7: "Alice",
+            field_3c4708a7_a85d_457e_b69d_3226b0a1cfd5: 100,
+          },
+          {
+            field_fdd13f3e_b880_4524_a829_6515aeb7ccc7: "Bob",
+            field_3c4708a7_a85d_457e_b69d_3226b0a1cfd5: 200,
+          },
         ],
+        columnLabels: {
+          field_fdd13f3e_b880_4524_a829_6515aeb7ccc7: "region",
+          field_3c4708a7_a85d_457e_b69d_3226b0a1cfd5: "Revenue (USD)",
+        },
       };
       const diff = makeDiff([insightNode("ins-head", "create", compute)]);
 
       render(<PreviewDiffRenderer diff={diff} />);
 
       // Column headers.
-      expect(screen.getByText("name")).toBeDefined();
-      expect(screen.getByText("score")).toBeDefined();
+      expect(screen.getByText("region")).toBeDefined();
+      expect(screen.getByText("Revenue (USD)")).toBeDefined();
+      expect(
+        screen.queryByText("field_fdd13f3e_b880_4524_a829_6515aeb7ccc7"),
+      ).toBeNull();
       // Row values.
       expect(screen.getByText("Alice")).toBeDefined();
       expect(screen.getByText("Bob")).toBeDefined();

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -161,7 +161,7 @@ describe("PreviewDiffRenderer", () => {
       ).toBeDefined();
     });
 
-    it("renders a merged nested update for every target", () => {
+    it("renders a merged nested update once without fabricating target changes", () => {
       const node: PreviewDirectNode = {
         ...dataTableNode("dt-merged-nested-update"),
         before: {
@@ -192,16 +192,40 @@ describe("PreviewDiffRenderer", () => {
         screen.getByText(
           (_, element) =>
             element?.tagName === "LI" &&
-            element.textContent === "name: revenue → Total revenue",
+            element.textContent ===
+              'applies to: field revenue, metric Revenue: — → {"name":"Total revenue"}',
         ),
       ).toBeDefined();
       expect(
-        screen.getByText(
+        screen.queryByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "name: revenue → Total revenue",
+        ),
+      ).toBeNull();
+      expect(
+        screen.queryByText(
           (_, element) =>
             element?.tagName === "LI" &&
             element.textContent === "name: Revenue → Total revenue",
         ),
-      ).toBeDefined();
+      ).toBeNull();
+    });
+
+    it("does not render a fallback row for a resolved no-op nested update", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("unchanged-field"),
+        before: { fields: [{ id: "f1", name: "revenue" }] },
+        proposedDefinition: {
+          nodeId: "unchanged-field",
+          fieldId: "f1",
+          updates: { name: "revenue" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(screen.queryByText(/name:/)).toBeNull();
     });
 
     it("expands dashboard item updates into per-key detail rows", () => {

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.test.tsx
@@ -161,7 +161,7 @@ describe("PreviewDiffRenderer", () => {
       ).toBeDefined();
     });
 
-    it("does not attribute a merged nested update to the wrong target", () => {
+    it("renders a merged nested update for every target", () => {
       const node: PreviewDirectNode = {
         ...dataTableNode("dt-merged-nested-update"),
         before: {
@@ -189,13 +189,131 @@ describe("PreviewDiffRenderer", () => {
       render(<PreviewDiffRenderer diff={makeDiff([node])} />);
 
       expect(
-        screen.queryByText(
+        screen.getByText(
           (_, element) =>
             element?.tagName === "LI" &&
             element.textContent === "name: revenue → Total revenue",
         ),
-      ).toBeNull();
-      expect(screen.queryByText("Total revenue")).toBeNull();
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "name: Revenue → Total revenue",
+        ),
+      ).toBeDefined();
+    });
+
+    it("expands dashboard item updates into per-key detail rows", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("dashboard-item"),
+        before: { items: [] },
+        proposedDefinition: {
+          nodeId: "dashboard-item",
+          itemId: "item-1",
+          updates: { w: 4, h: 2 },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" && element.textContent === "w: — → 4",
+        ),
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" && element.textContent === "h: — → 2",
+        ),
+      ).toBeDefined();
+      expect(screen.queryByText(/updates:/)).toBeNull();
+    });
+
+    it("expands an unresolvable field update into per-key detail rows", () => {
+      const node: PreviewDirectNode = {
+        ...dataTableNode("missing-field"),
+        before: { fields: [] },
+        proposedDefinition: {
+          nodeId: "missing-field",
+          fieldId: "missing-field-id",
+          updates: { name: "Renamed field" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent === "name: — → Renamed field",
+        ),
+      ).toBeDefined();
+      expect(screen.queryByText(/updates:/)).toBeNull();
+    });
+
+    it("compares source objects using their stored source shape", () => {
+      const node: PreviewDirectNode = {
+        ...insightNode("source", "update"),
+        before: {
+          definition: {
+            source: { sourceType: "dataTable", sourceId: "table-1" },
+            baseTableId: "table-1",
+          },
+        },
+        proposedDefinition: {
+          source: { sourceType: "dataTable", sourceId: "table-1" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(screen.queryByText(/source:/)).toBeNull();
+    });
+
+    it("renders changed source objects without comparing them to baseTableId", () => {
+      const node: PreviewDirectNode = {
+        ...insightNode("changed-source", "update"),
+        before: {
+          definition: {
+            source: { sourceType: "dataTable", sourceId: "table-1" },
+            baseTableId: "table-1",
+          },
+        },
+        proposedDefinition: {
+          source: { sourceType: "dataTable", sourceId: "table-2" },
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(
+        screen.getByText(
+          (_, element) =>
+            element?.tagName === "LI" &&
+            element.textContent ===
+              'source: {"sourceType":"dataTable","sourceId":"table-1"} → {"sourceType":"dataTable","sourceId":"table-2"}',
+        ),
+      ).toBeDefined();
+    });
+
+    it("does not render a change for objects with reordered keys", () => {
+      const node: PreviewDirectNode = {
+        ...insightNode("same-filter", "update"),
+        before: {
+          definition: { filters: [{ field: "region", op: "eq" }] },
+        },
+        proposedDefinition: {
+          filters: [{ op: "eq", field: "region" }],
+        },
+      };
+
+      render(<PreviewDiffRenderer diff={makeDiff([node])} />);
+
+      expect(screen.queryByText(/filters:/)).toBeNull();
     });
   });
 

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -246,6 +246,8 @@ type ChangeDetail = {
   after: unknown;
 };
 
+type NestedCollectionKey = "fields" | "metrics" | "joins";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -290,10 +292,23 @@ function formatValue(value: unknown): string {
 function nestedUpdateDetails(
   before: Record<string, unknown>,
   proposed: Record<string, unknown>,
-  collectionKey: "fields" | "metrics" | "joins",
+  collectionKey: NestedCollectionKey,
   targetId: unknown,
 ): ChangeDetail[] | null {
   if (!isRecord(proposed.updates)) return null;
+  const target = findNestedTarget(before, collectionKey, targetId);
+  if (!target) return null;
+
+  return Object.entries(proposed.updates)
+    .filter(([key, after]) => !valuesMatch(target[key], after))
+    .map(([key, after]) => ({ key, before: target[key], after }));
+}
+
+function findNestedTarget(
+  before: Record<string, unknown>,
+  collectionKey: NestedCollectionKey,
+  targetId: unknown,
+): Record<string, unknown> | null {
   const collection = comparableBefore(before)[collectionKey];
   if (!Array.isArray(collection)) return null;
 
@@ -303,11 +318,20 @@ function nestedUpdateDetails(
   } else {
     target = collection.find((item) => isRecord(item) && item.id === targetId);
   }
-  if (!isRecord(target)) return null;
+  return isRecord(target) ? target : null;
+}
 
-  return Object.entries(proposed.updates)
-    .filter(([key, after]) => !valuesMatch(target[key], after))
-    .map(([key, after]) => ({ key, before: target[key], after }));
+function nestedTargetLabel(
+  before: Record<string, unknown>,
+  collectionKey: NestedCollectionKey,
+  targetId: unknown,
+): string | null {
+  const target = findNestedTarget(before, collectionKey, targetId);
+  if (!target) return null;
+
+  const kind = collectionKey === "joins" ? "join" : collectionKey.slice(0, -1);
+  const name = typeof target.name === "string" ? target.name : targetId;
+  return `${kind} ${name}`;
 }
 
 function fallbackUpdateDetails(
@@ -330,13 +354,34 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
     ["metrics", proposed.metricId],
     ["joins", proposed.joinIndex],
   ] as const;
-  const resolvedNestedDetails = nestedDetails.flatMap(
+  const selectedNestedTargets = nestedDetails.filter(
+    ([, target]) => target !== undefined,
+  );
+
+  if (selectedNestedTargets.length > 1 && isRecord(proposed.updates)) {
+    const labels = selectedNestedTargets.flatMap(([collection, target]) => {
+      const label = nestedTargetLabel(before, collection, target);
+      return label ? [label] : [];
+    });
+    return [
+      {
+        key: `applies to: ${labels.join(", ") || "multiple targets"}`,
+        before: undefined,
+        after: proposed.updates,
+      },
+    ];
+  }
+
+  let anyResolved = false;
+  const resolvedNestedDetails = selectedNestedTargets.flatMap(
     ([collection, target]) => {
-      if (target === undefined) return [];
-      return nestedUpdateDetails(before, proposed, collection, target) ?? [];
+      const details = nestedUpdateDetails(before, proposed, collection, target);
+      if (details === null) return [];
+      anyResolved = true;
+      return details;
     },
   );
-  if (resolvedNestedDetails.length > 0) return resolvedNestedDetails;
+  if (anyResolved) return resolvedNestedDetails;
 
   const fallbackDetails = fallbackUpdateDetails(proposed);
   if (fallbackDetails !== null) return fallbackDetails;

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -120,7 +120,13 @@ function RowCountDelta({
  * A head-rows sample table for the compute display.
  * Renders the first N rows of the proposed result as a compact table.
  */
-function HeadTable({ head }: { head: Array<Record<string, unknown>> }) {
+function HeadTable({
+  head,
+  labels = {},
+}: {
+  head: Array<Record<string, unknown>>;
+  labels?: Record<string, string>;
+}) {
   if (head.length === 0) return null;
   const columns = Object.keys(head[0] ?? {});
   if (columns.length === 0) return null;
@@ -137,7 +143,7 @@ function HeadTable({ head }: { head: Array<Record<string, unknown>> }) {
                 key={col}
                 className="px-2 py-1 text-left font-semibold text-neutral-fg/60"
               >
-                {col}
+                {labels[col] ?? col}
               </th>
             ))}
           </tr>
@@ -216,7 +222,7 @@ function ComputeDisplay({
         before={compute.rowCountBefore}
         after={compute.rowCountAfter}
       />
-      <HeadTable head={compute.head} />
+      <HeadTable head={compute.head} labels={compute.columnLabels} />
     </div>
   );
 }
@@ -234,9 +240,108 @@ interface PreviewDiffRendererProps {
 // Sub-components
 // ---------------------------------------------------------------------------
 
+type ChangeDetail = {
+  key: string;
+  before: unknown;
+  after: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function comparableBefore(
+  before: Record<string, unknown>,
+): Record<string, unknown> {
+  const definition = isRecord(before.definition) ? before.definition : {};
+  return { ...definition, ...before };
+}
+
+function valuesMatch(before: unknown, after: unknown): boolean {
+  return JSON.stringify(before) === JSON.stringify(after);
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return "—";
+  if (typeof value === "string") return value;
+  const serialized = JSON.stringify(value);
+  return serialized ?? String(value);
+}
+
+function nestedUpdateDetails(
+  before: Record<string, unknown>,
+  proposed: Record<string, unknown>,
+  collectionKey: "fields" | "metrics" | "joins",
+  targetId: unknown,
+): ChangeDetail[] | null {
+  if (!isRecord(proposed.updates)) return null;
+  const collection = comparableBefore(before)[collectionKey];
+  if (!Array.isArray(collection)) return null;
+
+  let target: unknown;
+  if (collectionKey === "joins") {
+    target = collection[typeof targetId === "number" ? targetId : -1];
+  } else {
+    target = collection.find((item) => isRecord(item) && item.id === targetId);
+  }
+  if (!isRecord(target)) return null;
+
+  return Object.entries(proposed.updates)
+    .filter(([key, after]) => !valuesMatch(target[key], after))
+    .map(([key, after]) => ({ key, before: target[key], after }));
+}
+
+function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
+  if (node.before === null || node.change === "noop") return [];
+
+  const { before, proposedDefinition: proposed } = node;
+  const fieldDetails = nestedUpdateDetails(
+    before,
+    proposed,
+    "fields",
+    proposed.fieldId,
+  );
+  if (fieldDetails) return fieldDetails;
+
+  const metricDetails = nestedUpdateDetails(
+    before,
+    proposed,
+    "metrics",
+    proposed.metricId,
+  );
+  if (metricDetails) return metricDetails;
+
+  const joinDetails = nestedUpdateDetails(
+    before,
+    proposed,
+    "joins",
+    proposed.joinIndex,
+  );
+  if (joinDetails) return joinDetails;
+
+  const canonical = comparableBefore(before);
+  const ignoredKeys = new Set([
+    "id",
+    "nodeId",
+    "fieldId",
+    "metricId",
+    "itemId",
+  ]);
+  return Object.entries(proposed)
+    .filter(([key]) => !ignoredKeys.has(key))
+    .map(([key, after]) => {
+      const beforeKey = key === "fieldIds" ? "selectedFields" : key;
+      return { key, before: canonical[beforeKey], after };
+    })
+    .filter(
+      ({ before: beforeValue, after }) => !valuesMatch(beforeValue, after),
+    );
+}
+
 function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
   const changeLabel = CHANGE_LABELS[node.change];
   const kindLabel = KIND_LABELS[node.kind];
+  const changeDetails = getChangeDetails(node);
 
   return (
     <div className="flex items-start gap-3 rounded-[var(--surface-radius)] bg-neutral-bg/60 px-3 py-2">
@@ -267,6 +372,18 @@ function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
                 title={intent.command}
               >
                 {intent.summary}
+              </li>
+            ))}
+          </ul>
+        )}
+        {changeDetails.length > 0 && (
+          <ul className="ml-0 list-none space-y-0.5 text-xs text-neutral-fg/70">
+            {changeDetails.map((detail) => (
+              <li key={detail.key}>
+                <span className="font-medium text-neutral-fg/80">
+                  {detail.key}:{" "}
+                </span>
+                {formatValue(detail.before)} → {formatValue(detail.after)}
               </li>
             ))}
           </ul>

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -14,6 +14,7 @@
  * renders whatever is present and leaves the slot empty when absent.
  */
 
+import { sanitizeDashboardItemUpdates } from "@dashframe/server/dashboard-item-updates";
 import type {
   ArtifactKind,
   PreviewCompute,
@@ -256,6 +257,7 @@ function comparableBefore(
   before: Record<string, unknown>,
 ): Record<string, unknown> {
   const definition = isRecord(before.definition) ? before.definition : {};
+  // The row-level slice wins so persisted columns override same-named definition keys.
   return { ...definition, ...before };
 }
 
@@ -280,13 +282,47 @@ function valuesMatch(before: unknown, after: unknown): boolean {
   );
 }
 
+function redactSecretRefs(value: unknown): unknown {
+  if (
+    typeof value === "string" &&
+    /^secret:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(value)
+  ) {
+    return "••••••";
+  }
+  if (Array.isArray(value)) return value.map(redactSecretRefs);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, redactSecretRefs(entry)]),
+  );
+}
+
 function formatValue(value: unknown): string {
   if (value === undefined) return "—";
+  const redacted = redactSecretRefs(value);
   const serialized =
-    typeof value === "string"
-      ? value
-      : (JSON.stringify(value) ?? String(value));
+    typeof redacted === "string"
+      ? redacted
+      : (JSON.stringify(redacted) ?? String(redacted));
   return serialized.length > 120 ? `${serialized.slice(0, 120)}…` : serialized;
+}
+
+function dashboardItemUpdateDetails(
+  before: Record<string, unknown>,
+  proposed: Record<string, unknown>,
+): ChangeDetail[] | null {
+  if (typeof proposed.itemId !== "string" || !isRecord(proposed.updates)) {
+    return null;
+  }
+  const layout = comparableBefore(before).layout;
+  if (!Array.isArray(layout)) return null;
+  const item = layout.find(
+    (candidate) => isRecord(candidate) && candidate.id === proposed.itemId,
+  );
+  if (!isRecord(item)) return null;
+
+  return Object.entries(sanitizeDashboardItemUpdates(proposed.updates))
+    .filter(([key, after]) => !valuesMatch(item[key], after))
+    .map(([key, after]) => ({ key, before: item[key], after }));
 }
 
 function nestedUpdateDetails(
@@ -329,9 +365,14 @@ function nestedTargetLabel(
   const kind = collectionKey === "joins" ? "join" : collectionKey.slice(0, -1);
   const target = findNestedTarget(before, collectionKey, targetId);
   if (!target || typeof target.name !== "string") {
+    const targetLabel =
+      typeof targetId === "string" &&
+      /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(targetId)
+        ? `${targetId.slice(0, 8)}…`
+        : targetId;
     return collectionKey === "joins"
       ? `join #${targetId}`
-      : `${kind} ${targetId}`;
+      : `${kind} ${targetLabel}`;
   }
 
   return `${kind} ${target.name}`;
@@ -352,6 +393,8 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
   if (node.before === null || node.change === "noop") return [];
 
   const { before, proposedDefinition: proposed } = node;
+  const dashboardDetails = dashboardItemUpdateDetails(before, proposed);
+  if (dashboardDetails !== null) return dashboardDetails;
   const nestedDetails = [
     ["fields", proposed.fieldId],
     ["metrics", proposed.metricId],
@@ -403,9 +446,19 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
   return Object.entries(proposed)
     .filter(([key]) => !ignoredKeys.has(key))
     .map(([key, after]) => {
+      if (key === "spec") {
+        return {
+          key,
+          before: isRecord(canonical.options)
+            ? canonical.options.spec
+            : undefined,
+          after,
+        };
+      }
       let beforeKey = key;
       if (key === "fieldIds") beforeKey = "selectedFields";
-      return { key, before: canonical[beforeKey], after };
+      else if (key === "visualizationType") beforeKey = "chartType";
+      return { key: beforeKey, before: canonical[beforeKey], after };
     })
     .filter(
       ({ before: beforeValue, after }) => !valuesMatch(beforeValue, after),

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -258,7 +258,24 @@ function comparableBefore(
 }
 
 function valuesMatch(before: unknown, after: unknown): boolean {
-  return JSON.stringify(before) === JSON.stringify(after);
+  if (Object.is(before, after)) return true;
+  if (Array.isArray(before) && Array.isArray(after)) {
+    return (
+      before.length === after.length &&
+      before.every((value, index) => valuesMatch(value, after[index]))
+    );
+  }
+  if (!isRecord(before) || !isRecord(after)) return false;
+
+  const beforeKeys = Object.keys(before);
+  const afterKeys = Object.keys(after);
+  return (
+    beforeKeys.length === afterKeys.length &&
+    beforeKeys.every(
+      (key) =>
+        Object.hasOwn(after, key) && valuesMatch(before[key], after[key]),
+    )
+  );
 }
 
 function formatValue(value: unknown): string {
@@ -293,41 +310,36 @@ function nestedUpdateDetails(
     .map(([key, after]) => ({ key, before: target[key], after }));
 }
 
+function fallbackUpdateDetails(
+  proposed: Record<string, unknown>,
+): ChangeDetail[] | null {
+  if (!isRecord(proposed.updates)) return null;
+  return Object.entries(proposed.updates).map(([key, after]) => ({
+    key,
+    before: undefined,
+    after,
+  }));
+}
+
 function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
   if (node.before === null || node.change === "noop") return [];
 
   const { before, proposedDefinition: proposed } = node;
-  const nestedTargetCount = [
-    proposed.fieldId,
-    proposed.metricId,
-    proposed.joinIndex,
-    proposed.itemId,
-  ].filter((target) => target !== undefined).length;
-  if (nestedTargetCount > 1) return [];
-
-  const fieldDetails = nestedUpdateDetails(
-    before,
-    proposed,
-    "fields",
-    proposed.fieldId,
+  const nestedDetails = [
+    ["fields", proposed.fieldId],
+    ["metrics", proposed.metricId],
+    ["joins", proposed.joinIndex],
+  ] as const;
+  const resolvedNestedDetails = nestedDetails.flatMap(
+    ([collection, target]) => {
+      if (target === undefined) return [];
+      return nestedUpdateDetails(before, proposed, collection, target) ?? [];
+    },
   );
-  if (fieldDetails !== null) return fieldDetails;
+  if (resolvedNestedDetails.length > 0) return resolvedNestedDetails;
 
-  const metricDetails = nestedUpdateDetails(
-    before,
-    proposed,
-    "metrics",
-    proposed.metricId,
-  );
-  if (metricDetails !== null) return metricDetails;
-
-  const joinDetails = nestedUpdateDetails(
-    before,
-    proposed,
-    "joins",
-    proposed.joinIndex,
-  );
-  if (joinDetails !== null) return joinDetails;
+  const fallbackDetails = fallbackUpdateDetails(proposed);
+  if (fallbackDetails !== null) return fallbackDetails;
 
   const canonical = comparableBefore(before);
   const ignoredKeys = new Set([
@@ -339,15 +351,13 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
     "dashboardId",
     "joinIndex",
     "sourceItemId",
+    "updates",
   ]);
   return Object.entries(proposed)
     .filter(([key]) => !ignoredKeys.has(key))
     .map(([key, after]) => {
-      // foldInsightArgs in usePreviewComputeFill.ts is the source of truth for
-      // proposed argument keys that map to stored canonical keys.
       let beforeKey = key;
       if (key === "fieldIds") beforeKey = "selectedFields";
-      if (key === "source") beforeKey = "baseTableId";
       return { key, before: canonical[beforeKey], after };
     })
     .filter(
@@ -395,8 +405,8 @@ function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
         )}
         {changeDetails.length > 0 && (
           <ul className="ml-0 list-none space-y-0.5 text-xs text-neutral-fg/70">
-            {changeDetails.map((detail) => (
-              <li key={detail.key} className="break-all">
+            {changeDetails.map((detail, index) => (
+              <li key={`${detail.key}-${index}`} className="break-all">
                 <span className="font-medium text-neutral-fg/80">
                   {detail.key}:{" "}
                 </span>

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -263,9 +263,11 @@ function valuesMatch(before: unknown, after: unknown): boolean {
 
 function formatValue(value: unknown): string {
   if (value === undefined) return "—";
-  if (typeof value === "string") return value;
-  const serialized = JSON.stringify(value);
-  return serialized ?? String(value);
+  const serialized =
+    typeof value === "string"
+      ? value
+      : (JSON.stringify(value) ?? String(value));
+  return serialized.length > 120 ? `${serialized.slice(0, 120)}…` : serialized;
 }
 
 function nestedUpdateDetails(
@@ -295,13 +297,21 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
   if (node.before === null || node.change === "noop") return [];
 
   const { before, proposedDefinition: proposed } = node;
+  const nestedTargetCount = [
+    proposed.fieldId,
+    proposed.metricId,
+    proposed.joinIndex,
+    proposed.itemId,
+  ].filter((target) => target !== undefined).length;
+  if (nestedTargetCount > 1) return [];
+
   const fieldDetails = nestedUpdateDetails(
     before,
     proposed,
     "fields",
     proposed.fieldId,
   );
-  if (fieldDetails) return fieldDetails;
+  if (fieldDetails !== null) return fieldDetails;
 
   const metricDetails = nestedUpdateDetails(
     before,
@@ -309,7 +319,7 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
     "metrics",
     proposed.metricId,
   );
-  if (metricDetails) return metricDetails;
+  if (metricDetails !== null) return metricDetails;
 
   const joinDetails = nestedUpdateDetails(
     before,
@@ -317,7 +327,7 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
     "joins",
     proposed.joinIndex,
   );
-  if (joinDetails) return joinDetails;
+  if (joinDetails !== null) return joinDetails;
 
   const canonical = comparableBefore(before);
   const ignoredKeys = new Set([
@@ -326,11 +336,18 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
     "fieldId",
     "metricId",
     "itemId",
+    "dashboardId",
+    "joinIndex",
+    "sourceItemId",
   ]);
   return Object.entries(proposed)
     .filter(([key]) => !ignoredKeys.has(key))
     .map(([key, after]) => {
-      const beforeKey = key === "fieldIds" ? "selectedFields" : key;
+      // foldInsightArgs in usePreviewComputeFill.ts is the source of truth for
+      // proposed argument keys that map to stored canonical keys.
+      let beforeKey = key;
+      if (key === "fieldIds") beforeKey = "selectedFields";
+      if (key === "source") beforeKey = "baseTableId";
       return { key, before: canonical[beforeKey], after };
     })
     .filter(
@@ -379,7 +396,7 @@ function DirectNodeRow({ node }: { node: PreviewDirectNode }) {
         {changeDetails.length > 0 && (
           <ul className="ml-0 list-none space-y-0.5 text-xs text-neutral-fg/70">
             {changeDetails.map((detail) => (
-              <li key={detail.key}>
+              <li key={detail.key} className="break-all">
                 <span className="font-medium text-neutral-fg/80">
                   {detail.key}:{" "}
                 </span>

--- a/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
+++ b/packages/app/src/components/preview-diff/PreviewDiffRenderer.tsx
@@ -325,13 +325,16 @@ function nestedTargetLabel(
   before: Record<string, unknown>,
   collectionKey: NestedCollectionKey,
   targetId: unknown,
-): string | null {
-  const target = findNestedTarget(before, collectionKey, targetId);
-  if (!target) return null;
-
+): string {
   const kind = collectionKey === "joins" ? "join" : collectionKey.slice(0, -1);
-  const name = typeof target.name === "string" ? target.name : targetId;
-  return `${kind} ${name}`;
+  const target = findNestedTarget(before, collectionKey, targetId);
+  if (!target || typeof target.name !== "string") {
+    return collectionKey === "joins"
+      ? `join #${targetId}`
+      : `${kind} ${targetId}`;
+  }
+
+  return `${kind} ${target.name}`;
 }
 
 function fallbackUpdateDetails(
@@ -359,17 +362,16 @@ function getChangeDetails(node: PreviewDirectNode): ChangeDetail[] {
   );
 
   if (selectedNestedTargets.length > 1 && isRecord(proposed.updates)) {
-    const labels = selectedNestedTargets.flatMap(([collection, target]) => {
-      const label = nestedTargetLabel(before, collection, target);
-      return label ? [label] : [];
-    });
-    return [
-      {
-        key: `applies to: ${labels.join(", ") || "multiple targets"}`,
-        before: undefined,
-        after: proposed.updates,
-      },
-    ];
+    const label = `one of: ${selectedNestedTargets
+      .map(([collection, target]) =>
+        nestedTargetLabel(before, collection, target),
+      )
+      .join(", ")}`;
+    return Object.entries(proposed.updates).map(([key, after]) => ({
+      key: `${label} — ${key}`,
+      before: undefined,
+      after,
+    }));
   }
 
   let anyResolved = false;

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.test.ts
@@ -11,6 +11,7 @@
  * 5. Compute stays client-side: the mock seam is DuckDB, not an RPC call.
  */
 
+import { fieldIdToColumnAlias } from "@dashframe/engine";
 import type {
   PreviewCompute,
   PreviewDiff,
@@ -574,6 +575,69 @@ describe("usePreviewComputeFill", () => {
       expect(proposedInsight.selectedFields).toEqual(["fld-a", "fld-b"]);
       // baseTableId comes from the canonical definition (not lost in the fold).
       expect(proposedInsight.baseTableId).toBe(tableId);
+    });
+
+    it("uses proposed table field names for selected-field column labels", async () => {
+      const tableId = "10101010-1010-1010-1010-101010101010";
+      const fieldId = "30303030-3030-3030-3030-303030303030";
+      const table = {
+        ...makeDataTable(tableId),
+        fields: [
+          {
+            id: fieldId,
+            name: "Revenue",
+            tableId,
+            columnName: "revenue",
+            type: "number",
+          },
+        ],
+      };
+
+      mockGetDataTable.mockResolvedValue(table);
+      mockGetDataFrame.mockResolvedValue(makeDataFrame(`df-${tableId}`));
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue(
+        "SELECT revenue FROM proposed_fields",
+      );
+      mockQuery
+        .mockResolvedValueOnce(makeCountResult(1))
+        .mockResolvedValueOnce(makeHeadResult([{ revenue: 1 }]))
+        .mockResolvedValueOnce(makeCountResult(1));
+
+      const tableNode: PreviewDirectNode = {
+        ...nonInsightNode(tableId),
+        nodeId: tableId as PreviewDirectNode["nodeId"],
+        before: { fields: table.fields },
+        proposedDefinition: {
+          fieldId,
+          updates: { name: "Net revenue" },
+        },
+      };
+      const insightNodeWithSelection = insightNode(
+        "n-proposed-fields",
+        "update",
+        {
+          baseTableId: tableId,
+          before: {
+            definition: {
+              baseTableId: tableId,
+              selectedFields: [],
+              metrics: [],
+            },
+          },
+          proposedDefinition: { fieldIds: [fieldId] },
+        },
+      );
+
+      const diff = makeDiff([tableNode, insightNodeWithSelection]);
+      const { result } = renderHook(() => usePreviewComputeFill(diff));
+
+      await waitFor(() => expect(result.current.allResolved).toBe(true));
+
+      const compute = result.current.diff?.directNodes[1]?.compute;
+      expect(compute?.columnLabels?.[fieldIdToColumnAlias(fieldId)]).toBe(
+        "Net revenue",
+      );
     });
 
     it("maps proposedDefinition.source.sourceId → baseTableId (SetInsightSource)", async () => {

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -297,6 +297,39 @@ function indexDirectNodes(diff: PreviewDiff): DirectNodeIndex {
   return index;
 }
 
+function foldProposedFieldUpdate(
+  table: DataTable,
+  proposedDefinition: Record<string, unknown>,
+): DataTable {
+  if (typeof proposedDefinition.fieldId !== "string") return table;
+
+  const fields = table.fields ?? [];
+  const target = fields.find(
+    (field) => field.id === proposedDefinition.fieldId,
+  );
+  const updates = proposedDefinition.updates;
+  if (
+    !target ||
+    typeof updates !== "object" ||
+    updates === null ||
+    Array.isArray(updates)
+  ) {
+    return {
+      ...table,
+      fields: fields.filter((field) => field.id !== proposedDefinition.fieldId),
+    };
+  }
+
+  return {
+    ...table,
+    fields: fields.map((field) =>
+      field.id === proposedDefinition.fieldId
+        ? { ...field, ...updates, id: field.id }
+        : field,
+    ),
+  };
+}
+
 /**
  * Resolve a base-table id to a loadable DataTable.
  *
@@ -331,9 +364,10 @@ async function resolveBaseTable(
       // Same-batch update may re-point this table's dataFrameId. Overlay the
       // PROPOSED frame id so the count reflects the proposed table, not the
       // stale canonical one. (No proposed override → use canonical as-is.)
-      return proposedFrameId
+      const table = proposedFrameId
         ? { ...canonical, dataFrameId: proposedFrameId }
         : canonical;
+      return foldProposedFieldUpdate(table, def);
     }
     // create-node DataTable: the canonical store has no row (preview rolled
     // back). We can only compute if a proposed definition names a local

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -29,9 +29,12 @@
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame } from "@/lib/data-access/data-frames";
 import { getDataTable } from "@/lib/data-access/data-tables";
+import { buildInsightColumnDisplayNames } from "@/lib/insight-column-display-names";
+import { buildInsightAvailableFields } from "@dashframe/engine";
 import { buildInsightSQL, ensureTableLoaded } from "@dashframe/engine-browser";
 import type {
   DataTable,
+  Field,
   Insight,
   PreviewCompute,
   PreviewDiff,
@@ -526,6 +529,17 @@ async function computeNode(
     return { rowCountBefore: null, rowCountAfter: null, head: [] };
   }
 
+  const resolvedFields: Field[] =
+    buildInsightAvailableFields(
+      proposedTables.baseTable,
+      proposedTables.joinedTables,
+      { joins: proposed.joins },
+    ) ??
+    (proposedTables.baseTable.fields ?? []).filter(
+      (field) => !field.name.startsWith("_"),
+    );
+  const columnLabels = buildInsightColumnDisplayNames(proposed, resolvedFields);
+
   const [rowCountAfter, head, rowCountBefore] = await Promise.all([
     computeRowCount(proposed, proposedTables, conn),
     computeHead(proposed, proposedTables, conn),
@@ -534,7 +548,7 @@ async function computeNode(
       : Promise.resolve(null),
   ]);
 
-  return { rowCountBefore, rowCountAfter, head };
+  return { rowCountBefore, rowCountAfter, head, columnLabels };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -538,7 +538,14 @@ async function computeNode(
     (proposedTables.baseTable.fields ?? []).filter(
       (field) => !field.name.startsWith("_"),
     );
-  const columnLabels = buildInsightColumnDisplayNames(proposed, resolvedFields);
+  const columnLabels = buildInsightColumnDisplayNames(
+    proposed,
+    resolvedFields,
+    {
+      baseTable: proposedTables.baseTable,
+      joinedTables: proposedTables.joinedTables,
+    },
+  );
 
   const [rowCountAfter, head, rowCountBefore] = await Promise.all([
     computeRowCount(proposed, proposedTables, conn),

--- a/packages/app/src/components/visualizations/CreateVisualizationModal.tsx
+++ b/packages/app/src/components/visualizations/CreateVisualizationModal.tsx
@@ -15,6 +15,7 @@ interface CreateVisualizationModalProps {
   isOpen: boolean;
   onClose: () => void;
   visualizeOnCreate?: boolean;
+  title?: string;
 }
 
 /**
@@ -28,6 +29,7 @@ export function CreateVisualizationModal({
   isOpen,
   onClose,
   visualizeOnCreate = false,
+  title = "Create Visualization",
 }: CreateVisualizationModalProps) {
   const navigate = useNavigate();
   const { createInsightFromTable, createInsightFromInsight } =
@@ -87,7 +89,7 @@ export function CreateVisualizationModal({
       <DataPickerModal
         isOpen={isOpen && !selectedInsight}
         onClose={onClose}
-        title="Create Visualization"
+        title={title}
         onInsightSelect={handleInsightSelect}
         onTableSelect={handleTableSelect}
         showInsights={true}

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -90,6 +90,10 @@ export function useInsightPagination({
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [resolvedFields, setResolvedFields] = useState<Field[]>([]);
+  const [resolvedTables, setResolvedTables] = useState<{
+    baseTable: DataTable | null;
+    joinedTables: Map<UUID, DataTable>;
+  }>({ baseTable: null, joinedTables: new Map() });
 
   // Generation counter: incremented on every init effect run so stale async
   // completions from a superseded insight config never overwrite current state.
@@ -161,13 +165,13 @@ export function useInsightPagination({
   }, [insight.baseTableId, insight.joins]);
 
   const columnDisplayNames = useMemo(() => {
-    const { baseTable, joinedTables } = resolvedTablesRef.current;
+    const { baseTable, joinedTables } = resolvedTables;
     return buildInsightColumnDisplayNames(
       { joins: insight.joins, metrics: insight.metrics },
       resolvedFields,
       baseTable ? { baseTable, joinedTables } : undefined,
     );
-  }, [resolvedFields, insight.metrics, insight.joins]);
+  }, [resolvedFields, resolvedTables, insight.metrics, insight.joins]);
 
   // Build mapping from UUID column aliases to ColumnType.
   // Metrics are always numeric (aggregations); fields carry their declared type.
@@ -269,6 +273,7 @@ export function useInsightPagination({
         // Write the table cache AFTER the gen check so a stale init for insight A
         // cannot overwrite the cache that a faster init for insight B already set.
         resolvedTablesRef.current = { baseTable, joinedTables };
+        setResolvedTables({ baseTable, joinedTables });
 
         // Store resolved fields for display name mapping
         setResolvedFields(allFields);

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -1,11 +1,11 @@
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame } from "@/lib/data-access/data-frames";
 import { getDataTable } from "@/lib/data-access/data-tables";
+import { buildInsightColumnDisplayNames } from "@/lib/insight-column-display-names";
 import type { EffectiveParams } from "@dashframe/engine";
 import {
   buildInsightAvailableFields,
   buildInsightSQL,
-  extractColumnAliasComponents,
   fieldIdToColumnAlias,
   metricIdToColumnAlias,
 } from "@dashframe/engine";
@@ -19,101 +19,6 @@ import type {
 } from "@dashframe/types";
 import type { FetchDataParams, FetchDataResult } from "@dashframe/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-// ── Module-level pure helpers ─────────────────────────────────────────────────
-
-/**
- * Build a map of `"${rightTableId}:${instanceIndex}" → leftKey` by walking
- * insight.joins, mirroring buildInsightAvailableFields' skip behaviour.
- *
- * A join that was SKIPPED by buildInsightAvailableFields (invalid type, missing
- * table, missing key fields) must NOT advance the per-rightTableId counter —
- * otherwise subsequent valid joins get a wrong index, and
- * buildRepeatJoinDisplayNames would look up the wrong leftKey for each synthetic
- * field's (tableId, instanceIndex) pair.
- *
- * We detect skipped joins by checking whether resolvedFields contains any field
- * from that (rightTableId, instanceIndex) slot.  Because resolvedFields is the
- * OUTPUT of buildInsightAvailableFields, any index it consumed is guaranteed
- * valid; indices not represented in resolvedFields were skipped.  This avoids
- * re-implementing the engine's whitelist + key-validation logic in the hook.
- */
-function buildJoinKeyByInstance(
-  joins: NonNullable<Insight["joins"]>,
-  resolvedFields: Field[],
-): Map<string, string> {
-  // Build a quick-lookup set of (tableId, instanceIndex) pairs that exist in
-  // resolvedFields.  If a slot is absent, the join at that logical position was
-  // skipped by buildInsightAvailableFields.
-  const resolvedSlots = new Set<string>();
-  for (const field of resolvedFields) {
-    const components = extractColumnAliasComponents(
-      fieldIdToColumnAlias(field.id),
-    );
-    if (components) {
-      resolvedSlots.add(`${field.tableId}:${components.instanceIndex}`);
-    }
-  }
-
-  const result = new Map<string, string>();
-  const instanceCount = new Map<string, number>();
-  for (const join of joins) {
-    const idx = instanceCount.get(join.rightTableId) ?? 0;
-    const slot = `${join.rightTableId}:${idx}`;
-    if (resolvedSlots.has(slot)) {
-      // This join was NOT skipped by buildInsightAvailableFields — record it.
-      result.set(slot, join.leftKey);
-      instanceCount.set(join.rightTableId, idx + 1);
-    }
-    // Skipped join: do NOT advance the counter.
-  }
-  return result;
-}
-
-/**
- * Build a display-name record for the given resolved fields, disambiguating
- * repeat-join collisions by appending the join's leftKey in parentheses.
- *
- * When the same right-table is joined more than once (N≥2, e.g. orders→users on
- * `created_by` AND `approved_by`), all instances produce fields with the same
- * `field.name` (e.g. "User Name").  This function detects collisions and
- * produces distinct labels for ALL instances: "User Name (created_by)" and
- * "User Name (approved_by)".  Fields not involved in a collision keep their
- * bare `field.name`.
- *
- * `field.name` is NOT mutated — it remains the canonical human name.
- */
-function buildRepeatJoinDisplayNames(
-  resolvedFields: Field[],
-  joinKeyByInstance: Map<string, string>,
-): Record<string, string> {
-  // First pass: find which base UUIDs have ≥2 instances (any _j1+ sibling).
-  const baseUuidsWithRepeat = new Set<string>();
-  for (const field of resolvedFields) {
-    const components = extractColumnAliasComponents(
-      fieldIdToColumnAlias(field.id),
-    );
-    if (components && components.instanceIndex > 0) {
-      baseUuidsWithRepeat.add(components.uuid);
-    }
-  }
-
-  // Second pass: build display names, applying disambiguation for collisions.
-  const displayNames: Record<string, string> = {};
-  for (const field of resolvedFields) {
-    const alias = fieldIdToColumnAlias(field.id);
-    const components = extractColumnAliasComponents(alias);
-    if (components && baseUuidsWithRepeat.has(components.uuid)) {
-      const leftKey = joinKeyByInstance.get(
-        `${field.tableId}:${components.instanceIndex}`,
-      );
-      displayNames[alias] = leftKey ? `${field.name} (${leftKey})` : field.name;
-    } else {
-      displayNames[alias] = field.name;
-    }
-  }
-  return displayNames;
-}
 
 /**
  * Options for useInsightPagination hook.
@@ -255,31 +160,11 @@ export function useInsightPagination({
     return { baseTable, joinedTables, allFields };
   }, [insight.baseTableId, insight.joins]);
 
-  // Build mapping from UUID column aliases to display names.
-  // This allows VirtualTable to show human-readable column headers.
-  //
-  // For repeat-join insights (same rightTableId joined twice), both join
-  // instances produce fields with identical `field.name` values.
-  // buildRepeatJoinDisplayNames detects these collisions and appends the
-  // join's leftKey so pickers and headers show e.g. "User Name (created_by)"
-  // vs "User Name (approved_by)".  field.name is NOT mutated.
   const columnDisplayNames = useMemo(() => {
-    const joinKeyByInstance = insight.joins?.length
-      ? buildJoinKeyByInstance(insight.joins, resolvedFields)
-      : new Map<string, string>();
-
-    const displayNames = buildRepeatJoinDisplayNames(
+    return buildInsightColumnDisplayNames(
+      { joins: insight.joins, metrics: insight.metrics },
       resolvedFields,
-      joinKeyByInstance,
     );
-
-    // Map metric IDs to display names
-    for (const metric of insight.metrics ?? []) {
-      const alias = metricIdToColumnAlias(metric.id);
-      displayNames[alias] = metric.name;
-    }
-
-    return displayNames;
   }, [resolvedFields, insight.metrics, insight.joins]);
 
   // Build mapping from UUID column aliases to ColumnType.

--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -161,9 +161,11 @@ export function useInsightPagination({
   }, [insight.baseTableId, insight.joins]);
 
   const columnDisplayNames = useMemo(() => {
+    const { baseTable, joinedTables } = resolvedTablesRef.current;
     return buildInsightColumnDisplayNames(
       { joins: insight.joins, metrics: insight.metrics },
       resolvedFields,
+      baseTable ? { baseTable, joinedTables } : undefined,
     );
   }, [resolvedFields, insight.metrics, insight.joins]);
 

--- a/packages/app/src/lib/insight-column-display-names.test.ts
+++ b/packages/app/src/lib/insight-column-display-names.test.ts
@@ -1,0 +1,110 @@
+import {
+  buildInsightAvailableFields,
+  fieldIdToColumnAlias,
+} from "@dashframe/engine";
+import type { DataTable, Field, Insight, UUID } from "@dashframe/types";
+import { describe, expect, it } from "vitest";
+import { buildInsightColumnDisplayNames } from "./insight-column-display-names";
+
+const BASE_TABLE_ID = "10101010-1010-1010-1010-101010101010" as UUID;
+const USERS_TABLE_ID = "30303030-3030-3030-3030-303030303030" as UUID;
+
+const createdBy: Field = {
+  id: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0" as UUID,
+  name: "Created By",
+  tableId: BASE_TABLE_ID,
+  columnName: "created_by",
+  type: "string",
+};
+const approvedBy: Field = {
+  id: "c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0" as UUID,
+  name: "Approved By",
+  tableId: BASE_TABLE_ID,
+  columnName: "approved_by",
+  type: "string",
+};
+const userId: Field = {
+  id: "d0d0d0d0-d0d0-d0d0-d0d0-d0d0d0d0d0d0" as UUID,
+  name: "User ID",
+  tableId: USERS_TABLE_ID,
+  columnName: "id",
+  type: "string",
+};
+const userName: Field = {
+  id: "e0e0e0e0-e0e0-e0e0-e0e0-e0e0e0e0e0e0" as UUID,
+  name: "User Name",
+  tableId: USERS_TABLE_ID,
+  columnName: "name",
+  type: "string",
+};
+
+const baseTable: DataTable = {
+  id: BASE_TABLE_ID,
+  name: "orders",
+  dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+  table: "orders.csv",
+  fields: [createdBy, approvedBy],
+  metrics: [],
+  dataFrameId: "20202020-2020-2020-2020-202020202020" as UUID,
+  createdAt: 0,
+};
+const usersTable: DataTable = {
+  id: USERS_TABLE_ID,
+  name: "users",
+  dataSourceId: "33333333-3333-3333-3333-333333333333" as UUID,
+  table: "users.csv",
+  fields: [userId, userName],
+  metrics: [],
+  dataFrameId: "40404040-4040-4040-4040-404040404040" as UUID,
+  createdAt: 0,
+};
+
+describe("buildInsightColumnDisplayNames", () => {
+  it("does not advance a repeat-join instance for a skipped join", () => {
+    const insight: Insight = {
+      id: "50505050-5050-5050-5050-505050505050" as UUID,
+      name: "Orders with users",
+      baseTableId: BASE_TABLE_ID,
+      selectedFields: [],
+      metrics: [],
+      joins: [
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "missing_creator",
+          rightKey: "id",
+        },
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "created_by",
+          rightKey: "id",
+        },
+        {
+          type: "inner",
+          rightTableId: USERS_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "id",
+        },
+      ],
+      createdAt: 0,
+    };
+    const fields = buildInsightAvailableFields(
+      baseTable,
+      new Map([[USERS_TABLE_ID, usersTable]]),
+      insight,
+    );
+
+    expect(fields).not.toBeNull();
+
+    const labels = buildInsightColumnDisplayNames(insight, fields!, {
+      baseTable,
+      joinedTables: new Map([[USERS_TABLE_ID, usersTable]]),
+    });
+    const firstAlias = fieldIdToColumnAlias(userName.id);
+    const secondAlias = fieldIdToColumnAlias(`${userName.id}_j1`);
+
+    expect(labels[firstAlias]).toBe("User Name (created_by)");
+    expect(labels[secondAlias]).toBe("User Name (approved_by)");
+  });
+});

--- a/packages/app/src/lib/insight-column-display-names.test.ts
+++ b/packages/app/src/lib/insight-column-display-names.test.ts
@@ -1,6 +1,7 @@
 import {
   buildInsightAvailableFields,
   fieldIdToColumnAlias,
+  metricIdToColumnAlias,
 } from "@dashframe/engine";
 import type { DataTable, Field, Insight, UUID } from "@dashframe/types";
 import { describe, expect, it } from "vitest";
@@ -106,5 +107,55 @@ describe("buildInsightColumnDisplayNames", () => {
 
     expect(labels[firstAlias]).toBe("User Name (created_by)");
     expect(labels[secondAlias]).toBe("User Name (approved_by)");
+  });
+
+  it("uses the metric name for metric aliases", () => {
+    const metricId = "f0f0f0f0-f0f0-f0f0-f0f0-f0f0f0f0f0f0" as UUID;
+    const labels = buildInsightColumnDisplayNames(
+      { metrics: [{ id: metricId, name: "Order count" }] } as Insight,
+      [createdBy],
+    );
+
+    expect(labels[metricIdToColumnAlias(metricId)]).toBe("Order count");
+  });
+
+  it("labels repeated self-joins using the shared base-table instance key", () => {
+    const insight: Insight = {
+      id: "50505050-5050-5050-5050-505050505050" as UUID,
+      name: "Orders hierarchy",
+      baseTableId: BASE_TABLE_ID,
+      selectedFields: [],
+      metrics: [],
+      joins: [
+        {
+          type: "inner",
+          rightTableId: BASE_TABLE_ID,
+          leftKey: "created_by",
+          rightKey: "approved_by",
+        },
+        {
+          type: "inner",
+          rightTableId: BASE_TABLE_ID,
+          leftKey: "approved_by",
+          rightKey: "created_by",
+        },
+      ],
+      createdAt: 0,
+    };
+    const fields = buildInsightAvailableFields(
+      baseTable,
+      new Map([[BASE_TABLE_ID, baseTable]]),
+      insight,
+    );
+
+    expect(fields).not.toBeNull();
+    const labels = buildInsightColumnDisplayNames(insight, fields!, {
+      baseTable,
+      joinedTables: new Map([[BASE_TABLE_ID, baseTable]]),
+    });
+
+    expect(labels[fieldIdToColumnAlias(`${approvedBy.id}_j1`)]).toBe(
+      "Approved By (approved_by)",
+    );
   });
 });

--- a/packages/app/src/lib/insight-column-display-names.ts
+++ b/packages/app/src/lib/insight-column-display-names.ts
@@ -1,9 +1,15 @@
 import {
+  buildInsightAvailableFields,
   extractColumnAliasComponents,
   fieldIdToColumnAlias,
   metricIdToColumnAlias,
 } from "@dashframe/engine";
-import type { Field, Insight } from "@dashframe/types";
+import type { DataTable, Field, Insight, UUID } from "@dashframe/types";
+
+type InsightTableContext = {
+  baseTable: DataTable;
+  joinedTables: Map<UUID, DataTable>;
+};
 
 /**
  * Build a map of `${rightTableId}:${instanceIndex}` → leftKey from the field
@@ -16,26 +22,41 @@ import type { Field, Insight } from "@dashframe/types";
 function buildJoinKeyByInstance(
   joins: NonNullable<Insight["joins"]>,
   resolvedFields: Field[],
+  tables: InsightTableContext | undefined,
 ): Map<string, string> {
-  const resolvedSlots = new Set<string>();
-  for (const field of resolvedFields) {
-    const components = extractColumnAliasComponents(
-      fieldIdToColumnAlias(field.id),
-    );
-    if (components) {
-      resolvedSlots.add(`${field.tableId}:${components.instanceIndex}`);
-    }
-  }
+  if (!tables) return new Map<string, string>();
+
+  const resolvedAliases = new Set(
+    resolvedFields.map((field) => fieldIdToColumnAlias(field.id)),
+  );
+  let previousFieldIds = new Set(
+    (tables.baseTable.fields ?? [])
+      .filter((field) => !field.name.startsWith("_"))
+      .map((field) => field.id),
+  );
 
   const result = new Map<string, string>();
-  const instanceCount = new Map<string, number>();
-  for (const join of joins) {
-    const idx = instanceCount.get(join.rightTableId) ?? 0;
-    const slot = `${join.rightTableId}:${idx}`;
-    if (resolvedSlots.has(slot)) {
-      result.set(slot, join.leftKey);
-      instanceCount.set(join.rightTableId, idx + 1);
+  for (const [index, join] of joins.entries()) {
+    const fields = buildInsightAvailableFields(
+      tables.baseTable,
+      tables.joinedTables,
+      { joins: joins.slice(0, index + 1) },
+    );
+    if (!fields) continue;
+
+    for (const field of fields) {
+      if (previousFieldIds.has(field.id) || field.tableId !== join.rightTableId)
+        continue;
+      const alias = fieldIdToColumnAlias(field.id);
+      const components = extractColumnAliasComponents(alias);
+      if (components && resolvedAliases.has(alias)) {
+        result.set(
+          `${field.tableId}:${components.instanceIndex}`,
+          join.leftKey,
+        );
+      }
     }
+    previousFieldIds = new Set(fields.map((field) => field.id));
   }
   return result;
 }
@@ -48,9 +69,10 @@ function buildJoinKeyByInstance(
 export function buildInsightColumnDisplayNames(
   insight: Pick<Insight, "joins" | "metrics">,
   resolvedFields: Field[],
+  tables?: InsightTableContext,
 ): Record<string, string> {
   const joinKeyByInstance = insight.joins?.length
-    ? buildJoinKeyByInstance(insight.joins, resolvedFields)
+    ? buildJoinKeyByInstance(insight.joins, resolvedFields, tables)
     : new Map<string, string>();
   const repeatedFieldIds = new Set<string>();
 

--- a/packages/app/src/lib/insight-column-display-names.ts
+++ b/packages/app/src/lib/insight-column-display-names.ts
@@ -1,5 +1,4 @@
 import {
-  buildInsightAvailableFields,
   extractColumnAliasComponents,
   fieldIdToColumnAlias,
   metricIdToColumnAlias,
@@ -11,13 +10,62 @@ type InsightTableContext = {
   joinedTables: Map<UUID, DataTable>;
 };
 
+type InsightJoin = NonNullable<Insight["joins"]>[number];
+
+const VALID_JOIN_TYPES = new Set(["inner", "left", "right", "full"]);
+
+function buildResolvedJoinInstances(resolvedFields: Field[]): Set<string> {
+  return new Set(
+    resolvedFields.flatMap((field) => {
+      const components = extractColumnAliasComponents(
+        fieldIdToColumnAlias(field.id),
+      );
+      return components ? [`${field.tableId}:${components.instanceIndex}`] : [];
+    }),
+  );
+}
+
+function findValidJoinFields(
+  join: InsightJoin,
+  tables: InsightTableContext,
+  fieldsByColumnName: Map<string, Field>,
+): { joinFields: Field[]; rightKey: string } | null {
+  const joinTable = tables.joinedTables.get(join.rightTableId);
+  if (!joinTable?.dataFrameId || !VALID_JOIN_TYPES.has(join.type ?? "inner")) {
+    return null;
+  }
+
+  const joinFields = (joinTable.fields ?? []).filter(
+    (field) => !field.name.startsWith("_"),
+  );
+  const joinKeyField = joinFields.find(
+    (field) => (field.columnName ?? field.name) === join.rightKey,
+  );
+  if (!fieldsByColumnName.has(join.leftKey) || !joinKeyField) return null;
+
+  return {
+    joinFields,
+    rightKey: joinKeyField.columnName ?? joinKeyField.name,
+  };
+}
+
+function addJoinFields(
+  fieldsByColumnName: Map<string, Field>,
+  joinFields: Field[],
+  rightKey: string,
+) {
+  for (const field of joinFields) {
+    const columnName = field.columnName ?? field.name;
+    if (columnName !== rightKey && !fieldsByColumnName.has(columnName)) {
+      fieldsByColumnName.set(columnName, field);
+    }
+  }
+}
+
 /**
- * Build a map of `${rightTableId}:${instanceIndex}` → leftKey from the field
- * instances emitted by buildInsightAvailableFields.
- *
- * Only fields returned by buildInsightAvailableFields advance an instance
- * counter. This keeps repeat-join display names aligned with the aliases the
- * SQL builder actually emitted when an invalid join is skipped.
+ * Build a map of `${rightTableId}:${instanceIndex}` → leftKey in one pass over
+ * the joins. The validation mirrors buildInsightAvailableFields so invalid
+ * joins do not consume a repeat-join instance.
  */
 function buildJoinKeyByInstance(
   joins: NonNullable<Insight["joins"]>,
@@ -26,37 +74,33 @@ function buildJoinKeyByInstance(
 ): Map<string, string> {
   if (!tables) return new Map<string, string>();
 
-  const resolvedAliases = new Set(
-    resolvedFields.map((field) => fieldIdToColumnAlias(field.id)),
-  );
-  let previousFieldIds = new Set(
-    (tables.baseTable.fields ?? [])
-      .filter((field) => !field.name.startsWith("_"))
-      .map((field) => field.id),
-  );
+  if (!tables.baseTable.dataFrameId || resolvedFields.length === 0) {
+    return new Map<string, string>();
+  }
+
+  const resolvedJoinInstances = buildResolvedJoinInstances(resolvedFields);
+
+  const fieldsByColumnName = new Map<string, Field>();
+  for (const field of tables.baseTable.fields ?? []) {
+    if (!field.name.startsWith("_")) {
+      fieldsByColumnName.set(field.columnName ?? field.name, field);
+    }
+  }
 
   const result = new Map<string, string>();
-  for (const [index, join] of joins.entries()) {
-    const fields = buildInsightAvailableFields(
-      tables.baseTable,
-      tables.joinedTables,
-      { joins: joins.slice(0, index + 1) },
-    );
-    if (!fields) continue;
+  const joinInstanceCounts = new Map<UUID, number>();
+  for (const join of joins) {
+    const validJoin = findValidJoinFields(join, tables, fieldsByColumnName);
+    if (!validJoin) continue;
 
-    for (const field of fields) {
-      if (previousFieldIds.has(field.id) || field.tableId !== join.rightTableId)
-        continue;
-      const alias = fieldIdToColumnAlias(field.id);
-      const components = extractColumnAliasComponents(alias);
-      if (components && resolvedAliases.has(alias)) {
-        result.set(
-          `${field.tableId}:${components.instanceIndex}`,
-          join.leftKey,
-        );
-      }
+    const instanceIndex = joinInstanceCounts.get(join.rightTableId) ?? 0;
+    const instanceKey = `${join.rightTableId}:${instanceIndex}`;
+    if (resolvedJoinInstances.has(instanceKey)) {
+      result.set(instanceKey, join.leftKey);
     }
-    previousFieldIds = new Set(fields.map((field) => field.id));
+    joinInstanceCounts.set(join.rightTableId, instanceIndex + 1);
+
+    addJoinFields(fieldsByColumnName, validJoin.joinFields, validJoin.rightKey);
   }
   return result;
 }

--- a/packages/app/src/lib/insight-column-display-names.ts
+++ b/packages/app/src/lib/insight-column-display-names.ts
@@ -1,0 +1,84 @@
+import {
+  extractColumnAliasComponents,
+  fieldIdToColumnAlias,
+  metricIdToColumnAlias,
+} from "@dashframe/engine";
+import type { Field, Insight } from "@dashframe/types";
+
+/**
+ * Build a map of `${rightTableId}:${instanceIndex}` → leftKey from the field
+ * instances emitted by buildInsightAvailableFields.
+ *
+ * Only fields returned by buildInsightAvailableFields advance an instance
+ * counter. This keeps repeat-join display names aligned with the aliases the
+ * SQL builder actually emitted when an invalid join is skipped.
+ */
+function buildJoinKeyByInstance(
+  joins: NonNullable<Insight["joins"]>,
+  resolvedFields: Field[],
+): Map<string, string> {
+  const resolvedSlots = new Set<string>();
+  for (const field of resolvedFields) {
+    const components = extractColumnAliasComponents(
+      fieldIdToColumnAlias(field.id),
+    );
+    if (components) {
+      resolvedSlots.add(`${field.tableId}:${components.instanceIndex}`);
+    }
+  }
+
+  const result = new Map<string, string>();
+  const instanceCount = new Map<string, number>();
+  for (const join of joins) {
+    const idx = instanceCount.get(join.rightTableId) ?? 0;
+    const slot = `${join.rightTableId}:${idx}`;
+    if (resolvedSlots.has(slot)) {
+      result.set(slot, join.leftKey);
+      instanceCount.set(join.rightTableId, idx + 1);
+    }
+  }
+  return result;
+}
+
+/**
+ * Build SQL-column-alias display names from fields resolved by
+ * buildInsightAvailableFields. Repeat joins are disambiguated with their
+ * left-key, while metric aliases use their metric names.
+ */
+export function buildInsightColumnDisplayNames(
+  insight: Pick<Insight, "joins" | "metrics">,
+  resolvedFields: Field[],
+): Record<string, string> {
+  const joinKeyByInstance = insight.joins?.length
+    ? buildJoinKeyByInstance(insight.joins, resolvedFields)
+    : new Map<string, string>();
+  const repeatedFieldIds = new Set<string>();
+
+  for (const field of resolvedFields) {
+    const components = extractColumnAliasComponents(
+      fieldIdToColumnAlias(field.id),
+    );
+    if (components && components.instanceIndex > 0) {
+      repeatedFieldIds.add(components.uuid);
+    }
+  }
+
+  const displayNames: Record<string, string> = {};
+  for (const field of resolvedFields) {
+    const alias = fieldIdToColumnAlias(field.id);
+    const components = extractColumnAliasComponents(alias);
+    const leftKey = components
+      ? joinKeyByInstance.get(`${field.tableId}:${components.instanceIndex}`)
+      : undefined;
+    displayNames[alias] =
+      components && repeatedFieldIds.has(components.uuid) && leftKey
+        ? `${field.name} (${leftKey})`
+        : field.name;
+  }
+
+  for (const metric of insight.metrics ?? []) {
+    displayNames[metricIdToColumnAlias(metric.id)] = metric.name;
+  }
+
+  return displayNames;
+}

--- a/packages/types/src/preview-diff.ts
+++ b/packages/types/src/preview-diff.ts
@@ -81,6 +81,8 @@ export interface PreviewCompute {
   rowCountAfter: number | null;
   /** A `head(n)` sample of the proposed result — column-major rows for the renderer. */
   head: Array<Record<string, unknown>>;
+  /** Human-readable labels keyed by the SQL aliases used in `head`. */
+  columnLabels?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
Polishes the draft-review surface so the preview diff tells reviewers the truth about proposed changes, and fixes two adjacent UI defects (mobile nav drawer, insight column display names).

## Changes

- **Preview diff (draft review)** — `PreviewDiffRenderer` now compares the proposed `source` against its stored counterpart directly (was comparing an object against a UUID, producing phantom change rows); renders real per-key before→after rows for single-target nested updates instead of leaking raw JSON or rendering nothing; renders merged multi-target updates as one explicitly ambiguous `one of: <targets> — <key>` row per update key (the server flattens per-op args, so definite attribution is unknowable — see below); suppresses phantom rows for resolved-but-no-op updates; and uses structural deep-equality so key order never fabricates a change.
- **Mobile nav drawer** — tapping the currently active route's item now closes the drawer (dismissal moved into the item's own `onClick`, independent of pathname changes).
- **Insight column display names** — display-name context now flows through React state (the memo previously read a ref its dep array couldn't observe), and `buildJoinKeyByInstance` is a single linear pass over joins (was O(joins² × fields)).

## Screenshots

### Mobile drawer open (light)
![Mobile drawer open (light)](https://github.com/youhaowei/DashFrame/releases/download/pr-291-screenshots/01-mobile-drawer-open-light.png)

### Mobile drawer open (dark)
![Mobile drawer open (dark)](https://github.com/youhaowei/DashFrame/releases/download/pr-291-screenshots/01-mobile-drawer-open-dark.png)

### Insight display names (light)
![Insight display names (light)](https://github.com/youhaowei/DashFrame/releases/download/pr-291-screenshots/02-insight-columns-light.png)

### Insight display names (dark)
![Insight display names (dark)](https://github.com/youhaowei/DashFrame/releases/download/pr-291-screenshots/02-insight-columns-dark.png)

### Drafts empty state (light)
![Drafts empty state (light)](https://github.com/youhaowei/DashFrame/releases/download/pr-291-screenshots/03-drafts-empty-light.png)

### Drafts empty state (dark)
![Drafts empty state (dark)](https://github.com/youhaowei/DashFrame/releases/download/pr-291-screenshots/03-drafts-empty-dark.png)

_Screenshots via pr-screenshots (prerelease `pr-291-screenshots`, not in git)._
## Verification

- Local gate: `bunx turbo lint/test --filter='!@wystack/*'` and `bun run check` green after every fix round (85/85 tasks; independently re-run, not taken from the implementer's report).
- Multi-round review: a multi-model review found 7 findings; three fix rounds followed, each re-reviewed on its own delta, closing with an empty converge round. The merged-multi-target rendering was reshaped twice during review — first to stop fabricating per-target rows, then to keep unresolvable targets in the label and expand per key so truncation can't hide payload keys on a consent surface.
- Runtime QA (headless Chrome via agent-browser, fresh data dir): mobile drawer dismiss-on-active-route-tap verified across 3 clean trials (DOM unmount asserted, not just visual); CSV import → insight → all 5 columns render humanized headers with no raw alias leakage; no console errors across the session. The preview-diff surface itself requires a live AI backend to produce a draft and was not exercisable at runtime; its rendering logic is covered by 27 component tests, including regression tests for every finding above.
- Known root cause left out of scope: the server merges batch command args flatly (`foldCommand` `Object.assign`), which destroys per-op attribution before the client sees it — the ambiguous rendering here is the honest interim. Server-side per-op retention is tracked separately.

Tracked internally as TASK-746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANXFmfHVyfnqD1tYwVjApd

