### PR TITLE
[codex] TASK-766: Stop visualization action keyboard propagation

### DIFF
--- a/packages/app/src/components/visualizations/VisualizationItemCard.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationItemCard.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { VisualizationItemCard } from "./VisualizationItemCard";
+
+vi.mock("./VisualizationPreview", () => ({
+  VisualizationPreview: () => <div data-testid="visualization-preview" />,
+}));
+
+const visualization = {
+  id: "viz-1",
+  name: "Test Chart",
+  insightId: "insight-1",
+  visualizationType: "bar",
+  encoding: { x: "field:category", y: "metric:count" },
+  createdAt: 0,
+} as unknown as import("@dashframe/types").Visualization;
+
+describe("VisualizationItemCard nested actions", () => {
+  function renderCard(onCardClick: ReturnType<typeof vi.fn>) {
+    render(
+      <VisualizationItemCard
+        visualization={visualization}
+        onClick={onCardClick}
+        actions={[{ label: "Duplicate", onClick: vi.fn() }]}
+      />,
+    );
+
+    return screen.getByRole("button", { name: "Actions" });
+  }
+
+  it("does not activate the parent card when its action trigger is clicked", () => {
+    const onCardClick = vi.fn();
+    const actionTrigger = renderCard(onCardClick);
+
+    fireEvent.click(actionTrigger);
+
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it.each(["Enter", " "])(
+    "does not activate the parent card when its action trigger receives %s",
+    (key) => {
+      const onCardClick = vi.fn();
+      const actionTrigger = renderCard(onCardClick);
+
+      fireEvent.keyDown(actionTrigger, { key });
+
+      expect(onCardClick).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/app/src/components/visualizations/VisualizationItemCard.tsx
+++ b/packages/app/src/components/visualizations/VisualizationItemCard.tsx
@@ -141,7 +141,15 @@ export function VisualizationItemCard({
 
           {/* Actions dropdown menu */}
           {hasActions && (
-            <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+            <div
+              className="shrink-0"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.stopPropagation();
+                }
+              }}
+            >
               <DropdownMenu>
                 <DropdownMenuTrigger
                   render={


### PR DESCRIPTION
Fix keyboard activation leaking from a visualization card action control to its parent card.

## Changes

- Stop Enter and Space keydown events at the nested visualization action container.
- Add pointer, Enter, and Space regression coverage for the nested action trigger.
- The ChartTypePicker leg is intentionally omitted because that component is concurrently being removed as dead code.

## Screenshots

### Focused action control — light
![Focused action control — light](https://github.com/youhaowei/DashFrame/releases/download/pr-294-screenshots/task-766-visualization-card-light.png)

### Focused action control — dark
![Focused action control — dark](https://github.com/youhaowei/DashFrame/releases/download/pr-294-screenshots/task-766-visualization-card-dark.png)

_Screenshots via pr-screenshots (prerelease `pr-294-screenshots`, not in git)._
## Verification

- `bun run check`
- `bun run format:check`
- Real browser QA against the component with a live provider: Enter and Space opened the nested action menu while the parent activation counter stayed at zero.
- Independent Claude second review: no findings.

Tracked internally as TASK-766
