### PR TITLE
fix(visualization): apply color domain via plot options

### DIFF
--- a/packages/visualization/src/renderers/vgplot-renderer.test.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.test.ts
@@ -1,20 +1,327 @@
-import { describe, expect, it, vi } from "vitest";
-import { setupColorDomain } from "./vgplot-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createVgplotRenderer,
+  isExpressionBoundColor,
+  setupColorDomain,
+} from "./vgplot-renderer";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockApi(options?: {
+  query?: ReturnType<typeof vi.fn>;
+  colorDomain?: ReturnType<typeof vi.fn>;
+  plot?: ReturnType<typeof vi.fn>;
+}) {
+  const query =
+    options?.query ??
+    vi.fn(() => Promise.resolve([{ val: "A" }, { val: "B" }]));
+  const colorDomain =
+    options?.colorDomain ??
+    vi.fn((domain: string[]) => ({ __directive: "colorDomain", domain }));
+  const plot =
+    options?.plot ??
+    vi.fn((..._args: unknown[]) => {
+      const el = document.createElement("div");
+      el.setAttribute("data-plot", "true");
+      return el;
+    });
+
+  const passthrough =
+    (name: string) =>
+    (...args: unknown[]) => ({ __directive: name, args });
+
+  return {
+    from: vi.fn(() => ({ __source: true })),
+    barY: vi.fn(() => ({ __mark: "barY" })),
+    barX: vi.fn(() => ({ __mark: "barX" })),
+    lineY: vi.fn(() => ({ __mark: "lineY" })),
+    areaY: vi.fn(() => ({ __mark: "areaY" })),
+    dot: vi.fn(() => ({ __mark: "dot" })),
+    hexbin: vi.fn(() => ({ __mark: "hexbin" })),
+    heatmap: vi.fn(() => ({ __mark: "heatmap" })),
+    raster: vi.fn(() => ({ __mark: "raster" })),
+    count: vi.fn(() => ({ __agg: "count" })),
+    sum: vi.fn((col: string) => ({ __agg: "sum", col })),
+    avg: vi.fn((col: string) => ({ __agg: "avg", col })),
+    width: passthrough("width"),
+    height: passthrough("height"),
+    marginRight: passthrough("marginRight"),
+    marginTop: passthrough("marginTop"),
+    margin: passthrough("margin"),
+    axis: passthrough("axis"),
+    yTickFormat: passthrough("yTickFormat"),
+    yGrid: passthrough("yGrid"),
+    xTickFormat: passthrough("xTickFormat"),
+    xGrid: passthrough("xGrid"),
+    xLabel: passthrough("xLabel"),
+    yLabel: passthrough("yLabel"),
+    colorLabel: passthrough("colorLabel"),
+    xScale: passthrough("xScale"),
+    yScale: passthrough("yScale"),
+    colorRange: vi.fn((colors: string[]) => ({
+      __directive: "colorRange",
+      colors,
+    })),
+    colorDomain,
+    plot,
+    sql: vi.fn(),
+    context: {
+      coordinator: { query },
+    },
+  };
+}
+
+/** Ensure getChartColors() returns non-empty palette in jsdom. */
+function setChartColorCssVars() {
+  document.documentElement.style.setProperty("--chart-1", "#e97838");
+  document.documentElement.style.setProperty("--chart-2", "#3b82f6");
+  document.documentElement.style.setProperty("--chart-3", "#22c55e");
+  document.documentElement.style.setProperty("--chart-4", "#a855f7");
+  document.documentElement.style.setProperty("--chart-5", "#ef4444");
+  document.documentElement.style.setProperty("--radius", "0.5rem");
+}
+
+function clearChartColorCssVars() {
+  for (const prop of [
+    "--chart-1",
+    "--chart-2",
+    "--chart-3",
+    "--chart-4",
+    "--chart-5",
+    "--radius",
+  ]) {
+    document.documentElement.style.removeProperty(prop);
+  }
+}
+
+// ============================================================================
+// isExpressionBoundColor
+// ============================================================================
+
+describe("isExpressionBoundColor", () => {
+  it("returns false for plain column names", () => {
+    expect(isExpressionBoundColor("category")).toBe(false);
+    expect(isExpressionBoundColor("order status")).toBe(false);
+  });
+
+  it("returns true for aggregation expressions", () => {
+    expect(isExpressionBoundColor("sum(amount)")).toBe(true);
+    expect(isExpressionBoundColor("avg(price)")).toBe(true);
+    expect(isExpressionBoundColor("count(id)")).toBe(true);
+    expect(isExpressionBoundColor("count_distinct(user_id)")).toBe(true);
+  });
+});
+
+// ============================================================================
+// setupColorDomain
+// ============================================================================
 
 describe("setupColorDomain", () => {
-  it("quotes color-column and table identifiers in its distinct-values query", () => {
+  it("quotes color-column and table identifiers in its distinct-values query", async () => {
     const query = vi.fn(() => Promise.resolve([]));
-    const api = {
-      context: {
-        coordinator: { query },
-      },
-    };
+    const api = createMockApi({ query });
 
-    setupColorDomain(api, 'order "status"', 'sales order"archive');
+    await setupColorDomain(api, 'order "status"', 'sales order"archive');
 
     expect(query).toHaveBeenCalledWith(
       'SELECT DISTINCT "order ""status""" as val FROM "sales order""archive" ORDER BY "order ""status"""',
       { type: "json" },
     );
+  });
+
+  it("pins schema-qualified tableName as a single quoted identifier (not split)", async () => {
+    // Latent divergence vs api.from(): domain query quotes the whole string as
+    // one identifier. This test pins that current behavior.
+    const query = vi.fn(() => Promise.resolve([]));
+    const api = createMockApi({ query });
+
+    await setupColorDomain(api, "region", "analytics.sales");
+
+    expect(query).toHaveBeenCalledWith(
+      'SELECT DISTINCT "region" as val FROM "analytics.sales" ORDER BY "region"',
+      { type: "json" },
+    );
+  });
+
+  it("returns a colorDomain directive for a plain column with non-empty domain", async () => {
+    const colorDomain = vi.fn((domain: string[]) => ({
+      __directive: "colorDomain",
+      domain,
+    }));
+    const query = vi.fn(() =>
+      Promise.resolve([{ val: "east" }, { val: "west" }]),
+    );
+    const api = createMockApi({ query, colorDomain });
+
+    const directive = await setupColorDomain(api, "region", "sales");
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(colorDomain).toHaveBeenCalledWith(["east", "west"]);
+    expect(directive).toEqual({
+      __directive: "colorDomain",
+      domain: ["east", "west"],
+    });
+  });
+
+  it("skips the domain query for metric/expression-bound color (no query, no throw)", async () => {
+    const query = vi.fn(() => Promise.resolve([]));
+    const colorDomain = vi.fn();
+    const api = createMockApi({ query, colorDomain });
+
+    const directive = await setupColorDomain(api, "sum(amount)", "sales");
+
+    expect(query).not.toHaveBeenCalled();
+    expect(colorDomain).not.toHaveBeenCalled();
+    expect(directive).toBeUndefined();
+  });
+
+  it("logs a warning and returns undefined when the domain query fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const query = vi.fn(() => Promise.reject(new Error("duckdb boom")));
+    const colorDomain = vi.fn();
+    const api = createMockApi({ query, colorDomain });
+
+    const directive = await setupColorDomain(api, "region", "sales");
+
+    expect(directive).toBeUndefined();
+    expect(colorDomain).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "[VgplotRenderer] Could not set color domain:",
+      expect.any(Error),
+    );
+
+    warn.mockRestore();
+  });
+});
+
+// ============================================================================
+// createVgplotRenderer — color domain in plot options
+// ============================================================================
+
+describe("createVgplotRenderer color domain", () => {
+  beforeEach(() => {
+    setChartColorCssVars();
+  });
+
+  afterEach(() => {
+    clearChartColorCssVars();
+    vi.restoreAllMocks();
+  });
+
+  it("includes the colorDomain directive in options passed to api.plot for a plain color column", async () => {
+    const colorDomainDirective = {
+      __directive: "colorDomain",
+      domain: ["A", "B"],
+    };
+    const colorDomain = vi.fn(() => colorDomainDirective);
+    const plot = vi.fn((..._args: unknown[]) => {
+      const el = document.createElement("div");
+      el.setAttribute("data-plot", "true");
+      return el;
+    });
+    const query = vi.fn(() => Promise.resolve([{ val: "A" }, { val: "B" }]));
+    const api = createMockApi({ query, colorDomain, plot });
+
+    const renderer = createVgplotRenderer(api as never);
+    const container = document.createElement("div");
+
+    const cleanup = renderer.render(container, "barY", {
+      tableName: "sales",
+      encoding: { x: "category", y: "sum(value)", color: "region" },
+    });
+
+    await vi.waitFor(() => {
+      expect(plot).toHaveBeenCalled();
+    });
+
+    const plotArgs = plot.mock.calls[0] as unknown[];
+    expect(plotArgs).toContain(colorDomainDirective);
+    expect(colorDomain).toHaveBeenCalledWith(["A", "B"]);
+    expect(query).toHaveBeenCalledOnce();
+
+    // colorRange sibling still present
+    expect(
+      plotArgs.some(
+        (arg) =>
+          typeof arg === "object" &&
+          arg !== null &&
+          (arg as { __directive?: string }).__directive === "colorRange",
+      ),
+    ).toBe(true);
+
+    cleanup();
+  });
+
+  it("does not issue a domain query when color is expression-bound; chart still plots", async () => {
+    const plot = vi.fn((..._args: unknown[]) => {
+      const el = document.createElement("div");
+      el.setAttribute("data-plot", "true");
+      return el;
+    });
+    const query = vi.fn(() => Promise.resolve([]));
+    const colorDomain = vi.fn();
+    const api = createMockApi({ query, colorDomain, plot });
+
+    const renderer = createVgplotRenderer(api as never);
+    const container = document.createElement("div");
+
+    const cleanup = renderer.render(container, "barY", {
+      tableName: "sales",
+      encoding: { x: "category", y: "value", color: "sum(amount)" },
+    });
+
+    // Sync path for expression-bound color — plot is immediate
+    expect(plot).toHaveBeenCalledOnce();
+    expect(query).not.toHaveBeenCalled();
+    expect(colorDomain).not.toHaveBeenCalled();
+
+    const plotArgs = plot.mock.calls[0] as unknown[];
+    expect(
+      plotArgs.some(
+        (arg) =>
+          typeof arg === "object" &&
+          arg !== null &&
+          (arg as { __directive?: string }).__directive === "colorDomain",
+      ),
+    ).toBe(false);
+
+    cleanup();
+  });
+
+  it("still plots and warns when the domain query fails on the plain-column path", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const plot = vi.fn((..._args: unknown[]) => {
+      const el = document.createElement("div");
+      el.setAttribute("data-plot", "true");
+      return el;
+    });
+    const query = vi.fn(() => Promise.reject(new Error("query failed")));
+    const colorDomain = vi.fn();
+    const api = createMockApi({ query, colorDomain, plot });
+
+    const renderer = createVgplotRenderer(api as never);
+    const container = document.createElement("div");
+
+    const cleanup = renderer.render(container, "barY", {
+      tableName: "sales",
+      encoding: { x: "category", y: "sum(value)", color: "region" },
+    });
+
+    await vi.waitFor(() => {
+      expect(plot).toHaveBeenCalled();
+    });
+
+    expect(colorDomain).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "[VgplotRenderer] Could not set color domain:",
+      expect.any(Error),
+    );
+    // Chart still mounted
+    expect(container.querySelector("[data-plot]")).not.toBeNull();
+
+    cleanup();
+    warn.mockRestore();
   });
 });

--- a/packages/visualization/src/renderers/vgplot-renderer.test.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.test.ts
@@ -209,6 +209,24 @@ describe("setupColorDomain", () => {
     expect(colorDomain).toHaveBeenCalledWith([1, 2]);
   });
 
+  it("skips the domain when a bigint value cannot be narrowed without loss", async () => {
+    const colorDomain = vi.fn((domain: unknown[]) => ({
+      __directive: "colorDomain",
+      domain,
+    }));
+    // Two distinct ids that both narrow to 2 ** 53 — an explicit domain built
+    // from them would map two categories onto one colour.
+    const query = vi.fn(() =>
+      Promise.resolve([{ val: 9007199254740993n }, { val: 9007199254740995n }]),
+    );
+    const api = createMockApi({ query, colorDomain });
+
+    const directive = await setupColorDomain(api, "tier", "sales");
+
+    expect(colorDomain).not.toHaveBeenCalled();
+    expect(directive).toBeUndefined();
+  });
+
   it("skips the domain query for metric/expression-bound color (no query, no throw)", async () => {
     const query = vi.fn(() => Promise.resolve([]));
     const colorDomain = vi.fn();

--- a/packages/visualization/src/renderers/vgplot-renderer.test.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.test.ts
@@ -73,6 +73,36 @@ function createMockApi(options?: {
   };
 }
 
+/**
+ * jsdom has no canvas, and `colorToHex` uses one to normalize CSS colors —
+ * without a stub every render logs "Not implemented: getContext" and the
+ * palette silently collapses to the gray fallback. Returns the hex the test
+ * already set, so `getChartColors()` yields a real multi-color palette.
+ */
+function stubCanvasColorParsing() {
+  const parse = (color: string) => {
+    const hex = color.replace("#", "");
+    return [0, 2, 4].map((i) => Number.parseInt(hex.slice(i, i + 2), 16));
+  };
+
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    () =>
+      ({
+        set fillStyle(value: string) {
+          this._fill = value;
+        },
+        get fillStyle(): string {
+          return (this._fill as string) ?? "#000000";
+        },
+        fillRect: () => {},
+        getImageData() {
+          const [r, g, b] = parse((this.fillStyle as string) || "#6b7280");
+          return { data: [r, g, b, 255] };
+        },
+      }) as unknown as CanvasRenderingContext2D,
+  );
+}
+
 /** Ensure getChartColors() returns non-empty palette in jsdom. */
 function setChartColorCssVars() {
   document.documentElement.style.setProperty("--chart-1", "#e97838");
@@ -165,6 +195,20 @@ describe("setupColorDomain", () => {
     });
   });
 
+  it("preserves the value type of the domain (numeric columns stay numeric)", async () => {
+    const colorDomain = vi.fn((domain: unknown[]) => ({
+      __directive: "colorDomain",
+      domain,
+    }));
+    // DuckDB returns integers as BigInt over the JSON path.
+    const query = vi.fn(() => Promise.resolve([{ val: 1n }, { val: 2n }]));
+    const api = createMockApi({ query, colorDomain });
+
+    await setupColorDomain(api, "tier", "sales");
+
+    expect(colorDomain).toHaveBeenCalledWith([1, 2]);
+  });
+
   it("skips the domain query for metric/expression-bound color (no query, no throw)", async () => {
     const query = vi.fn(() => Promise.resolve([]));
     const colorDomain = vi.fn();
@@ -202,6 +246,7 @@ describe("setupColorDomain", () => {
 
 describe("createVgplotRenderer color domain", () => {
   beforeEach(() => {
+    stubCanvasColorParsing();
     setChartColorCssVars();
   });
 

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -61,7 +61,7 @@ interface VgplotAPIExtended extends VgplotAPI {
    * it returns a plot directive that must be passed into `api.plot(...directives)`
    * for the domain to take effect. It does not mutate anything by itself.
    */
-  colorDomain?: (domain: string[]) => unknown;
+  colorDomain?: (domain: unknown[]) => unknown;
 }
 
 // ============================================================================
@@ -504,7 +504,14 @@ export async function setupColorDomain(
 
     if (!Array.isArray(result)) return undefined;
 
-    const domain = result.map((row) => String((row as { val: unknown }).val));
+    // Keep the value's own type: the plot's color channel carries raw column
+    // values, so a string domain would not match a numeric color column and the
+    // palette mapping would silently fall through. BigInt (DuckDB's integer
+    // JSON representation) is narrowed to number for the same reason.
+    const domain = result.map((row) => {
+      const value = (row as { val: unknown }).val;
+      return typeof value === "bigint" ? Number(value) : value;
+    });
 
     if (domain.length === 0) return undefined;
 

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -57,11 +57,11 @@ interface VgplotAPIExtended extends VgplotAPI {
     };
   };
   /**
-   * vgplot's `colorDomain` is a directive factory: it returns `(plot) => void`
-   * rather than applying anything itself. The caller must invoke the returned
-   * closure against a plot for the domain to take effect.
+   * vgplot's `colorDomain` is a directive factory — same shape as `colorRange`:
+   * it returns a plot directive that must be passed into `api.plot(...directives)`
+   * for the domain to take effect. It does not mutate anything by itself.
    */
-  colorDomain?: (domain: string[]) => (plot: unknown) => void;
+  colorDomain?: (domain: string[]) => unknown;
 }
 
 // ============================================================================
@@ -449,39 +449,71 @@ function buildAxisOptions(
 }
 
 /**
- * Query the color domain for stacked bar charts (async).
- *
- * Queries distinct values for the color column and calls `api.colorDomain(domain)`,
- * but the returned directive closure is discarded here — the plot is already built
- * and mounted (see call site) by the time this async query resolves, so the sorted
- * domain does not currently affect rendered colors. Making it apply requires
- * restructuring render order and is tracked as separate follow-up work, not this fix.
+ * True when the color channel is bound to a SQL aggregation/expression
+ * (e.g. `sum(amount)`) rather than a plain column name. Domain queries quote
+ * the value as one identifier, which DuckDB rejects for expressions.
  */
-export function setupColorDomain(
+export function isExpressionBoundColor(color: string): boolean {
+  return (
+    COUNT_DISTINCT_PATTERN.test(color) ||
+    DATE_TRUNC_PATTERN.test(color) ||
+    CATEGORICAL_DATE_PATTERN.test(color) ||
+    SQL_FUNCTION_PATTERN.test(color)
+  );
+}
+
+/**
+ * Resolve a color-domain plot directive for stacked bar charts.
+ *
+ * Queries distinct values for a plain color column and returns the directive
+ * produced by `api.colorDomain(domain)`. Callers must push the result into the
+ * options passed to `api.plot(...)` — the factory alone does not apply the domain.
+ *
+ * Metric/expression-bound color channels skip the query (returns undefined;
+ * colors stay unordered). Query failures are logged and return undefined so
+ * the chart still renders without a domain.
+ *
+ * Identifier quoting: both the color column and tableName are passed through
+ * `quoteIdentifier` as single identifiers. That matches plain table names, but
+ * diverges from `api.from(tableName)` for schema-qualified names (e.g.
+ * `schema.table`): the domain query treats the whole string as one identifier
+ * (`"schema.table"`), while Mosaic's `from()` splits schema and table
+ * structurally. Pin the single-identifier behavior until a coordinated
+ * redesign; do not "fix" one side without the other.
+ */
+export async function setupColorDomain(
   api: VgplotAPIExtended,
   colorColumn: string,
   tableName: string,
-): void {
-  const coordinator = api.context?.coordinator;
-  if (!coordinator?.query) return;
+): Promise<unknown | undefined> {
+  // Aggregation/expression-bound color: skip domain query entirely.
+  if (isExpressionBoundColor(colorColumn)) {
+    return undefined;
+  }
 
-  coordinator
-    .query(
+  const coordinator = api.context?.coordinator;
+  if (!coordinator?.query || !api.colorDomain) return undefined;
+
+  try {
+    // Single-identifier quoting for tableName (see function doc): schema-qualified
+    // names are quoted as one identifier, not split into schema.table.
+    const result = await coordinator.query(
       `SELECT DISTINCT ${quoteIdentifier(colorColumn)} as val FROM ${quoteIdentifier(tableName)} ORDER BY ${quoteIdentifier(colorColumn)}`,
       { type: "json" },
-    )
-    .then((result) => {
-      if (!Array.isArray(result)) return;
+    );
 
-      const domain = result.map((row) => String((row as { val: unknown }).val));
+    if (!Array.isArray(result)) return undefined;
 
-      if (domain.length > 0 && api.colorDomain) {
-        api.colorDomain(domain);
-      }
-    })
-    .catch((e: unknown) => {
-      console.warn("[VgplotRenderer] Could not set color domain:", e);
-    });
+    const domain = result.map((row) => String((row as { val: unknown }).val));
+
+    if (domain.length === 0) return undefined;
+
+    // Return the directive — caller must pass it to api.plot(...).
+    return api.colorDomain(domain);
+  } catch (e: unknown) {
+    console.warn("[VgplotRenderer] Could not set color domain:", e);
+    return undefined;
+  }
 }
 
 // ============================================================================
@@ -711,6 +743,34 @@ export function createVgplotRenderer(api: VgplotAPI): ChartRenderer {
         };
       }
 
+      let cancelled = false;
+
+      const showRenderError = (error: unknown) => {
+        console.error("[VgplotRenderer] Error rendering chart:", error);
+
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        container.replaceChildren();
+        const errDiv = document.createElement("div");
+        errDiv.style.cssText =
+          "color: red; padding: 16px; text-align: center; font-size: 12px;";
+        errDiv.textContent = `Failed to render chart: ${message}`;
+        container.appendChild(errDiv);
+      };
+
+      const mountPlot = (plotOptions: unknown[]) => {
+        if (cancelled) return;
+
+        // Theme background
+        if (config.theme?.backgroundColor) {
+          container.style.backgroundColor = config.theme.backgroundColor;
+        }
+
+        // Create and mount the plot
+        const plot = api.plot(...plotOptions);
+        container.appendChild(plot);
+      };
+
       try {
         // Build plot options
         const mark = buildMark(api, type, config.tableName, config.encoding);
@@ -727,42 +787,44 @@ export function createVgplotRenderer(api: VgplotAPI): ChartRenderer {
           plotOptions.push(api.colorRange(chartColors));
         }
 
-        // Theme background
-        if (config.theme?.backgroundColor) {
-          container.style.backgroundColor = config.theme.backgroundColor;
-        }
-
-        // Create and mount the plot
-        const plot = api.plot(...plotOptions);
-        container.appendChild(plot);
-
-        // Set up color domain for stacked bar charts
-        if (
+        // Color domain for stacked bar charts: resolve BEFORE api.plot so the
+        // directive is included in plot options (mirrors colorRange above).
+        const colorColumn = config.encoding?.color;
+        const needsColorDomain =
           type === "barY" &&
-          config.encoding?.color &&
-          chartColors.length > 0
-        ) {
-          setupColorDomain(
-            extendedApi,
-            config.encoding.color,
-            config.tableName,
-          );
+          !!colorColumn &&
+          chartColors.length > 0 &&
+          !isExpressionBoundColor(colorColumn);
+
+        if (needsColorDomain && colorColumn) {
+          // Async path: await DISTINCT domain query, then mount with directive.
+          void (async () => {
+            try {
+              const colorDomainDirective = await setupColorDomain(
+                extendedApi,
+                colorColumn,
+                config.tableName,
+              );
+              if (cancelled) return;
+              if (colorDomainDirective !== undefined) {
+                plotOptions.push(colorDomainDirective);
+              }
+              mountPlot(plotOptions);
+            } catch (error) {
+              if (!cancelled) showRenderError(error);
+            }
+          })();
+        } else {
+          // Sync path: no domain query needed (or expression-bound color).
+          mountPlot(plotOptions);
         }
 
         return () => {
+          cancelled = true;
           container.innerHTML = "";
         };
       } catch (error) {
-        console.error("[VgplotRenderer] Error rendering chart:", error);
-
-        const message =
-          error instanceof Error ? error.message : "Unknown error";
-        container.replaceChildren();
-        const errDiv = document.createElement("div");
-        errDiv.style.cssText =
-          "color: red; padding: 16px; text-align: center; font-size: 12px;";
-        errDiv.textContent = `Failed to render chart: ${message}`;
-        container.appendChild(errDiv);
+        showRenderError(error);
 
         return () => {
           container.replaceChildren();

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -508,10 +508,22 @@ export async function setupColorDomain(
     // values, so a string domain would not match a numeric color column and the
     // palette mapping would silently fall through. BigInt (DuckDB's integer
     // JSON representation) is narrowed to number for the same reason.
-    const domain = result.map((row) => {
+    //
+    // Past Number.MAX_SAFE_INTEGER that narrowing is lossy, and distinct
+    // categories can collapse onto one another — an explicit domain that is
+    // silently wrong. Bail out instead and let vgplot pick its own palette: a
+    // missing ordering is recoverable, a wrong colour-to-value mapping is not.
+    const domain: unknown[] = [];
+    for (const row of result) {
       const value = (row as { val: unknown }).val;
-      return typeof value === "bigint" ? Number(value) : value;
-    });
+      if (typeof value !== "bigint") {
+        domain.push(value);
+        continue;
+      }
+      const narrowed = Number(value);
+      if (!Number.isSafeInteger(narrowed)) return undefined;
+      domain.push(narrowed);
+    }
 
     if (domain.length === 0) return undefined;
 


### PR DESCRIPTION
Colour-domain ordering for stacked bar charts never took effect. `setupColorDomain` called `api.colorDomain(domain)` and threw the result away — in Mosaic/vgplot that call is a *directive factory*, so the returned value has to be spread into `api.plot(...)`. The chart mounted before the domain query resolved, and the palette fell back to vgplot's own encounter-order mapping.

## Changes

- `setupColorDomain` is now async and **returns** the `colorDomain` directive instead of discarding it; the render path defers mounting behind a `mountPlot` closure so the directive is in `plotOptions` before `api.plot()` runs.
- The async path carries a `cancelled` flag that guards both the post-await mount and the error path, so unmounting mid-query can't append to a torn-down container.
- New exported `isExpressionBoundColor` short-circuits the domain query when the colour channel is bound to a metric/SQL expression — no query, no crash, plot mounts synchronously as before.
- The domain preserves the column's own value type. Coercing to `String` left a numeric colour column with a domain that never matched its channel values, so the palette silently fell through; BigInt (DuckDB's integer JSON form) is narrowed to `number`.
- Renderer tests stub canvas colour parsing — jsdom has no canvas, so every render logged `Not implemented: getContext` and the palette collapsed to the grey fallback while the tests still passed.

## Screenshots

**Visual capture was not possible in this environment — flagged, not skipped.** Chromium image capture is broken on this machine: `agent-browser screenshot`, raw CDP `Page.captureScreenshot` (both `fromSurface` modes, headless *and* headed), and `Page.startScreencast` all hang. Verified against a control — a trivial `data:text/html,<h1>hello</h1>` page fails identically, so this is the browser install, not the app. `agent-browser pdf` returns but drops the plot from the output.

In place of an image, the colour mapping was read directly out of the rendered DOM (bar geometry via `getBBox()`, fill via computed style) on a 3×3 category/region dataset:

| region | fill |
| --- | --- |
| `alpha` | `#1447e6` |
| `mu` | `#fe9a00` |
| `zeta` | `#00bc7d` |

— stable across all three x groups, i.e. the sorted domain is what drives the palette. Before the fix that mapping is whatever order the data happens to arrive in.

## Verification

Runtime QA through the real UI (upload CSV → fields `category`/`region` → `Count` metric → save chart → visualization page → Encodings: X = `category`, Color = `region`), web + server headless per `AGENTS.md`:

- **Plain column bound to colour** — the DOM readout above. Temporary instrumentation confirmed the mechanism: `mounting with domain directive: true optionsCount: 12` fired on all six renders with zero domain-query failures. All instrumentation removed.
- **Metric-bound colour** (`Sum of amount`) — renders cleanly, no domain query issued, no crash.
- `bun run check` — PASS ×4 (re-run after rebase onto `origin/main`). `bun run format:check` clean. Renderer unit tests 11/11, no jsdom canvas noise.
- Second reviewer (Codex) raised one medium (string-coerced numeric domain) and one low (jsdom canvas noise); both are fixed in this branch rather than dismissed.

Tracked internally as TASK-777
