### PR TITLE
fix(ui): only format a VirtualTable cell as a date when the column is one

### DIFF
--- a/packages/app/src/hooks/useInsightPagination.ts
+++ b/packages/app/src/hooks/useInsightPagination.ts
@@ -17,7 +17,11 @@ import type {
   Insight,
   UUID,
 } from "@dashframe/types";
-import type { FetchDataParams, FetchDataResult } from "@dashframe/ui";
+import type {
+  FetchDataParams,
+  FetchDataResult,
+  VirtualTableColumn,
+} from "@dashframe/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
@@ -85,7 +89,7 @@ export function useInsightPagination({
 
   // State
   const [totalCount, setTotalCount] = useState<number>(0);
-  const [columns, setColumns] = useState<{ name: string; type?: string }[]>([]);
+  const [columns, setColumns] = useState<VirtualTableColumn[]>([]);
   const [fieldCount, setFieldCount] = useState<number>(0);
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/packages/ui/src/components/VirtualTable.tsx
+++ b/packages/ui/src/components/VirtualTable.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import type { ColumnType } from "@dashframe/types";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn, Spinner } from "@wystack/ui-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { formatNumeric } from "../lib/format-numeric";
+import { defaultFormatValue } from "../lib/format-virtual-table-value";
 
 // ============================================================================
 // Types
@@ -35,7 +36,7 @@ export interface VirtualTableColumnConfig {
 /** Column definition passed to VirtualTable */
 export interface VirtualTableColumn {
   name: string;
-  type?: string;
+  type?: ColumnType;
 }
 
 /** Parameters for async data fetching */
@@ -82,41 +83,6 @@ export interface VirtualTableProps {
   onCellClick?: (columnName: string, value: unknown, rowIndex: number) => void;
   /** Called when a column header is clicked */
   onHeaderClick?: (columnName: string) => void;
-}
-
-// ============================================================================
-// Utilities
-// ============================================================================
-
-function formatDate(value: unknown): string | null {
-  if (value instanceof Date && !isNaN(value.getTime())) {
-    return value.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  }
-  if (typeof value === "string") {
-    const parsed = Date.parse(value);
-    if (!isNaN(parsed)) {
-      const date = new Date(parsed);
-      return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      });
-    }
-  }
-  return null;
-}
-
-function defaultFormatValue(value: unknown): string {
-  if (value === null || value === undefined) return "—";
-  const dateStr = formatDate(value);
-  if (dateStr) return dateStr;
-  if (typeof value === "number") return formatNumeric(value);
-  if (typeof value === "object") return JSON.stringify(value);
-  return String(value);
 }
 
 // ============================================================================
@@ -199,7 +165,7 @@ export function VirtualTable({
   }, [columnConfigs]);
 
   // Compute effective columns
-  const effectiveColumns = useMemo(() => {
+  const effectiveColumns = useMemo<VirtualTableColumn[]>(() => {
     if (isAsyncMode) {
       return inferredColumns;
     }
@@ -705,8 +671,9 @@ export function VirtualTable({
                   const align = config?.align || "left";
 
                   const rawValue = rowData[col.name];
-                  const formatter = config?.format || defaultFormatValue;
-                  const cellValue = formatter(rawValue);
+                  const cellValue = config?.format
+                    ? config.format(rawValue)
+                    : defaultFormatValue(rawValue, col.type);
                   const isClickable = !!onCellClick;
 
                   return (

--- a/packages/ui/src/lib/format-virtual-table-value.test.ts
+++ b/packages/ui/src/lib/format-virtual-table-value.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { defaultFormatValue } from "./format-virtual-table-value";
+
+// Date-only values must keep their calendar day in a zone behind UTC, so the
+// assertions below are only meaningful with the zone pinned. Restore the
+// original afterwards — this process is shared with the other test files in
+// the worker, and a leaked TZ would silently change their local-time results.
+const originalTz = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "America/Phoenix";
+});
+afterAll(() => {
+  if (originalTz === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTz;
+});
+
+describe("defaultFormatValue", () => {
+  it("keeps a string-typed version value as text", () => {
+    expect(defaultFormatValue("1.5", "string")).toBe("1.5");
+  });
+
+  it("keeps a string-typed year as text", () => {
+    expect(defaultFormatValue("2024", "string")).toBe("2024");
+  });
+
+  it("does not automatically convert ISO-looking strings", () => {
+    expect(defaultFormatValue("2024-03-15", "string")).toBe("2024-03-15");
+    expect(defaultFormatValue("2024-01", "string")).toBe("2024-01");
+  });
+
+  // VirtualTable's async mode infers columns as `{ name }` with no `type`
+  // (see VirtualTable.tsx), so an untyped column is the common production
+  // path — it must never coerce a string into a date either.
+  it("never coerces strings when the column type is absent or unknown", () => {
+    expect(defaultFormatValue("2024-03-15")).toBe("2024-03-15");
+    expect(defaultFormatValue("1.5")).toBe("1.5");
+    expect(defaultFormatValue("2024-03-15", "unknown")).toBe("2024-03-15");
+  });
+
+  it("formats date-only strings from their calendar parts", () => {
+    expect(defaultFormatValue("2024-03-15", "date")).toBe("Mar 15, 2024");
+  });
+
+  it("leaves an impossible calendar date as text rather than rolling it over", () => {
+    expect(defaultFormatValue("2024-02-30", "date")).toBe("2024-02-30");
+  });
+
+  it("renders null and undefined as the empty placeholder", () => {
+    expect(defaultFormatValue(null, "date")).toBe("—");
+    expect(defaultFormatValue(undefined, "string")).toBe("—");
+  });
+
+  it("continues to format Date objects and numbers", () => {
+    expect(defaultFormatValue(new Date(2024, 2, 15), "string")).toBe(
+      "Mar 15, 2024",
+    );
+    expect(defaultFormatValue(1.5, "number")).toBe("1.5");
+  });
+});

--- a/packages/ui/src/lib/format-virtual-table-value.ts
+++ b/packages/ui/src/lib/format-virtual-table-value.ts
@@ -1,0 +1,64 @@
+import type { ColumnType } from "@dashframe/types";
+import { formatNumeric } from "./format-numeric";
+
+function formatCalendarDate(
+  year: number,
+  month: number,
+  day: number,
+): string | null {
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDate(value: unknown, type?: ColumnType): string | null {
+  if (value instanceof Date && !isNaN(value.getTime())) {
+    return value.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  if (type !== "date" || typeof value !== "string") return null;
+
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnly) {
+    return formatCalendarDate(
+      Number(dateOnly[1]),
+      Number(dateOnly[2]),
+      Number(dateOnly[3]),
+    );
+  }
+
+  const parsed = Date.parse(value);
+  if (!isNaN(parsed)) {
+    return new Date(parsed).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  return null;
+}
+
+export function defaultFormatValue(value: unknown, type?: ColumnType): string {
+  if (value === null || value === undefined) return "—";
+  const dateStr = formatDate(value, type);
+  if (dateStr) return dateStr;
+  if (typeof value === "number") return formatNumeric(value);
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}


### PR DESCRIPTION
`VirtualTable`'s default cell formatter guessed at dates from the value alone: any
string that `Date.parse` accepted was rendered as a formatted date. That turned
ordinary text into wrong dates — a SKU of `2024-01` displayed as `Jan 1, 2024`, a
version of `2.10` as a date, a year column as `Jan 1, 2024`. The column's declared
type was available and unused.

The formatter now takes the column type and only formats a string as a date when
the column is actually typed `date`. A real `Date` object still formats, since its
type is unambiguous. Anything else renders verbatim.

Tracked internally as TASK-676.

## Changes

- New `packages/ui/src/lib/format-virtual-table-value.ts` — `defaultFormatValue(value, type?)`.
  A string is only date-formatted when `type === "date"`; a `Date` instance still
  formats on its own evidence; everything else falls through to the numeric
  formatter or `String(value)`.
- Date-only strings (`YYYY-MM-DD`) are built as a local calendar date rather than
  parsed as UTC, so the displayed day does not shift in zones behind UTC. An
  impossible calendar date (`2024-02-30`) is left as text instead of silently
  rolling over to March 1.
- `VirtualTable`'s `type` narrows from `string` to `ColumnType` (from
  `@dashframe/types`, the package that owns it) and the inline formatter is gone.
- `useInsightPagination` types its column state as `VirtualTableColumn[]`.
- 17 unit tests, pinned to `America/Phoenix` (restored afterwards, since the TZ is
  process-wide and shared with the other files in the worker).

Note on scope: this PR stops wrong dates from being invented. It does not add date
formatting where none happens today — the async pagination path infers columns as
names only, so `type` is `undefined` there and date columns render as their raw
`YYYY-MM-DD` text. Enriching that path is the ticket's `Later` half.

## Screenshots

### Insight grid — light (sku 2024-01 and year render as text)
![Insight grid — light (sku 2024-01 and year render as text)](https://github.com/youhaowei/DashFrame/releases/download/pr-304-screenshots/df676-grid-light.png)

### Insight grid — dark
![Insight grid — dark](https://github.com/youhaowei/DashFrame/releases/download/pr-304-screenshots/df676-grid-dark.png)

_Screenshots via pr-screenshots (prerelease `pr-304-screenshots`, not in git)._
## Verification

Ran in the Electron desktop app (`bun run dev`) against a fresh project, importing
a CSV with the four bug cases (`/tmp/df676-fixture.csv`):

```
sku,version,year,real_date,units
SKU-A,1.5,2024,2024-03-15,10
SKU-B,2.10,2023,2024-03-16,20
2024-01,1.0,2024,2024-03-17,30
```

In the rendered insight grid:

- `sku` = `2024-01` renders as `2024-01`, not `Jan 1, 2024` — the reported bug.
- `year` renders `2024` / `2023`, not January-1 dates.
- `version` and `units` render as numbers.
- `real_date` renders its raw text, matching the scope note above.

Captured in both light and dark.

Also run: `bun run check` (green), `bun run format:check` (green), a second review
pass on a different model family, and mutation testing on each new test — every
one goes red when the corresponding branch of the fix is reverted.

