### PR TITLE
fix(app): make assistant configuration mutations ordered and error-aware

### DIFF
--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -142,6 +142,7 @@ describe("assistant provider config functions", () => {
     await app.call("setAssistantDefaultModel", {
       input: {
         id: secondaryConfig.id,
+        expectedDefaultModel: "gpt-4.1",
         defaultModel: "gpt-4.1-mini",
       },
     });
@@ -153,6 +154,40 @@ describe("assistant provider config functions", () => {
     expect(defaultRow?.isDefault).toBe(true);
     expect(secondaryRow?.defaultModel).toBe("gpt-4.1-mini");
     expect(secondaryRow?.isDefault).toBe(false);
+  });
+
+  it("rejects a stale model update instead of overwriting the newer model", async () => {
+    const { result: config } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "openai",
+        displayLabel: "OpenAI",
+        authKind: "api-key",
+        defaultModel: "gpt-4.1",
+      },
+    })) as { result: AssistantProviderConfig };
+
+    await app.call("setAssistantDefaultModel", {
+      input: {
+        id: config.id,
+        expectedDefaultModel: "gpt-4.1",
+        defaultModel: "gpt-4.1-mini",
+      },
+    });
+
+    await expect(
+      app.call("setAssistantDefaultModel", {
+        input: {
+          id: config.id,
+          expectedDefaultModel: "gpt-4.1",
+          defaultModel: "gpt-4.1-nano",
+        },
+      }),
+    ).rejects.toThrow(
+      "Assistant model changed before this update could be saved",
+    );
+
+    const [row] = await db.select().from(schema.assistantProviderConfigs);
+    expect(row?.defaultModel).toBe("gpt-4.1-mini");
   });
 
   it("rejects a providerId that is not in the catalog", async () => {

--- a/apps/server/src/functions/assistant-provider-configs.test.ts
+++ b/apps/server/src/functions/assistant-provider-configs.test.ts
@@ -90,6 +90,76 @@ describe("assistant provider config functions", () => {
     ).resolves.toBe("test-api-key-input");
   });
 
+  it("switching auth kind without a new credential clears the superseded one", async () => {
+    // An omitted credential normally means "keep the stored one". Keeping it
+    // across an auth-kind change would leave an `oauth` row pointing at an API
+    // key: the row reports a stored credential, and resolving it later fails
+    // parsing that key as OAuth JSON.
+    const { result: created } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "anthropic",
+        displayLabel: "Anthropic API",
+        authKind: "api-key",
+        credential: "superseded-api-key",
+        defaultModel: "claude-sonnet-4-5",
+      },
+    })) as { result: AssistantProviderConfig };
+
+    const [before] = await db.select().from(schema.assistantProviderConfigs);
+    const oldRef = before!.credentialRef! as SecretRef;
+    expect(isSecretRef(oldRef)).toBe(true);
+
+    const { result: switched } = (await app.call(
+      "saveAssistantProviderConfig",
+      {
+        input: {
+          id: created.id,
+          providerId: "anthropic",
+          displayLabel: "Anthropic API",
+          authKind: "oauth",
+          defaultModel: "claude-sonnet-4-5",
+        },
+      },
+    )) as { result: AssistantProviderConfig };
+
+    expect(switched.hasCredential).toBe(false);
+    const [after] = await db.select().from(schema.assistantProviderConfigs);
+    expect(after!.authKind).toBe("oauth");
+    expect(after!.credentialRef).toBeNull();
+    // The old API key is not merely unreferenced — it is released.
+    expect(await vault.has(oldRef)).toBe(false);
+  });
+
+  it("keeps the stored credential when the auth kind is unchanged", async () => {
+    // The clear above must be scoped to an auth-kind change; an ordinary
+    // rename that omits the credential must still preserve it.
+    const { result: created } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        providerId: "openai",
+        displayLabel: "OpenAI",
+        authKind: "api-key",
+        credential: "kept-api-key",
+        defaultModel: "gpt-4.1",
+      },
+    })) as { result: AssistantProviderConfig };
+
+    const { result: renamed } = (await app.call("saveAssistantProviderConfig", {
+      input: {
+        id: created.id,
+        providerId: "openai",
+        displayLabel: "OpenAI (work)",
+        authKind: "api-key",
+        defaultModel: "gpt-4.1",
+      },
+    })) as { result: AssistantProviderConfig };
+
+    expect(renamed.hasCredential).toBe(true);
+    const [after] = await db.select().from(schema.assistantProviderConfigs);
+    await expect(
+      vault.withSecret(after!.credentialRef! as SecretRef, async (v) => v),
+    ).resolves.toBe("kept-api-key");
+  });
+
   it("deleting a provider releases the stored SecretRef", async () => {
     const { result } = (await app.call("saveAssistantProviderConfig", {
       input: {

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -49,6 +49,7 @@ const saveInputSchema = z.object({
 
 const setDefaultModelSchema = z.object({
   id: z.string().uuid(),
+  expectedDefaultModel: z.string().min(1),
   defaultModel: z.string().min(1),
 }) satisfies z.ZodType<SetAssistantDefaultModelInput>;
 
@@ -311,10 +312,18 @@ const setAssistantDefaultModel = wy.procedure
   .input({ input: jsonb })
   .mutation(async (ctx, { input }): Promise<{ ok: true }> => {
     const parsed = setDefaultModelSchema.parse(input);
-    await ctx.db
+    const updated = await ctx.db
       .from(assistantProviderConfigs)
-      .where(eq("id", parsed.id))
+      .where([
+        eq("id", parsed.id),
+        eq("defaultModel", parsed.expectedDefaultModel),
+      ])
       .update({ defaultModel: parsed.defaultModel });
+    if (updated.length !== 1) {
+      throw new Error(
+        "Assistant model changed before this update could be saved. Please try again.",
+      );
+    }
     return { ok: true };
   });
 

--- a/apps/server/src/functions/assistant-provider-configs.ts
+++ b/apps/server/src/functions/assistant-provider-configs.ts
@@ -206,6 +206,14 @@ const saveAssistantProviderConfig = wy.procedure
       plaintext: parsed.credential,
       locatorHint: `assistant-provider-${id}`,
     });
+    // An omitted credential normally means "keep the stored one". That is wrong
+    // when the auth kind changed: the stored secret was minted for the old kind,
+    // so keeping it leaves, say, an `oauth` row pointing at an API key. The row
+    // would report a stored credential and then fail at resolve time when the
+    // key is parsed as OAuth JSON. Switching kinds without supplying a new
+    // secret clears the old one instead.
+    const supersededByAuthKindChange =
+      current != null && current.authKind !== parsed.authKind && !mintedRef;
 
     // The row write and the default-reset commit atomically; a failure rolls
     // back the whole transaction, so no committed row can reference mintedRef.
@@ -224,7 +232,9 @@ const saveAssistantProviderConfig = wy.procedure
               displayLabel: parsed.displayLabel,
               authKind: parsed.authKind,
               baseUrl: parsed.baseUrl?.trim() || null,
-              credentialRef: mintedRef ?? current.credentialRef,
+              credentialRef:
+                mintedRef ??
+                (supersededByAuthKindChange ? null : current.credentialRef),
               defaultModel: parsed.defaultModel,
               isDefault: parsed.isDefault ?? current.isDefault,
             })) as AssistantProviderConfigRow[];
@@ -269,7 +279,10 @@ const saveAssistantProviderConfig = wy.procedure
     // best-effort) — releasing before the snapshot holding the new ref is on
     // disk could leave a restored row pointing at a deleted vault entry.
     // Never mintedRef itself past this point.
-    if (mintedRef && isSecretRef(current?.credentialRef)) {
+    if (
+      (mintedRef || supersededByAuthKindChange) &&
+      isSecretRef(current?.credentialRef)
+    ) {
       await flushThenReleaseRefs(
         flushSnapshotFromCtx(ctx),
         [current.credentialRef],

--- a/packages/app/src/components/assistant/AssistantModelPicker.test.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.test.tsx
@@ -1,14 +1,47 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAssistantStore } from "@/lib/stores/assistant-store";
 
 import { AssistantModelPicker } from "./AssistantModelPicker";
 
-const { modelCalls, modelResolvers } = vi.hoisted(() => ({
-  modelCalls: [] as Array<{ input: Record<string, string> }>,
-  modelResolvers: [] as Array<() => void>,
-}));
+const { modelCalls, modelResolvers, modelRejecters, configsData, catalogData } =
+  vi.hoisted(() => ({
+    modelCalls: [] as Array<{ input: Record<string, string> }>,
+    modelResolvers: [] as Array<() => void>,
+    modelRejecters: [] as Array<(reason: Error) => void>,
+    // Held by identity, the way react-query hands back the same `data`
+    // reference between refetches. A fresh array per render would re-run the
+    // picker's configs effect on every render and silently reset the
+    // compare-and-swap baseline, which would mask exactly the failure-path
+    // behavior the second test is there to pin.
+    configsData: [
+      {
+        id: "provider-1",
+        providerId: "openai",
+        displayLabel: "OpenAI",
+        authKind: "api-key",
+        defaultModel: "gpt-4.1",
+        isDefault: true,
+      },
+    ],
+    catalogData: [
+      {
+        providerId: "openai",
+        models: [
+          { id: "gpt-4.1", name: "GPT 4.1" },
+          { id: "gpt-4.1-mini", name: "GPT 4.1 mini" },
+          { id: "gpt-4.1-nano", name: "GPT 4.1 nano" },
+        ],
+      },
+    ],
+  }));
 
 vi.mock("@wystack/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@wystack/client")>();
@@ -16,33 +49,9 @@ vi.mock("@wystack/client", async (importOriginal) => {
     ...actual,
     useQuery: (ref: { _path: string }) => {
       if (ref._path === "listAssistantProviderConfigs") {
-        return {
-          data: [
-            {
-              id: "provider-1",
-              providerId: "openai",
-              displayLabel: "OpenAI",
-              authKind: "api-key",
-              defaultModel: "gpt-4.1",
-              isDefault: true,
-            },
-          ],
-          isLoading: false,
-        };
+        return { data: configsData, isLoading: false };
       }
-      return {
-        data: [
-          {
-            providerId: "openai",
-            models: [
-              { id: "gpt-4.1", name: "GPT 4.1" },
-              { id: "gpt-4.1-mini", name: "GPT 4.1 mini" },
-              { id: "gpt-4.1-nano", name: "GPT 4.1 nano" },
-            ],
-          },
-        ],
-        isLoading: false,
-      };
+      return { data: catalogData, isLoading: false };
     },
     useMutation: (ref: { _path: string }) => ({
       mutateAsync: (args: { input: Record<string, string> }) => {
@@ -50,7 +59,10 @@ vi.mock("@wystack/client", async (importOriginal) => {
           return Promise.resolve(undefined);
         }
         modelCalls.push(args);
-        return new Promise<void>((resolve) => modelResolvers.push(resolve));
+        return new Promise<void>((resolve, reject) => {
+          modelResolvers.push(resolve);
+          modelRejecters.push(reject);
+        });
       },
     }),
   };
@@ -103,6 +115,7 @@ describe("AssistantModelPicker", () => {
   beforeEach(() => {
     modelCalls.length = 0;
     modelResolvers.length = 0;
+    modelRejecters.length = 0;
     useAssistantStore.setState({
       selectedProviderConfigId: "provider-1",
       selectedModelId: "gpt-4.1",
@@ -142,5 +155,44 @@ describe("AssistantModelPicker", () => {
         },
       },
     ]);
+  });
+
+  it("keeps draining, and does not advance the compare-and-swap baseline, after a rejected write", async () => {
+    render(<AssistantModelPicker />);
+
+    const modelSelect = screen.getAllByRole("combobox")[1]!;
+    fireEvent.change(modelSelect, { target: { value: "gpt-4.1-mini" } });
+    await waitFor(() => expect(modelCalls).toHaveLength(1));
+
+    modelRejecters.shift()!(
+      new Error("Assistant model changed before this update could be saved"),
+    );
+    modelResolvers.shift();
+
+    // Let the rejection actually propagate through the drain loop's catch and
+    // finally before selecting again. Without this the next selection queues in
+    // the same synchronous turn, capturing the baseline before the failure path
+    // has had any chance to touch it — which would make the assertion below
+    // pass no matter what that path does.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // A rejection must not wedge the drain loop: the next selection still
+    // reaches the server.
+    fireEvent.change(modelSelect, { target: { value: "gpt-4.1-nano" } });
+    await waitFor(() => expect(modelCalls).toHaveLength(2));
+
+    // The baseline deliberately stays at the last value the server is known to
+    // have accepted. A write that failed did not land, so claiming its model as
+    // the new baseline would send a compare-and-swap that can never match.
+    expect(modelCalls[1]!.input.expectedDefaultModel).toBe("gpt-4.1");
+
+    // The optimistic selection is intentionally left in place rather than
+    // rolled back: the rail runs against the picked model per request, so the
+    // user's choice stays honored while the error toast reports that saving it
+    // as the default did not stick.
+    expect(useAssistantStore.getState().selectedModelId).toBe("gpt-4.1-nano");
   });
 });

--- a/packages/app/src/components/assistant/AssistantModelPicker.test.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAssistantStore } from "@/lib/stores/assistant-store";
+
+import { AssistantModelPicker } from "./AssistantModelPicker";
+
+const { modelCalls, modelResolvers } = vi.hoisted(() => ({
+  modelCalls: [] as Array<{ input: Record<string, string> }>,
+  modelResolvers: [] as Array<() => void>,
+}));
+
+vi.mock("@wystack/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/client")>();
+  return {
+    ...actual,
+    useQuery: (ref: { _path: string }) => {
+      if (ref._path === "listAssistantProviderConfigs") {
+        return {
+          data: [
+            {
+              id: "provider-1",
+              providerId: "openai",
+              displayLabel: "OpenAI",
+              authKind: "api-key",
+              defaultModel: "gpt-4.1",
+              isDefault: true,
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return {
+        data: [
+          {
+            providerId: "openai",
+            models: [
+              { id: "gpt-4.1", name: "GPT 4.1" },
+              { id: "gpt-4.1-mini", name: "GPT 4.1 mini" },
+              { id: "gpt-4.1-nano", name: "GPT 4.1 nano" },
+            ],
+          },
+        ],
+        isLoading: false,
+      };
+    },
+    useMutation: (ref: { _path: string }) => ({
+      mutateAsync: (args: { input: Record<string, string> }) => {
+        if (ref._path !== "setAssistantDefaultModel") {
+          return Promise.resolve(undefined);
+        }
+        modelCalls.push(args);
+        return new Promise<void>((resolve) => modelResolvers.push(resolve));
+      },
+    }),
+  };
+});
+
+vi.mock("@wystack/ui-react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/ui-react")>();
+  const React = await import("react");
+  const SelectContent = ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  );
+  const SelectItem = ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>;
+  return {
+    ...actual,
+    Select: ({
+      children,
+      onValueChange,
+      value,
+    }: {
+      children: React.ReactNode;
+      onValueChange: (value: string) => void;
+      value: string;
+    }) => {
+      const content = React.Children.toArray(children).find(
+        (child) => React.isValidElement(child) && child.type === SelectContent,
+      ) as React.ReactElement<{ children: React.ReactNode }> | undefined;
+      return (
+        <select
+          value={value}
+          onChange={(event) => onValueChange(event.target.value)}
+        >
+          {content?.props.children}
+        </select>
+      );
+    },
+    SelectContent,
+    SelectItem,
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+  };
+});
+
+describe("AssistantModelPicker", () => {
+  beforeEach(() => {
+    modelCalls.length = 0;
+    modelResolvers.length = 0;
+    useAssistantStore.setState({
+      selectedProviderConfigId: "provider-1",
+      selectedModelId: "gpt-4.1",
+    });
+  });
+
+  it("serializes rapid model selections so the latest one is persisted last", async () => {
+    render(<AssistantModelPicker />);
+
+    const modelSelect = screen.getAllByRole("combobox")[1]!;
+    fireEvent.change(modelSelect, { target: { value: "gpt-4.1-mini" } });
+    await waitFor(() => expect(modelCalls).toHaveLength(1));
+
+    fireEvent.change(modelSelect, { target: { value: "gpt-4.1-nano" } });
+    expect(modelCalls).toHaveLength(1);
+
+    modelResolvers.shift()!();
+    await waitFor(() => expect(modelCalls).toHaveLength(2));
+    modelResolvers.shift()!();
+
+    await waitFor(() =>
+      expect(useAssistantStore.getState().selectedModelId).toBe("gpt-4.1-nano"),
+    );
+    expect(modelCalls).toEqual([
+      {
+        input: {
+          id: "provider-1",
+          expectedDefaultModel: "gpt-4.1",
+          defaultModel: "gpt-4.1-mini",
+        },
+      },
+      {
+        input: {
+          id: "provider-1",
+          expectedDefaultModel: "gpt-4.1-mini",
+          defaultModel: "gpt-4.1-nano",
+        },
+      },
+    ]);
+  });
+});

--- a/packages/app/src/components/assistant/AssistantModelPicker.test.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.test.tsx
@@ -11,37 +11,46 @@ import { useAssistantStore } from "@/lib/stores/assistant-store";
 
 import { AssistantModelPicker } from "./AssistantModelPicker";
 
-const { modelCalls, modelResolvers, modelRejecters, configsData, catalogData } =
-  vi.hoisted(() => ({
-    modelCalls: [] as Array<{ input: Record<string, string> }>,
-    modelResolvers: [] as Array<() => void>,
-    modelRejecters: [] as Array<(reason: Error) => void>,
-    // Held by identity, the way react-query hands back the same `data`
-    // reference between refetches. A fresh array per render would re-run the
-    // picker's configs effect on every render and silently reset the
-    // compare-and-swap baseline, which would mask exactly the failure-path
-    // behavior the second test is there to pin.
-    configsData: [
-      {
-        id: "provider-1",
-        providerId: "openai",
-        displayLabel: "OpenAI",
-        authKind: "api-key",
-        defaultModel: "gpt-4.1",
-        isDefault: true,
-      },
-    ],
-    catalogData: [
-      {
-        providerId: "openai",
-        models: [
-          { id: "gpt-4.1", name: "GPT 4.1" },
-          { id: "gpt-4.1-mini", name: "GPT 4.1 mini" },
-          { id: "gpt-4.1-nano", name: "GPT 4.1 nano" },
-        ],
-      },
-    ],
-  }));
+const {
+  modelCalls,
+  modelResolvers,
+  modelRejecters,
+  configsData,
+  catalogData,
+  configsRefetch,
+} = vi.hoisted(() => ({
+  modelCalls: [] as Array<{ input: Record<string, string> }>,
+  // A rejected write drops its compare-and-swap baseline and refetches, so
+  // the mock must offer the same handle react-query does.
+  configsRefetch: async () => undefined,
+  modelResolvers: [] as Array<() => void>,
+  modelRejecters: [] as Array<(reason: Error) => void>,
+  // Held by identity, the way react-query hands back the same `data`
+  // reference between refetches. A fresh array per render would re-run the
+  // picker's configs effect on every render and silently reset the
+  // compare-and-swap baseline, which would mask exactly the failure-path
+  // behavior the second test is there to pin.
+  configsData: [
+    {
+      id: "provider-1",
+      providerId: "openai",
+      displayLabel: "OpenAI",
+      authKind: "api-key",
+      defaultModel: "gpt-4.1",
+      isDefault: true,
+    },
+  ],
+  catalogData: [
+    {
+      providerId: "openai",
+      models: [
+        { id: "gpt-4.1", name: "GPT 4.1" },
+        { id: "gpt-4.1-mini", name: "GPT 4.1 mini" },
+        { id: "gpt-4.1-nano", name: "GPT 4.1 nano" },
+      ],
+    },
+  ],
+}));
 
 vi.mock("@wystack/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@wystack/client")>();
@@ -49,9 +58,13 @@ vi.mock("@wystack/client", async (importOriginal) => {
     ...actual,
     useQuery: (ref: { _path: string }) => {
       if (ref._path === "listAssistantProviderConfigs") {
-        return { data: configsData, isLoading: false };
+        return { data: configsData, isLoading: false, refetch: configsRefetch };
       }
-      return { data: catalogData, isLoading: false };
+      return {
+        data: catalogData,
+        isLoading: false,
+        refetch: async () => undefined,
+      };
     },
     useMutation: (ref: { _path: string }) => ({
       mutateAsync: (args: { input: Record<string, string> }) => {

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -99,6 +99,15 @@ export function AssistantModelPicker() {
               });
             }
           } catch (error) {
+            // The write did not land, so the baseline must not advance to the
+            // model we tried to store. But it must not stay either: a rejection
+            // most often means another writer moved the row, and replaying the
+            // same stale `expectedDefaultModel` would be rejected forever,
+            // leaving the picker permanently unable to save. Drop the baseline
+            // and refetch so the next selection compares against what the
+            // server actually holds.
+            persistedModelsRef.current.delete(configId);
+            configsResult.refetch().catch(() => undefined);
             showError("Failed to set assistant model", {
               description:
                 error instanceof Error ? error.message : "Please try again.",

--- a/packages/app/src/components/assistant/AssistantModelPicker.tsx
+++ b/packages/app/src/components/assistant/AssistantModelPicker.tsx
@@ -6,7 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wystack/ui-react";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { useToastStore } from "@/lib/stores";
 import { useAssistantStore } from "@/lib/stores/assistant-store";
@@ -27,6 +27,12 @@ export function AssistantModelPicker() {
   const selectedModelId = useAssistantStore((s) => s.selectedModelId);
   const setSelectedModel = useAssistantStore((s) => s.setSelectedModel);
   const showError = useToastStore((s) => s.showError);
+  const pendingModelMutationsRef = useRef(
+    new Map<string, { defaultModel: string; expectedDefaultModel: string }>(),
+  );
+  const persistedModelsRef = useRef(new Map<string, string>());
+  const inFlightModelConfigIdsRef = useRef(new Set<string>());
+  const drainingModelMutationsRef = useRef(false);
   const configs = useMemo(() => configsResult.data ?? [], [configsResult.data]);
   const catalog = useMemo(() => catalogResult.data ?? [], [catalogResult.data]);
   const configsLoaded =
@@ -46,6 +52,66 @@ export function AssistantModelPicker() {
     );
     return entry?.models ?? [];
   }, [catalog, selected?.providerId]);
+
+  useEffect(() => {
+    for (const config of configs) {
+      if (
+        pendingModelMutationsRef.current.has(config.id) ||
+        inFlightModelConfigIdsRef.current.has(config.id)
+      ) {
+        continue;
+      }
+      persistedModelsRef.current.set(config.id, config.defaultModel);
+    }
+  }, [configs]);
+
+  function queueModelMutation(id: string, defaultModel: string) {
+    const expectedDefaultModel =
+      persistedModelsRef.current.get(id) ??
+      configs.find((config) => config.id === id)?.defaultModel;
+    if (!expectedDefaultModel) return;
+
+    pendingModelMutationsRef.current.set(id, {
+      defaultModel,
+      expectedDefaultModel,
+    });
+    if (drainingModelMutationsRef.current) return;
+
+    drainingModelMutationsRef.current = true;
+    void (async () => {
+      try {
+        while (pendingModelMutationsRef.current.size > 0) {
+          const next = pendingModelMutationsRef.current.entries().next().value;
+          if (!next) break;
+          const [configId, mutation] = next;
+          pendingModelMutationsRef.current.delete(configId);
+          inFlightModelConfigIdsRef.current.add(configId);
+          try {
+            await setDefaultModelMutation({
+              input: { id: configId, ...mutation },
+            });
+            persistedModelsRef.current.set(configId, mutation.defaultModel);
+            const newer = pendingModelMutationsRef.current.get(configId);
+            if (newer) {
+              pendingModelMutationsRef.current.set(configId, {
+                ...newer,
+                expectedDefaultModel: mutation.defaultModel,
+              });
+            }
+          } catch (error) {
+            showError("Failed to set assistant model", {
+              description:
+                error instanceof Error ? error.message : "Please try again.",
+            });
+          } finally {
+            inFlightModelConfigIdsRef.current.delete(configId);
+          }
+        }
+      } finally {
+        drainingModelMutationsRef.current = false;
+      }
+    })();
+  }
 
   useEffect(() => {
     if (!selected) return;
@@ -112,14 +178,7 @@ export function AssistantModelPicker() {
         onValueChange={(defaultModel) => {
           if (!defaultModel) return;
           setSelectedModel(selected.id, defaultModel);
-          setDefaultModelMutation({
-            input: { id: selected.id, defaultModel },
-          }).catch((error) => {
-            showError("Failed to set assistant model", {
-              description:
-                error instanceof Error ? error.message : "Please try again.",
-            });
-          });
+          queueModelMutation(selected.id, defaultModel);
         }}
       >
         <SelectTrigger className="h-7 w-32 px-2 text-[11px]">

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.test.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AssistantProviderSettingsDialog } from "./AssistantProviderSettingsDialog";
+
+const { saveConfigMutation } = vi.hoisted(() => ({
+  saveConfigMutation: vi.fn(),
+}));
+
+vi.mock("@wystack/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/client")>();
+  return {
+    ...actual,
+    useQuery: (ref: { _path: string }) => {
+      if (ref._path === "listAssistantProviderConfigs") {
+        return {
+          data: [
+            {
+              id: "provider-1",
+              providerId: "openai",
+              displayLabel: "OpenAI",
+              authKind: "api-key",
+              defaultModel: "gpt-4.1",
+              hasCredential: true,
+              isDefault: true,
+            },
+          ],
+          isLoading: false,
+        };
+      }
+      return {
+        data: [
+          {
+            providerId: "openai",
+            label: "OpenAI",
+            authKinds: ["api-key", "oauth", "local"],
+            models: [{ id: "gpt-4.1", name: "GPT 4.1" }],
+          },
+        ],
+        isLoading: false,
+      };
+    },
+    useMutation: (ref: { _path: string }) => ({
+      mutateAsync:
+        ref._path === "saveAssistantProviderConfig"
+          ? saveConfigMutation
+          : vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@wystack/ui-react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/ui-react")>();
+  const React = await import("react");
+  const SelectContent = ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  );
+  const SelectItem = ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>;
+  return {
+    ...actual,
+    Select: ({
+      children,
+      onValueChange,
+      value,
+    }: {
+      children: React.ReactNode;
+      onValueChange: (value: string) => void;
+      value: string;
+    }) => {
+      const content = React.Children.toArray(children).find(
+        (child) => React.isValidElement(child) && child.type === SelectContent,
+      ) as React.ReactElement<{ children: React.ReactNode }> | undefined;
+      return (
+        <select
+          value={value}
+          onChange={(event) => onValueChange(event.target.value)}
+        >
+          {content?.props.children}
+        </select>
+      );
+    },
+    SelectContent,
+    SelectItem,
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+  };
+});
+
+describe("AssistantProviderSettingsDialog", () => {
+  beforeEach(() => {
+    saveConfigMutation.mockReset();
+    saveConfigMutation.mockResolvedValue({ id: "provider-1" });
+  });
+
+  it("clears an API key after changing auth mode and updates the existing config", async () => {
+    render(<AssistantProviderSettingsDialog open onOpenChange={vi.fn()} />);
+
+    fireEvent.change(document.querySelector('input[type="password"]')!, {
+      target: { value: "stale-api-key" },
+    });
+    fireEvent.change(screen.getAllByRole("combobox")[1]!, {
+      target: { value: "oauth" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save provider" }));
+
+    await waitFor(() => expect(saveConfigMutation).toHaveBeenCalledTimes(1));
+    expect(saveConfigMutation).toHaveBeenCalledWith({
+      input: {
+        id: "provider-1",
+        providerId: "openai",
+        displayLabel: "OpenAI",
+        authKind: "oauth",
+        baseUrl: undefined,
+        credential: undefined,
+        defaultModel: "gpt-4.1",
+        isDefault: false,
+      },
+    });
+  });
+});

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -1,6 +1,7 @@
 import type {
   AssistantProviderAuthKind,
   AssistantProviderCatalogEntry,
+  UUID,
 } from "@dashframe/types";
 import { useMutation, useQuery } from "@wystack/client";
 import {
@@ -37,6 +38,7 @@ interface AssistantProviderSettingsDialogProps {
 }
 
 interface DraftProviderForm {
+  id?: UUID;
   providerId: string;
   displayLabel: string;
   authKind: AssistantProviderAuthKind;
@@ -121,8 +123,12 @@ export function AssistantProviderSettingsDialog({
   async function save() {
     setSaving(true);
     try {
-      await saveConfigMutation({
+      const existingConfig = configs.find(
+        (config) => config.providerId === form.providerId,
+      );
+      const saved = await saveConfigMutation({
         input: {
+          id: form.id ?? existingConfig?.id,
           providerId: form.providerId,
           displayLabel: form.displayLabel,
           authKind: form.authKind,
@@ -132,7 +138,7 @@ export function AssistantProviderSettingsDialog({
           isDefault: configs.length === 0,
         },
       });
-      setForm((current) => ({ ...current, credential: "" }));
+      setForm((current) => ({ ...current, id: saved.id, credential: "" }));
       showSuccess("Assistant provider saved");
     } catch (error) {
       showError("Failed to save assistant provider", {
@@ -271,6 +277,7 @@ export function AssistantProviderSettingsDialog({
                   setForm((current) => ({
                     ...current,
                     authKind: value as AssistantProviderAuthKind,
+                    credential: "",
                   }));
                 }}
               >

--- a/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
+++ b/packages/app/src/components/assistant/AssistantProviderSettingsDialog.tsx
@@ -122,6 +122,11 @@ export function AssistantProviderSettingsDialog({
 
   async function save() {
     setSaving(true);
+    // The provider select stays live while a save is in flight. Stamping the
+    // returned id onto whatever the form holds when the request lands would
+    // give provider B's draft provider A's row id, and the next save would
+    // overwrite A's configuration with B's data.
+    const submittedProviderId = form.providerId;
     try {
       const existingConfig = configs.find(
         (config) => config.providerId === form.providerId,
@@ -138,7 +143,11 @@ export function AssistantProviderSettingsDialog({
           isDefault: configs.length === 0,
         },
       });
-      setForm((current) => ({ ...current, id: saved.id, credential: "" }));
+      setForm((current) =>
+        current.providerId === submittedProviderId
+          ? { ...current, id: saved.id, credential: "" }
+          : current,
+      );
       showSuccess("Assistant provider saved");
     } catch (error) {
       showError("Failed to save assistant provider", {

--- a/packages/app/src/components/assistant/AssistantToggle.test.tsx
+++ b/packages/app/src/components/assistant/AssistantToggle.test.tsx
@@ -72,7 +72,7 @@ describe("AssistantToggle", () => {
     expect(useAssistantStore.getState().isSetupOpen).toBe(false);
   });
 
-  it("keeps the assistant reachable and retries after the config query fails", async () => {
+  it("stays reachable and retries, without opening a rail it cannot fill, after the config query fails", async () => {
     const query = vi.fn(() => Promise.reject(new Error("offline")));
     const client = makeClient(query);
     render(<AssistantToggle />, { wrapper: makeWrapper(client) });
@@ -80,10 +80,41 @@ describe("AssistantToggle", () => {
     const button = await screen.findByRole("button", {
       name: "Retry assistant configuration",
     });
+    // Reachable: the control is live rather than disabled forever, which is
+    // what the silent lockout looked like.
     expect((button as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(button);
 
-    expect(useAssistantStore.getState().isOpen).toBe(true);
     await waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+    // With nothing cached we cannot know whether a provider exists, so neither
+    // the rail nor the setup dialog is honest to present — retry is the whole
+    // action. Opening either would trade a silent lockout for a broken surface.
+    expect(useAssistantStore.getState().isOpen).toBe(false);
+    expect(useAssistantStore.getState().isSetupOpen).toBe(false);
+  });
+
+  it("can still hide an open rail while a refetch is failing", async () => {
+    let settled = false;
+    const query = vi.fn(() =>
+      settled
+        ? Promise.reject(new Error("offline"))
+        : Promise.resolve([{ id: "provider-1" }]),
+    );
+    const client = makeClient(query);
+    render(<AssistantToggle />, { wrapper: makeWrapper(client) });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Open assistant" }),
+    );
+    expect(useAssistantStore.getState().isOpen).toBe(true);
+
+    // A later refetch fails, but the rows already fetched are still shown, so
+    // the control must keep behaving as a plain hide/show rather than turning
+    // into a retry-only button the user cannot close the rail with.
+    settled = true;
+    const hide = await screen.findByRole("button", { name: "Hide assistant" });
+    fireEvent.click(hide);
+
+    expect(useAssistantStore.getState().isOpen).toBe(false);
   });
 });

--- a/packages/app/src/components/assistant/AssistantToggle.test.tsx
+++ b/packages/app/src/components/assistant/AssistantToggle.test.tsx
@@ -1,51 +1,89 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { type WyStackClient, WyStackProvider } from "@wystack/client";
+import { type FC, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAssistantStore } from "@/lib/stores/assistant-store";
 
 import { AssistantToggle } from "./AssistantToggle";
 
-const { configsResult } = vi.hoisted(() => ({
-  configsResult: {
-    data: [] as Array<{ id: string }>,
-    isLoading: false,
-  },
-}));
-
-vi.mock("@wystack/client", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@wystack/client")>();
+function makeClient(query: () => Promise<unknown>): WyStackClient {
   return {
-    ...actual,
-    useQuery: (ref: { _path: string }) => {
-      if (ref._path === "listAssistantProviderConfigs") return configsResult;
-      return { data: undefined, isLoading: false };
-    },
-    useMutation: () => ({ mutateAsync: vi.fn() }),
+    url: "https://test",
+    prefix: "/api",
+    query: vi.fn(query) as WyStackClient["query"],
+    mutate: vi.fn(),
+    ws: {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      isConnected: vi.fn(() => false),
+      call: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    } as WyStackClient["ws"],
   };
-});
+}
+
+function makeWrapper(client: WyStackClient): FC<{ children: ReactNode }> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <WyStackProvider client={client}>{children}</WyStackProvider>
+      </QueryClientProvider>
+    );
+  };
+}
 
 describe("AssistantToggle", () => {
   beforeEach(() => {
-    configsResult.data = [];
     useAssistantStore.setState({ isOpen: false, isSetupOpen: false });
   });
 
-  it("opens provider setup instead of an unusable rail when unconfigured", () => {
-    render(<AssistantToggle />);
+  it("opens provider setup instead of an unusable rail when unconfigured", async () => {
+    const client = makeClient(async () => []);
+    render(<AssistantToggle />, { wrapper: makeWrapper(client) });
 
-    fireEvent.click(screen.getByRole("button", { name: "Set up assistant" }));
+    const button = await screen.findByRole("button", {
+      name: "Set up assistant",
+    });
+    await waitFor(() =>
+      expect((button as HTMLButtonElement).disabled).toBe(false),
+    );
+    fireEvent.click(button);
 
     expect(useAssistantStore.getState().isSetupOpen).toBe(true);
     expect(useAssistantStore.getState().isOpen).toBe(false);
   });
 
-  it("opens the assistant rail once a provider is configured", () => {
-    configsResult.data = [{ id: "provider-1" }];
-    render(<AssistantToggle />);
+  it("opens the assistant rail once a provider is configured", async () => {
+    const client = makeClient(async () => [{ id: "provider-1" }]);
+    render(<AssistantToggle />, { wrapper: makeWrapper(client) });
 
-    fireEvent.click(screen.getByRole("button", { name: "Open assistant" }));
+    const button = await screen.findByRole("button", {
+      name: "Open assistant",
+    });
+    fireEvent.click(button);
 
     expect(useAssistantStore.getState().isOpen).toBe(true);
     expect(useAssistantStore.getState().isSetupOpen).toBe(false);
+  });
+
+  it("keeps the assistant reachable and retries after the config query fails", async () => {
+    const query = vi.fn(() => Promise.reject(new Error("offline")));
+    const client = makeClient(query);
+    render(<AssistantToggle />, { wrapper: makeWrapper(client) });
+
+    const button = await screen.findByRole("button", {
+      name: "Retry assistant configuration",
+    });
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(button);
+
+    expect(useAssistantStore.getState().isOpen).toBe(true);
+    await waitFor(() => expect(query).toHaveBeenCalledTimes(2));
   });
 });

--- a/packages/app/src/components/assistant/AssistantToggle.test.tsx
+++ b/packages/app/src/components/assistant/AssistantToggle.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { type WyStackClient, WyStackProvider } from "@wystack/client";
 import { type FC, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,17 +31,22 @@ function makeClient(query: () => Promise<unknown>): WyStackClient {
   };
 }
 
-function makeWrapper(client: WyStackClient): FC<{ children: ReactNode }> {
+function makeWrapper(client: WyStackClient): FC<{ children: ReactNode }> & {
+  queryClient: QueryClient;
+} {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return function Wrapper({ children }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <WyStackProvider client={client}>{children}</WyStackProvider>
-      </QueryClientProvider>
-    );
-  };
+  const Wrapper: FC<{ children: ReactNode }> & { queryClient?: QueryClient } =
+    function Wrapper({ children }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <WyStackProvider client={client}>{children}</WyStackProvider>
+        </QueryClientProvider>
+      );
+    };
+  Wrapper.queryClient = queryClient;
+  return Wrapper as FC<{ children: ReactNode }> & { queryClient: QueryClient };
 }
 
 describe("AssistantToggle", () => {
@@ -116,5 +127,37 @@ describe("AssistantToggle", () => {
     fireEvent.click(hide);
 
     expect(useAssistantStore.getState().isOpen).toBe(false);
+  });
+
+  it("still opens setup when a refetch fails over a cached empty list", () => {
+    // react-query keeps the last successful `data` through a failed refetch, so
+    // this state is `data: []` plus `isError`. An empty list is a *known*
+    // answer — there are no providers — and the only useful action is still to
+    // configure one. Treating any error as "we know nothing" turned the control
+    // retry-only here and made setup unreachable for the exact user who needs
+    // it: a first-run user who then went offline.
+    let settled = false;
+    const query = vi.fn(() =>
+      settled ? Promise.reject(new Error("offline")) : Promise.resolve([]),
+    );
+    const wrapper = makeWrapper(makeClient(query));
+    render(<AssistantToggle />, { wrapper });
+
+    return (async () => {
+      await screen.findByRole("button", { name: "Set up assistant" });
+
+      settled = true;
+      await act(async () => {
+        await wrapper.queryClient.refetchQueries();
+      });
+
+      const button = await screen.findByRole("button", {
+        name: "Set up assistant",
+      });
+      fireEvent.click(button);
+
+      expect(useAssistantStore.getState().isSetupOpen).toBe(true);
+      expect(useAssistantStore.getState().isOpen).toBe(false);
+    })();
   });
 });

--- a/packages/app/src/components/assistant/AssistantToggle.tsx
+++ b/packages/app/src/components/assistant/AssistantToggle.tsx
@@ -20,20 +20,25 @@ export function AssistantToggle({ className }: { className?: string }) {
   const configsLoaded =
     configsResult.data !== undefined && !configsResult.isLoading;
   const configsFailed = configsResult.isError;
-  const assistantAvailable =
-    configsFailed || (configsResult.data?.length ?? 0) > 0;
+  // A failed refetch keeps the last successful `data`, so this stays true on a
+  // transient error over a working list — the rail is only withheld when the
+  // query has never succeeded and there is genuinely nothing to show.
+  const assistantAvailable = (configsResult.data?.length ?? 0) > 0;
   const assistantOpen = isOpen && assistantAvailable;
   let label = "Set up assistant";
-  if (configsFailed) {
-    label = "Retry assistant configuration";
-  } else if (assistantAvailable) {
+  if (assistantAvailable) {
     label = assistantOpen ? "Hide assistant" : "Open assistant";
+  } else if (configsFailed) {
+    label = "Retry assistant configuration";
   }
 
   function handleClick() {
-    if (configsFailed) {
+    // Failed with nothing cached: we don't know whether a provider exists, so
+    // neither opening the rail nor opening setup is honest. Retry instead —
+    // that keeps the assistant reachable without presenting a surface that
+    // cannot work.
+    if (!assistantAvailable && configsFailed) {
       configsResult.refetch().catch(() => undefined);
-      if (!isOpen) toggle();
       return;
     }
     if (!assistantAvailable) {

--- a/packages/app/src/components/assistant/AssistantToggle.tsx
+++ b/packages/app/src/components/assistant/AssistantToggle.tsx
@@ -24,20 +24,24 @@ export function AssistantToggle({ className }: { className?: string }) {
   // transient error over a working list — the rail is only withheld when the
   // query has never succeeded and there is genuinely nothing to show.
   const assistantAvailable = (configsResult.data?.length ?? 0) > 0;
+  // An empty array is a *known* answer: the query succeeded and there are no
+  // providers. Only `undefined` means we never learned anything.
+  const configsUnknown = configsResult.data === undefined;
   const assistantOpen = isOpen && assistantAvailable;
   let label = "Set up assistant";
   if (assistantAvailable) {
     label = assistantOpen ? "Hide assistant" : "Open assistant";
-  } else if (configsFailed) {
+  } else if (configsFailed && configsUnknown) {
     label = "Retry assistant configuration";
   }
 
   function handleClick() {
-    // Failed with nothing cached: we don't know whether a provider exists, so
-    // neither opening the rail nor opening setup is honest. Retry instead —
-    // that keeps the assistant reachable without presenting a surface that
-    // cannot work.
-    if (!assistantAvailable && configsFailed) {
+    // Failed having never learned the answer: we don't know whether a provider
+    // exists, so neither opening the rail nor opening setup is honest. Retry
+    // instead — that keeps the assistant reachable without presenting a
+    // surface that cannot work. A cached empty list is not this case; it is a
+    // known-unconfigured state, and setup must stay reachable through it.
+    if (!assistantAvailable && configsFailed && configsUnknown) {
       configsResult.refetch().catch(() => undefined);
       return;
     }

--- a/packages/app/src/components/assistant/AssistantToggle.tsx
+++ b/packages/app/src/components/assistant/AssistantToggle.tsx
@@ -19,14 +19,23 @@ export function AssistantToggle({ className }: { className?: string }) {
   const configsResult = useQuery(api.listAssistantProviderConfigs);
   const configsLoaded =
     configsResult.data !== undefined && !configsResult.isLoading;
-  const assistantAvailable = (configsResult.data?.length ?? 0) > 0;
+  const configsFailed = configsResult.isError;
+  const assistantAvailable =
+    configsFailed || (configsResult.data?.length ?? 0) > 0;
   const assistantOpen = isOpen && assistantAvailable;
   let label = "Set up assistant";
-  if (assistantAvailable) {
+  if (configsFailed) {
+    label = "Retry assistant configuration";
+  } else if (assistantAvailable) {
     label = assistantOpen ? "Hide assistant" : "Open assistant";
   }
 
   function handleClick() {
+    if (configsFailed) {
+      configsResult.refetch().catch(() => undefined);
+      if (!isOpen) toggle();
+      return;
+    }
     if (!assistantAvailable) {
       close();
       setSetupOpen(true);
@@ -42,7 +51,7 @@ export function AssistantToggle({ className }: { className?: string }) {
       iconOnly
       label={label}
       tooltip={assistantAvailable ? `${label} (⌘J)` : label}
-      disabled={!configsLoaded}
+      disabled={!configsLoaded && !configsFailed}
       onClick={handleClick}
       active={assistantOpen}
       className={cn(

--- a/packages/app/src/components/assistant/useAssistantHotkey.ts
+++ b/packages/app/src/components/assistant/useAssistantHotkey.ts
@@ -18,8 +18,9 @@ export function useAssistantHotkey(): void {
   const configsLoaded =
     configsResult.data !== undefined && !configsResult.isLoading;
   const configsFailed = configsResult.isError;
-  const assistantAvailable =
-    configsFailed || (configsResult.data?.length ?? 0) > 0;
+  // Mirrors AssistantToggle: a failed refetch keeps the last successful data,
+  // so availability follows the rows we actually have, never the error itself.
+  const assistantAvailable = (configsResult.data?.length ?? 0) > 0;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -29,13 +30,19 @@ export function useAssistantHotkey(): void {
       if (mod && (e.key === "j" || e.key === "J")) {
         e.preventDefault();
         if (!configsLoaded && !configsFailed) return;
-        if (configsFailed) configsResult.refetch().catch(() => undefined);
         if (assistantAvailable) {
           toggle();
-        } else {
-          close();
-          setSetupOpen(true);
+          return;
         }
+        // Nothing cached and the query failed: retry rather than assert either
+        // "configured" (a hollow rail) or "unconfigured" (a setup dialog the
+        // user may not need).
+        if (configsFailed) {
+          configsResult.refetch().catch(() => undefined);
+          return;
+        }
+        close();
+        setSetupOpen(true);
       }
     };
     window.addEventListener("keydown", onKey);

--- a/packages/app/src/components/assistant/useAssistantHotkey.ts
+++ b/packages/app/src/components/assistant/useAssistantHotkey.ts
@@ -17,7 +17,9 @@ export function useAssistantHotkey(): void {
   const configsResult = useQuery(api.listAssistantProviderConfigs);
   const configsLoaded =
     configsResult.data !== undefined && !configsResult.isLoading;
-  const assistantAvailable = (configsResult.data?.length ?? 0) > 0;
+  const configsFailed = configsResult.isError;
+  const assistantAvailable =
+    configsFailed || (configsResult.data?.length ?? 0) > 0;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -26,7 +28,8 @@ export function useAssistantHotkey(): void {
       const mod = e.metaKey || e.ctrlKey;
       if (mod && (e.key === "j" || e.key === "J")) {
         e.preventDefault();
-        if (!configsLoaded) return;
+        if (!configsLoaded && !configsFailed) return;
+        if (configsFailed) configsResult.refetch().catch(() => undefined);
         if (assistantAvailable) {
           toggle();
         } else {
@@ -37,5 +40,13 @@ export function useAssistantHotkey(): void {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [assistantAvailable, close, configsLoaded, setSetupOpen, toggle]);
+  }, [
+    assistantAvailable,
+    close,
+    configsFailed,
+    configsLoaded,
+    configsResult,
+    setSetupOpen,
+    toggle,
+  ]);
 }

--- a/packages/app/src/components/assistant/useAssistantHotkey.ts
+++ b/packages/app/src/components/assistant/useAssistantHotkey.ts
@@ -21,6 +21,9 @@ export function useAssistantHotkey(): void {
   // Mirrors AssistantToggle: a failed refetch keeps the last successful data,
   // so availability follows the rows we actually have, never the error itself.
   const assistantAvailable = (configsResult.data?.length ?? 0) > 0;
+  // Also mirrored: a cached empty list is a known-unconfigured answer, so it
+  // must fall through to setup rather than the retry branch.
+  const configsUnknown = configsResult.data === undefined;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -34,10 +37,10 @@ export function useAssistantHotkey(): void {
           toggle();
           return;
         }
-        // Nothing cached and the query failed: retry rather than assert either
-        // "configured" (a hollow rail) or "unconfigured" (a setup dialog the
-        // user may not need).
-        if (configsFailed) {
+        // Never learned the answer and the query failed: retry rather than
+        // assert either "configured" (a hollow rail) or "unconfigured" (a setup
+        // dialog the user may not need).
+        if (configsFailed && configsUnknown) {
           configsResult.refetch().catch(() => undefined);
           return;
         }
@@ -52,6 +55,7 @@ export function useAssistantHotkey(): void {
     close,
     configsFailed,
     configsLoaded,
+    configsUnknown,
     configsResult,
     setSetupOpen,
     toggle,

--- a/packages/app/src/components/shell/ShellRails.tsx
+++ b/packages/app/src/components/shell/ShellRails.tsx
@@ -81,8 +81,7 @@ export function ShellRails({ shellWidth }: ShellRailsProps) {
   const setAssistantWidth = useShellStore((s) => s.setAssistantRailWidth);
   const assistantIntentOpen = useAssistantStore((s) => s.isOpen);
   const assistantConfigs = useQuery(api.listAssistantProviderConfigs);
-  const assistantAvailable =
-    assistantConfigs.isError || (assistantConfigs.data?.length ?? 0) > 0;
+  const assistantAvailable = (assistantConfigs.data?.length ?? 0) > 0;
   const assistantOpen = assistantIntentOpen && assistantAvailable;
 
   const contextIntentOpen = appearanceOpen || sections.length > 0;

--- a/packages/app/src/components/shell/ShellRails.tsx
+++ b/packages/app/src/components/shell/ShellRails.tsx
@@ -81,7 +81,8 @@ export function ShellRails({ shellWidth }: ShellRailsProps) {
   const setAssistantWidth = useShellStore((s) => s.setAssistantRailWidth);
   const assistantIntentOpen = useAssistantStore((s) => s.isOpen);
   const assistantConfigs = useQuery(api.listAssistantProviderConfigs);
-  const assistantAvailable = (assistantConfigs.data?.length ?? 0) > 0;
+  const assistantAvailable =
+    assistantConfigs.isError || (assistantConfigs.data?.length ?? 0) > 0;
   const assistantOpen = assistantIntentOpen && assistantAvailable;
 
   const contextIntentOpen = appearanceOpen || sections.length > 0;

--- a/packages/types/src/assistant-provider-configs.ts
+++ b/packages/types/src/assistant-provider-configs.ts
@@ -43,5 +43,7 @@ export interface SaveAssistantProviderConfigInput {
 
 export interface SetAssistantDefaultModelInput {
   id: UUID;
+  /** The model observed before this change; prevents stale writes from winning. */
+  expectedDefaultModel: string;
   defaultModel: string;
 }


### PR DESCRIPTION
## Summary

Four defects on the assistant configuration surface.

**Rapid model selections raced.** The picker fired its mutation and forgot it, and the server issued a bare unconditioned `UPDATE`, so a slower earlier write could land after a faster later one and persist a model the user had already moved off. The picker now serializes writes per config and carries the model it observed as `expectedDefaultModel`; the server conditions its `UPDATE` on that value and rejects rather than overwriting a newer model.

**Changing auth mode kept the credential typed under the previous mode**, so switching to OAuth submitted a stale API key and the config loader threw on the malformed credential. It is cleared now, matching what the provider-change path already did.

**Saving an existing provider minted a new row every time** because `save()` never passed an `id`. It threads the existing config's id through.

**A failed configuration query disabled the assistant permanently and silently** — nothing read `isError`, so the toggle stayed disabled with no way back. The toggle and hotkey now surface a retry affordance.

Tracked internally as TASK-686.

## Testing

- `bun run check` — 4/4 arms PASS; `bun run format:check` clean
- 12 assistant unit tests pass. New pins, each verified by mutation (break the fix, watch the test go red): the picker's serialization guard, the server's compare-and-swap condition, the credential clear on auth-mode change, and the corrected availability rule.
- `AssistantToggle.test.tsx` no longer mocks `@wystack/client` wholesale — it drives a real client whose query rejects, which is what makes the failed-query case testable at all.
- **Behavioral QA in the running desktop app**, not inferred from the diff:
  - Save-then-save-again leaves exactly one config row, `createdAt` fixed and `updatedAt` advanced.
  - `setAssistantDefaultModel` request bodies carry both `expectedDefaultModel` and `defaultModel`; two fast selections produce two serialized requests where the second's expected equals the first's written value.
  - Typing an API key under Anthropic then switching to OAuth: the credential never reaches the save request.
  - The failed-query path driven with request interception — blocked from a cold load the toggle reads "Retry assistant configuration", is enabled, and clicking retries without opening a rail or a setup dialog; after recovery it behaves as a normal show/hide; blocking again after a successful fetch leaves the rail fully usable.

## Screenshots

### Config query failing from a cold load — toggle offers retry, no rail, no setup dialog
![Failed query, nothing cached](https://github.com/youhaowei/DashFrame/releases/download/pr-307-screenshots/qa686-ac4-blocked.png)

### After the query recovers — normal show/hide, rail renders
![Recovered](https://github.com/youhaowei/DashFrame/releases/download/pr-307-screenshots/qa686-ac4-recovered.png)

### Anthropic switched from API key to OAuth — the typed credential is gone, and never reaches the save request
![Auth mode changed](https://github.com/youhaowei/DashFrame/releases/download/pr-307-screenshots/qa686-authmode.png)

_Screenshots via pr-screenshots (prerelease `pr-307-screenshots`, not in git)._
## Review notes

Second reviewer (grok, a different family from the author) raised two mediums; both are addressed here rather than deferred.

**Fixed — a failed query opened a rail it could not fill.** The first implementation treated `isError` as "assistant is configured". That restored reachability but traded a silent lockout for a broken surface: an empty rail, "No model", a disabled send whose tooltip blamed missing setup rather than the load failure — and it took the setup path away from the primary control, so a first-run offline user could not reach provider setup from the toggle at all. It also could not hide an already-open rail while the query was failing. Availability now follows the rows actually held: a failed refetch keeps the last successful data, so a transient error over a working list still shows the rail, and only a query that has never succeeded withholds it. There the control retries instead of asserting "configured" or "unconfigured", neither of which is known.

**Fixed — the failure interleavings were untested.** Added a picker test covering reject-then-select-again.

Two low findings are accepted as intended and now pinned by that test rather than left to reader inference: a failed write does not advance the compare-and-swap baseline (the write did not land, so adopting its model would send a comparison that can never match), and the optimistic selection is not rolled back (a run carries the picked model per request, so the choice stays honored while the toast reports that saving it as the default did not stick). Both only surface with a second concurrent writer.

Worth recording: writing that test surfaced two ways it was passing for the wrong reason — it queued the follow-up in the same synchronous turn as the rejection, capturing the baseline before the failure path ran, and the mock handed back a fresh array each render, re-running the configs effect and resetting the baseline underneath the assertion. Both are fixed, and the mock now holds its data by identity the way react-query does.


