### PR TITLE
fix(app): ignore key auto-repeat on sensitivity confirmation badge

### DIFF
--- a/packages/app/src/components/data-sources/SensitivityBadge.test.tsx
+++ b/packages/app/src/components/data-sources/SensitivityBadge.test.tsx
@@ -1,0 +1,33 @@
+import type { Field } from "@dashframe/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SensitivityBadge } from "./SensitivityBadge";
+
+const field = {
+  id: "field-1",
+  name: "Email",
+  tableId: "table-1",
+  type: "string",
+} as unknown as Field;
+
+describe("SensitivityBadge", () => {
+  it("ignores repeated confirmation keys while handling the initial keydown", () => {
+    const onConfirmSuggestion = vi.fn();
+
+    render(
+      <SensitivityBadge
+        field={field}
+        suggestedReasons={["Contains email addresses"]}
+        onConfirmSuggestion={onConfirmSuggestion}
+      />,
+    );
+
+    const badge = screen.getByRole("button", { name: "Likely sensitive" });
+    fireEvent.keyDown(badge, { key: "Enter", repeat: true });
+    expect(onConfirmSuggestion).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(badge, { key: "Enter" });
+    expect(onConfirmSuggestion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/components/data-sources/SensitivityBadge.test.tsx
+++ b/packages/app/src/components/data-sources/SensitivityBadge.test.tsx
@@ -12,22 +12,29 @@ const field = {
 } as unknown as Field;
 
 describe("SensitivityBadge", () => {
-  it("ignores repeated confirmation keys while handling the initial keydown", () => {
-    const onConfirmSuggestion = vi.fn();
+  it.each(["Enter", " "])(
+    "confirms once on %j and ignores auto-repeat",
+    (key) => {
+      const onConfirmSuggestion = vi.fn();
 
-    render(
-      <SensitivityBadge
-        field={field}
-        suggestedReasons={["Contains email addresses"]}
-        onConfirmSuggestion={onConfirmSuggestion}
-      />,
-    );
+      render(
+        <SensitivityBadge
+          field={field}
+          suggestedReasons={["Contains email addresses"]}
+          onConfirmSuggestion={onConfirmSuggestion}
+        />,
+      );
 
-    const badge = screen.getByRole("button", { name: "Likely sensitive" });
-    fireEvent.keyDown(badge, { key: "Enter", repeat: true });
-    expect(onConfirmSuggestion).not.toHaveBeenCalled();
+      const badge = screen.getByRole("button", { name: "Likely sensitive" });
 
-    fireEvent.keyDown(badge, { key: "Enter" });
-    expect(onConfirmSuggestion).toHaveBeenCalledTimes(1);
-  });
+      fireEvent.keyDown(badge, { key });
+      expect(onConfirmSuggestion).toHaveBeenCalledTimes(1);
+
+      // Holding the key must not confirm again, but the default action stays
+      // suppressed so a held Space cannot scroll the page.
+      const repeated = fireEvent.keyDown(badge, { key, repeat: true });
+      expect(onConfirmSuggestion).toHaveBeenCalledTimes(1);
+      expect(repeated).toBe(false);
+    },
+  );
 });

--- a/packages/app/src/components/data-sources/SensitivityBadge.tsx
+++ b/packages/app/src/components/data-sources/SensitivityBadge.tsx
@@ -61,6 +61,8 @@ export function SensitivityBadge({
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
+            // Ignore auto-repeat so holding Enter/Space doesn't confirm repeatedly.
+            if (e.repeat) return;
             onConfirmSuggestion();
           }
         }}


### PR DESCRIPTION
## Summary

Holding Enter or Space on the "Likely sensitive" badge fired `onConfirmSuggestion` once per key auto-repeat. The badge's keydown handler now ignores repeated events (`e.repeat`), using the same guard shape as `useAssistantHotkey`. `preventDefault` still runs for repeats so a held Space doesn't scroll the page — matching native button semantics; only the action is suppressed.

New `SensitivityBadge.test.tsx` asserts a repeat keydown does not confirm while an initial keydown does.

## Verification

- `bun run check` — all four arms PASS (85/85 turbo tasks).
- Independent second review of the diff: no findings.

UI change is behavioral only (keyboard event handling) — no visual state changes; no screenshot applicable.

Tracked internally as TASK-768