### PR TITLE
fix(engine): quote source column identifiers consistently in insight SQL

### DIFF
--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -1001,6 +1001,69 @@ describe("buildInsightSQL — identifier quoting: embedded double-quotes in disp
     // A simple structural check: the AS alias must be wrapped in outer quotes.
     expect(sql!).toMatch(/AS "my ""best"" sales table"/);
   });
+
+  it("doubles embedded double-quotes in a raw-mode filter column reference", () => {
+    // Source column names are CSV-header-derived verbatim, so an RFC-4180 header
+    // `"he""llo"` yields the column name `he"llo`. The raw-mode filter path
+    // references the source column name directly (no UUID alias), so it must
+    // quote through the same helper the SELECT side uses — otherwise the WHERE
+    // clause closes its identifier early and DuckDB rejects the whole query.
+    const WEIRD = 'he"llo';
+    const weirdField = field(REGION_FIELD_ID, "Region", WEIRD, "string");
+    const tableWithQuotedColumn: typeof BASE_TABLE = {
+      ...BASE_TABLE,
+      fields: [weirdField],
+    };
+    const insight: Insight = {
+      id: "77777777-7777-7777-7777-777777777777" as UUID,
+      name: "Raw rows",
+      baseTableId: TABLE_ID,
+      // No selectedFields and no metrics → buildSimpleSQL's raw-reference path.
+      selectedFields: [],
+      metrics: [],
+      filters: [{ field: WEIRD, operator: "eq", value: "x" }],
+      createdAt: 0,
+    };
+
+    const sql = buildInsightSQL(tableWithQuotedColumn, new Map(), insight, {
+      mode: "query",
+    });
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`WHERE "he""llo" = 'x'`);
+    // The unescaped form would terminate the identifier after `he`.
+    expect(sql!).not.toContain(`WHERE "he"llo"`);
+  });
+
+  it("doubles embedded double-quotes in model-mode effective filters", () => {
+    // The dashboard-cell chart-view path: model mode with caller-supplied
+    // effective filters, which also resolves against raw source column names.
+    const WEIRD = 'he"llo';
+    const weirdField = field(REGION_FIELD_ID, "Region", WEIRD, "string");
+    const tableWithQuotedColumn: typeof BASE_TABLE = {
+      ...BASE_TABLE,
+      fields: [weirdField],
+    };
+    const filters: InsightFilter[] = [
+      { field: WEIRD, operator: "eq", value: "x" },
+    ];
+    const insight: Insight = {
+      id: "66666666-6666-6666-6666-666666666666" as UUID,
+      name: "Cell view",
+      baseTableId: TABLE_ID,
+      selectedFields: [],
+      metrics: [],
+      filters,
+      createdAt: 0,
+    };
+
+    const sql = buildInsightSQL(tableWithQuotedColumn, new Map(), insight, {
+      mode: "model",
+      effectiveFilters: filters,
+    });
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`WHERE "he""llo" = 'x'`);
+    expect(sql!).not.toContain(`WHERE "he"llo"`);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/sql/insight-sql.test.ts
+++ b/packages/engine/src/sql/insight-sql.test.ts
@@ -1035,8 +1035,11 @@ describe("buildInsightSQL — identifier quoting: embedded double-quotes in disp
   });
 
   it("doubles embedded double-quotes in model-mode effective filters", () => {
-    // The dashboard-cell chart-view path: model mode with caller-supplied
-    // effective filters, which also resolves against raw source column names.
+    // Model mode with caller-supplied effective filters (how the dashboard-cell
+    // chart view invokes this), on a table with no joins — so it reaches the
+    // same raw-reference path through buildSimpleSQL as the test above, by a
+    // different entry condition. The joined variant of model mode resolves
+    // through the "alias" refMode instead and is not exercised here.
     const WEIRD = 'he"llo';
     const weirdField = field(REGION_FIELD_ID, "Region", WEIRD, "string");
     const tableWithQuotedColumn: typeof BASE_TABLE = {
@@ -1063,6 +1066,49 @@ describe("buildInsightSQL — identifier quoting: embedded double-quotes in disp
     expect(sql).not.toBeNull();
     expect(sql!).toContain(`WHERE "he""llo" = 'x'`);
     expect(sql!).not.toContain(`WHERE "he"llo"`);
+  });
+
+  it("doubles embedded double-quotes in a metric aggregation over an unmapped column", () => {
+    // buildMetricExpressionWithUUID resolves a metric's source column to its
+    // UUID alias, and falls back to the raw source column name when the column
+    // is not in the field map. A `_`-prefixed field is filtered out of the
+    // field map upstream, so a metric over it reaches that fallback — and the
+    // raw name is CSV-header-derived, so it can carry a double-quote.
+    //
+    // This SQL does not execute either way: the same upstream filtering keeps
+    // the column out of the wrapped subquery, so DuckDB rejects it whatever
+    // the quoting. What is pinned here is the failure mode, not query validity
+    // — quoted, it is a binder error naming the missing column; unquoted, the
+    // identifier closes after `he` and it degrades to an unreadable parser
+    // error. That the fallback can reference an out-of-scope column at all is
+    // a separate, pre-existing defect.
+    const WEIRD = 'he"llo';
+    const hiddenField = field(
+      "55555555-5555-5555-5555-555555555555" as UUID,
+      "_hidden",
+      WEIRD,
+      "number",
+    );
+    const tableWithHiddenColumn: typeof BASE_TABLE = {
+      ...BASE_TABLE,
+      fields: [REGION_FIELD, hiddenField],
+    };
+    const insight: Insight = {
+      id: "44444444-4444-4444-4444-444444444444" as UUID,
+      name: "Sum of a hidden column",
+      baseTableId: TABLE_ID,
+      selectedFields: [REGION_FIELD_ID],
+      metrics: [{ ...REVENUE_METRIC, columnName: WEIRD }],
+      createdAt: 0,
+    };
+
+    const sql = buildInsightSQL(tableWithHiddenColumn, new Map(), insight, {
+      mode: "query",
+    });
+    expect(sql).not.toBeNull();
+    expect(sql!).toContain(`SUM("he""llo")`);
+    // The unescaped form would terminate the identifier after `he`.
+    expect(sql!).not.toContain(`SUM("he"llo")`);
   });
 });
 

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -1288,17 +1288,19 @@ function buildMetricExpressionWithUUID(
     // Source is a field with UUID alias
     sourceColumnRef = fieldIdToColumnAlias(sourceField.id);
   } else {
-    // Fallback: use raw column name (shouldn't happen with proper config)
+    // Fallback: the raw source column name, which comes from the data verbatim
+    // (CSV headers) and so can contain double-quotes (shouldn't happen with
+    // proper config, but the quoting below has to hold either way).
     sourceColumnRef = metric.columnName;
   }
 
   // COUNT(DISTINCT column)
   if (metric.aggregation === "count_distinct") {
-    return `COUNT(DISTINCT "${sourceColumnRef}") AS "${outputAlias}"`;
+    return `COUNT(DISTINCT ${quoteIdentifier(sourceColumnRef)}) AS "${outputAlias}"`;
   }
 
   // Standard aggregation: SUM, AVG, MIN, MAX, COUNT
-  return `${aggFn}("${sourceColumnRef}") AS "${outputAlias}"`;
+  return `${aggFn}(${quoteIdentifier(sourceColumnRef)}) AS "${outputAlias}"`;
 }
 
 /** Build SELECT parts for all metrics with UUID aliases */

--- a/packages/engine/src/sql/insight-sql.ts
+++ b/packages/engine/src/sql/insight-sql.ts
@@ -1041,7 +1041,9 @@ function resolveFilterColumnRef(
   if (refMode === "alias") {
     return `"${fieldIdToColumnAlias(field.id)}"`;
   }
-  return `"${field.columnName ?? field.name}"`;
+  // Source column names come from the data verbatim (CSV headers), so they can
+  // contain double-quotes — quote through the shared helper, which doubles them.
+  return quoteIdentifier(field.columnName ?? field.name);
 }
 
 /**


### PR DESCRIPTION
Two emitters in `insight-sql.ts` hand-built quoted identifiers from a **source
column name** instead of routing it through `quoteIdentifier`. Source column
names are CSV-header-derived verbatim, so an RFC-4180 header `"he""llo"` yields
the column name `he"llo` — and an undoubled quote closes the identifier early.

1. `resolveFilterColumnRef`'s raw branch emitted `WHERE "he"llo" = 'x'`, which
   DuckDB rejects with a parser error. Two live paths reach it, both in
   `buildSimpleSQL` (non-joined tables): query mode with no `selectedFields` and
   no `metrics`, and model mode when a caller supplies `effectiveFilters` (the
   dashboard-cell chart view).
2. `buildMetricExpressionWithUUID`'s fallback — taken when a metric's source
   column is not in the field map, e.g. a `_`-prefixed field filtered out
   upstream — emitted `SUM("he"llo")`. Its sibling `resolveMetricAggRef` already
   quoted the identical fallback, so the two aggregate-expression builders
   disagreed.

Both fix at the sink rather than sanitizing column names upstream, which keeps
the guard where the SQL is actually built.

## Changes

- `packages/engine/src/sql/insight-sql.ts` — route the raw branch of
  `resolveFilterColumnRef`, and both aggregation branches of
  `buildMetricExpressionWithUUID`, through `quoteIdentifier`.
- `packages/engine/src/sql/insight-sql.test.ts` — three regression tests: both
  raw-branch filter entry points, and the metric fallback. All fail against the
  pre-fix code.

The remaining hand-quoted sites in this file (`577`, `811`, `841`, `1276`, and
the `alias` branch at `1042`) quote `fieldIdToColumnAlias` /
`metricIdToColumnAlias` output. Those aliases are UUID-derived **by contract**,
not by validation — `fieldIdToColumnAlias` does no escaping of its own, and the
`addField` write path checks only `typeof value.id === "string"` where the
sibling `patchDataTableArray` enforces `z.string().uuid()`. Tightening that write
path plus sweeping those sites is a different premise and a different blast
radius; noted, not addressed here.

Worth noting: the comment block at `insight-sql.test.ts:1083` already documented
`buildMetricExpressionWithUUID` as calling `quoteIdentifier`. That was false
before this change and is true after — the fix restores a documented invariant
rather than inventing one.

## Screenshots

No UI change.

## Verification

- **Emitted SQL, before → after** (built an insight over a table whose column is
  named `he"llo`, printed `buildInsightSQL` output for both raw-branch paths):

  ```
  before:  … FROM df_… AS "sales" WHERE "he"llo" = 'x'
  after:   … FROM df_… AS "sales" WHERE "he""llo" = 'x'
  ```

  The SELECT side was already correct in both runs — only the WHERE clause
  changed.

- **Executed against a real DuckDB** (`@duckdb/node-api`, table created with the
  quoted column) to confirm the two forms differ at runtime, not just textually:

  ```
  before (single-quoted): ERROR Parser Error: syntax error at or near "llo"
  after  (doubled):       OK rows=[["x"]]
  ```

- **Regression tests are discriminating**: each new test fails against the
  pre-fix source (reverted each change in turn, kept the tests) and passes with
  it.

- `bun test packages/engine/src/sql/insight-sql.test.ts` — 72 pass.
- `bun run check` — all four checks PASS (lint + typecheck + test across the
  whole graph, which covers the server packages that consume built engine
  output). `bun run format:check` clean.

### Review findings dismissed as out of scope

- **Second reviewer (Codex) — medium, dismissed.** It flagged that the metric
  fallback still emits a column absent from the wrapped subquery, so the query
  fails either way. True, and pre-existing: the same upstream `_`-prefix
  filtering that triggers the fallback is what removes the column. The quoting
  strictly improves the failure mode and makes nothing worse —
  `Binder Error: Referenced column "he"llo" not found in FROM clause` (quoted)
  versus `Parser Error: syntax error at or near "llo"` (unquoted). Its suggested
  fixes — project the column into the subquery, or delete the fallback path —
  both change behavior for every metric that reaches the fallback, which is not
  a quoting change. The test comment now states plainly that it pins the failure
  mode rather than query validity.
- **Code review — ORDER BY dropped for joined model-mode insights**
  (`insight-sql.ts:459`). Pre-existing and unrelated to quoting: `validColumns`
  is built from raw source column names while the joined subquery emits only
  `field_<uuid>` aliases, so the sort column never matches. Separate change.

Tracked internally as TASK-778
