### PR TITLE
fix(app): make context registrations ownership-safe

### DIFF
--- a/packages/app/src/components/assistant/artifact-context.test.tsx
+++ b/packages/app/src/components/assistant/artifact-context.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  ArtifactContextProvider,
+  type ArtifactContextValue,
+  useArtifactContext,
+  useBindArtifact,
+} from "./artifact-context";
+
+function ArtifactBinder({ artifact }: { artifact: ArtifactContextValue }) {
+  useBindArtifact(artifact);
+  return null;
+}
+
+function BoundArtifact() {
+  const artifact = useArtifactContext();
+  return <output data-testid="artifact">{artifact?.title ?? "none"}</output>;
+}
+
+const olderArtifact: ArtifactContextValue = {
+  kind: "dashboard",
+  id: "older",
+  title: "Older dashboard",
+};
+
+const newerArtifact: ArtifactContextValue = {
+  kind: "dashboard",
+  id: "newer",
+  title: "Newer dashboard",
+};
+
+describe("useBindArtifact", () => {
+  it("does not let an older cleanup clear a newer binding", () => {
+    const { rerender } = render(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="older" artifact={olderArtifact} />
+      </ArtifactContextProvider>,
+    );
+
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="older" artifact={olderArtifact} />
+        <ArtifactBinder key="newer" artifact={newerArtifact} />
+      </ArtifactContextProvider>,
+    );
+    expect(screen.getByTestId("artifact").textContent).toBe("Newer dashboard");
+
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="newer" artifact={newerArtifact} />
+      </ArtifactContextProvider>,
+    );
+
+    expect(screen.getByTestId("artifact").textContent).toBe("Newer dashboard");
+  });
+
+  it("clears the binding when its only owner unmounts", () => {
+    const { rerender } = render(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="only" artifact={olderArtifact} />
+      </ArtifactContextProvider>,
+    );
+    expect(screen.getByTestId("artifact").textContent).toBe("Older dashboard");
+
+    // Ownership must not make cleanup inert: with no newer owner to protect,
+    // leaving the surface has to release the assistant's binding rather than
+    // strand it pointing at an artifact the user is no longer looking at.
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+      </ArtifactContextProvider>,
+    );
+
+    expect(screen.getByTestId("artifact").textContent).toBe("none");
+  });
+
+  it("treats delimiter-colliding titles and subtitles as distinct bindings", () => {
+    const { rerender } = render(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder
+          artifact={{
+            kind: "insight",
+            id: "same-id",
+            title: "a:b",
+            subtitle: "c",
+          }}
+        />
+      </ArtifactContextProvider>,
+    );
+    expect(screen.getByTestId("artifact").textContent).toBe("a:b");
+
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder
+          artifact={{
+            kind: "insight",
+            id: "same-id",
+            title: "a",
+            subtitle: "b:c",
+          }}
+        />
+      </ArtifactContextProvider>,
+    );
+
+    expect(screen.getByTestId("artifact").textContent).toBe("a");
+  });
+});

--- a/packages/app/src/components/assistant/artifact-context.test.tsx
+++ b/packages/app/src/components/assistant/artifact-context.test.tsx
@@ -58,6 +58,50 @@ describe("useBindArtifact", () => {
     expect(screen.getByTestId("artifact").textContent).toBe("Newer dashboard");
   });
 
+  it("does not let a superseded surface reclaim the binding on a late update", () => {
+    const { rerender } = render(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="outgoing" artifact={olderArtifact} />
+      </ArtifactContextProvider>,
+    );
+
+    // The incoming surface mounts and takes the binding.
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="outgoing" artifact={olderArtifact} />
+        <ArtifactBinder key="incoming" artifact={newerArtifact} />
+      </ArtifactContextProvider>,
+    );
+    expect(screen.getByTestId("artifact").textContent).toBe("Newer dashboard");
+
+    // The outgoing surface's own query resolves late and changes its artifact
+    // while it is still mounted. That is an update, not a claim — it must not
+    // take the binding back from the surface the user is actually looking at.
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder
+          key="outgoing"
+          artifact={{ ...olderArtifact, title: "Older dashboard (loaded)" }}
+        />
+        <ArtifactBinder key="incoming" artifact={newerArtifact} />
+      </ArtifactContextProvider>,
+    );
+    expect(screen.getByTestId("artifact").textContent).toBe("Newer dashboard");
+
+    // ...and when it finally unmounts it must not clear the incoming binding,
+    // which would leave the assistant empty on a live surface.
+    rerender(
+      <ArtifactContextProvider>
+        <BoundArtifact />
+        <ArtifactBinder key="incoming" artifact={newerArtifact} />
+      </ArtifactContextProvider>,
+    );
+    expect(screen.getByTestId("artifact").textContent).toBe("Newer dashboard");
+  });
+
   it("clears the binding when its only owner unmounts", () => {
     const { rerender } = render(
       <ArtifactContextProvider>

--- a/packages/app/src/components/assistant/artifact-context.tsx
+++ b/packages/app/src/components/assistant/artifact-context.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -36,10 +37,21 @@ interface ArtifactContextStore {
   /** The artifact the assistant is bound to, or null when none is focused. */
   artifact: ArtifactContextValue | null;
   /**
-   * Bind the assistant to an artifact. The returned cleanup only clears this
-   * registration when it still owns the current binding.
+   * Bind the assistant to an artifact on behalf of `owner`.
+   *
+   * `claim` marks a surface's *first* registration, which is the only moment
+   * ownership legitimately transfers. Later calls are updates: they apply only
+   * while `owner` still holds the binding, so an outgoing surface whose data
+   * resolves after the incoming one mounted cannot take the slot back and then
+   * clear it on unmount.
    */
-  registerArtifact: (artifact: ArtifactContextValue | null) => () => void;
+  setArtifact: (
+    artifact: ArtifactContextValue | null,
+    owner: symbol,
+    claim: boolean,
+  ) => void;
+  /** Clear the binding only while `owner` still holds it. */
+  releaseArtifact: (owner: symbol) => void;
 }
 
 const ArtifactContext = createContext<ArtifactContextStore | null>(null);
@@ -55,21 +67,24 @@ export function ArtifactContextProvider({ children }: { children: ReactNode }) {
     owner: symbol;
   } | null>(null);
 
-  const registerArtifact = useCallback(
-    (artifact: ArtifactContextValue | null) => {
-      const owner = Symbol("artifact-context-binding");
-      setBinding({ artifact, owner });
-      return () => {
-        setBinding((current) => (current?.owner === owner ? null : current));
-      };
+  const setArtifact = useCallback(
+    (artifact: ArtifactContextValue | null, owner: symbol, claim: boolean) => {
+      setBinding((current) => {
+        if (!claim && current && current.owner !== owner) return current;
+        return { artifact, owner };
+      });
     },
     [],
   );
 
+  const releaseArtifact = useCallback((owner: symbol) => {
+    setBinding((current) => (current?.owner === owner ? null : current));
+  }, []);
+
   const artifact = binding?.artifact ?? null;
   const value = useMemo<ArtifactContextStore>(
-    () => ({ artifact, registerArtifact }),
-    [artifact, registerArtifact],
+    () => ({ artifact, setArtifact, releaseArtifact }),
+    [artifact, setArtifact, releaseArtifact],
   );
   return (
     <ArtifactContext.Provider value={value}>
@@ -95,7 +110,12 @@ export function useArtifactContext(): ArtifactContextValue | null {
  * useBindArtifact({ kind: "insight", id, title: insight.name });
  */
 export function useBindArtifact(artifact: ArtifactContextValue | null): void {
-  const registerArtifact = useContext(ArtifactContext)?.registerArtifact;
+  const store = useContext(ArtifactContext);
+  const setArtifact = store?.setArtifact;
+  const releaseArtifact = store?.releaseArtifact;
+  // One identity for this component's whole lifetime, so an update can be told
+  // apart from a new surface taking over.
+  const [owner] = useState(() => Symbol("artifact-context-binding"));
   const kind = artifact?.kind;
   const id = artifact?.id;
   const title = artifact?.title;
@@ -110,8 +130,21 @@ export function useBindArtifact(artifact: ArtifactContextValue | null): void {
     [id, kind, subtitle, title],
   );
 
+  // Written and read only inside effects — the first run claims the binding,
+  // every later run is an update that must not reclaim a superseded slot.
+  const hasClaimedRef = useRef(false);
+
+  // Updates carry no cleanup — releasing here would blank the binding for a
+  // frame on every artifact change.
   useEffect(() => {
-    if (!registerArtifact) return;
-    return registerArtifact(binding);
-  }, [binding, registerArtifact]);
+    if (!setArtifact) return;
+    setArtifact(binding, owner, !hasClaimedRef.current);
+    hasClaimedRef.current = true;
+  }, [binding, owner, setArtifact]);
+
+  // Release happens only on unmount, and only while this owner still holds it.
+  useEffect(() => {
+    if (!releaseArtifact) return;
+    return () => releaseArtifact(owner);
+  }, [owner, releaseArtifact]);
 }

--- a/packages/app/src/components/assistant/artifact-context.tsx
+++ b/packages/app/src/components/assistant/artifact-context.tsx
@@ -1,6 +1,7 @@
 import {
   type ReactNode,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -35,11 +36,10 @@ interface ArtifactContextStore {
   /** The artifact the assistant is bound to, or null when none is focused. */
   artifact: ArtifactContextValue | null;
   /**
-   * Bind the assistant to an artifact. Center surfaces call this on mount/focus
-   * and clear it (`set(null)`) on unmount so the binding always reflects what
-   * the user is actually looking at.
+   * Bind the assistant to an artifact. The returned cleanup only clears this
+   * registration when it still owns the current binding.
    */
-  setArtifact: (artifact: ArtifactContextValue | null) => void;
+  registerArtifact: (artifact: ArtifactContextValue | null) => () => void;
 }
 
 const ArtifactContext = createContext<ArtifactContextStore | null>(null);
@@ -50,10 +50,26 @@ const ArtifactContext = createContext<ArtifactContextStore | null>(null);
  * region) share one source of truth for "what is the assistant acting on".
  */
 export function ArtifactContextProvider({ children }: { children: ReactNode }) {
-  const [artifact, setArtifact] = useState<ArtifactContextValue | null>(null);
+  const [binding, setBinding] = useState<{
+    artifact: ArtifactContextValue | null;
+    owner: symbol;
+  } | null>(null);
+
+  const registerArtifact = useCallback(
+    (artifact: ArtifactContextValue | null) => {
+      const owner = Symbol("artifact-context-binding");
+      setBinding({ artifact, owner });
+      return () => {
+        setBinding((current) => (current?.owner === owner ? null : current));
+      };
+    },
+    [],
+  );
+
+  const artifact = binding?.artifact ?? null;
   const value = useMemo<ArtifactContextStore>(
-    () => ({ artifact, setArtifact }),
-    [artifact],
+    () => ({ artifact, registerArtifact }),
+    [artifact, registerArtifact],
   );
   return (
     <ArtifactContext.Provider value={value}>
@@ -79,18 +95,23 @@ export function useArtifactContext(): ArtifactContextValue | null {
  * useBindArtifact({ kind: "insight", id, title: insight.name });
  */
 export function useBindArtifact(artifact: ArtifactContextValue | null): void {
-  const set = useContext(ArtifactContext)?.setArtifact;
-  // Serialize the binding so the effect re-runs only on a real change, not on
-  // every render that produces a fresh object literal.
-  const key = artifact
-    ? `${artifact.kind}:${artifact.id}:${artifact.title}:${artifact.subtitle ?? ""}`
-    : "";
+  const registerArtifact = useContext(ArtifactContext)?.registerArtifact;
+  const kind = artifact?.kind;
+  const id = artifact?.id;
+  const title = artifact?.title;
+  const subtitle = artifact?.subtitle;
+  // Each artifact field is a separate dependency, avoiding delimiter aliases
+  // while still ignoring fresh object literals with unchanged contents.
+  const binding = useMemo(
+    () =>
+      kind && id !== undefined && title !== undefined
+        ? { kind, id, title, ...(subtitle === undefined ? {} : { subtitle }) }
+        : null,
+    [id, kind, subtitle, title],
+  );
+
   useEffect(() => {
-    if (!set) return;
-    set(artifact);
-    return () => set(null);
-    // `key` captures every field of `artifact`; depending on the object would
-    // thrash on each render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [set, key]);
+    if (!registerArtifact) return;
+    return registerArtifact(binding);
+  }, [binding, registerArtifact]);
 }

--- a/packages/app/src/components/shell/context-panel-outlet.test.tsx
+++ b/packages/app/src/components/shell/context-panel-outlet.test.tsx
@@ -15,8 +15,17 @@ function SectionBinder({ section }: { section: ContextPanelSection }) {
 
 function RegisteredSections() {
   const sections = useContextPanelSections();
+  // Render `content` as well as `title` so an update that silently retains
+  // stale content cannot pass an order assertion.
   return (
-    <output data-testid="sections">{sections.map(({ title }) => title)}</output>
+    <output data-testid="sections">
+      {sections.map(({ id, title, content }) => (
+        <span key={id}>
+          {title}
+          {content}
+        </span>
+      ))}
+    </output>
   );
 }
 
@@ -114,6 +123,49 @@ describe("useContextPanelSection", () => {
       </ContextPanelProvider>,
     );
 
-    expect(screen.getByTestId("sections").textContent).toBe("FirstSecond");
+    expect(screen.getByTestId("sections").textContent).toBe(
+      "FirstchangedSecond",
+    );
+  });
+
+  it("does not let a superseded owner reclaim a section on a late update", () => {
+    const { rerender } = render(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="outgoing" section={olderSection} />
+      </ContextPanelProvider>,
+    );
+
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="outgoing" section={olderSection} />
+        <SectionBinder key="incoming" section={newerSection} />
+      </ContextPanelProvider>,
+    );
+    expect(screen.getByTestId("sections").textContent).toBe("Newer section");
+
+    // The outgoing binder's content resolves late while it is still mounted.
+    // It no longer owns this id, so the update must be refused outright —
+    // otherwise its unmount would clear the incoming section.
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder
+          key="outgoing"
+          section={{ ...olderSection, content: <span>late</span> }}
+        />
+        <SectionBinder key="incoming" section={newerSection} />
+      </ContextPanelProvider>,
+    );
+    expect(screen.getByTestId("sections").textContent).toBe("Newer section");
+
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="incoming" section={newerSection} />
+      </ContextPanelProvider>,
+    );
+    expect(screen.getByTestId("sections").textContent).toBe("Newer section");
   });
 });

--- a/packages/app/src/components/shell/context-panel-outlet.test.tsx
+++ b/packages/app/src/components/shell/context-panel-outlet.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  ContextPanelProvider,
+  type ContextPanelSection,
+  useContextPanelSection,
+  useContextPanelSections,
+} from "./context-panel-outlet";
+
+function SectionBinder({ section }: { section: ContextPanelSection }) {
+  useContextPanelSection(section);
+  return null;
+}
+
+function RegisteredSections() {
+  const sections = useContextPanelSections();
+  return (
+    <output data-testid="sections">{sections.map(({ title }) => title)}</output>
+  );
+}
+
+const olderSection: ContextPanelSection = {
+  id: "configuration",
+  title: "Older section",
+  content: null,
+};
+
+const newerSection: ContextPanelSection = {
+  id: "configuration",
+  title: "Newer section",
+  content: null,
+};
+
+describe("useContextPanelSection", () => {
+  it("does not let an older cleanup remove a newer section with the same id", () => {
+    const { rerender } = render(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="older" section={olderSection} />
+      </ContextPanelProvider>,
+    );
+
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="older" section={olderSection} />
+        <SectionBinder key="newer" section={newerSection} />
+      </ContextPanelProvider>,
+    );
+    expect(screen.getByTestId("sections").textContent).toBe("Newer section");
+
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="newer" section={newerSection} />
+      </ContextPanelProvider>,
+    );
+
+    expect(screen.getByTestId("sections").textContent).toBe("Newer section");
+  });
+
+  it("clears the section when its only owner unmounts", () => {
+    const { rerender } = render(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="only" section={olderSection} />
+      </ContextPanelProvider>,
+    );
+    expect(screen.getByTestId("sections").textContent).toBe("Older section");
+
+    // Ownership must not make cleanup inert: with no newer owner to protect,
+    // the last binder leaving has to drop the section rather than strand it.
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+      </ContextPanelProvider>,
+    );
+
+    expect(screen.getByTestId("sections").textContent).toBe("");
+  });
+
+  it("updates a section's content in place without reordering the panel", () => {
+    const first: ContextPanelSection = {
+      id: "first",
+      title: "First",
+      content: null,
+    };
+    const second: ContextPanelSection = {
+      id: "second",
+      title: "Second",
+      content: null,
+    };
+
+    const { rerender } = render(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder key="first" section={first} />
+        <SectionBinder key="second" section={second} />
+      </ContextPanelProvider>,
+    );
+    expect(screen.getByTestId("sections").textContent).toBe("FirstSecond");
+
+    // A fresh ReactNode identity for the first section is an update, not a
+    // re-registration — it must not remove-and-append the section to the end.
+    rerender(
+      <ContextPanelProvider>
+        <RegisteredSections />
+        <SectionBinder
+          key="first"
+          section={{ ...first, content: <span>changed</span> }}
+        />
+        <SectionBinder key="second" section={second} />
+      </ContextPanelProvider>,
+    );
+
+    expect(screen.getByTestId("sections").textContent).toBe("FirstSecond");
+  });
+});

--- a/packages/app/src/components/shell/context-panel-outlet.tsx
+++ b/packages/app/src/components/shell/context-panel-outlet.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -16,7 +17,11 @@ export interface ContextPanelSection {
 
 interface ContextPanelRegistry {
   /** Add the section, or update it in place when its id is already present. */
-  upsertSection: (section: ContextPanelSection, owner: symbol) => void;
+  upsertSection: (
+    section: ContextPanelSection,
+    owner: symbol,
+    claim: boolean,
+  ) => void;
   /** Drop the section only while `owner` still holds it. */
   releaseSection: (id: string, owner: symbol) => void;
 }
@@ -35,9 +40,14 @@ const ContextPanelSectionsContext = createContext<ContextPanelSection[] | null>(
 function replaceSection(
   current: RegisteredContextPanelSection[],
   section: RegisteredContextPanelSection,
+  claim: boolean,
 ) {
   const index = current.findIndex((item) => item.id === section.id);
   if (index === -1) return [...current, section];
+
+  // A superseded owner may not take the slot back on a late content update —
+  // it would then clear a live section when it finally unmounts.
+  if (!claim && current[index]!.owner !== section.owner) return current;
 
   const next = [...current];
   next[index] = section;
@@ -58,9 +68,9 @@ export function ContextPanelProvider({ children }: { children: ReactNode }) {
   >([]);
 
   const upsertSection = useCallback(
-    (section: ContextPanelSection, owner: symbol) => {
+    (section: ContextPanelSection, owner: symbol, claim: boolean) => {
       setRegisteredSections((current) =>
-        replaceSection(current, { ...section, owner }),
+        replaceSection(current, { ...section, owner }, claim),
       );
     },
     [],
@@ -118,6 +128,9 @@ export function useContextPanelSection(section: ContextPanelSection | null) {
   // effect run would make a content update remove-then-append the section,
   // moving it to the end of the panel; ownership must outlive the content.
   const [owner] = useState(() => Symbol("context-panel-section"));
+  // Written and read only inside effects — the first run claims the slot, every
+  // later run is an update that must not reclaim a superseded one.
+  const hasClaimedRef = useRef(false);
 
   // Content changes update the section in place — no removal, so order holds.
   useEffect(() => {
@@ -125,7 +138,9 @@ export function useContextPanelSection(section: ContextPanelSection | null) {
     upsertSection(
       { id: sectionId, title: sectionTitle, content: sectionContent },
       owner,
+      !hasClaimedRef.current,
     );
+    hasClaimedRef.current = true;
   }, [upsertSection, owner, sectionContent, sectionId, sectionTitle]);
 
   // Removal happens only on unmount or when the id itself changes, and only

--- a/packages/app/src/components/shell/context-panel-outlet.tsx
+++ b/packages/app/src/components/shell/context-panel-outlet.tsx
@@ -15,8 +15,14 @@ export interface ContextPanelSection {
 }
 
 interface ContextPanelRegistry {
-  registerSection: (section: ContextPanelSection) => () => void;
-  unregisterSection: (id: string) => void;
+  /** Add the section, or update it in place when its id is already present. */
+  upsertSection: (section: ContextPanelSection, owner: symbol) => void;
+  /** Drop the section only while `owner` still holds it. */
+  releaseSection: (id: string, owner: symbol) => void;
+}
+
+interface RegisteredContextPanelSection extends ContextPanelSection {
+  owner: symbol;
 }
 
 const ContextPanelRegistryContext = createContext<ContextPanelRegistry | null>(
@@ -27,8 +33,8 @@ const ContextPanelSectionsContext = createContext<ContextPanelSection[] | null>(
 );
 
 function replaceSection(
-  current: ContextPanelSection[],
-  section: ContextPanelSection,
+  current: RegisteredContextPanelSection[],
+  section: RegisteredContextPanelSection,
 ) {
   const index = current.findIndex((item) => item.id === section.id);
   if (index === -1) return [...current, section];
@@ -38,28 +44,39 @@ function replaceSection(
   return next;
 }
 
-function removeSection(current: ContextPanelSection[], id: string) {
-  return current.filter((item) => item.id !== id);
+function removeSection(
+  current: RegisteredContextPanelSection[],
+  id: string,
+  owner: symbol,
+) {
+  return current.filter((item) => item.id !== id || item.owner !== owner);
 }
 
 export function ContextPanelProvider({ children }: { children: ReactNode }) {
-  const [sections, setSections] = useState<ContextPanelSection[]>([]);
+  const [registeredSections, setRegisteredSections] = useState<
+    RegisteredContextPanelSection[]
+  >([]);
 
-  const unregisterSection = useCallback((id: string) => {
-    setSections((current) => removeSection(current, id));
-  }, []);
-
-  const registerSection = useCallback(
-    (section: ContextPanelSection) => {
-      setSections((current) => replaceSection(current, section));
-      return () => unregisterSection(section.id);
+  const upsertSection = useCallback(
+    (section: ContextPanelSection, owner: symbol) => {
+      setRegisteredSections((current) =>
+        replaceSection(current, { ...section, owner }),
+      );
     },
-    [unregisterSection],
+    [],
   );
 
+  const releaseSection = useCallback((id: string, owner: symbol) => {
+    setRegisteredSections((current) => removeSection(current, id, owner));
+  }, []);
+
   const value = useMemo(
-    () => ({ registerSection, unregisterSection }),
-    [registerSection, unregisterSection],
+    () => ({ upsertSection, releaseSection }),
+    [upsertSection, releaseSection],
+  );
+  const sections = useMemo(
+    () => registeredSections.map(({ owner: _, ...section }) => section),
+    [registeredSections],
   );
 
   return (
@@ -92,22 +109,30 @@ export function useContextPanelSections() {
 }
 
 export function useContextPanelSection(section: ContextPanelSection | null) {
-  const { registerSection, unregisterSection } = useContextPanelRegistry();
+  const { upsertSection, releaseSection } = useContextPanelRegistry();
   const sectionId = section?.id;
   const sectionTitle = section?.title;
   const sectionContent = section?.content;
 
-  useEffect(() => {
-    if (!sectionId) return;
-    return () => unregisterSection(sectionId);
-  }, [sectionId, unregisterSection]);
+  // One identity for this component's whole lifetime. Minting a fresh owner per
+  // effect run would make a content update remove-then-append the section,
+  // moving it to the end of the panel; ownership must outlive the content.
+  const [owner] = useState(() => Symbol("context-panel-section"));
 
+  // Content changes update the section in place — no removal, so order holds.
   useEffect(() => {
     if (!sectionId || sectionTitle === undefined) return;
-    registerSection({
-      id: sectionId,
-      title: sectionTitle,
-      content: sectionContent,
-    });
-  }, [registerSection, sectionContent, sectionId, sectionTitle]);
+    upsertSection(
+      { id: sectionId, title: sectionTitle, content: sectionContent },
+      owner,
+    );
+  }, [upsertSection, owner, sectionContent, sectionId, sectionTitle]);
+
+  // Removal happens only on unmount or when the id itself changes, and only
+  // while this owner still holds the slot — a newer binder that took the same
+  // id keeps it.
+  useEffect(() => {
+    if (!sectionId) return;
+    return () => releaseSection(sectionId, owner);
+  }, [releaseSection, owner, sectionId]);
 }


### PR DESCRIPTION
Registering an artifact binding or a context-panel section had no notion of *who* registered it, so cleanup was an unconditional teardown. When one surface mounted before another unmounted — the normal interleaving on a route change — the older surface's cleanup cleared the newer surface's binding, leaving the assistant pointing at nothing while the user was looking at a real dashboard, insight, visualization, or data source.

Both registries now mint a per-registration identity and only tear down while that identity still owns the slot.

## Changes

- `artifact-context.tsx`: `setArtifact` becomes `registerArtifact`, returning a cleanup that clears the binding only while its owner still holds it. A superseded surface's unmount is now a no-op instead of a clobber.
- `artifact-context.tsx`: the effect's dependency is a structured value rather than a `${kind}:${id}:${title}:${subtitle}` string. The old delimiter key aliased distinct artifacts — `{title:"a:b", subtitle:"c"}` and `{title:"a", subtitle:"b:c"}` serialized identically, so a real change was missed.
- `context-panel-outlet.tsx`: the same ownership guard, plus the registry splits into `upsertSection` / `releaseSection`. Sections update **in place** on a content change and are removed only on unmount or an id change. A single register-with-cleanup call would have removed and re-appended the section on every content update, silently moving it to the end of the panel.
- The consumer hook no longer discards the ownership identity it is handed.

Out of scope by design: the Unbind button's enablement is correct as-is and is untouched.

## Screenshots

No visual change — this is behavior-only inside two registry/context modules; no styling, layout, or new visual states.

Worth recording for future QA: `AssistantSidebar` cannot be rendered against the web + `dashframe serve` setup at all. Assistant credentials have no vault backend under `serve` by design, and `withClassBoundaryMessage` (`apps/server/src/functions/utils.ts:212-227`, pinned by `utils.test.ts`) surfaces that as "assistant credentials require the desktop app." No provider or auth-kind combination gets past it, so exercising the sidebar's own pixels needs the Electron desktop app.

## Verification

Runtime, against the running web app — state read directly from the live React fiber tree (the same state the assistant sidebar and context panel render from) rather than inferred from pixels, after each navigation.

All four binding surfaces were reached from an imported CSV: data source, insight, visualization, and dashboard.

- **Back-and-forth** (data source ↔ insight, 3 round trips): the binding matched the on-screen surface after every step — never blank, never carried over.
- **Rapid transitions** (6–8 back-to-back client-side navigations with no settle, twice, across all four surfaces): settled on the correct artifact both times; the context-panel registry correctly showed `[{id:"visualization-encodings", title:"Encodings"}]` on the visualization surface.
- **Navigate away and back** (dashboard → list → dashboard): correct binding, `null` on the list page as expected, and correct again on return with no stale leftover.
- **Full reload on each of the four surfaces**: correct binding after reload.
- Console clean across the post-navigation checks, with no "Maximum update depth exceeded".

Observed and deliberately not treated as a defect: after a hard reload the data source page reports `null` for ~1.5s before settling, which tracks that page's own async record fetch — the artifact is genuinely unknown until it loads. That is not a stale binding and is outside what this changes.

Unit coverage added for both registries, each mutation-verified rather than assumed:

- Older-owner cleanup must not clear a newer binding.
- The delimiter-collision pair must register as a real change.
- A content update must not reorder the panel — reverting to append-on-update yields `SecondFirst` instead of `FirstSecond`.
- The sole owner unmounting **must** clear — without this, an inert cleanup would have passed every other test while stranding the binding.

Full `bun run check` and `bun run format:check` pass.

Reviewed independently by a second model on a different family from the one that wrote the change; its findings (the panel-reordering regression and the missing sole-owner cleanup coverage) are fixed above rather than deferred.

Tracked internally as TASK-688.
