### PR TITLE
fix(app): preserve markdown widget draft across external content updates

### DIFF
--- a/packages/app/src/components/dashboards/MarkdownWidget.test.tsx
+++ b/packages/app/src/components/dashboards/MarkdownWidget.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MarkdownWidget } from "./MarkdownWidget";
+
+describe("MarkdownWidget", () => {
+  it("preserves an in-progress draft when content changes externally", () => {
+    const { rerender } = render(
+      <MarkdownWidget
+        content="Initial content"
+        isEditing
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const editor = screen.getByPlaceholderText("Enter markdown...");
+    fireEvent.change(editor, { target: { value: "My draft" } });
+
+    rerender(
+      <MarkdownWidget
+        content="External update"
+        isEditing
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(editor).toHaveProperty("value", "My draft");
+  });
+
+  it("syncs external content changes while not editing", () => {
+    const { rerender } = render(
+      <MarkdownWidget
+        content="Initial content"
+        isEditing={false}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Initial content")).toBeDefined();
+
+    rerender(
+      <MarkdownWidget
+        content="External update"
+        isEditing={false}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("External update")).toBeDefined();
+
+    rerender(
+      <MarkdownWidget
+        content="External update"
+        isEditing
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Enter markdown...")).toHaveProperty(
+      "value",
+      "External update",
+    );
+  });
+
+  it("discards an abandoned draft when edit mode exits", () => {
+    const { rerender } = render(
+      <MarkdownWidget
+        content="Initial content"
+        isEditing
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Enter markdown..."), {
+      target: { value: "Abandoned draft" },
+    });
+
+    // External update lands mid-edit, then the parent leaves edit mode without
+    // saving: the buffer must resync to the latest content, not resurrect the
+    // draft the next time the editor opens.
+    rerender(
+      <MarkdownWidget
+        content="External update"
+        isEditing
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    rerender(
+      <MarkdownWidget
+        content="External update"
+        isEditing={false}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    rerender(
+      <MarkdownWidget
+        content="External update"
+        isEditing
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Enter markdown...")).toHaveProperty(
+      "value",
+      "External update",
+    );
+  });
+
+  it("saves the draft and resets it when cancelled", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <MarkdownWidget
+        content="Initial content"
+        isEditing
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+
+    const editor = screen.getByPlaceholderText("Enter markdown...");
+    fireEvent.change(editor, { target: { value: "Saved draft" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith("Saved draft");
+
+    fireEvent.change(editor, { target: { value: "Discarded draft" } });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(editor).toHaveProperty("value", "Initial content");
+  });
+});

--- a/packages/app/src/components/dashboards/MarkdownWidget.tsx
+++ b/packages/app/src/components/dashboards/MarkdownWidget.tsx
@@ -22,16 +22,21 @@ export function MarkdownWidget({
   isSaving = false,
   className,
 }: MarkdownWidgetProps) {
-  // Edit buffer — initialized from `content` and reset when `content` changes
-  // externally (i.e. saved from another session or undo).
+  // Edit buffer — initialized from `content` and synced with external changes
+  // (i.e. saved from another session or undo) only while not editing.
   const [value, setValue] = useState(content);
   const prevContentRef = useRef(content);
+  const wasEditingRef = useRef(isEditing);
   useEffect(() => {
-    if (prevContentRef.current !== content) {
-      prevContentRef.current = content;
+    if (
+      !isEditing &&
+      (wasEditingRef.current || prevContentRef.current !== content)
+    ) {
       setValue(content);
     }
-  }, [content]);
+    prevContentRef.current = content;
+    wasEditingRef.current = isEditing;
+  }, [content, isEditing]);
 
   if (isEditing) {
     return (


### PR DESCRIPTION
Fixes #285.

The Markdown widget's edit buffer synced from the `content` prop on every change, with no check for whether the user was editing. An external content update arriving mid-edit (a save from another session, an undo) silently replaced the unsaved draft with no warning and no way back.

## Changes

- `MarkdownWidget.tsx` — the sync effect now runs only while **not** editing, so a mid-edit external update leaves the draft alone. A `wasEditingRef` transition resyncs the buffer when edit mode exits, so an abandoned draft is discarded rather than resurfacing the next time the editor opens. `prevContentRef` still advances during editing, so the buffer picks up the latest content on exit rather than a stale value.
- Scope is one guard: no cross-session draft persistence and no conflict-resolution UI.

## Verification

- New `MarkdownWidget.test.tsx` — four cases: draft survives a mid-edit external update; content syncs while idle; an abandoned draft is discarded on exit (external-update-then-exit); save and cancel behave as before.
- The exit-resync case is a real regression test, not a restatement: removing the `wasEditingRef` branch turns that test — and only that test — red.
- `bun run check` — all four arms PASS. `packages/app` suite: 744 tests green.
- Independent second review of the diff; its one finding (the exit-resync path lacked coverage) is what the added case closes.

UI change is behavioral only (edit-buffer state) — no visual change; no screenshot applicable.

Tracked internally as TASK-692