### PR TITLE
fix(app): reveal hover-only actions on keyboard focus-within

### DIFF
--- a/packages/app/src/app/dashboards/page.tsx
+++ b/packages/app/src/app/dashboards/page.tsx
@@ -1,5 +1,6 @@
 import { useToastStore } from "@/lib/stores";
 import { api } from "@/wystack/api";
+import { groupHoverAndFocusWithinReveal } from "@dashframe/ui";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@wystack/client";
 import {
@@ -134,7 +135,7 @@ export default function DashboardsPage() {
                         iconOnly
                         label="Delete dashboard"
                         color="danger"
-                        className="-mt-2 -mr-2 text-neutral-fg-subtle opacity-0 transition-opacity group-hover:opacity-100 hover:text-palette-danger"
+                        className={`-mt-2 -mr-2 text-neutral-fg-subtle transition-opacity hover:text-palette-danger ${groupHoverAndFocusWithinReveal}`}
                         onClick={() => handleDelete(dashboard.id)}
                       />
                     </div>

--- a/packages/app/src/app/data-sources/page.test.tsx
+++ b/packages/app/src/app/data-sources/page.test.tsx
@@ -130,4 +130,48 @@ describe("DataSourcesPage query states", () => {
       expect(mockRemoveDataSource).toHaveBeenCalledWith({ id: "source-123" });
     });
   });
+
+  it("opts the more-options action into the group focus-within reveal", () => {
+    mockUseDataSources.mockReturnValue({
+      ...successfulQuery(mockRefetchDataSources),
+      data: [
+        {
+          id: "source-123",
+          name: "Local Files",
+          type: "local",
+          config: { hasApiKey: false, hasConnectionString: false },
+          createdAt: 0,
+        },
+      ],
+    });
+
+    render(<DataSourcesPage />);
+
+    const action = screen.getByRole("button", { name: "More options" });
+
+    // The reveal is a CSS group relationship and jsdom computes no Tailwind, so
+    // actual visibility cannot be asserted here — the name says what this pins
+    // rather than overstating it. What it does check is every part the behavior
+    // needs, because dropping any one of them ships a broken UI that still
+    // looks right in the markup:
+    //   - `opacity-0` hides the action by default (without it, always visible)
+    //   - `group-hover:opacity-100` keeps the pointer path working
+    //   - `group-focus-within:opacity-100` is the keyboard path this fixes
+    //   - a `.group` ancestor is what those two selectors key on; with no group
+    //     the action stays invisible to a keyboard user forever
+    // The tokens are spelled out rather than compared against the shared
+    // constant: asserting a value against itself passes whatever it becomes.
+    for (const token of [
+      "opacity-0",
+      "group-hover:opacity-100",
+      "group-focus-within:opacity-100",
+    ]) {
+      expect(action.classList).toContain(token);
+    }
+    expect(action.closest(".group")).not.toBeNull();
+
+    // Focus is still exercised so the control is known to be reachable at all.
+    action.focus();
+    expect(document.activeElement).toBe(action);
+  });
 });

--- a/packages/app/src/app/data-sources/page.tsx
+++ b/packages/app/src/app/data-sources/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/connectors/registry";
 import { api } from "@/wystack/api";
 import type { DataSource, UUID } from "@dashframe/types";
+import { groupHoverAndFocusWithinReveal } from "@dashframe/ui";
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@wystack/client";
 import {
@@ -165,7 +166,7 @@ export default function DataSourcesPage() {
                   iconOnly
                   label="More options"
                   size="sm"
-                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                  className={`transition-opacity ${groupHoverAndFocusWithinReveal}`}
                   onClick={() => {}}
                 />
               }

--- a/packages/app/src/app/insights/page.tsx
+++ b/packages/app/src/app/insights/page.tsx
@@ -6,6 +6,7 @@ import {
   type Insight,
   type UUID,
 } from "@dashframe/types";
+import { groupHoverAndFocusWithinReveal } from "@dashframe/ui";
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@wystack/client";
 import {
@@ -296,7 +297,7 @@ export default function InsightsPage() {
                   iconOnly
                   label="More options"
                   size="sm"
-                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                  className={`transition-opacity ${groupHoverAndFocusWithinReveal}`}
                   onClick={() => {}}
                 />
               }

--- a/packages/app/src/app/visualizations/page.tsx
+++ b/packages/app/src/app/visualizations/page.tsx
@@ -1,6 +1,7 @@
 import { CreateVisualizationModal } from "@/components/visualizations/CreateVisualizationModal";
 import { api } from "@/wystack/api";
 import type { Insight, UUID, Visualization } from "@dashframe/types";
+import { groupHoverAndFocusWithinReveal } from "@dashframe/ui";
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@wystack/client";
 import {
@@ -216,7 +217,7 @@ export default function VisualizationsPage() {
                   iconOnly
                   label="More options"
                   size="sm"
-                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                  className={`transition-opacity ${groupHoverAndFocusWithinReveal}`}
                   onClick={() => {}}
                 />
               }

--- a/packages/app/src/components/dashboards/DashboardItem.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.tsx
@@ -5,6 +5,7 @@ import type {
   DashboardItemOverrides,
   DashboardItem as DashboardItemType,
 } from "@dashframe/types";
+import { groupHoverAndFocusWithinReveal } from "@dashframe/ui";
 import { useMutation } from "@wystack/client";
 import { Button, cn, Surface } from "@wystack/ui-react";
 import { DeleteIcon, DragHandleIcon, EditIcon } from "@wystack/ui-react/icons";
@@ -84,9 +85,14 @@ export function DashboardItem({
       onTouchEnd={onTouchEnd}
       {...props}
     >
-      {/* Action header - tucked under the container's rounded corners, visible on hover */}
+      {/* Action header - tucked under the container's rounded corners, visible on hover or focus within */}
       {isEditable && (
-        <div className="grid-drag-handle absolute -top-8 right-0 left-0 z-0 flex h-12 cursor-move items-center justify-between rounded-t-lg bg-neutral-bg-muted px-2 pt-4 pb-8 opacity-0 transition-all group-hover:opacity-100 hover:bg-neutral-bg-muted/80">
+        <div
+          className={cn(
+            "grid-drag-handle absolute -top-8 right-0 left-0 z-0 flex h-12 cursor-move items-center justify-between rounded-t-lg bg-neutral-bg-muted px-2 pt-4 pb-8 transition-all hover:bg-neutral-bg-muted/80",
+            groupHoverAndFocusWithinReveal,
+          )}
+        >
           {/* Drag Handle Indicator */}
           <div className="flex items-center gap-2 text-neutral-fg-subtle/60">
             <DragHandleIcon className="h-4 w-4" />
@@ -147,10 +153,13 @@ export function DashboardItem({
         {/* Customize button + override badge — visualization cells only, editor-mode only.
             Hidden from non-editors: a non-editor invoking updateItem/updateControls
             would persist their changes, which is not the intended v0.3 scope.
-            Visible on hover, anchored bottom-right inside the surface. */}
+            Visible on hover or focus within, anchored bottom-right inside the surface. */}
         {item.type === "visualization" && isEditable && (
           <div
-            className="absolute right-2 bottom-2 z-20 opacity-0 transition-opacity group-hover:opacity-100"
+            className={cn(
+              "absolute right-2 bottom-2 z-20 transition-opacity",
+              groupHoverAndFocusWithinReveal,
+            )}
             onMouseDown={(e) => e.stopPropagation()}
           >
             <OverridePopover

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -85,3 +85,4 @@ export { Select as SelectField } from "./fields/select";
 // -- Display-layer utilities --
 
 export { formatNumeric } from "./lib/format-numeric";
+export { groupHoverAndFocusWithinReveal } from "./lib/reveal-on-focus-within";

--- a/packages/ui/src/lib/reveal-on-focus-within.ts
+++ b/packages/ui/src/lib/reveal-on-focus-within.ts
@@ -1,0 +1,16 @@
+/**
+ * Keeps hover-revealed actions visible while keyboard focus is within the
+ * containing Tailwind group. The consuming element needs an ancestor carrying
+ * Tailwind's `group` class — without one, neither selector ever matches and the
+ * action is permanently invisible.
+ *
+ * Known limit: `:focus-within` only sees the group's own DOM subtree, and
+ * dropdown/popover content is portaled out of it. Opening a menu by keyboard
+ * therefore moves focus outside the group and fades the trigger back out while
+ * the menu stays open. The menu remains operable; only the trigger's visual
+ * continuity is affected, and pointer users are unaffected because hover still
+ * matches. Fixing it needs an open-state selector on the trigger, not a change
+ * here.
+ */
+export const groupHoverAndFocusWithinReveal =
+  "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100";


### PR DESCRIPTION
## Summary

Hover-revealed action controls were operable by keyboard but invisible while focused: their visibility relied solely on `group-hover:opacity-100`, so a keyboard user tabbing to a card's delete / more-options / customize button saw nothing move.

Adds a shared `groupHoverAndFocusWithinReveal` class-string constant in `packages/ui` and applies it at every affected call site, so the reveal also fires on `group-focus-within`:

- `app/dashboards/page.tsx` — delete button
- `app/data-sources/page.tsx`, `app/insights/page.tsx`, `app/visualizations/page.tsx` — More options
- `components/dashboards/DashboardItem.tsx` — action header strip and customize chrome

Every call site was checked to sit under a real Tailwind `group` ancestor; without one neither selector matches and the control would be permanently invisible.

Tracked internally as TASK-767.

## Testing

- `bun run check` — 4/4 arms PASS (85/85 tasks)
- `bun run format:check` — clean
- New regression test in `app/data-sources/page.test.tsx`. jsdom computes no Tailwind, so it pins the structural prerequisites rather than visibility: the three literal utility tokens (`opacity-0`, `group-hover:opacity-100`, `group-focus-within:opacity-100`) on the control, plus a `.group` ancestor. Verified by mutation: dropping any one token from the constant, or the `group` class from the card wrapper, turns it red. The tokens are spelled out rather than compared against the shared constant — asserting a value against itself passes whatever it becomes.
- Behavioral QA in the running Electron app: computed `opacity` on the More-options button is `"0"` unfocused and `"1"` with keyboard focus.

## Screenshots

### Data source card, nothing focused — action hidden (`opacity: 0`)
![Unfocused](https://github.com/youhaowei/DashFrame/releases/download/pr-306-screenshots/df767-unfocused-light.png)

### Same card, More options keyboard-focused — action revealed (`opacity: 1`)
![Keyboard focused](https://github.com/youhaowei/DashFrame/releases/download/pr-306-screenshots/df767-focus-light.png)

Light mode only: the change is a pure opacity utility with no color involved, so the dark theme renders identically apart from the palette it already had.

_Screenshots via pr-screenshots (prerelease `pr-306-screenshots`, not in git)._
## Review notes

Second reviewer (grok, different family from the author) returned no critical/high/medium findings. Two accepted limitations, neither in this change's scope:

- **Portaled menus drop the reveal while open.** `:focus-within` only sees the group's own DOM subtree, and dropdown/popover content is portaled out of it, so opening a menu by keyboard fades the trigger back out while the menu stays open. The menu remains fully operable and pointer users are unaffected. Fixing it needs an open-state selector on the trigger, not a change to this constant — documented in the constant's docblock.
- **`DashboardItem` chrome now stays up for any in-cell focus.** Editing a markdown widget without hovering keeps the drag/remove strip visible for the focus session. That mirrors hover's "show all chrome when the cell is active" model and is what the ticket asks for.


