### PR TITLE
fix(visualization): contain malformed chart encodings (#289)

### DIFF
--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -24,7 +24,11 @@ import type {
   VisualizationEncoding,
   VisualizationType,
 } from "@dashframe/types";
-import { isUnmodifiedDraft, stripSampleValues } from "@dashframe/types";
+import {
+  isUnmodifiedDraft,
+  stripSampleValues,
+  validateVisualizationEncoding,
+} from "@dashframe/types";
 import { eq, int, jsonb, text, uuid } from "@wystack/db";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { isSecretRef } from "@wystack/secret-vault";
@@ -977,6 +981,11 @@ const createVisualization = wy.procedure
       ctx,
       { name, insightId, visualizationType, spec, encoding },
     ): Promise<{ id: string }> => {
+      // Same write-time gate as the CreateVisualization command handler in
+      // commands.ts — this legacy RPC writes the same column, so leaving it
+      // unchecked would keep the malformed-encoding hole open (GH #289).
+      const problem = validateVisualizationEncoding(encoding);
+      if (problem) throw new Error(`createVisualization: ${problem}`);
       const [row] = (await ctx.db.into(visualizations).insert({
         name,
         insightId,

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2083,14 +2083,43 @@ describe("command vocabulary", () => {
             encoding: { x: { field: "region" } } as never,
           }),
         ),
-      ).rejects.toThrow(/encoding\.x must be .*field:<uuid>/);
+      ).rejects.toThrow(/encoding\.x must be a string .*field:<uuid>/);
 
       // Nothing was written — the visualization keeps its original encoding.
       const rows = await vizsById(vizId);
       expect(rows[0]?.encoding).toEqual({});
     });
 
-    it("should reject a raw column name as an encoding value", async () => {
+    // The axis picker offers raw data-frame columns while analysis is
+    // unavailable, and `resolveToSql` resolves them. Rejecting a bare column
+    // name would break the picker's own writes and duplicating older charts.
+    it("should accept a bare column name — a form the axis picker still writes", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Chart",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+      );
+
+      const encoding = { x: "region", y: "sum(amount)" };
+      await commit(
+        cmd("SetChartEncoding", { id: vizId, encoding: encoding as never }),
+      );
+      expect((await vizsById(vizId))[0]?.encoding).toEqual(encoding);
+    });
+
+    it("should reject a value that claims to be an ID reference but carries no uuid", async () => {
       const { tableId } = await makeTable();
       const insightId = id();
       const vizId = id();
@@ -2113,10 +2142,44 @@ describe("command vocabulary", () => {
         commit(
           cmd("SetChartEncoding", {
             id: vizId,
-            encoding: { x: "region", y: "sum(amount)" } as never,
+            encoding: { x: "field:not-a-uuid" } as never,
           }),
         ),
-      ).rejects.toThrow(/encoding\.x must be/);
+      ).rejects.toThrow(/looks like an ID reference but is malformed/);
+    });
+
+    // `applyTransform` reads transform.transform.kind at render — a half-built
+    // transform throws there exactly like a non-string channel value does.
+    it("should reject a half-built date transform", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Chart",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+      );
+
+      await expect(
+        commit(
+          cmd("SetChartEncoding", {
+            id: vizId,
+            encoding: {
+              x: "field:550e8400-e29b-41d4-a716-446655440000",
+              xTransform: { type: "date" },
+            } as never,
+          }),
+        ),
+      ).rejects.toThrow(/encoding\.xTransform must be/);
     });
 
     it("should reject a malformed encoding on CreateVisualization — nothing is inserted", async () => {

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2119,6 +2119,34 @@ describe("command vocabulary", () => {
       expect((await vizsById(vizId))[0]?.encoding).toEqual(encoding);
     });
 
+    // Clearing the optional Color or Size picker saves `""` through this very
+    // command. The write gate must not turn "clear this channel" into an error.
+    it("should accept a cleared optional channel — the picker saves an empty string", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Chart",
+          insightId,
+          visualizationType: "dot",
+          spec: {},
+        }),
+      );
+
+      const encoding = { x: "region", y: "sum(amount)", color: "", size: "" };
+      await commit(
+        cmd("SetChartEncoding", { id: vizId, encoding: encoding as never }),
+      );
+      expect((await vizsById(vizId))[0]?.encoding).toEqual(encoding);
+    });
+
     it("should reject a value that claims to be an ID reference but carries no uuid", async () => {
       const { tableId } = await makeTable();
       const insightId = id();

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -2033,7 +2033,10 @@ describe("command vocabulary", () => {
         }),
       );
 
-      const encoding = { x: "field:abc", y: "metric:xyz" } as never;
+      const encoding = {
+        x: "field:550e8400-e29b-41d4-a716-446655440000",
+        y: "metric:6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+      } as never;
       await commit(cmd("SetChartEncoding", { id: vizId, encoding }));
       const rows = await vizsById(vizId);
       expect(rows[0]?.encoding).toEqual(encoding);
@@ -2049,6 +2052,126 @@ describe("command vocabulary", () => {
       await expect(
         commit(cmd("SetChartEncoding", { id: id(), encoding: {} as never })),
       ).rejects.toThrow(/not found/);
+    });
+
+    // GH #289 — a malformed encoding used to write through to canonical state
+    // and only fail at RENDER, where it replaced the whole page. The command
+    // layer is the write-time gate.
+    it("should reject a structurally malformed encoding on SetChartEncoding, naming the format", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Chart",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+      );
+
+      await expect(
+        commit(
+          cmd("SetChartEncoding", {
+            id: vizId,
+            encoding: { x: { field: "region" } } as never,
+          }),
+        ),
+      ).rejects.toThrow(/encoding\.x must be .*field:<uuid>/);
+
+      // Nothing was written — the visualization keeps its original encoding.
+      const rows = await vizsById(vizId);
+      expect(rows[0]?.encoding).toEqual({});
+    });
+
+    it("should reject a raw column name as an encoding value", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Chart",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+        }),
+      );
+
+      await expect(
+        commit(
+          cmd("SetChartEncoding", {
+            id: vizId,
+            encoding: { x: "region", y: "sum(amount)" } as never,
+          }),
+        ),
+      ).rejects.toThrow(/encoding\.x must be/);
+    });
+
+    it("should reject a malformed encoding on CreateVisualization — nothing is inserted", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+
+      await expect(
+        commit(
+          cmd("CreateVisualization", {
+            id: vizId,
+            name: "Chart",
+            insightId,
+            visualizationType: "barY",
+            spec: {},
+            encoding: { y: { field: "amount" } } as never,
+          }),
+        ),
+      ).rejects.toThrow(/CreateVisualization: encoding\.y must be/);
+
+      expect(await vizsById(vizId)).toHaveLength(0);
+    });
+
+    it("should accept a repeat-join instance encoding — the axis picker emits it", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const vizId = id();
+      const encoding = {
+        x: "field:550e8400-e29b-41d4-a716-446655440000_j1",
+        y: "metric:6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+      };
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+        cmd("CreateVisualization", {
+          id: vizId,
+          name: "Chart",
+          insightId,
+          visualizationType: "barY",
+          spec: {},
+          encoding: encoding as never,
+        }),
+      );
+      const rows = await vizsById(vizId);
+      expect(rows[0]?.encoding).toEqual(encoding);
     });
   });
 

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -100,6 +100,7 @@ import {
   type InsightSourceInput,
   type LateBoundRef,
   type TypedInsightFilter,
+  validateVisualizationEncoding,
 } from "@dashframe/types";
 import { eq, jsonb, text, uuid } from "@wystack/db";
 import {
@@ -1337,6 +1338,22 @@ function stripDataFromSpec(spec: VegaLiteSpec): VegaLiteSpec {
 }
 
 /**
+ * Reject a structurally wrong encoding at WRITE time.
+ *
+ * `encoding` arrives as opaque `jsonb`, so the RPC schema only proves it is
+ * JSON — nothing checks that a channel holds an `EncodingValue`. An agent
+ * guessing the shape (`{"x":{"field":"region"}}`) therefore used to write
+ * straight through to canonical state and only fail at RENDER, where
+ * `parseEncoding` calls `.startsWith` on a non-string (GH #289). The error text
+ * states the expected format so the caller can correct itself without reading
+ * source.
+ */
+function assertValidEncoding(encoding: unknown, command: string): void {
+  const problem = validateVisualizationEncoding(encoding);
+  if (problem) throw new Error(`${command}: ${problem}`);
+}
+
+/**
  * CreateVisualization — mints a chart over an Insight's DataFrame with a
  * client-supplied id. Insight and Visualization stay 1:many (spec decision):
  * the UI creates a 1:1 feel by batching CreateInsight + CreateVisualization in
@@ -1353,6 +1370,7 @@ const createVisualization = wy.procedure
   })
   .authorize(permissions.commands.commit)
   .mutation(async (ctx, args): Promise<{ id: string }> => {
+    assertValidEncoding(args.encoding, "CreateVisualization");
     const [row] = (await ctx.db.into(visualizations).insert({
       id: args.id,
       name: args.name,
@@ -1399,6 +1417,7 @@ const setChartEncoding = wy.procedure
   .input({ id: uuid, encoding: jsonb, spec: jsonb.optional() })
   .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, encoding, spec }): Promise<{ ok: true }> => {
+    assertValidEncoding(encoding, "SetChartEncoding");
     await requireVisualization(ctx, id);
     const patch: Partial<VisualizationRow> = {
       encoding: encoding as VisualizationEncoding,

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -75,8 +75,24 @@ export function VisualizationDisplay(props: VisualizationDisplayProps) {
   // same untrusted encoding, so an unguarded throw here would take the
   // visualization detail route or a whole dashboard down with one bad panel
   // (GH #289).
+  //
+  // The reset key carries `updatedAt`, not just the id: the config panel that
+  // repairs a bad encoding lives OUTSIDE this boundary, on the same route, and
+  // keying on the id alone would leave the repaired chart stuck on the broken
+  // card until the user navigated away. The query is the one the content
+  // component already issues, so this shares its cache rather than adding a
+  // fetch.
+  const { data: visualizations = [] } = useQuery(api.listVisualizations, {
+    args: {},
+  });
+  const active = visualizations.find(
+    (candidate) => candidate.id === props.visualizationId,
+  );
+
   return (
-    <VisualizationErrorBoundary resetKey={props.visualizationId}>
+    <VisualizationErrorBoundary
+      resetKey={`${props.visualizationId ?? ""}:${active?.updatedAt ?? ""}`}
+    >
       <VisualizationDisplayContent {...props} />
     </VisualizationErrorBoundary>
   );

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -33,6 +33,7 @@ import {
   type ReactNode,
 } from "react";
 import { EngineUnavailableState } from "./EngineUnavailableState";
+import { VisualizationErrorBoundary } from "./VisualizationErrorBoundary";
 
 /**
  * Wraps `children` in a WASM-backed VisualizationProvider when `nativeCapable`
@@ -69,10 +70,19 @@ function WasmFallbackWrapper({
 // Minimum visible rows needed to enable "Show Both" mode
 const MIN_VISIBLE_ROWS_FOR_BOTH = 5;
 
-export function VisualizationDisplay({
-  visualizationId,
-  overrides,
-}: {
+export function VisualizationDisplay(props: VisualizationDisplayProps) {
+  // Same containment as VisualizationPreview: the full-size chart resolves the
+  // same untrusted encoding, so an unguarded throw here would take the
+  // visualization detail route or a whole dashboard down with one bad panel
+  // (GH #289).
+  return (
+    <VisualizationErrorBoundary resetKey={props.visualizationId}>
+      <VisualizationDisplayContent {...props} />
+    </VisualizationErrorBoundary>
+  );
+}
+
+interface VisualizationDisplayProps {
   visualizationId?: string;
   /**
    * Per-cell param overrides from the dashboard item.  When present, the
@@ -81,7 +91,12 @@ export function VisualizationDisplay({
    * behaviour, satisfying the no-override no-regression constraint).
    */
   overrides?: DashboardItemOverrides;
-}) {
+}
+
+function VisualizationDisplayContent({
+  visualizationId,
+  overrides,
+}: VisualizationDisplayProps) {
   // Whole-engine-down signals. `engineError` is the native bootstrap failure
   // (connector never came up); `visualizationError` is the provider failing to
   // initialize its Mosaic coordinator. Both mean the same thing to the user —

--- a/packages/app/src/components/visualizations/VisualizationErrorBoundary.test.tsx
+++ b/packages/app/src/components/visualizations/VisualizationErrorBoundary.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Containment tests for the per-visualization error boundary (GH #289).
+ *
+ * The regression these lock down is NOT "the boundary catches" in the abstract:
+ * it is that a render throw from ONE chart leaves the rest of the page mounted.
+ * Before the boundary the nearest catch was the router's `errorComponent`, so a
+ * single malformed encoding replaced the whole page — home included.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VisualizationErrorBoundary } from "./VisualizationErrorBoundary";
+
+/** Reproduces the real failure: `parseEncoding` calling `.startsWith` on an object. */
+function ThrowsLikeAMalformedEncoding(): never {
+  const value = { field: "region" } as unknown as string;
+  value.startsWith("field:");
+  throw new Error("unreachable");
+}
+
+describe("VisualizationErrorBoundary", () => {
+  beforeEach(() => {
+    // React logs caught errors through console.error; the boundary adds its
+    // own. Silence both so a passing run is not a wall of red.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it("renders its children when nothing throws", () => {
+    render(
+      <VisualizationErrorBoundary>
+        <div>chart</div>
+      </VisualizationErrorBoundary>,
+    );
+    expect(screen.getByText("chart")).toBeTruthy();
+  });
+
+  it("contains a render throw to its own card", () => {
+    render(
+      <VisualizationErrorBoundary>
+        <ThrowsLikeAMalformedEncoding />
+      </VisualizationErrorBoundary>,
+    );
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Can't display this chart",
+    );
+  });
+
+  it("leaves sibling visualizations and the surrounding page mounted", () => {
+    render(
+      <div>
+        <h1>Home</h1>
+        <VisualizationErrorBoundary>
+          <ThrowsLikeAMalformedEncoding />
+        </VisualizationErrorBoundary>
+        <VisualizationErrorBoundary>
+          <div>healthy chart</div>
+        </VisualizationErrorBoundary>
+      </div>,
+    );
+
+    expect(screen.getByText("Home")).toBeTruthy();
+    expect(screen.getByText("healthy chart")).toBeTruthy();
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("uses the caller's fallback when one is supplied", () => {
+    render(
+      <VisualizationErrorBoundary fallback={<div>custom fallback</div>}>
+        <ThrowsLikeAMalformedEncoding />
+      </VisualizationErrorBoundary>,
+    );
+    expect(screen.getByText("custom fallback")).toBeTruthy();
+  });
+
+  it("logs the caught error so the failure is not silent for an operator", () => {
+    render(
+      <VisualizationErrorBoundary>
+        <ThrowsLikeAMalformedEncoding />
+      </VisualizationErrorBoundary>,
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      "Visualization failed to render",
+      expect.any(Error),
+      expect.anything(),
+    );
+  });
+
+  it("retries when resetKey changes — a fixed chart recovers without a reload", () => {
+    const { rerender } = render(
+      <VisualizationErrorBoundary resetKey="v1">
+        <ThrowsLikeAMalformedEncoding />
+      </VisualizationErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    rerender(
+      <VisualizationErrorBoundary resetKey="v2">
+        <div>repaired chart</div>
+      </VisualizationErrorBoundary>,
+    );
+    expect(screen.getByText("repaired chart")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps the error while resetKey is unchanged", () => {
+    const { rerender } = render(
+      <VisualizationErrorBoundary resetKey="v1">
+        <ThrowsLikeAMalformedEncoding />
+      </VisualizationErrorBoundary>,
+    );
+    rerender(
+      <VisualizationErrorBoundary resetKey="v1">
+        <div>still broken</div>
+      </VisualizationErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.queryByText("still broken")).toBeNull();
+  });
+});

--- a/packages/app/src/components/visualizations/VisualizationErrorBoundary.tsx
+++ b/packages/app/src/components/visualizations/VisualizationErrorBoundary.tsx
@@ -1,0 +1,96 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * Containment boundary for ONE visualization's render.
+ *
+ * Without it, the nearest boundary above a chart is the router's own
+ * `errorComponent`, so a single malformed visualization replaces the WHOLE
+ * page — including the home page, which previews the three most recent charts
+ * (GH #289). A chart renders data of unknown provenance (an encoding an agent
+ * authored, a spec from an older schema, a column that no longer exists), so a
+ * render throw is a state this surface must degrade through, not a state that
+ * should take its neighbours with it.
+ *
+ * Deliberately a class component: `componentDidCatch` / `getDerivedStateFromError`
+ * have no hook equivalent — React offers no functional error boundary.
+ */
+
+interface VisualizationErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Rendered in place of the failed chart. Defaults to the inline broken-card
+   * message below. Callers that already pass a compact fallback for other
+   * terminal states (e.g. a chart-type icon) can reuse it here.
+   */
+  fallback?: ReactNode;
+  /**
+   * Remounting key. When it changes, the boundary clears its error and retries
+   * the children — a chart whose encoding was just fixed must recover without a
+   * page reload.
+   */
+  resetKey?: string;
+}
+
+interface VisualizationErrorBoundaryState {
+  error: Error | undefined;
+  /** The resetKey this state was last reconciled against. */
+  resetKey: string | undefined;
+}
+
+function BrokenVisualizationCard() {
+  return (
+    <div
+      role="alert"
+      className="flex h-full w-full flex-col items-center justify-center gap-1 bg-neutral-bg-muted/50 px-3 py-2 text-center"
+    >
+      <span className="text-xs font-medium text-neutral-fg">
+        Can&apos;t display this chart
+      </span>
+      <span className="text-xs text-neutral-fg-subtle">
+        Its configuration is invalid.
+      </span>
+    </div>
+  );
+}
+
+export class VisualizationErrorBoundary extends Component<
+  VisualizationErrorBoundaryProps,
+  VisualizationErrorBoundaryState
+> {
+  override state: VisualizationErrorBoundaryState = {
+    error: undefined,
+    resetKey: undefined,
+  };
+
+  static getDerivedStateFromError(
+    error: Error,
+  ): Partial<VisualizationErrorBoundaryState> {
+    return { error };
+  }
+
+  static getDerivedStateFromProps(
+    props: VisualizationErrorBoundaryProps,
+    state: VisualizationErrorBoundaryState,
+  ): Partial<VisualizationErrorBoundaryState> | null {
+    // Only a CHANGE of resetKey clears the error. Re-running with the same key
+    // must keep it, or the boundary would re-render the throwing child on
+    // every parent update and loop.
+    if (props.resetKey !== state.resetKey) {
+      return { resetKey: props.resetKey, error: undefined };
+    }
+    return null;
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // The boundary swallows the throw for the user; the operator still needs
+    // it. Nothing else logs this — React's own logging stops at the boundary.
+    console.error("Visualization failed to render", error, info.componentStack);
+  }
+
+  override render(): ReactNode {
+    if (this.state.error) {
+      return this.props.fallback ?? <BrokenVisualizationCard />;
+    }
+    return this.props.children;
+  }
+}

--- a/packages/app/src/components/visualizations/VisualizationPreview.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.tsx
@@ -8,6 +8,8 @@ import { useQuery } from "@wystack/client";
 import { Spinner } from "@wystack/ui-react";
 import { useMemo } from "react";
 
+import { VisualizationErrorBoundary } from "./VisualizationErrorBoundary";
+
 const PREVIEW_HEIGHT = 200; // px
 
 function PreviewLoading() {
@@ -36,8 +38,23 @@ interface VisualizationPreviewProps {
  * This component is self-contained: it fetches the insight and creates
  * the DuckDB view if needed using useInsightView. This unifies the approach
  * with insight detail pages - same hook, same caching, same view creation.
+ *
+ * The boundary lives HERE rather than at each callsite so no consumer can
+ * mount a preview without containment: the home page renders three of these,
+ * and before the boundary one bad encoding replaced that whole page (GH #289).
+ * A boundary cannot catch its own render, hence the inner component.
  */
-export function VisualizationPreview({
+export function VisualizationPreview(props: VisualizationPreviewProps) {
+  return (
+    <VisualizationErrorBoundary
+      resetKey={`${props.visualization.id}:${props.visualization.updatedAt ?? ""}`}
+    >
+      <VisualizationPreviewContent {...props} />
+    </VisualizationErrorBoundary>
+  );
+}
+
+function VisualizationPreviewContent({
   visualization,
   height = PREVIEW_HEIGHT,
   fallback = null,

--- a/packages/app/src/lib/visualizations/encoding-enforcer.test.ts
+++ b/packages/app/src/lib/visualizations/encoding-enforcer.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { isColumnValidForChannel, validateEncoding } from "./encoding-enforcer";
+
+/**
+ * The enforcer runs during RENDER, in the visualization page's `encodingErrors`
+ * memo and in the axis picker's `validationError` memo — both of which sit
+ * ABOVE the per-chart error boundary. A throw here is not contained by that
+ * boundary: it unwinds to the router and replaces the whole page, which is the
+ * GH #289 symptom the boundary was added to prevent.
+ *
+ * `encoding` is stored as opaque jsonb, so a row written before the write gate
+ * existed can still hold any shape. The enforcer must therefore TOLERATE a
+ * malformed value rather than trust its declared `string` type.
+ */
+const ANALYSIS = [
+  { columnName: "region", dataType: "VARCHAR", semanticType: "categorical" },
+  { columnName: "amount", dataType: "DOUBLE", semanticType: "numeric" },
+] as never;
+
+describe("encoding enforcer — malformed stored values", () => {
+  // The exact payload from GH #289.
+  const objectValue = { field: "region" } as never;
+
+  it("does not throw on an object-valued channel", () => {
+    expect(() =>
+      validateEncoding({ x: objectValue }, "barY", ANALYSIS),
+    ).not.toThrow();
+    expect(() =>
+      validateEncoding({ x: "field:x", y: objectValue }, "barY", ANALYSIS),
+    ).not.toThrow();
+  });
+
+  it("does not throw on any other non-string channel value", () => {
+    for (const bad of [42, true, ["field:a"], null] as never[]) {
+      expect(() =>
+        validateEncoding({ x: bad }, "barY", ANALYSIS),
+      ).not.toThrow();
+    }
+  });
+
+  it("does not throw when the axis picker validates a malformed value", () => {
+    // AxisSelectField passes its raw `value` prop straight through, so the
+    // config panel the user would repair the chart with must survive it too.
+    expect(() =>
+      isColumnValidForChannel(objectValue, "x", "barY", ANALYSIS),
+    ).not.toThrow();
+  });
+
+  it("still reports a real mismatch on a well-formed value", () => {
+    // Tolerating garbage must not make the enforcer tolerate everything.
+    const errors = validateEncoding({ y: "region" }, "barY", ANALYSIS);
+    expect(errors.y).toBeTruthy();
+  });
+});

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -24,6 +24,19 @@
  * source.
  */
 
+import { ENCODING_VALUE_FORMAT } from "@dashframe/types";
+
+/**
+ * The encoding argument is the one place the guide's terseness cost real
+ * writes: "field→channel encoding" describes the ROLE and not the SHAPE, so an
+ * agent guessed `{"x":{"field":"region"}}`, which the command layer now rejects
+ * (GH #289). Spell the shape out, sourced from the same constant the rejection
+ * message quotes so the two cannot drift.
+ */
+const ENCODING_ARG_CONTRACT = `{ x?, y?, color?, size? } — each value is ${ENCODING_VALUE_FORMAT}; plus optional xType/yType ("quantitative"|"nominal"|"ordinal"|"temporal") and xTransform/yTransform`;
+
+const ENCODING_ARG_NOTE = `Encoding channel values are ID references, NOT column names and NOT objects: each must be ${ENCODING_VALUE_FORMAT}. A field id comes from the data table's fields; a metric id from the insight's metrics. Anything else is REJECTED at write time.`;
+
 /** One command's agent-facing contract. */
 export interface CommandGuideEntry {
   /** The `cmd()` command name — what the apply tool dispatches on. */
@@ -276,9 +289,9 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
       insightId: "UUID",
       visualizationType: "chart type",
       spec: "Vega-Lite spec",
-      "encoding?": "field→channel encoding",
+      "encoding?": ENCODING_ARG_CONTRACT,
     },
-    notes: "The `data` key is stripped from spec before storage.",
+    notes: `The \`data\` key is stripped from spec before storage. ${ENCODING_ARG_NOTE}`,
   },
   {
     name: "SetChartType",
@@ -292,9 +305,10 @@ export const COMMAND_GUIDE: readonly CommandGuideEntry[] = [
     summary: "Set a chart's field→channel encoding (and optionally the spec).",
     args: {
       id: "UUID",
-      encoding: "field→channel encoding",
+      encoding: ENCODING_ARG_CONTRACT,
       "spec?": "Vega-Lite spec (omit to leave untouched)",
     },
+    notes: ENCODING_ARG_NOTE,
   },
   // --- Dashboard ---
   {

--- a/packages/assistant/src/read/command-guide.ts
+++ b/packages/assistant/src/read/command-guide.ts
@@ -35,7 +35,7 @@ import { ENCODING_VALUE_FORMAT } from "@dashframe/types";
  */
 const ENCODING_ARG_CONTRACT = `{ x?, y?, color?, size? } — each value is ${ENCODING_VALUE_FORMAT}; plus optional xType/yType ("quantitative"|"nominal"|"ordinal"|"temporal") and xTransform/yTransform`;
 
-const ENCODING_ARG_NOTE = `Encoding channel values are ID references, NOT column names and NOT objects: each must be ${ENCODING_VALUE_FORMAT}. A field id comes from the data table's fields; a metric id from the insight's metrics. Anything else is REJECTED at write time.`;
+const ENCODING_ARG_NOTE = `ALWAYS emit ID references, never objects and never column names: each channel value must be ${ENCODING_VALUE_FORMAT}. A field id comes from the data table's fields; a metric id from the insight's metrics. A non-string channel value, and a \`field:\`/\`metric:\` value whose id is not a uuid, are REJECTED at write time. (A bare column name is accepted only as a legacy form the UI still writes; it resolves by name and breaks on rename, so do not author one.)`;
 
 /** One command's agent-facing contract. */
 export interface CommandGuideEntry {

--- a/packages/engine/src/sql/encoding-resolution.test.ts
+++ b/packages/engine/src/sql/encoding-resolution.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `encoding` is stored as opaque jsonb, so a row written before the write gate
+ * existed can hold any shape at a channel. Both readers below have a deliberate
+ * legacy fallback that treats an unparseable value as a raw column name — for a
+ * non-string that would forward the value itself into SQL construction, so both
+ * must screen the type instead.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { resolveForAnalysis, resolveToSql } from "./encoding-resolution";
+
+const CONTEXT = { fields: [], metrics: [] } as never;
+
+// The exact payload from GH #289, plus the other non-string shapes jsonb allows.
+const MALFORMED = [{ field: "region" }, 42, true, ["field:a"], null] as never[];
+
+describe("encoding resolution — malformed stored values", () => {
+  it("resolveToSql returns undefined rather than emitting the value as SQL", () => {
+    for (const bad of MALFORMED) {
+      expect(resolveToSql(bad, CONTEXT)).toBeUndefined();
+    }
+  });
+
+  it("resolveForAnalysis reports invalid rather than naming a column", () => {
+    for (const bad of MALFORMED) {
+      const resolved = resolveForAnalysis(bad, CONTEXT);
+      expect(resolved.valid).toBe(false);
+      expect(resolved.columnName).toBeUndefined();
+    }
+  });
+
+  it("still passes a legacy raw column name through", () => {
+    // The fallback exists for saved visualizations that stored bare column
+    // names; screening the type must not close it.
+    expect(resolveToSql("sum(revenue)", CONTEXT)).toBe("sum(revenue)");
+    expect(resolveForAnalysis("sum(revenue)", CONTEXT)).toEqual({
+      columnName: "sum(revenue)",
+      isMetric: false,
+      valid: true,
+    });
+  });
+});

--- a/packages/engine/src/sql/encoding-resolution.ts
+++ b/packages/engine/src/sql/encoding-resolution.ts
@@ -109,7 +109,11 @@ export function resolveToSql(
   context: EncodingResolutionContext,
   transform?: ChannelTransform,
 ): string | undefined {
-  if (!value) return undefined;
+  // `string | undefined` is what the TYPE says; `encoding` is stored as opaque
+  // jsonb, so a row written before the write gate existed can hand this an
+  // object. The raw-column-name fallback below would pass that object on as a
+  // SQL fragment, so screen the type here rather than downstream.
+  if (!value || typeof value !== "string") return undefined;
   const parsed = parseEncoding(value);
 
   // Metrics: aggregations are already wrapped; transforms don't apply.
@@ -176,7 +180,10 @@ export function resolveForAnalysis(
   value: string | undefined,
   context: EncodingResolutionContext,
 ): ResolvedForAnalysis {
-  if (!value) return { isMetric: false, valid: false };
+  // Same jsonb-shaped hazard as `resolveToSql` above: a non-string must not
+  // fall through to the raw-column-name branch.
+  if (!value || typeof value !== "string")
+    return { isMetric: false, valid: false };
   const parsed = parseEncoding(value);
   if (!parsed) {
     return { columnName: value, isMetric: false, valid: !!value };

--- a/packages/types/src/encoding-helpers.test.ts
+++ b/packages/types/src/encoding-helpers.test.ts
@@ -462,8 +462,14 @@ describe("encoding-helpers", () => {
       expect(isEncodingValue(`metric:${uuid}`)).toBe(true);
     });
 
-    it("accepts an uppercase uuid", () => {
-      expect(isEncodingValue(`field:${uuid.toUpperCase()}`)).toBe(true);
+    it("rejects wrong case — parseEncoding matches the prefix case-sensitively", () => {
+      // `FIELD:<uuid>` would not parse as an ID reference at all; the reader
+      // falls back to treating it as a raw column name. Admitting it at the
+      // gate would persist a value the reader silently mis-resolves.
+      expect(isEncodingValue(`FIELD:${uuid}`)).toBe(false);
+      expect(isEncodingValue(`Metric:${uuid}`)).toBe(false);
+      expect(isEncodingValue(`field:${uuid.toUpperCase()}`)).toBe(false);
+      expect(isEncodingValue(`field:${uuid}_J1`)).toBe(false);
     });
 
     it("accepts a repeat-join instance suffix — the axis picker emits it", () => {
@@ -564,7 +570,14 @@ describe("encoding-helpers", () => {
     });
 
     it("rejects a value that claims to be an ID reference but carries no uuid", () => {
-      for (const bad of ["field:", "field:abc", `metric:${x}-nope`]) {
+      for (const bad of [
+        "field:",
+        "field:abc",
+        `metric:${x}-nope`,
+        // Wrong case: the reader's prefix match is case-sensitive, so this
+        // would be silently mis-read as a raw column name rather than an id.
+        `FIELD:${x}`,
+      ]) {
         expect(validateVisualizationEncoding({ x: bad })).toContain(
           "looks like an ID reference but is malformed",
         );

--- a/packages/types/src/encoding-helpers.test.ts
+++ b/packages/types/src/encoding-helpers.test.ts
@@ -516,6 +516,10 @@ describe("encoding-helpers", () => {
             type: "date",
             transform: { kind: "temporal", aggregation: "yearMonth" },
           },
+          yTransform: {
+            type: "date",
+            transform: { kind: "categorical", groupBy: "monthName" },
+          },
         }),
       ).toBeUndefined();
     });
@@ -523,15 +527,47 @@ describe("encoding-helpers", () => {
     it("rejects the documented-looking guess and names the channel + format", () => {
       const problem = validateVisualizationEncoding({ x: { field: "region" } });
       expect(problem).toContain("encoding.x");
+      expect(problem).toContain("must be a string");
       expect(problem).toContain("field:<uuid>");
       expect(problem).toContain('{"field":"region"}');
     });
 
-    it("rejects a raw column name on any value-bearing channel", () => {
+    it("rejects any non-string on any value-bearing channel", () => {
       for (const channel of ["x", "y", "color", "size"]) {
         expect(
-          validateVisualizationEncoding({ [channel]: "region" }),
+          validateVisualizationEncoding({ [channel]: { field: "c" } }),
         ).toContain(`encoding.${channel}`);
+        expect(validateVisualizationEncoding({ [channel]: 7 })).toContain(
+          `encoding.${channel}`,
+        );
+        expect(validateVisualizationEncoding({ [channel]: null })).toContain(
+          `encoding.${channel}`,
+        );
+      }
+    });
+
+    // The axis picker offers raw data-frame columns while analysis is
+    // unavailable, and offers an unmatched analyzed column under its own name;
+    // `resolveToSql` resolves both. Rejecting these would break the picker's
+    // own writes and duplicating any older chart that stored one.
+    it("accepts a bare column name — a form the axis picker still writes", () => {
+      expect(validateVisualizationEncoding({ x: "region" })).toBeUndefined();
+      expect(
+        validateVisualizationEncoding({ x: "region", y: "sum(amount)" }),
+      ).toBeUndefined();
+    });
+
+    it("rejects an empty channel value — omit the channel instead", () => {
+      expect(validateVisualizationEncoding({ x: "" })).toContain(
+        "must not be empty",
+      );
+    });
+
+    it("rejects a value that claims to be an ID reference but carries no uuid", () => {
+      for (const bad of ["field:", "field:abc", `metric:${x}-nope`]) {
+        expect(validateVisualizationEncoding({ x: bad })).toContain(
+          "looks like an ID reference but is malformed",
+        );
       }
     });
 
@@ -543,6 +579,43 @@ describe("encoding-helpers", () => {
         "must be an object",
       );
       expect(validateVisualizationEncoding([])).toContain("must be an object");
+    });
+
+    it("rejects a bad axis type", () => {
+      expect(
+        validateVisualizationEncoding({
+          x: `field:${x}`,
+          xType: "categorical",
+        }),
+      ).toContain("encoding.xType");
+      expect(
+        validateVisualizationEncoding({ y: `field:${x}`, yType: 3 }),
+      ).toContain("encoding.yType");
+    });
+
+    // `applyTransform` reads transform.transform.kind — a half-built transform
+    // throws at render exactly like a non-string channel value.
+    it("rejects a half-built date transform", () => {
+      const cases: unknown[] = [
+        { type: "date" },
+        { type: "date", transform: {} },
+        { type: "date", transform: { kind: "temporal" } },
+        { type: "date", transform: { kind: "temporal", aggregation: "daily" } },
+        { type: "date", transform: { kind: "categorical" } },
+        { type: "date", transform: { kind: "categorical", groupBy: "week" } },
+        { type: "date", transform: { kind: "weird", aggregation: "year" } },
+        { transform: { kind: "temporal", aggregation: "year" } },
+        "yearMonth",
+        null,
+      ];
+      for (const bad of cases) {
+        expect(
+          validateVisualizationEncoding({ x: `field:${x}`, xTransform: bad }),
+        ).toContain("encoding.xTransform");
+        expect(
+          validateVisualizationEncoding({ y: `field:${y}`, yTransform: bad }),
+        ).toContain("encoding.yTransform");
+      }
     });
 
     it("ignores keys it does not own rather than rejecting them", () => {

--- a/packages/types/src/encoding-helpers.test.ts
+++ b/packages/types/src/encoding-helpers.test.ts
@@ -563,10 +563,14 @@ describe("encoding-helpers", () => {
       ).toBeUndefined();
     });
 
-    it("rejects an empty channel value — omit the channel instead", () => {
-      expect(validateVisualizationEncoding({ x: "" })).toContain(
-        "must not be empty",
-      );
+    it("accepts an empty channel value — that is how the picker clears one", () => {
+      // Clearing the optional Color/Size picker saves `""`; `resolveToSql`
+      // reads it as "channel not set".
+      expect(validateVisualizationEncoding({ color: "" })).toBeUndefined();
+      expect(validateVisualizationEncoding({ size: "" })).toBeUndefined();
+      expect(
+        validateVisualizationEncoding({ x: `field:${x}`, color: "" }),
+      ).toBeUndefined();
     });
 
     it("rejects a value that claims to be an ID reference but carries no uuid", () => {

--- a/packages/types/src/encoding-helpers.test.ts
+++ b/packages/types/src/encoding-helpers.test.ts
@@ -73,6 +73,18 @@ describe("encoding-helpers", () => {
   });
 
   describe("parseEncoding()", () => {
+    // `encoding` is stored as opaque jsonb, so a row written before the write
+    // gate existed can hand any shape to a reader. parseEncoding sits under
+    // every one of them, so screening the type here is what keeps a malformed
+    // stored row from throwing in render code that no error boundary covers.
+    it("returns undefined for a non-string, rather than throwing", () => {
+      for (const bad of [{ field: "region" }, 42, true, ["field:a"], null]) {
+        expect(parseEncoding(bad as never)).toBeUndefined();
+      }
+      expect(isFieldEncoding({ field: "region" } as never)).toBe(false);
+      expect(isMetricEncoding({ metric: "revenue" } as never)).toBe(false);
+    });
+
     describe("valid field encodings", () => {
       it("should parse field encoding correctly", () => {
         const result = parseEncoding("field:abc-123-def");
@@ -462,14 +474,21 @@ describe("encoding-helpers", () => {
       expect(isEncodingValue(`metric:${uuid}`)).toBe(true);
     });
 
-    it("rejects wrong case — parseEncoding matches the prefix case-sensitively", () => {
+    it("rejects a wrong-case PREFIX — parseEncoding matches it case-sensitively", () => {
       // `FIELD:<uuid>` would not parse as an ID reference at all; the reader
       // falls back to treating it as a raw column name. Admitting it at the
       // gate would persist a value the reader silently mis-resolves.
       expect(isEncodingValue(`FIELD:${uuid}`)).toBe(false);
       expect(isEncodingValue(`Metric:${uuid}`)).toBe(false);
-      expect(isEncodingValue(`field:${uuid.toUpperCase()}`)).toBe(false);
       expect(isEncodingValue(`field:${uuid}_J1`)).toBe(false);
+    });
+
+    it("accepts an uppercase uuid BODY — the reader compares it exactly", () => {
+      // The id is sliced out and compared to the stored field id, so an
+      // uppercase id resolves fine when that is how it was stored. Rejecting
+      // it would make the gate stricter than the reader.
+      expect(isEncodingValue(`field:${uuid.toUpperCase()}`)).toBe(true);
+      expect(isEncodingValue(`metric:${uuid.toUpperCase()}_j2`)).toBe(true);
     });
 
     it("accepts a repeat-join instance suffix — the axis picker emits it", () => {

--- a/packages/types/src/encoding-helpers.test.ts
+++ b/packages/types/src/encoding-helpers.test.ts
@@ -8,15 +8,18 @@
  * - isFieldEncoding() - Type guard for field encodings
  * - isMetricEncoding() - Type guard for metric encodings
  * - isValidEncoding() - Type guard for valid encodings
+ * - isEncodingValue() / validateVisualizationEncoding() - write-time validation
  */
 import { describe, expect, it } from "vitest";
 import {
   fieldEncoding,
+  isEncodingValue,
   isFieldEncoding,
   isMetricEncoding,
   isValidEncoding,
   metricEncoding,
   parseEncoding,
+  validateVisualizationEncoding,
 } from "./encoding-helpers";
 import type { UUID } from "./uuid";
 
@@ -445,6 +448,107 @@ describe("encoding-helpers", () => {
       validEncodings.forEach((valid) => {
         expect(isValidEncoding(valid)).toBe(true);
       });
+    });
+  });
+  // ==========================================================================
+  // Write-time validation (GH #289)
+  // ==========================================================================
+
+  describe("isEncodingValue()", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+
+    it("accepts a canonical field and metric encoding", () => {
+      expect(isEncodingValue(`field:${uuid}`)).toBe(true);
+      expect(isEncodingValue(`metric:${uuid}`)).toBe(true);
+    });
+
+    it("accepts an uppercase uuid", () => {
+      expect(isEncodingValue(`field:${uuid.toUpperCase()}`)).toBe(true);
+    });
+
+    it("accepts a repeat-join instance suffix — the axis picker emits it", () => {
+      expect(isEncodingValue(`field:${uuid}_j1`)).toBe(true);
+      expect(isEncodingValue(`field:${uuid}_j12`)).toBe(true);
+    });
+
+    it("rejects a _j0 suffix — instance 0 is the bare uuid", () => {
+      expect(isEncodingValue(`field:${uuid}_j0`)).toBe(false);
+    });
+
+    it("rejects a non-string, which is exactly what crashed the renderer", () => {
+      expect(isEncodingValue({ field: "region" })).toBe(false);
+      expect(isEncodingValue(null)).toBe(false);
+      expect(isEncodingValue(42)).toBe(false);
+      expect(isEncodingValue(["field:" + uuid])).toBe(false);
+    });
+
+    it("rejects a prefixed non-uuid, a raw column name, and a SQL aggregate", () => {
+      expect(isEncodingValue("field:abc")).toBe(false);
+      expect(isEncodingValue("field:")).toBe(false);
+      expect(isEncodingValue("region")).toBe(false);
+      expect(isEncodingValue("sum(revenue)")).toBe(false);
+      expect(isEncodingValue(`dimension:${uuid}`)).toBe(false);
+    });
+
+    it("accepts what the constructors produce", () => {
+      expect(isEncodingValue(fieldEncoding(uuid as UUID))).toBe(true);
+      expect(isEncodingValue(metricEncoding(uuid as UUID))).toBe(true);
+    });
+  });
+
+  describe("validateVisualizationEncoding()", () => {
+    const x = "550e8400-e29b-41d4-a716-446655440000";
+    const y = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+    it("accepts an absent encoding — encodings are built up incrementally", () => {
+      expect(validateVisualizationEncoding(undefined)).toBeUndefined();
+      expect(validateVisualizationEncoding({})).toBeUndefined();
+    });
+
+    it("accepts a full encoding with types and transforms", () => {
+      expect(
+        validateVisualizationEncoding({
+          x: `field:${x}`,
+          y: `metric:${y}`,
+          color: `field:${x}_j1`,
+          xType: "temporal",
+          xTransform: {
+            type: "date",
+            transform: { kind: "temporal", aggregation: "yearMonth" },
+          },
+        }),
+      ).toBeUndefined();
+    });
+
+    it("rejects the documented-looking guess and names the channel + format", () => {
+      const problem = validateVisualizationEncoding({ x: { field: "region" } });
+      expect(problem).toContain("encoding.x");
+      expect(problem).toContain("field:<uuid>");
+      expect(problem).toContain('{"field":"region"}');
+    });
+
+    it("rejects a raw column name on any value-bearing channel", () => {
+      for (const channel of ["x", "y", "color", "size"]) {
+        expect(
+          validateVisualizationEncoding({ [channel]: "region" }),
+        ).toContain(`encoding.${channel}`);
+      }
+    });
+
+    it("rejects a non-object encoding", () => {
+      expect(validateVisualizationEncoding(null)).toContain(
+        "must be an object",
+      );
+      expect(validateVisualizationEncoding("field:" + x)).toContain(
+        "must be an object",
+      );
+      expect(validateVisualizationEncoding([])).toContain("must be an object");
+    });
+
+    it("ignores keys it does not own rather than rejecting them", () => {
+      expect(
+        validateVisualizationEncoding({ x: `field:${x}`, xLabel: "Region" }),
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/types/src/encoding-helpers.ts
+++ b/packages/types/src/encoding-helpers.ts
@@ -177,11 +177,20 @@ export const ENCODING_VALUE_FORMAT =
  * table (`<uuid>_j1`, `<uuid>_j2`, …). Selecting a repeat-join instance in the
  * axis picker persists exactly that form, so rejecting it would break a
  * legitimate encoding the UI itself writes.
+ *
+ * Case-SENSITIVE, deliberately: `parseEncoding` matches the prefix with a
+ * case-sensitive `startsWith`, and ids are compared to stored lowercase UUIDs.
+ * Admitting `FIELD:<uuid>` here would let a value through the gate that the
+ * reader then falls back to treating as a raw column name.
  */
 const ENCODING_VALUE_PATTERN =
-  /^(?:field|metric):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:_j[1-9][0-9]*)?$/i;
+  /^(?:field|metric):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:_j[1-9][0-9]*)?$/;
 
-/** Anything claiming to be an ID reference, well-formed or not. */
+/**
+ * Anything claiming to be an ID reference, well-formed or not. Case-insensitive
+ * so a wrong-case prefix is reported as the malformed reference it is, rather
+ * than passing as a bare column name.
+ */
 const ENCODING_PREFIX_PATTERN = /^(?:field|metric):/i;
 
 /**

--- a/packages/types/src/encoding-helpers.ts
+++ b/packages/types/src/encoding-helpers.ts
@@ -151,6 +151,105 @@ export function isValidEncoding(
 }
 
 // ============================================================================
+// Write-time Validation
+// ============================================================================
+
+/**
+ * The encoding channels whose values are `EncodingValue` strings. The other
+ * keys of `VisualizationEncoding` (`xType`, `yType`, `xTransform`,
+ * `yTransform`) carry their own shapes and are not checked here.
+ */
+export const ENCODING_VALUE_CHANNELS = ["x", "y", "color", "size"] as const;
+
+export type EncodingValueChannel = (typeof ENCODING_VALUE_CHANNELS)[number];
+
+/**
+ * The exact accepted `EncodingValue` shape, in one place, phrased for a human
+ * or an agent reading a rejection. Both the command-layer error text and the
+ * agent-facing command guide quote this so they cannot drift apart.
+ */
+export const ENCODING_VALUE_FORMAT =
+  'a string "field:<uuid>" or "metric:<uuid>" (a repeat-join instance may suffix the uuid, e.g. "field:<uuid>_j1")';
+
+/**
+ * Canonical UUID, optionally carrying the repeat-join instance suffix that
+ * `joinInstanceFieldId` appends for the second and later joins to the same
+ * table (`<uuid>_j1`, `<uuid>_j2`, …). Selecting a repeat-join instance in the
+ * axis picker persists exactly that form, so rejecting it would break a
+ * legitimate encoding the UI itself writes.
+ */
+const ENCODING_VALUE_PATTERN =
+  /^(?:field|metric):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:_j[1-9][0-9]*)?$/i;
+
+/**
+ * Runtime guard for a value of unknown provenance — an RPC argument, a command
+ * envelope authored by an agent, a row read back from storage. Unlike
+ * `isValidEncoding`, this takes `unknown` (so a non-string cannot reach it as a
+ * type error) and checks the WHOLE shape, not just the prefix.
+ *
+ * @param value - Candidate of any type
+ * @returns True if value is a well-formed `field:<uuid>` / `metric:<uuid>`
+ */
+export function isEncodingValue(value: unknown): value is EncodingValue {
+  return typeof value === "string" && ENCODING_VALUE_PATTERN.test(value);
+}
+
+/**
+ * Validate a whole `VisualizationEncoding` supplied by an untrusted caller.
+ *
+ * The render path (`parseEncoding` → `value.startsWith`) assumes every channel
+ * value is a string, so a structurally wrong encoding written to canonical
+ * state throws at render rather than at write. This is the write-time gate:
+ * anything it rejects can never reach storage.
+ *
+ * Absent channels are fine — encodings are built up incrementally, and a
+ * missing axis already has its own terminal UI.
+ *
+ * @param encoding - Candidate encoding of any type
+ * @returns A human-readable problem description, or undefined when valid
+ *
+ * @example
+ * ```typescript
+ * validateVisualizationEncoding({ x: { field: "region" } })
+ * // Returns: 'encoding.x must be a string "field:<uuid>" … — received {"field":"region"}'
+ * ```
+ */
+export function validateVisualizationEncoding(
+  encoding: unknown,
+): string | undefined {
+  if (encoding === undefined) return undefined;
+  if (
+    typeof encoding !== "object" ||
+    encoding === null ||
+    Array.isArray(encoding)
+  ) {
+    return `encoding must be an object mapping channels to encoding values — received ${describeValue(encoding)}`;
+  }
+
+  const record = encoding as Record<string, unknown>;
+  for (const channel of ENCODING_VALUE_CHANNELS) {
+    const value = record[channel];
+    if (value === undefined) continue;
+    if (!isEncodingValue(value)) {
+      return `encoding.${channel} must be ${ENCODING_VALUE_FORMAT} — received ${describeValue(value)}`;
+    }
+  }
+  return undefined;
+}
+
+/** Render an offending value compactly for an error message. */
+function describeValue(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === null) return "null";
+  if (typeof value !== "object") return `${typeof value} ${String(value)}`;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+// ============================================================================
 // Date Transform Types
 // ============================================================================
 

--- a/packages/types/src/encoding-helpers.ts
+++ b/packages/types/src/encoding-helpers.ts
@@ -73,7 +73,13 @@ export interface ParsedEncoding {
 export function parseEncoding(
   value: string | undefined,
 ): ParsedEncoding | undefined {
-  if (!value) return undefined;
+  // `string | undefined` is what the TYPE says; `encoding` is stored as opaque
+  // jsonb, so a row written before the write gate existed can hand this an
+  // object. Calling `.startsWith` on one is the GH #289 crash, and this
+  // function sits under every reader — the enforcer the config panel runs, the
+  // SQL resolver, the renderer. Screening the type here closes the class at all
+  // of them rather than at whichever call site was noticed.
+  if (!value || typeof value !== "string") return undefined;
 
   if (value.startsWith("field:")) {
     return { type: "field", id: value.slice(6) as UUID };
@@ -123,7 +129,7 @@ export function metricEncoding(id: UUID): MetricEncodingValue {
 export function isFieldEncoding(
   value: string | undefined,
 ): value is FieldEncodingValue {
-  return value?.startsWith("field:") ?? false;
+  return typeof value === "string" && value.startsWith("field:");
 }
 
 /**
@@ -135,7 +141,7 @@ export function isFieldEncoding(
 export function isMetricEncoding(
   value: string | undefined,
 ): value is MetricEncodingValue {
-  return value?.startsWith("metric:") ?? false;
+  return typeof value === "string" && value.startsWith("metric:");
 }
 
 /**
@@ -178,13 +184,15 @@ export const ENCODING_VALUE_FORMAT =
  * axis picker persists exactly that form, so rejecting it would break a
  * legitimate encoding the UI itself writes.
  *
- * Case-SENSITIVE, deliberately: `parseEncoding` matches the prefix with a
- * case-sensitive `startsWith`, and ids are compared to stored lowercase UUIDs.
- * Admitting `FIELD:<uuid>` here would let a value through the gate that the
- * reader then falls back to treating as a raw column name.
+ * The PREFIX is case-sensitive, deliberately: `parseEncoding` matches it with a
+ * case-sensitive `startsWith`, so admitting `FIELD:<uuid>` would let a value
+ * through the gate that the reader then falls back to treating as a raw column
+ * name. The UUID BODY is not: the reader slices it out and compares it to the
+ * stored field id exactly, so an uppercase id resolves fine if that is how it
+ * was stored, and rejecting it here would be stricter than the reader.
  */
 const ENCODING_VALUE_PATTERN =
-  /^(?:field|metric):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:_j[1-9][0-9]*)?$/;
+  /^(?:field|metric):[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?:_j[1-9][0-9]*)?$/;
 
 /**
  * Anything claiming to be an ID reference, well-formed or not. Case-insensitive

--- a/packages/types/src/encoding-helpers.ts
+++ b/packages/types/src/encoding-helpers.ts
@@ -155,9 +155,9 @@ export function isValidEncoding(
 // ============================================================================
 
 /**
- * The encoding channels whose values are `EncodingValue` strings. The other
- * keys of `VisualizationEncoding` (`xType`, `yType`, `xTransform`,
- * `yTransform`) carry their own shapes and are not checked here.
+ * The encoding channels whose values are channel references. The other keys of
+ * `VisualizationEncoding` (`xType`, `yType`, `xTransform`, `yTransform`) carry
+ * their own shapes and are validated separately below.
  */
 export const ENCODING_VALUE_CHANNELS = ["x", "y", "color", "size"] as const;
 
@@ -181,6 +181,9 @@ export const ENCODING_VALUE_FORMAT =
 const ENCODING_VALUE_PATTERN =
   /^(?:field|metric):[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:_j[1-9][0-9]*)?$/i;
 
+/** Anything claiming to be an ID reference, well-formed or not. */
+const ENCODING_PREFIX_PATTERN = /^(?:field|metric):/i;
+
 /**
  * Runtime guard for a value of unknown provenance — an RPC argument, a command
  * envelope authored by an agent, a row read back from storage. Unlike
@@ -195,12 +198,89 @@ export function isEncodingValue(value: unknown): value is EncodingValue {
 }
 
 /**
+ * Why a channel value is not writable, or undefined when it is.
+ *
+ * The write gate is deliberately NOT "must be an `EncodingValue`". A bare
+ * column name is a form the product itself still produces: the axis picker
+ * offers raw data-frame columns while analysis is unavailable, and offers a
+ * column that matched no field under its own name, and `resolveToSql` resolves
+ * both. Requiring the ID form here would reject the picker's own writes and
+ * break duplicating any older chart that stored one.
+ *
+ * What is NOT writable is the crash class and the near-miss:
+ * - a NON-STRING — the render path calls `.startsWith` on channel values, so an
+ *   object or number is the defect from GH #289;
+ * - a value that CLAIMS to be an ID reference (`field:` / `metric:` prefix) but
+ *   carries no valid id — silently unresolvable, and always a caller mistake
+ *   rather than a legacy form.
+ */
+function channelValueProblem(
+  channel: string,
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") {
+    return `encoding.${channel} must be a string — ${ENCODING_VALUE_FORMAT} — received ${describeValue(value)}`;
+  }
+  if (value === "") {
+    return `encoding.${channel} must not be empty — omit the channel instead`;
+  }
+  if (
+    ENCODING_PREFIX_PATTERN.test(value) &&
+    !ENCODING_VALUE_PATTERN.test(value)
+  )
+    return `encoding.${channel} looks like an ID reference but is malformed — expected ${ENCODING_VALUE_FORMAT} — received ${describeValue(value)}`;
+  return undefined;
+}
+
+const AXIS_TYPES = new Set(["quantitative", "nominal", "ordinal", "temporal"]);
+const TEMPORAL_AGGREGATIONS = new Set([
+  "none",
+  "yearWeek",
+  "yearMonth",
+  "year",
+]);
+const CATEGORICAL_DATE_GROUPS = new Set(["monthName", "dayOfWeek", "quarter"]);
+
+/**
+ * Why a channel transform is not writable, or undefined when it is.
+ *
+ * `applyTransform` reads `transform.transform.kind` and `applyDateTransformToSql`
+ * switches on the inner union without a default, so a half-built transform
+ * throws at render exactly like a non-string channel value does. Same class of
+ * defect, same gate.
+ */
+function transformProblem(key: string, value: unknown): string | undefined {
+  const shape = `{ type: "date", transform: { kind: "temporal", aggregation: "none"|"yearWeek"|"yearMonth"|"year" } | { kind: "categorical", groupBy: "monthName"|"dayOfWeek"|"quarter" } }`;
+  const reject = () =>
+    `encoding.${key} must be ${shape} — received ${describeValue(value)}`;
+
+  if (!isPlainObject(value)) return reject();
+  if (value.type !== "date") return reject();
+  const transform = value.transform;
+  if (!isPlainObject(transform)) return reject();
+  if (transform.kind === "temporal") {
+    return typeof transform.aggregation === "string" &&
+      TEMPORAL_AGGREGATIONS.has(transform.aggregation)
+      ? undefined
+      : reject();
+  }
+  if (transform.kind === "categorical") {
+    return typeof transform.groupBy === "string" &&
+      CATEGORICAL_DATE_GROUPS.has(transform.groupBy)
+      ? undefined
+      : reject();
+  }
+  return reject();
+}
+
+/**
  * Validate a whole `VisualizationEncoding` supplied by an untrusted caller.
  *
- * The render path (`parseEncoding` → `value.startsWith`) assumes every channel
- * value is a string, so a structurally wrong encoding written to canonical
- * state throws at render rather than at write. This is the write-time gate:
- * anything it rejects can never reach storage.
+ * The render path assumes channel values are strings and transforms are whole,
+ * so a structurally wrong encoding written to canonical state throws at RENDER
+ * rather than at write — and before the error boundary that took the entire
+ * page with it (GH #289). This is the write-time gate: what it rejects can
+ * never reach storage.
  *
  * Absent channels are fine — encodings are built up incrementally, and a
  * missing axis already has its own terminal UI.
@@ -211,30 +291,45 @@ export function isEncodingValue(value: unknown): value is EncodingValue {
  * @example
  * ```typescript
  * validateVisualizationEncoding({ x: { field: "region" } })
- * // Returns: 'encoding.x must be a string "field:<uuid>" … — received {"field":"region"}'
+ * // Returns: 'encoding.x must be a string — a string "field:<uuid>" … — received {"field":"region"}'
  * ```
  */
 export function validateVisualizationEncoding(
   encoding: unknown,
 ): string | undefined {
   if (encoding === undefined) return undefined;
-  if (
-    typeof encoding !== "object" ||
-    encoding === null ||
-    Array.isArray(encoding)
-  ) {
+  if (!isPlainObject(encoding)) {
     return `encoding must be an object mapping channels to encoding values — received ${describeValue(encoding)}`;
   }
 
-  const record = encoding as Record<string, unknown>;
   for (const channel of ENCODING_VALUE_CHANNELS) {
-    const value = record[channel];
+    const value = encoding[channel];
     if (value === undefined) continue;
-    if (!isEncodingValue(value)) {
-      return `encoding.${channel} must be ${ENCODING_VALUE_FORMAT} — received ${describeValue(value)}`;
+    const problem = channelValueProblem(channel, value);
+    if (problem) return problem;
+  }
+
+  for (const key of ["xType", "yType"] as const) {
+    const value = encoding[key];
+    if (value === undefined) continue;
+    if (typeof value !== "string" || !AXIS_TYPES.has(value)) {
+      return `encoding.${key} must be one of "quantitative", "nominal", "ordinal", "temporal" — received ${describeValue(value)}`;
     }
   }
+
+  for (const key of ["xTransform", "yTransform"] as const) {
+    const value = encoding[key];
+    if (value === undefined) continue;
+    const problem = transformProblem(key, value);
+    if (problem) return problem;
+  }
+
   return undefined;
+}
+
+/** Narrow to a non-array, non-null object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /** Render an offending value compactly for an error message. */

--- a/packages/types/src/encoding-helpers.ts
+++ b/packages/types/src/encoding-helpers.ts
@@ -230,9 +230,10 @@ function channelValueProblem(
   if (typeof value !== "string") {
     return `encoding.${channel} must be a string — ${ENCODING_VALUE_FORMAT} — received ${describeValue(value)}`;
   }
-  if (value === "") {
-    return `encoding.${channel} must not be empty — omit the channel instead`;
-  }
+  // "" is the CLEARED channel, not a malformed one: clearing the optional
+  // Color or Size picker saves `""`, and `resolveToSql` short-circuits on it
+  // (`if (!value) return undefined`). Rejecting it would break clearing.
+  if (value === "") return undefined;
   if (
     ENCODING_PREFIX_PATTERN.test(value) &&
     !ENCODING_VALUE_PATTERN.test(value)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -121,6 +121,7 @@ export type {
   DateTransform,
   EncodingType,
   EncodingValue,
+  EncodingValueChannel,
   FieldEncodingValue,
   MetricEncodingValue,
   ParsedEncoding,
@@ -128,12 +129,16 @@ export type {
 } from "./encoding-helpers";
 
 export {
+  ENCODING_VALUE_CHANNELS,
+  ENCODING_VALUE_FORMAT,
   fieldEncoding,
+  isEncodingValue,
   isFieldEncoding,
   isMetricEncoding,
   isValidEncoding,
   metricEncoding,
   parseEncoding,
+  validateVisualizationEncoding,
 } from "./encoding-helpers";
 
 export type {


### PR DESCRIPTION
Fixes #289.

One malformed chart encoding — `{"x": {"field": "region"}}`, authored by an agent
from what the `draft_batch` guide made look like a documented shape — replaced the
**entire page** with "Something went wrong!", including the home page, which
previews the three most recent charts.

Three independent links had to all be broken for that to happen, so all three are
fixed here:

1. `draft_batch` documented the parameter only as `encoding?: field→channel
   encoding`. The object shape is the natural reading of that sentence.
2. Nothing between the tool call and canonical state rejected it — `encoding`
   arrives as opaque `jsonb`, so the RPC schema proves only "is JSON".
3. It threw at render (`TypeError: value.startsWith is not a function`) with no
   error boundary below the route, so one bad chart took its whole page down.

## Changes

- **Write gate** (`packages/types/src/encoding-helpers.ts`,
  `apps/server/src/functions/commands.ts`,
  `apps/server/src/functions/app-artifacts.ts`) — one shared
  `validateVisualizationEncoding()` guards every write to `visualizations.encoding`:
  both inserts (`CreateVisualization` command + the legacy `createVisualization`
  RPC) and the update (`SetChartEncoding`). Drafts replay the command log through
  the same handlers, so the draft path is covered by construction. The error states
  the expected format and echoes what was received.
  - Deliberately **not** "must be an `EncodingValue`": a bare column name is a form
    the product itself still writes (the axis picker offers raw data-frame columns
    while analysis is unavailable, and `resolveToSql` resolves them), so requiring
    the ID form would reject the picker's own writes and break duplicating older
    charts. The gate rejects the crash class (a non-string) and the near-miss (a
    `field:`/`metric:` value carrying no uuid).
  - Case-sensitive, matching `parseEncoding`'s case-sensitive prefix match — a
    value the gate admits must be a value the reader resolves the same way.
  - `xType`/`yType` and the `xTransform`/`yTransform` discriminated shape are
    validated too; `applyTransform` reads `transform.transform.kind` with no
    default, so a half-built transform is the same bug in a different channel.
- **Guide** (`packages/assistant/src/read/command-guide.ts`) — `CreateVisualization`
  and `SetChartEncoding` now spell out the exact value format, where the ids come
  from, and that a non-string channel value is rejected at write time. The guide
  text is generated from the same `ENCODING_VALUE_FORMAT` constant the rejection
  message uses, so they cannot drift.
- **Containment** (`packages/app/src/components/visualizations/`) — new
  `VisualizationErrorBoundary` wrapping `VisualizationPreview` and
  `VisualizationDisplay`. Both use a wrapper/content split so no consumer can mount
  a chart without containment. `resetKey` includes `updatedAt`, so a chart whose
  encoding was just repaired recovers in place — the config panel that repairs it
  lives outside the boundary on the same route.
- **Readers tolerate what is already stored.** The gate only guards new writes;
  `encoding` is opaque jsonb, so an existing row can still hand a reader an
  object. `parseEncoding` and its two type guards screen the type at the root,
  and both SQL readers do too — their legacy raw-column-name fallback would
  otherwise forward a non-string into SQL construction. This is what closes the
  crash: the enforcer runs in a render memo *above* the new boundary, so its
  throw unwound past it to the router and replaced the page — the #289 symptom
  itself.
- **Tests** — command-layer rejection and acceptance (malformed object, prefixed
  non-uuid, half-built transform, bare column name, repeat-join `_j1`), validator
  unit coverage, and boundary containment proving a throwing chart does not unmount
  its siblings or the surrounding page.

## Screenshots

### Before — main, whole page replaced by the error
![Before — main, whole page replaced by the error](https://github.com/youhaowei/DashFrame/releases/download/pr-296-screenshots/t775-before-light.png)

### After — light, page survives with a broken card
![After — light, page survives with a broken card](https://github.com/youhaowei/DashFrame/releases/download/pr-296-screenshots/t775-after-light.png)

### After — dark
![After — dark](https://github.com/youhaowei/DashFrame/releases/download/pr-296-screenshots/t775-after-dark.png)

_Screenshots via pr-screenshots (prerelease `pr-296-screenshots`, not in git)._
## Verification

- **Reproduced first, on `origin/main`** — separate worktree + server, home page
  read back as `Something went wrong! / value.startsWith is not a function`.
- **Fix proven at runtime** — same project on this branch: full home page (Recent
  Visualizations, Recent Insights, Quick Links all intact) with one card reading
  "Can't display this chart / Its configuration is invalid."
- **Drove the real actor** — the live MCP `draft_batch` tool against a running
  server, not a unit test. Confirmed against the running gate: the object shape is
  rejected with the format-stating error; `field:region` is rejected as "looks like
  an ID reference but is malformed"; a half-built `{type:"date"}` transform is
  rejected; a bare column name and a well-formed encoding are accepted. Also
  confirmed the rendered `draft_batch` tool description now spells the shape out.
- `bun run check` (PASS ×4) and `bun run format:check` clean.

## Review findings still open (deliberately not fixed here)

A cross-model review panel confirmed one blocker and three further findings. The
blocker is fixed in this branch; the other three are real but out of this PR's
scope — each is a separate change with its own surface and its own evidence
needs. Listing them so they route rather than disappear:

1. **No repair path for rows already holding a malformed encoding.** The write
   gate stops new ones and the readers now tolerate old ones, but three paths
   still refuse to move a bad row forward: Duplicate (the gate throws and the
   navigate never runs, so the click looks inert), an axis edit that spreads a
   bad `color`/`size` through, and a pre-existing draft whose
   `draft_command_log` holds a malformed `SetChartEncoding` — permanently
   unpublishable. This is a migration/backfill design spanning a second durable
   store, not a bug fix.
2. **A rejected encoding write is swallowed silently.** `updateVisualizationMutation`
   has no `onError` and none of its call sites catch; because the axis picker is
   controlled off `visualization.encoding`, the control just snaps back with no
   message. Surfacing it needs an error-presentation pattern this file does not
   have yet — a UI change with its own visual evidence.
3. **Unprefixed encoding values reach Mosaic as raw SQL** in the vgplot
   renderer's date-transform paths. Pre-existing, and the sibling fix already
   exists in the same file from #286 (`quoteIdentifier`) — a consistency gap to
   copy, not a new solution to design.

Also noted, not fixed: three call sites still mount `<Chart>` directly rather
than through the new boundary.

Tracked internally as TASK-775


