### PR TITLE
fix(app): scope file-upload replacement to file-backed tables

### DIFF
--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -173,6 +173,18 @@ describe("privacy floor — no raw sampleValues persist in artifact DB", () => {
     }
   });
 
+  it("should clear a previously stored analysis when updated with null", async () => {
+    const id = crypto.randomUUID();
+    await call("putDataFrameEntry", {
+      entry: makeDataFrameEntry(id, makeAnalysisWithSamples()),
+    });
+    expect(await readAnalysis(id)).not.toBeNull();
+
+    await call("updateDataFrameEntry", { id, updates: { analysis: null } });
+
+    expect(await readAnalysis(id)).toBeNull();
+  });
+
   it("should store profiles intact when analysis has no sampleValues", async () => {
     const id = crypto.randomUUID();
     // Analysis already clean (sampleValues: []).

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -75,7 +75,10 @@ type DataFrameEntry = DataFrameJSON & {
   definitionId?: UUID;
   rowCount?: number;
   columnCount?: number;
-  analysis?: DataFrameAnalysis;
+  // `null` is a deliberate clear signal (see updateDataFrameEntry below), not
+  // merely "absent" — keep it distinct from `undefined` so a future cleanup
+  // doesn't read the clearing branch as dead code and revert it.
+  analysis?: DataFrameAnalysis | null;
   lastRefreshedAt?: number;
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -483,6 +483,7 @@
       "devDependencies": {
         "@dashframe/eslint-config": "workspace:*",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.3",
         "@types/papaparse": "5.3.16",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",
@@ -1650,7 +1651,7 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
-    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.3", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g=="],
 
     "@tmcp/adapter-valibot": ["@tmcp/adapter-valibot@0.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@valibot/to-json-schema": "^1.3.0", "valibot": "^1.1.0" }, "peerDependencies": { "tmcp": "^1.17.0" } }, "sha512-9P2wrVYPngemNK0UvPb/opC722/jfd09QxXmme1TRp/wPsl98vpSk/MXt24BCMqBRv4Dvs0xxJH4KHDcjXW52Q=="],
 
@@ -4077,6 +4078,8 @@
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "storybook/@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -71,11 +71,12 @@
   "devDependencies": {
     "@dashframe/eslint-config": "workspace:*",
     "@testing-library/react": "^16.3.0",
-    "eslint-plugin-react-hooks": "^7.1.1",
+    "@testing-library/user-event": "^14.6.3",
     "@types/papaparse": "5.3.16",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "@types/react-grid-layout": "^1.3.6",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "jsdom": "^25.0.1",
     "typescript": "5.7.2",
     "vitest": "^4.0.16"

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -155,7 +155,11 @@ async function analyzeAndCacheDataFrame(
 interface DataFrameEntry {
   id: UUID;
   rowCount?: number;
-  analysis?: DataFrameAnalysis;
+  // `null` is a deliberate "cleared" signal (e.g. after a table replacement
+  // invalidates cached analysis) — every read site below already treats it
+  // the same as `undefined` via a truthy check, so this is a type-only
+  // widening to match the real shape from data-access/data-frames.ts.
+  analysis?: DataFrameAnalysis | null;
 }
 
 /** Table entry with optional fields */

--- a/packages/app/src/components/data-sources/DataPickerContent.test.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.test.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useConfirmDialogStore } from "@/lib/stores";
@@ -413,9 +414,11 @@ describe("DataPickerContent file replacement", () => {
       "Renamed or removed columns can break Insights that reference them.",
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Replace table" }));
-    });
+    // userEvent (not fireEvent) so this exercises real pointer-events
+    // through the nested dialog stack, not just a synthetic click
+    // dispatched straight at the button node.
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Replace table" }));
 
     await waitFor(() => {
       expect(mockParse).toHaveBeenCalledWith(expect.any(File), FILE_TABLE_ID);

--- a/packages/app/src/components/data-sources/DataPickerContent.test.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.test.tsx
@@ -5,7 +5,13 @@ import {
   type ValidationResult,
 } from "@dashframe/engine";
 import type { DataSource, DataTable, UUID } from "@dashframe/types";
-import { act, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useConfirmDialogStore } from "@/lib/stores";
@@ -23,6 +29,7 @@ const {
   queryData: {
     dataSources: [] as DataSource[],
     dataTables: [] as DataTable[],
+    dataSourcesQueryState: {} as { isLoading?: boolean; isError?: boolean },
   },
 }));
 
@@ -35,7 +42,10 @@ vi.mock("@wystack/client", async (importOriginal) => {
     useQuery: (ref: { _path: string }) => {
       switch (ref._path) {
         case "listDataSources":
-          return { data: queryData.dataSources };
+          return {
+            data: queryData.dataSources,
+            ...queryData.dataSourcesQueryState,
+          };
         case "listDataTables":
           return { data: queryData.dataTables };
         case "listInsights":
@@ -69,12 +79,22 @@ vi.mock("./AddConnectionPanel", () => ({
 vi.mock("./DataSourceList", () => ({ DataSourceList: () => null }));
 vi.mock("./DataTableList", () => ({ DataTableList: () => null }));
 vi.mock("./InsightList", () => ({ InsightList: () => null }));
-vi.mock("@wystack/ui-react", () => ({
-  Button: () => null,
-  SectionList: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-vi.mock("@wystack/ui-react/icons", () => ({ ArrowLeftIcon: () => null }));
+vi.mock("@wystack/ui-react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/ui-react")>();
+  return {
+    ...actual,
+    SectionList: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+vi.mock("@wystack/ui-react/icons", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@wystack/ui-react/icons")>();
+  return { ...actual, ArrowLeftIcon: () => null };
+});
 
+import { ConfirmDialog } from "../confirm-dialog";
 import { DataPickerContent } from "./DataPickerContent";
 
 const FILE_SOURCE_ID = "file-source-id" as UUID;
@@ -130,8 +150,12 @@ function makeTable(id: UUID, dataSourceId: UUID, name: string): DataTable {
 }
 
 function uploadSalesCsv(): void {
+  uploadFile("sales.csv");
+}
+
+function uploadFile(fileName: string): void {
   act(() => {
-    handleFileSelect?.(fileConnector, new File(["amount\n10"], "sales.csv"));
+    handleFileSelect?.(fileConnector, new File(["amount\n10"], fileName));
   });
 }
 
@@ -141,6 +165,7 @@ describe("DataPickerContent file replacement", () => {
     handleFileSelect = undefined;
     queryData.dataSources = [];
     queryData.dataTables = [];
+    queryData.dataSourcesQueryState = {};
     mockGetConnectorById.mockImplementation((id: string) => {
       if (id === "local") return { name: "CSV upload", sourceType: "file" };
       if (id === "notion") return { name: "Notion", sourceType: "remote-api" };
@@ -176,8 +201,45 @@ describe("DataPickerContent file replacement", () => {
     expect(mockHandleFileConnectorResult).toHaveBeenCalledWith(
       "sales.csv",
       PARSE_RESULT,
-      undefined,
+      { overrideTableId: NEW_TABLE_ID },
     );
+  });
+
+  it("does not offer to replace an excluded file-backed table", async () => {
+    queryData.dataSources = [
+      makeSource(FILE_SOURCE_ID, "Quarterly CSV uploads", "local"),
+    ];
+    queryData.dataTables = [makeTable(FILE_TABLE_ID, FILE_SOURCE_ID, "sales")];
+
+    render(
+      <DataPickerContent
+        excludeTableIds={[FILE_TABLE_ID]}
+        onTableSelect={vi.fn()}
+      />,
+    );
+    uploadSalesCsv();
+
+    await waitFor(() => {
+      expect(mockParse).toHaveBeenCalledWith(expect.any(File), NEW_TABLE_ID);
+    });
+    expect(useConfirmDialogStore.getState().config).toBeNull();
+    expect(mockHandleFileConnectorResult).toHaveBeenCalledWith(
+      "sales.csv",
+      PARSE_RESULT,
+      { overrideTableId: NEW_TABLE_ID },
+    );
+  });
+
+  it("waits for data sources before allowing an upload", async () => {
+    queryData.dataSourcesQueryState = { isLoading: true };
+
+    render(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadSalesCsv();
+
+    await waitFor(() => {
+      expect(mockParse).not.toHaveBeenCalled();
+    });
+    expect(mockHandleFileConnectorResult).not.toHaveBeenCalled();
   });
 
   it("confirms the named file-backed target before replacing it", async () => {
@@ -193,9 +255,9 @@ describe("DataPickerContent file replacement", () => {
       expect(useConfirmDialogStore.getState().config).not.toBeNull();
     });
     expect(useConfirmDialogStore.getState().config).toMatchObject({
-      title: 'Replace table "sales" from "CSV upload"?',
+      title: 'Replace table "sales" from "Quarterly CSV uploads"?',
       description:
-        'The existing file-backed table "sales" from "CSV upload" will be overwritten by "sales.csv".',
+        'The existing file-backed table "sales" from "Quarterly CSV uploads" will be overwritten by "sales.csv". Renamed or removed columns can break Insights that reference them.',
       confirmLabel: "Replace table",
       cancelLabel: "Cancel upload",
     });
@@ -236,5 +298,68 @@ describe("DataPickerContent file replacement", () => {
     });
     expect(mockParse).not.toHaveBeenCalled();
     expect(mockHandleFileConnectorResult).not.toHaveBeenCalled();
+  });
+
+  it("offers to replace a file-backed table when the same JSON file is uploaded twice", async () => {
+    queryData.dataSources = [
+      makeSource(FILE_SOURCE_ID, "Quarterly JSON uploads", "local"),
+    ];
+
+    const { rerender } = render(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadFile("orders.json");
+
+    await waitFor(() => {
+      expect(mockParse).toHaveBeenCalledWith(expect.any(File), NEW_TABLE_ID);
+    });
+    queryData.dataTables = [makeTable(NEW_TABLE_ID, FILE_SOURCE_ID, "orders")];
+    rerender(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadFile("orders.json");
+
+    await waitFor(() => {
+      expect(useConfirmDialogStore.getState().config).toMatchObject({
+        title: 'Replace table "orders" from "Quarterly JSON uploads"?',
+      });
+    });
+    expect(mockParse).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the real destructive confirm dialog and replaces through its button", async () => {
+    queryData.dataSources = [
+      makeSource(FILE_SOURCE_ID, "Quarterly CSV uploads", "local"),
+    ];
+    queryData.dataTables = [makeTable(FILE_TABLE_ID, FILE_SOURCE_ID, "sales")];
+
+    render(
+      <>
+        <DataPickerContent onTableSelect={vi.fn()} />
+        <ConfirmDialog />
+      </>,
+    );
+    uploadSalesCsv();
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain(
+      'Replace table "sales" from "Quarterly CSV uploads"?',
+    );
+    expect(dialog.textContent).toContain(
+      "Renamed or removed columns can break Insights that reference them.",
+    );
+
+    const confirmButton = screen.getByRole("button", {
+      name: "Replace table",
+    });
+    expect(confirmButton.className).toContain("bg-palette-danger");
+    await act(async () => {
+      fireEvent.click(confirmButton);
+    });
+
+    await waitFor(() => {
+      expect(mockParse).toHaveBeenCalledWith(expect.any(File), FILE_TABLE_ID);
+    });
+    expect(mockHandleFileConnectorResult).toHaveBeenCalledWith(
+      "sales.csv",
+      PARSE_RESULT,
+      { overrideTableId: FILE_TABLE_ID },
+    );
   });
 });

--- a/packages/app/src/components/data-sources/DataPickerContent.test.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.test.tsx
@@ -30,6 +30,7 @@ const {
     dataSources: [] as DataSource[],
     dataTables: [] as DataTable[],
     dataSourcesQueryState: {} as { isLoading?: boolean; isError?: boolean },
+    dataTablesQueryState: {} as { isLoading?: boolean; isError?: boolean },
   },
 }));
 
@@ -47,7 +48,10 @@ vi.mock("@wystack/client", async (importOriginal) => {
             ...queryData.dataSourcesQueryState,
           };
         case "listDataTables":
-          return { data: queryData.dataTables };
+          return {
+            data: queryData.dataTables,
+            ...queryData.dataTablesQueryState,
+          };
         case "listInsights":
         case "listDataFrames":
           return { data: [] };
@@ -96,6 +100,7 @@ vi.mock("@wystack/ui-react/icons", async (importOriginal) => {
 
 import { ConfirmDialog } from "../confirm-dialog";
 import { DataPickerContent } from "./DataPickerContent";
+import { DataPickerModal } from "./DataPickerModal";
 
 const FILE_SOURCE_ID = "file-source-id" as UUID;
 const REMOTE_SOURCE_ID = "remote-source-id" as UUID;
@@ -166,6 +171,7 @@ describe("DataPickerContent file replacement", () => {
     queryData.dataSources = [];
     queryData.dataTables = [];
     queryData.dataSourcesQueryState = {};
+    queryData.dataTablesQueryState = {};
     mockGetConnectorById.mockImplementation((id: string) => {
       if (id === "local") return { name: "CSV upload", sourceType: "file" };
       if (id === "notion") return { name: "Notion", sourceType: "remote-api" };
@@ -180,7 +186,9 @@ describe("DataPickerContent file replacement", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    useConfirmDialogStore.setState({ isOpen: false, config: null });
+    act(() => {
+      useConfirmDialogStore.setState({ isOpen: false, config: null });
+    });
   });
 
   it("creates a new table rather than offering to replace a same-named remote table", async () => {
@@ -232,6 +240,18 @@ describe("DataPickerContent file replacement", () => {
 
   it("waits for data sources before allowing an upload", async () => {
     queryData.dataSourcesQueryState = { isLoading: true };
+
+    render(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadSalesCsv();
+
+    await waitFor(() => {
+      expect(mockParse).not.toHaveBeenCalled();
+    });
+    expect(mockHandleFileConnectorResult).not.toHaveBeenCalled();
+  });
+
+  it("waits for data tables before allowing an upload", async () => {
+    queryData.dataTablesQueryState = { isLoading: true };
 
     render(<DataPickerContent onTableSelect={vi.fn()} />);
     uploadSalesCsv();
@@ -335,7 +355,10 @@ describe("DataPickerContent file replacement", () => {
         <ConfirmDialog />
       </>,
     );
-    uploadSalesCsv();
+    await act(async () => {
+      handleFileSelect?.(fileConnector, new File(["amount\n10"], "sales.csv"));
+      await Promise.resolve();
+    });
 
     const dialog = await screen.findByRole("dialog");
     expect(dialog.textContent).toContain(
@@ -351,6 +374,47 @@ describe("DataPickerContent file replacement", () => {
     expect(confirmButton.className).toContain("bg-palette-danger");
     await act(async () => {
       fireEvent.click(confirmButton);
+    });
+
+    await waitFor(() => {
+      expect(mockParse).toHaveBeenCalledWith(expect.any(File), FILE_TABLE_ID);
+    });
+    expect(mockHandleFileConnectorResult).toHaveBeenCalledWith(
+      "sales.csv",
+      PARSE_RESULT,
+      { overrideTableId: FILE_TABLE_ID },
+    );
+  });
+
+  it("replaces through the nested confirm dialog in the real picker modal", async () => {
+    queryData.dataSources = [
+      makeSource(FILE_SOURCE_ID, "Quarterly CSV uploads", "local"),
+    ];
+    queryData.dataTables = [makeTable(FILE_TABLE_ID, FILE_SOURCE_ID, "sales")];
+
+    render(
+      <>
+        <DataPickerModal
+          isOpen
+          onClose={vi.fn()}
+          title="Create Visualization"
+          onTableSelect={vi.fn()}
+        />
+        <ConfirmDialog />
+      </>,
+    );
+    uploadSalesCsv();
+
+    const confirmDialog = await screen.findByRole("dialog", {
+      name: 'Replace table "sales" from "Quarterly CSV uploads"?',
+    });
+    expect(screen.getAllByRole("dialog", { hidden: true })).toHaveLength(2);
+    expect(confirmDialog.textContent).toContain(
+      "Renamed or removed columns can break Insights that reference them.",
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Replace table" }));
     });
 
     await waitFor(() => {

--- a/packages/app/src/components/data-sources/DataPickerContent.test.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.test.tsx
@@ -1,0 +1,240 @@
+import {
+  FileSourceConnector,
+  type FileParseResult,
+  type FormField,
+  type ValidationResult,
+} from "@dashframe/engine";
+import type { DataSource, DataTable, UUID } from "@dashframe/types";
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useConfirmDialogStore } from "@/lib/stores";
+import type { AddConnectionPanelProps } from "./AddConnectionPanel";
+
+const {
+  mockGetConnectorById,
+  mockHandleFileConnectorResult,
+  mockParse,
+  queryData,
+} = vi.hoisted(() => ({
+  mockGetConnectorById: vi.fn(),
+  mockHandleFileConnectorResult: vi.fn(),
+  mockParse: vi.fn(),
+  queryData: {
+    dataSources: [] as DataSource[],
+    dataTables: [] as DataTable[],
+  },
+}));
+
+let handleFileSelect: AddConnectionPanelProps["onFileSelect"] | undefined;
+
+vi.mock("@wystack/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/client")>();
+  return {
+    ...actual,
+    useQuery: (ref: { _path: string }) => {
+      switch (ref._path) {
+        case "listDataSources":
+          return { data: queryData.dataSources };
+        case "listDataTables":
+          return { data: queryData.dataTables };
+        case "listInsights":
+        case "listDataFrames":
+          return { data: [] };
+        default:
+          throw new Error(`Unexpected query: ${ref._path}`);
+      }
+    },
+    useMutation: () => ({ mutateAsync: vi.fn() }),
+  };
+});
+
+vi.mock("@/lib/connectors/registry", () => ({
+  getConnectorById: mockGetConnectorById,
+}));
+
+vi.mock("@/lib/local-csv-handler", () => ({
+  handleFileConnectorResult: mockHandleFileConnectorResult,
+}));
+
+vi.mock("./AddConnectionPanel", () => ({
+  AddConnectionPanel: ({
+    onFileSelect,
+  }: Pick<AddConnectionPanelProps, "onFileSelect">) => {
+    handleFileSelect = onFileSelect;
+    return <div data-testid="add-connection-panel" />;
+  },
+}));
+
+vi.mock("./DataSourceList", () => ({ DataSourceList: () => null }));
+vi.mock("./DataTableList", () => ({ DataTableList: () => null }));
+vi.mock("./InsightList", () => ({ InsightList: () => null }));
+vi.mock("@wystack/ui-react", () => ({
+  Button: () => null,
+  SectionList: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@wystack/ui-react/icons", () => ({ ArrowLeftIcon: () => null }));
+
+import { DataPickerContent } from "./DataPickerContent";
+
+const FILE_SOURCE_ID = "file-source-id" as UUID;
+const REMOTE_SOURCE_ID = "remote-source-id" as UUID;
+const FILE_TABLE_ID = "file-table-id" as UUID;
+const REMOTE_TABLE_ID = "remote-table-id" as UUID;
+const NEW_TABLE_ID = "new-table-id" as UUID;
+const PARSE_RESULT = {} as FileParseResult;
+
+class TestFileConnector extends FileSourceConnector {
+  readonly id = "local";
+  readonly name = "CSV upload";
+  readonly description = "Upload CSV files.";
+  readonly icon = "";
+  readonly accept = ".csv";
+
+  getFormFields(): FormField[] {
+    return [];
+  }
+
+  validate(): ValidationResult {
+    return { valid: true };
+  }
+
+  async parse(_file: File, _tableId: UUID): Promise<FileParseResult> {
+    mockParse(_file, _tableId);
+    return PARSE_RESULT;
+  }
+}
+
+const fileConnector = new TestFileConnector();
+
+function makeSource(id: UUID, name: string, type: string): DataSource {
+  return {
+    id,
+    name,
+    type,
+    config: { hasApiKey: false, hasConnectionString: false },
+    createdAt: 0,
+  };
+}
+
+function makeTable(id: UUID, dataSourceId: UUID, name: string): DataTable {
+  return {
+    id,
+    dataSourceId,
+    name,
+    table: name,
+    fields: [],
+    metrics: [],
+    createdAt: 0,
+  };
+}
+
+function uploadSalesCsv(): void {
+  act(() => {
+    handleFileSelect?.(fileConnector, new File(["amount\n10"], "sales.csv"));
+  });
+}
+
+describe("DataPickerContent file replacement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleFileSelect = undefined;
+    queryData.dataSources = [];
+    queryData.dataTables = [];
+    mockGetConnectorById.mockImplementation((id: string) => {
+      if (id === "local") return { name: "CSV upload", sourceType: "file" };
+      if (id === "notion") return { name: "Notion", sourceType: "remote-api" };
+      return undefined;
+    });
+    mockHandleFileConnectorResult.mockResolvedValue({
+      dataTableId: NEW_TABLE_ID,
+    });
+    useConfirmDialogStore.setState({ isOpen: false, config: null });
+    vi.stubGlobal("crypto", { randomUUID: vi.fn(() => NEW_TABLE_ID) });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useConfirmDialogStore.setState({ isOpen: false, config: null });
+  });
+
+  it("creates a new table rather than offering to replace a same-named remote table", async () => {
+    queryData.dataSources = [
+      makeSource(REMOTE_SOURCE_ID, "Sales workspace", "notion"),
+    ];
+    queryData.dataTables = [
+      makeTable(REMOTE_TABLE_ID, REMOTE_SOURCE_ID, "sales"),
+    ];
+
+    render(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadSalesCsv();
+
+    await waitFor(() => {
+      expect(mockParse).toHaveBeenCalledWith(expect.any(File), NEW_TABLE_ID);
+    });
+    expect(useConfirmDialogStore.getState().config).toBeNull();
+    expect(mockHandleFileConnectorResult).toHaveBeenCalledWith(
+      "sales.csv",
+      PARSE_RESULT,
+      undefined,
+    );
+  });
+
+  it("confirms the named file-backed target before replacing it", async () => {
+    queryData.dataSources = [
+      makeSource(FILE_SOURCE_ID, "Quarterly CSV uploads", "local"),
+    ];
+    queryData.dataTables = [makeTable(FILE_TABLE_ID, FILE_SOURCE_ID, "sales")];
+
+    render(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadSalesCsv();
+
+    await waitFor(() => {
+      expect(useConfirmDialogStore.getState().config).not.toBeNull();
+    });
+    expect(useConfirmDialogStore.getState().config).toMatchObject({
+      title: 'Replace table "sales" from "CSV upload"?',
+      description:
+        'The existing file-backed table "sales" from "CSV upload" will be overwritten by "sales.csv".',
+      confirmLabel: "Replace table",
+      cancelLabel: "Cancel upload",
+    });
+    expect(mockParse).not.toHaveBeenCalled();
+
+    act(() => {
+      useConfirmDialogStore.getState().handleConfirm();
+    });
+
+    await waitFor(() => {
+      expect(mockParse).toHaveBeenCalledWith(expect.any(File), FILE_TABLE_ID);
+    });
+    expect(mockHandleFileConnectorResult).toHaveBeenCalledWith(
+      "sales.csv",
+      PARSE_RESULT,
+      { overrideTableId: FILE_TABLE_ID },
+    );
+  });
+
+  it("returns before parsing when replacement is cancelled", async () => {
+    queryData.dataSources = [
+      makeSource(FILE_SOURCE_ID, "Quarterly CSV uploads", "local"),
+    ];
+    queryData.dataTables = [makeTable(FILE_TABLE_ID, FILE_SOURCE_ID, "sales")];
+
+    render(<DataPickerContent onTableSelect={vi.fn()} />);
+    uploadSalesCsv();
+
+    await waitFor(() => {
+      expect(useConfirmDialogStore.getState().config).not.toBeNull();
+    });
+    act(() => {
+      useConfirmDialogStore.getState().handleCancel();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockParse).not.toHaveBeenCalled();
+    expect(mockHandleFileConnectorResult).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -136,9 +136,9 @@ export function DataPickerContent({
   const dataSourcesQuery = useQuery(api.listDataSources);
   const { data: dataSources = [], isLoading: isLoadingDataSources } =
     dataSourcesQuery;
-  const { data: allDataTables = [] } = useQuery(api.listDataTables, {
-    args: {},
-  });
+  const dataTablesQuery = useQuery(api.listDataTables, { args: {} });
+  const { data: allDataTables = [], isLoading: isLoadingDataTables } =
+    dataTablesQuery;
   const { data: allInsights = [] } = useQuery(api.listInsights, { args: {} });
   const { data: dataFrames = [] } = useQuery(api.listDataFrames);
   const { mutateAsync: commitBatch } = useMutation(api.commitBatch);
@@ -292,6 +292,14 @@ export function DataPickerContent({
         setError("Data sources could not be loaded — try again in a moment.");
         return;
       }
+      if (isLoadingDataTables) {
+        setError("Data tables are still loading — try again in a moment.");
+        return;
+      }
+      if (dataTablesQuery.isError) {
+        setError("Data tables could not be loaded — try again in a moment.");
+        return;
+      }
       try {
         if (
           connector.maxSizeMB &&
@@ -360,7 +368,9 @@ export function DataPickerContent({
       onTableSelect,
       allDataTables,
       dataSources,
+      dataTablesQuery.isError,
       dataSourcesQuery.isError,
+      isLoadingDataTables,
       isLoadingDataSources,
       confirm,
       excludeTableIds,

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -30,11 +30,13 @@ import {
 import { useMutation, useQuery } from "@wystack/client";
 import { Button, SectionList } from "@wystack/ui-react";
 import { ArrowLeftIcon } from "@wystack/ui-react/icons";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddConnectionPanel } from "./AddConnectionPanel";
 import { DataSourceList, type DataSourceInfo } from "./DataSourceList";
 import { DataTableList } from "./DataTableList";
 import { InsightList, type InsightDisplayInfo } from "./InsightList";
+
+const FILE_TABLE_NAME_EXTENSION = /\.(csv|xlsx?|json)$/i;
 
 function requestRemoteFieldReview(
   confirm: (config: ConfirmDialogConfig) => void,
@@ -68,7 +70,7 @@ function requestFileTableReplacement(
   return new Promise((resolve) => {
     confirm({
       title: `Replace table "${tableName}" from "${sourceName}"?`,
-      description: `The existing file-backed table "${tableName}" from "${sourceName}" will be overwritten by "${fileName}".`,
+      description: `The existing file-backed table "${tableName}" from "${sourceName}" will be overwritten by "${fileName}". Renamed or removed columns can break Insights that reference them.`,
       confirmLabel: "Replace table",
       cancelLabel: "Cancel upload",
       variant: "destructive",
@@ -131,7 +133,9 @@ export function DataPickerContent({
   onCancel,
   showInsights = true,
 }: DataPickerContentProps) {
-  const { data: dataSources = [] } = useQuery(api.listDataSources);
+  const dataSourcesQuery = useQuery(api.listDataSources);
+  const { data: dataSources = [], isLoading: isLoadingDataSources } =
+    dataSourcesQuery;
   const { data: allDataTables = [] } = useQuery(api.listDataTables, {
     args: {},
   });
@@ -169,6 +173,14 @@ export function DataPickerContent({
   const [materializingResourceId, setMaterializingResourceId] = useState<
     string | null
   >(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   // Transform sources for DataSourceList
   const dataSourcesInfo: DataSourceInfo[] = useMemo(() => {
@@ -272,6 +284,14 @@ export function DataPickerContent({
   const handleFileSelect = useCallback(
     async (connector: FileSourceConnector, file: File) => {
       setError(null);
+      if (isLoadingDataSources) {
+        setError("Data sources are still loading — try again in a moment.");
+        return;
+      }
+      if (dataSourcesQuery.isError) {
+        setError("Data sources could not be loaded — try again in a moment.");
+        return;
+      }
       try {
         if (
           connector.maxSizeMB &&
@@ -291,8 +311,9 @@ export function DataPickerContent({
             getConnectorById(source?.type ?? "")?.sourceType === "file";
           return (
             isFileBacked &&
+            !excludeTableIds.includes(table.id) &&
             (table.name === file.name ||
-              table.name === file.name.replace(/\.(csv|xlsx?)$/i, ""))
+              table.name === file.name.replace(FILE_TABLE_NAME_EXTENSION, ""))
           );
         });
 
@@ -301,8 +322,8 @@ export function DataPickerContent({
             (dataSource) => dataSource.id === existingTable.dataSourceId,
           );
           const sourceName =
-            getConnectorById(source?.type ?? "")?.name ??
             source?.name ??
+            getConnectorById(source?.type ?? "")?.name ??
             source?.type ??
             "file source";
           const shouldOverride = await requestFileTableReplacement(confirm, {
@@ -311,6 +332,9 @@ export function DataPickerContent({
             sourceName,
           });
           if (!shouldOverride) {
+            return;
+          }
+          if (!isMountedRef.current) {
             return;
           }
         }
@@ -323,16 +347,24 @@ export function DataPickerContent({
         const { dataTableId } = await handleFileConnectorResult(
           file.name,
           result,
-          existingTable ? { overrideTableId: existingTable.id } : undefined,
+          { overrideTableId: tableId },
         );
 
-        const tableName = file.name.replace(/\.(csv|xlsx?)$/i, "");
+        const tableName = file.name.replace(FILE_TABLE_NAME_EXTENSION, "");
         onTableSelect(dataTableId, tableName);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to process file");
       }
     },
-    [onTableSelect, allDataTables, dataSources, confirm],
+    [
+      onTableSelect,
+      allDataTables,
+      dataSources,
+      dataSourcesQuery.isError,
+      isLoadingDataSources,
+      confirm,
+      excludeTableIds,
+    ],
   );
 
   const handleConnect = useCallback(

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -53,6 +53,31 @@ function requestRemoteFieldReview(
   });
 }
 
+function requestFileTableReplacement(
+  confirm: (config: ConfirmDialogConfig) => void,
+  {
+    fileName,
+    tableName,
+    sourceName,
+  }: {
+    fileName: string;
+    tableName: string;
+    sourceName: string;
+  },
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    confirm({
+      title: `Replace table "${tableName}" from "${sourceName}"?`,
+      description: `The existing file-backed table "${tableName}" from "${sourceName}" will be overwritten by "${fileName}".`,
+      confirmLabel: "Replace table",
+      cancelLabel: "Cancel upload",
+      variant: "destructive",
+      onConfirm: () => resolve(true),
+      onCancel: () => resolve(false),
+    });
+  });
+}
+
 export interface DataPickerContentProps {
   /**
    * Called when an existing insight is selected.
@@ -255,17 +280,36 @@ export function DataPickerContent({
           throw new Error(`File size exceeds ${connector.maxSizeMB}MB limit.`);
         }
 
-        // Check for duplicate table
-        const existingTable = allDataTables.find(
-          (table) =>
-            table.name === file.name ||
-            table.name === file.name.replace(/\.(csv|xlsx?)$/i, ""),
-        );
+        // Only file-backed tables can be replaced by an uploaded file. A
+        // remote table with the same name is a separate source of truth and
+        // must never be used as an overwrite target.
+        const existingTable = allDataTables.find((table) => {
+          const source = dataSources.find(
+            (dataSource) => dataSource.id === table.dataSourceId,
+          );
+          const isFileBacked =
+            getConnectorById(source?.type ?? "")?.sourceType === "file";
+          return (
+            isFileBacked &&
+            (table.name === file.name ||
+              table.name === file.name.replace(/\.(csv|xlsx?)$/i, ""))
+          );
+        });
 
         if (existingTable) {
-          const shouldOverride = window.confirm(
-            `"${file.name}" already exists. Replace the existing table with this file?`,
+          const source = dataSources.find(
+            (dataSource) => dataSource.id === existingTable.dataSourceId,
           );
+          const sourceName =
+            getConnectorById(source?.type ?? "")?.name ??
+            source?.name ??
+            source?.type ??
+            "file source";
+          const shouldOverride = await requestFileTableReplacement(confirm, {
+            fileName: file.name,
+            tableName: existingTable.name,
+            sourceName,
+          });
           if (!shouldOverride) {
             return;
           }
@@ -288,7 +332,7 @@ export function DataPickerContent({
         setError(err instanceof Error ? err.message : "Failed to process file");
       }
     },
-    [onTableSelect, allDataTables],
+    [onTableSelect, allDataTables, dataSources, confirm],
   );
 
   const handleConnect = useCallback(

--- a/packages/app/src/lib/data-access/data-frames.test.ts
+++ b/packages/app/src/lib/data-access/data-frames.test.ts
@@ -1,0 +1,63 @@
+import { setWyStackClient } from "@/wystack/client";
+import type { DataFrame, UUID } from "@dashframe/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { replaceDataFrame } from "./data-frames";
+
+const { mockDeleteArrowData, mockMutate, mockQuery } = vi.hoisted(() => ({
+  mockDeleteArrowData: vi.fn(),
+  mockMutate: vi.fn(),
+  mockQuery: vi.fn(),
+}));
+
+vi.mock("@dashframe/engine-browser", () => ({
+  DataFrame: class {},
+  deleteArrowData: mockDeleteArrowData,
+}));
+vi.mock("@/wystack/api", () => ({
+  api: {
+    getDataFrameEntry: "getDataFrameEntry",
+    updateDataFrameEntry: "updateDataFrameEntry",
+  },
+}));
+
+const DATA_FRAME_ID = "data-frame-id" as UUID;
+
+describe("replaceDataFrame", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue(undefined);
+    mockMutate.mockResolvedValue({ ok: true });
+    setWyStackClient({ query: mockQuery, mutate: mockMutate } as never);
+  });
+
+  it("clears stale column analysis while replacing frame storage", async () => {
+    const replacementFrame = {
+      id: DATA_FRAME_ID,
+      toJSON: () => ({
+        id: DATA_FRAME_ID,
+        storage: { type: "indexeddb", key: "replacement-arrow" },
+        fieldIds: ["new-field-id" as UUID],
+        primaryKey: "new-field-id",
+        createdAt: 123,
+      }),
+    } as DataFrame;
+
+    await replaceDataFrame(DATA_FRAME_ID, replacementFrame, {
+      rowCount: 20,
+      columnCount: 1,
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith("updateDataFrameEntry", {
+      id: DATA_FRAME_ID,
+      updates: expect.objectContaining({
+        storage: { type: "indexeddb", key: "replacement-arrow" },
+        fieldIds: ["new-field-id"],
+        primaryKey: "new-field-id",
+        createdAt: 123,
+        rowCount: 20,
+        columnCount: 1,
+        analysis: null,
+      }),
+    });
+  });
+});

--- a/packages/app/src/lib/data-access/data-frames.ts
+++ b/packages/app/src/lib/data-access/data-frames.ts
@@ -19,7 +19,7 @@ export type DataFrameEntry = DataFrameJSON & {
   definitionId?: UUID;
   rowCount?: number;
   columnCount?: number;
-  analysis?: DataFrameAnalysis;
+  analysis?: DataFrameAnalysis | null;
   lastRefreshedAt?: number;
 };
 
@@ -79,6 +79,7 @@ export async function replaceDataFrame(
     definitionId: metadata?.definitionId,
     rowCount: metadata?.rowCount,
     columnCount: metadata?.columnCount,
+    analysis: null,
     lastRefreshedAt: Date.now(),
   });
   if (oldEntity?.storage?.type === "indexeddb") {

--- a/packages/app/src/lib/local-csv-handler.test.ts
+++ b/packages/app/src/lib/local-csv-handler.test.ts
@@ -1,0 +1,136 @@
+import type { DataTable, Field, UUID } from "@dashframe/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockAddDataFrameEntry,
+  mockCsvToDataFrame,
+  mockGetDataTable,
+  mockGetOrCreateDataSourceByType,
+  mockReplaceDataFrame,
+  mockUpdateDataTable,
+} = vi.hoisted(() => ({
+  mockAddDataFrameEntry: vi.fn(),
+  mockCsvToDataFrame: vi.fn(),
+  mockGetDataTable: vi.fn(),
+  mockGetOrCreateDataSourceByType: vi.fn(),
+  mockReplaceDataFrame: vi.fn(),
+  mockUpdateDataTable: vi.fn(),
+}));
+
+vi.mock("@/lib/data-access/data-frames", () => ({
+  addDataFrameEntry: mockAddDataFrameEntry,
+  replaceDataFrame: mockReplaceDataFrame,
+}));
+vi.mock("@/lib/data-access/data-sources", () => ({
+  getOrCreateDataSourceByType: mockGetOrCreateDataSourceByType,
+}));
+vi.mock("@/lib/data-access/data-tables", () => ({
+  createDataTable: vi.fn(),
+  getDataTable: mockGetDataTable,
+  updateDataTable: mockUpdateDataTable,
+}));
+vi.mock("@dashframe/csv", () => ({ csvToDataFrame: mockCsvToDataFrame }));
+
+import {
+  handleFileConnectorResult,
+  handleLocalCSVUpload,
+} from "./local-csv-handler";
+
+const TABLE_ID = "table-id" as UUID;
+const EXISTING_FIELD_ID = "existing-field-id" as UUID;
+const NEW_FIELD_ID = "new-field-id" as UUID;
+const DATA_SOURCE_ID = "data-source-id" as UUID;
+
+const existingField: Field = {
+  id: EXISTING_FIELD_ID,
+  name: "amount",
+  tableId: TABLE_ID,
+  type: "number",
+  sensitivity: "cleared",
+  sensitivityReason: "Cleared by you",
+  sensitivitySource: "user",
+};
+
+const parsedFields: Field[] = [
+  {
+    id: NEW_FIELD_ID,
+    name: "amount",
+    tableId: TABLE_ID,
+    type: "string",
+  },
+  {
+    id: "new-column-id" as UUID,
+    name: "created_at",
+    tableId: TABLE_ID,
+    type: "date",
+  },
+];
+
+const existingTable: DataTable = {
+  id: TABLE_ID,
+  dataSourceId: DATA_SOURCE_ID,
+  name: "orders",
+  table: "orders.csv",
+  fields: [existingField],
+  metrics: [],
+  dataFrameId: "data-frame-id" as UUID,
+  createdAt: 0,
+};
+
+const parsedResult = {
+  dataFrame: { id: "replacement-data-frame-id" as UUID },
+  fields: parsedFields,
+  sourceSchema: { columns: [] },
+  rowCount: 1,
+  columnCount: 2,
+};
+
+describe("file table replacement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOrCreateDataSourceByType.mockResolvedValue({ id: DATA_SOURCE_ID });
+    mockGetDataTable.mockResolvedValue(existingTable);
+    mockReplaceDataFrame.mockResolvedValue(undefined);
+    mockUpdateDataTable.mockResolvedValue(undefined);
+    mockCsvToDataFrame.mockResolvedValue(parsedResult);
+  });
+
+  it.each([
+    [
+      "handleLocalCSVUpload",
+      () =>
+        handleLocalCSVUpload(new File([], "orders.csv"), [], {
+          overrideTableId: TABLE_ID,
+        }),
+    ],
+    [
+      "handleFileConnectorResult",
+      () =>
+        handleFileConnectorResult("orders.csv", parsedResult as never, {
+          overrideTableId: TABLE_ID,
+        }),
+    ],
+  ])(
+    "%s retains matching field identities and sensitivity marks",
+    async (_name, replace) => {
+      await replace();
+
+      expect(mockUpdateDataTable).toHaveBeenNthCalledWith(1, TABLE_ID, {
+        name: "orders",
+        table: "orders.csv",
+        sourceSchema: parsedResult.sourceSchema,
+        fields: [
+          {
+            ...parsedFields[0],
+            id: EXISTING_FIELD_ID,
+            sensitivity: "cleared",
+            sensitivityReason: "Cleared by you",
+            sensitivitySource: "user",
+          },
+          parsedFields[1],
+        ],
+        metrics: expect.any(Array),
+      });
+    },
+  );
+});

--- a/packages/app/src/lib/local-csv-handler.test.ts
+++ b/packages/app/src/lib/local-csv-handler.test.ts
@@ -277,4 +277,60 @@ describe("file table replacement", () => {
       fields.length,
     );
   });
+
+  it("does not reuse an id when only the new parse has a duplicate column name", async () => {
+    const duplicateParsedFields: Field[] = [
+      parsedFields[0],
+      {
+        ...parsedFields[0],
+        id: "second-new-field-id" as UUID,
+        name: "duplicate_amount",
+      },
+    ];
+    // Existing side is unambiguous — a single field named "amount".
+    mockGetDataTable.mockResolvedValue({
+      ...existingTable,
+      fields: [existingField],
+    });
+
+    await replacementHandlers[0].replace({
+      ...parsedResult,
+      fields: duplicateParsedFields,
+      columnCount: 2,
+    });
+
+    const [{ fields }] = mockUpdateDataTable.mock.calls[0].slice(1) as [
+      { fields: Field[] },
+    ];
+    expect(fields).toEqual(duplicateParsedFields);
+    expect(new Set(fields.map((field) => field.id))).toHaveLength(
+      fields.length,
+    );
+  });
+
+  it("does not reuse an id when only the existing table has a duplicate column name", async () => {
+    // Existing side is ambiguous — two fields both mapped to "amount".
+    mockGetDataTable.mockResolvedValue({
+      ...existingTable,
+      fields: [
+        existingField,
+        {
+          ...existingField,
+          id: "second-existing-field-id" as UUID,
+          name: "duplicate_amount",
+        },
+      ],
+    });
+
+    // New parse is unambiguous — a single "amount" column.
+    await replacementHandlers[0].replace(parsedResult);
+
+    const [{ fields }] = mockUpdateDataTable.mock.calls[0].slice(1) as [
+      { fields: Field[] },
+    ];
+    expect(fields).toEqual(parsedFields);
+    expect(new Set(fields.map((field) => field.id))).toHaveLength(
+      fields.length,
+    );
+  });
 });

--- a/packages/app/src/lib/local-csv-handler.test.ts
+++ b/packages/app/src/lib/local-csv-handler.test.ts
@@ -1,4 +1,4 @@
-import type { DataTable, Field, UUID } from "@dashframe/types";
+import type { DataTable, Field, Metric, UUID } from "@dashframe/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -45,6 +45,7 @@ const existingField: Field = {
   id: EXISTING_FIELD_ID,
   name: "amount",
   tableId: TABLE_ID,
+  columnName: "amount",
   type: "number",
   sensitivity: "cleared",
   sensitivityReason: "Cleared by you",
@@ -56,12 +57,14 @@ const parsedFields: Field[] = [
     id: NEW_FIELD_ID,
     name: "amount",
     tableId: TABLE_ID,
+    columnName: "amount",
     type: "string",
   },
   {
     id: "new-column-id" as UUID,
     name: "created_at",
     tableId: TABLE_ID,
+    columnName: "created_at",
     type: "date",
   },
 ];
@@ -85,6 +88,25 @@ const parsedResult = {
   columnCount: 2,
 };
 
+const replacementHandlers = [
+  {
+    name: "handleLocalCSVUpload",
+    replace: async (result = parsedResult) => {
+      mockCsvToDataFrame.mockResolvedValue(result);
+      return handleLocalCSVUpload(new File([], "orders.csv"), [], {
+        overrideTableId: TABLE_ID,
+      });
+    },
+  },
+  {
+    name: "handleFileConnectorResult",
+    replace: (result = parsedResult) =>
+      handleFileConnectorResult("orders.csv", result as never, {
+        overrideTableId: TABLE_ID,
+      }),
+  },
+];
+
 describe("file table replacement", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -95,24 +117,9 @@ describe("file table replacement", () => {
     mockCsvToDataFrame.mockResolvedValue(parsedResult);
   });
 
-  it.each([
-    [
-      "handleLocalCSVUpload",
-      () =>
-        handleLocalCSVUpload(new File([], "orders.csv"), [], {
-          overrideTableId: TABLE_ID,
-        }),
-    ],
-    [
-      "handleFileConnectorResult",
-      () =>
-        handleFileConnectorResult("orders.csv", parsedResult as never, {
-          overrideTableId: TABLE_ID,
-        }),
-    ],
-  ])(
-    "%s retains matching field identities and sensitivity marks",
-    async (_name, replace) => {
+  it.each(replacementHandlers)(
+    "$name retains matching field identities but resets cleared sensitivity",
+    async ({ replace }) => {
       await replace();
 
       expect(mockUpdateDataTable).toHaveBeenNthCalledWith(1, TABLE_ID, {
@@ -123,9 +130,9 @@ describe("file table replacement", () => {
           {
             ...parsedFields[0],
             id: EXISTING_FIELD_ID,
-            sensitivity: "cleared",
-            sensitivityReason: "Cleared by you",
-            sensitivitySource: "user",
+            sensitivity: "unclassified",
+            sensitivityReason: undefined,
+            sensitivitySource: undefined,
           },
           parsedFields[1],
         ],
@@ -133,4 +140,141 @@ describe("file table replacement", () => {
       });
     },
   );
+
+  it.each(replacementHandlers)(
+    "$name retains confirmed-sensitive fields across replacement",
+    async ({ replace }) => {
+      mockGetDataTable.mockResolvedValue({
+        ...existingTable,
+        fields: [
+          {
+            ...existingField,
+            sensitivity: "sensitive",
+            sensitivityReason: "Contains payment data",
+            sensitivitySource: "classifier",
+          },
+        ],
+      });
+
+      await replace();
+
+      expect(mockUpdateDataTable).toHaveBeenNthCalledWith(
+        1,
+        TABLE_ID,
+        expect.objectContaining({
+          fields: [
+            {
+              ...parsedFields[0],
+              id: EXISTING_FIELD_ID,
+              sensitivity: "sensitive",
+              sensitivityReason: "Contains payment data",
+              sensitivitySource: "classifier",
+            },
+            parsedFields[1],
+          ],
+        }),
+      );
+    },
+  );
+
+  it.each(replacementHandlers)(
+    "$name drops metrics for removed columns but keeps Count",
+    async ({ replace }) => {
+      const countMetric: Metric = {
+        id: "count-metric-id" as UUID,
+        name: "Count",
+        tableId: TABLE_ID,
+        aggregation: "count",
+      };
+      const amountMetric: Metric = {
+        id: "amount-metric-id" as UUID,
+        name: "Sum of amount",
+        tableId: TABLE_ID,
+        columnName: "amount",
+        aggregation: "sum",
+      };
+      mockGetDataTable.mockResolvedValue({
+        ...existingTable,
+        metrics: [amountMetric, countMetric],
+      });
+      const resultWithoutAmount = {
+        ...parsedResult,
+        fields: [parsedFields[1]],
+        columnCount: 1,
+      };
+
+      await replace(resultWithoutAmount);
+
+      expect(mockUpdateDataTable).toHaveBeenNthCalledWith(
+        1,
+        TABLE_ID,
+        expect.objectContaining({
+          fields: [parsedFields[1]],
+          metrics: [countMetric],
+        }),
+      );
+    },
+  );
+
+  it("matches user-renamed fields by source column name", async () => {
+    mockGetDataTable.mockResolvedValue({
+      ...existingTable,
+      fields: [{ ...existingField, name: "Revenue" }],
+    });
+
+    await replacementHandlers[0].replace();
+
+    expect(mockUpdateDataTable).toHaveBeenNthCalledWith(
+      1,
+      TABLE_ID,
+      expect.objectContaining({
+        fields: [
+          {
+            ...parsedFields[0],
+            id: EXISTING_FIELD_ID,
+            sensitivity: "unclassified",
+            sensitivityReason: undefined,
+            sensitivitySource: undefined,
+          },
+          parsedFields[1],
+        ],
+      }),
+    );
+  });
+
+  it("does not reuse an id when a source column name is ambiguous", async () => {
+    const duplicateParsedFields: Field[] = [
+      parsedFields[0],
+      {
+        ...parsedFields[0],
+        id: "second-new-field-id" as UUID,
+        name: "duplicate_amount",
+      },
+    ];
+    mockGetDataTable.mockResolvedValue({
+      ...existingTable,
+      fields: [
+        existingField,
+        {
+          ...existingField,
+          id: "second-existing-field-id" as UUID,
+          name: "duplicate_amount",
+        },
+      ],
+    });
+
+    await replacementHandlers[0].replace({
+      ...parsedResult,
+      fields: duplicateParsedFields,
+      columnCount: 2,
+    });
+
+    const [{ fields }] = mockUpdateDataTable.mock.calls[0].slice(1) as [
+      { fields: Field[] },
+    ];
+    expect(fields).toEqual(duplicateParsedFields);
+    expect(new Set(fields.map((field) => field.id))).toHaveLength(
+      fields.length,
+    );
+  });
 });

--- a/packages/app/src/lib/local-csv-handler.ts
+++ b/packages/app/src/lib/local-csv-handler.ts
@@ -44,29 +44,87 @@ const ensureCountMetric = (
   return [makeDefaultCountMetric(tableId), ...existing];
 };
 
+const retainReplacementMetrics = (
+  metrics: Metric[],
+  fields: Field[],
+): Metric[] => {
+  const columnNames = new Set(
+    fields.flatMap((field) =>
+      field.columnName === undefined ? [] : [field.columnName],
+    ),
+  );
+
+  return metrics.filter(
+    (metric) =>
+      (metric.aggregation === "count" && !metric.columnName) ||
+      (metric.columnName !== undefined && columnNames.has(metric.columnName)),
+  );
+};
+
 /**
- * Keep stable field identities and their user-reviewed sensitivity marks when
- * a file-backed table is replaced. Parsed fields provide the current schema;
- * a column with the same persisted display name retains its existing identity.
+ * Keep stable field identities and confirmed-sensitive marks when a file-backed
+ * table is replaced. Parsed fields provide the current schema; a column with
+ * the same source column name retains its existing identity.
  */
 const mergeReplacementFields = (
   fields: Field[],
   existingFields: Field[] = [],
 ): Field[] => {
-  const existingFieldsByName = new Map(
-    existingFields.map((field) => [field.name, field]),
-  );
+  const existingFieldsByColumnName = new Map<string, Field[]>();
+  const newFieldCountsByColumnName = new Map<string, number>();
+
+  for (const existingField of existingFields) {
+    if (existingField.columnName === undefined) continue;
+    const matchingFields = existingFieldsByColumnName.get(
+      existingField.columnName,
+    );
+    existingFieldsByColumnName.set(existingField.columnName, [
+      ...(matchingFields ?? []),
+      existingField,
+    ]);
+  }
+
+  for (const field of fields) {
+    if (field.columnName === undefined) continue;
+    newFieldCountsByColumnName.set(
+      field.columnName,
+      (newFieldCountsByColumnName.get(field.columnName) ?? 0) + 1,
+    );
+  }
 
   return fields.map((field) => {
-    const existingField = existingFieldsByName.get(field.name);
-    if (!existingField) return field;
+    if (
+      field.columnName === undefined ||
+      newFieldCountsByColumnName.get(field.columnName) !== 1
+    ) {
+      return field;
+    }
+
+    const matchingExistingFields = existingFieldsByColumnName.get(
+      field.columnName,
+    );
+    const existingField = matchingExistingFields?.[0];
+    if (!existingField || matchingExistingFields.length !== 1) return field;
+    if (existingField.sensitivity === "sensitive") {
+      return {
+        ...field,
+        id: existingField.id,
+        sensitivity: existingField.sensitivity,
+        sensitivityReason: existingField.sensitivityReason,
+        sensitivitySource: existingField.sensitivitySource,
+      };
+    }
 
     return {
       ...field,
       id: existingField.id,
-      sensitivity: existingField.sensitivity,
-      sensitivityReason: existingField.sensitivityReason,
-      sensitivitySource: existingField.sensitivitySource,
+      ...(existingField.sensitivity === "cleared"
+        ? {
+            sensitivity: "unclassified" as const,
+            sensitivityReason: undefined,
+            sensitivitySource: undefined,
+          }
+        : {}),
     };
   });
 };
@@ -117,10 +175,13 @@ export async function handleLocalCSVUpload(
 
   if (overrideTable) {
     // 3a. Override existing table instead of creating a new one
-    const metrics = ensureCountMetric(overrideTable.metrics, dataTableId);
     const replacementFields = mergeReplacementFields(
       fields,
       overrideTable.fields,
+    );
+    const metrics = retainReplacementMetrics(
+      ensureCountMetric(overrideTable.metrics, dataTableId),
+      replacementFields,
     );
 
     await updateDataTable(dataTableId, {
@@ -224,10 +285,13 @@ export async function handleFileConnectorResult(
 
   if (overrideTable) {
     // Override existing table
-    const metrics = ensureCountMetric(overrideTable.metrics, dataTableId);
     const replacementFields = mergeReplacementFields(
       fields,
       overrideTable.fields,
+    );
+    const metrics = retainReplacementMetrics(
+      ensureCountMetric(overrideTable.metrics, dataTableId),
+      replacementFields,
     );
 
     await updateDataTable(dataTableId, {

--- a/packages/app/src/lib/local-csv-handler.ts
+++ b/packages/app/src/lib/local-csv-handler.ts
@@ -11,7 +11,7 @@ import {
 import { csvToDataFrame } from "@dashframe/csv";
 import type { FileParseResult } from "@dashframe/engine";
 import type { BrowserDataFrame } from "@dashframe/engine-browser";
-import type { Metric } from "@dashframe/types";
+import type { Field, Metric } from "@dashframe/types";
 
 /**
  * Build the default Count metric for a new DataTable.
@@ -42,6 +42,33 @@ const ensureCountMetric = (
   if (hasCount) return existing;
 
   return [makeDefaultCountMetric(tableId), ...existing];
+};
+
+/**
+ * Keep stable field identities and their user-reviewed sensitivity marks when
+ * a file-backed table is replaced. Parsed fields provide the current schema;
+ * a column with the same persisted display name retains its existing identity.
+ */
+const mergeReplacementFields = (
+  fields: Field[],
+  existingFields: Field[] = [],
+): Field[] => {
+  const existingFieldsByName = new Map(
+    existingFields.map((field) => [field.name, field]),
+  );
+
+  return fields.map((field) => {
+    const existingField = existingFieldsByName.get(field.name);
+    if (!existingField) return field;
+
+    return {
+      ...field,
+      id: existingField.id,
+      sensitivity: existingField.sensitivity,
+      sensitivityReason: existingField.sensitivityReason,
+      sensitivitySource: existingField.sensitivitySource,
+    };
+  });
 };
 
 /**
@@ -91,12 +118,16 @@ export async function handleLocalCSVUpload(
   if (overrideTable) {
     // 3a. Override existing table instead of creating a new one
     const metrics = ensureCountMetric(overrideTable.metrics, dataTableId);
+    const replacementFields = mergeReplacementFields(
+      fields,
+      overrideTable.fields,
+    );
 
     await updateDataTable(dataTableId, {
       name: tableName,
       table: file.name,
       sourceSchema,
-      fields,
+      fields: replacementFields,
       metrics,
     });
 
@@ -194,12 +225,16 @@ export async function handleFileConnectorResult(
   if (overrideTable) {
     // Override existing table
     const metrics = ensureCountMetric(overrideTable.metrics, dataTableId);
+    const replacementFields = mergeReplacementFields(
+      fields,
+      overrideTable.fields,
+    );
 
     await updateDataTable(dataTableId, {
       name: tableName,
       table: fileName,
       sourceSchema,
-      fields,
+      fields: replacementFields,
       metrics,
     });
 

--- a/packages/app/src/lib/stores/confirm-dialog-store.test.ts
+++ b/packages/app/src/lib/stores/confirm-dialog-store.test.ts
@@ -152,6 +152,31 @@ describe("confirm-dialog-store", () => {
 
       expect(useConfirmDialogStore.getState().isOpen).toBe(true);
     });
+
+    it("cancels the pending dialog before replacing its config", async () => {
+      const { confirm } = useConfirmDialogStore.getState();
+      let resolveFirstDialog: (result: boolean) => void;
+      const firstDialog = new Promise<boolean>((resolve) => {
+        resolveFirstDialog = resolve;
+      });
+
+      confirm({
+        title: "First dialog",
+        description: "First description",
+        onConfirm: vi.fn(),
+        onCancel: () => resolveFirstDialog(false),
+      });
+      confirm({
+        title: "Second dialog",
+        description: "Second description",
+        onConfirm: vi.fn(),
+      });
+
+      await expect(firstDialog).resolves.toBe(false);
+      expect(useConfirmDialogStore.getState().config?.title).toBe(
+        "Second dialog",
+      );
+    });
   });
 
   describe("close()", () => {

--- a/packages/app/src/lib/stores/confirm-dialog-store.ts
+++ b/packages/app/src/lib/stores/confirm-dialog-store.ts
@@ -66,6 +66,7 @@ export const useConfirmDialogStore = create<
   config: null,
 
   confirm: (config) => {
+    get().config?.onCancel?.();
     set({ isOpen: true, config });
   },
 


### PR DESCRIPTION
File-upload replacement in `DataPickerContent` matched an uploaded CSV/JSON against **every** table by name, regardless of connector type — silently offering to overwrite a Notion- or Postgres-backed table with local file data (a `window.confirm` was the only guard). This PR scopes the replacement flow to file-backed tables only, and fixes everything the review arc below turned up along the way.

## Changes

- Scope replacement matching to file-backed (`local-csv`/file-connector) tables only — a same-named Notion/Postgres table is no longer offered as a replace target.
- Replace the `window.confirm` guard with the app's `ConfirmDialog`/`useConfirmDialogStore`, correctly nested over the picker modal.
- Preserve field identity (`Field.id`) and sensitivity classification across a replacement when a column persists, keyed on the stable `columnName` (not the user-renamable `name`), with an ambiguity guard when a column name isn't unique on either side.
- Drop metrics that reference a column the new file no longer has, always keeping the default Count metric.
- Clear stale cached `DataFrameEntry.analysis` on replacement (`analysis: null`, not `undefined` — the server only treats an explicit `null` as a clear signal, `undefined` is a no-op patch).
- Guard replacement against in-flight/failed table and data-source queries.
- Various smaller correctness fixes surfaced by review: JSON-detection regex, `overrideTableId` threading, matching by source name (not connector display name), hardening against an orphaned confirm-dialog promise.

## Review arc

Went through a full local review gate, then three fix rounds plus a micro-round, each round re-reviewed against its own delta before moving on:

1. Initial cross-review: 8 findings (7 confirmed, 1 plausible) — all fixed.
2. Converge on round 1's diff: 5 new/incomplete issues in the round-1 fix itself — all fixed (this is the round that added the `columnName`-keyed merge, the ambiguous-duplicate-id guard, and the stale-analysis clear).
3. Micro-round: 3 small items closed (a type-widening + server test for the `analysis: null` clear signal, two asymmetric duplicate-column-name test cases, and hardening one test to use `userEvent` instead of `fireEvent` for more realistic pointer-event simulation).
4. Final converge: clean, with one comment-only wording fix taken (a test comment overclaimed what `userEvent` actually validates) and one dismissed finding (two test cases use direct calls instead of `it.each`; coverage is identical either way — consciously left as-is).

Two items came up in review that are intentionally **not** part of this PR:

- Insight-owned metrics can still emit SQL against a column a replacement just dropped, when a table's fields change but its own metric definitions live on the Insight rather than the table. Real, but a separate slice — tracked separately.
- The field-identity merge above preserves `Field.id` and sensitivity across a replacement, but not a user-set `name`/`isIdentifier`/`isReference` on the preserved field — those still reset to the freshly-parsed value. This is latent today (nothing routes field-editing through this path yet) but worth knowing before that lands.

## Screenshots

### Before - initial upload
![Before - initial upload](https://github.com/youhaowei/DashFrame/releases/download/pr-292-screenshots/t677r2-01-first-upload.png)

### Replace confirm dialog (nested)
![Replace confirm dialog (nested)](https://github.com/youhaowei/DashFrame/releases/download/pr-292-screenshots/t677r2-02-replace-dialog.png)

### After replace
![After replace](https://github.com/youhaowei/DashFrame/releases/download/pr-292-screenshots/t677r2-03-after-replace.png)

_Screenshots via pr-screenshots (prerelease `pr-292-screenshots`, not in git)._
## Verification

- `bun run check` (lint + typecheck + test across all non-`@wystack` packages) run clean after every round, most recently at `af8dc253` — 85/85 tasks green.
- Runtime QA in a real headless Chrome session (not just unit tests): uploaded a file, triggered replacement of a file-backed table, confirmed the nested `ConfirmDialog` stacks correctly over the picker modal and the confirm/cancel paths both work cleanly (see attached screenshots).
- New/extended unit and integration tests cover: connector-type scoping, field-identity/sensitivity preservation and reset, ambiguous-column-name guards (both directions), metric retention/drop, the `analysis: null` clear signal end-to-end (client → server → storage), and the real `DataPickerModal` + `ConfirmDialog` nested-stack behavior.

Tracked internally as TASK-677

