### PR TITLE
fix(insights): stable filter identity and awaited config-dialog saves

### DIFF
--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -40,6 +40,7 @@ import {
   decodeInsight,
   decodeStoredInsightDefinition,
   encodeInsightDefinition,
+  ensureInsightFilterIds,
   storedInsightDefinitionSchema,
   toInsight,
   type InsightDefinition,
@@ -860,6 +861,9 @@ const updateInsight = wy.procedure
           definition: storedInsightDefinitionSchema.parse({
             ...stored,
             ...patch,
+            ...(patch.filters !== undefined
+              ? { filters: ensureInsightFilterIds(patch.filters) }
+              : {}),
             // Pinned from the stored blob, never the patch. `source` is a valid
             // schema key, so an untyped `updates` carrying one would otherwise
             // win the spread and write a composition edge that never passed

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -1163,7 +1163,7 @@ describe("command vocabulary", () => {
   });
 
   describe("SetInsightFilter", () => {
-    it("should replace filters with tagged-union operands", async () => {
+    it("persists ids for agent-created filters that omit them", async () => {
       const { tableId } = await makeTable();
       const insightId = id();
       await commit(
@@ -1183,8 +1183,42 @@ describe("command vocabulary", () => {
       ];
       await commit(cmd("SetInsightFilter", { id: insightId, filters }));
       const rows = await insightsById(insightId);
-      const def = rows[0]?.definition as { filters: typeof filters };
-      expect(def.filters).toEqual(filters);
+      const def = rows[0]?.definition as {
+        filters: Array<(typeof filters)[number] & { id: string }>;
+      };
+      expect(def.filters).toEqual([{ ...filters[0], id: expect.any(String) }]);
+    });
+
+    it("preserves a filter id supplied by an API caller", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+
+      await commit(
+        cmd("SetInsightFilter", {
+          id: insightId,
+          filters: [
+            {
+              id: "agent-filter-id",
+              field: "region",
+              operator: "eq",
+              value: { kind: "value", v: "EMEA" },
+            },
+          ],
+        }),
+      );
+
+      const rows = await insightsById(insightId);
+      const def = rows[0]?.definition as {
+        filters: Array<{ id: string }>;
+      };
+      expect(def.filters[0]?.id).toBe("agent-filter-id");
     });
 
     it("should replace filters with a late-bound operand (category handle)", async () => {

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -131,6 +131,7 @@ import { permissions } from "../permissions";
 import { wy } from "../wystack";
 import { sanitizeDashboardItemUpdates } from "./dashboard-item-updates";
 import {
+  ensureInsightFilterIds,
   type InsightSource,
   insightSourceSchema,
   type StoredInsightDefinition,
@@ -820,10 +821,19 @@ const setInsightFilter = wy.procedure
       ...definition,
       filters,
     });
+    // `filters` is a required input here, but the definition shape types it as
+    // optional, so guard rather than assert — same shape as the patch path in
+    // app-artifacts.ts, which must handle a genuinely absent key.
+    const normalized = {
+      ...next,
+      ...(next.filters === undefined
+        ? {}
+        : { filters: ensureInsightFilterIds(next.filters) }),
+    };
     await ctx.db
       .from(insights)
       .where(eq("id", id))
-      .update({ definition: next });
+      .update({ definition: normalized });
     return { ok: true };
   });
 

--- a/apps/server/src/functions/insights.ts
+++ b/apps/server/src/functions/insights.ts
@@ -67,6 +67,28 @@ export interface StoredInsightDefinition {
 }
 
 /**
+ * Stamp a persisted identity on every filter accepted at an API write boundary.
+ *
+ * Agent commands and legacy API calls may omit `id`; giving those predicates an
+ * id before they reach storage keeps UI identity independent of array order.
+ * Filter element validation remains intentionally opaque at this layer, so
+ * non-object entries are left for the existing definition contract to handle.
+ */
+export function ensureInsightFilterIds(filters: unknown[]): unknown[] {
+  return filters.map((filter) => {
+    if (
+      filter !== null &&
+      typeof filter === "object" &&
+      !Array.isArray(filter) &&
+      (!("id" in filter) || typeof filter.id !== "string" || !filter.id)
+    ) {
+      return { ...filter, id: crypto.randomUUID() };
+    }
+    return filter;
+  });
+}
+
+/**
  * The ideal stored-definition write shape (arrays conceptually present, element
  * types known). The encoder emits this; `app-artifacts.ts` patch/dedup paths
  * consume it. Kept hand-written (not `z.infer`) and separate from the tolerant

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FieldRenameDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FieldRenameDialog.tsx
@@ -1,5 +1,7 @@
 import type { CombinedField } from "@/lib/insights/compute-combined-fields";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Dialog,
   DialogContent,
@@ -16,7 +18,7 @@ interface FieldRenameDialogProps {
   field: CombinedField | null;
   tableName?: string;
   onOpenChange: (open: boolean) => void;
-  onSave: (field: CombinedField, newName: string) => void;
+  onSave: (field: CombinedField, newName: string) => Promise<void> | void;
 }
 
 /**
@@ -31,16 +33,27 @@ function FieldRenameForm({
 }: {
   field: CombinedField;
   tableName?: string;
-  onSave: (field: CombinedField, newName: string) => void;
+  onSave: (field: CombinedField, newName: string) => Promise<void> | void;
   onClose: () => void;
 }) {
   const [name, setName] = useState(field.name);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
   const columnName = field.columnName ?? field.name;
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!name.trim()) return;
-    onSave(field, name.trim());
-    onClose();
+    setError(null);
+    setIsSaving(true);
+    try {
+      await onSave(field, name.trim());
+      onClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setError(`Failed to rename field: ${message}`);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -61,6 +74,12 @@ function FieldRenameForm({
       </DialogHeader>
 
       <div className="space-y-4 py-4">
+        {error && (
+          <Alert color="danger">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {/* Source info (read-only) */}
         <div className="space-y-2 rounded-lg bg-neutral-bg-muted px-3 py-3">
           {tableName && (
@@ -98,11 +117,17 @@ function FieldRenameForm({
       </div>
 
       <DialogFooter>
-        <Button label="Cancel" variant="outline" onClick={onClose} />
         <Button
-          label="Save"
+          label="Cancel"
+          variant="outline"
+          onClick={onClose}
+          disabled={isSaving}
+        />
+        <Button
+          label={isSaving ? "Saving..." : "Save"}
           onClick={handleSave}
-          disabled={!name.trim() || name.trim() === field.name}
+          disabled={isSaving || !name.trim() || name.trim() === field.name}
+          loading={isSaving}
         />
       </DialogFooter>
     </>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FieldRenameDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FieldRenameDialog.tsx
@@ -13,6 +13,7 @@ import {
   Label,
 } from "@wystack/ui-react";
 import { useState } from "react";
+import { useSaveDismissGuard, useSavingFlag } from "./use-save-dismiss-guard";
 
 interface FieldRenameDialogProps {
   field: CombinedField | null;
@@ -30,15 +31,17 @@ function FieldRenameForm({
   tableName,
   onSave,
   onClose,
+  onPendingChange,
 }: {
   field: CombinedField;
   tableName?: string;
   onSave: (field: CombinedField, newName: string) => Promise<void> | void;
   onClose: () => void;
+  onPendingChange: (pending: boolean) => void;
 }) {
   const [name, setName] = useState(field.name);
   const [error, setError] = useState<string | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSaving, setIsSaving] = useSavingFlag(onPendingChange);
   const columnName = field.columnName ?? field.name;
 
   const handleSave = async () => {
@@ -149,6 +152,16 @@ export function FieldRenameDialog({
   onOpenChange,
   onSave,
 }: FieldRenameDialogProps) {
+  const { setPending, isPending } = useSaveDismissGuard();
+
+  // Escape and outside-click reach the shell directly, bypassing the disabled
+  // Cancel button. Dismissing a pending save lets a second editor open, and the
+  // first save's completion would then close it and discard that edit.
+  const handleDismiss = () => {
+    if (isPending()) return;
+    handleClose();
+  };
+
   const handleClose = () => {
     onOpenChange(false);
   };
@@ -156,7 +169,7 @@ export function FieldRenameDialog({
   const isOpen = field !== null;
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen} onOpenChange={handleDismiss}>
       <DialogContent className="sm:max-w-md">
         {field && (
           <FieldRenameForm
@@ -165,6 +178,7 @@ export function FieldRenameDialog({
             tableName={tableName}
             onSave={onSave}
             onClose={handleClose}
+            onPendingChange={setPending}
           />
         )}
       </DialogContent>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -4,6 +4,8 @@ import type {
   InsightFilterBetweenValue,
 } from "@dashframe/types";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Dialog,
   DialogContent,
@@ -40,7 +42,7 @@ interface FilterEditDialogProps {
   filter: FilterWithId | "new" | null;
   combinedFields: CombinedField[];
   onOpenChange: (open: boolean) => void;
-  onSave: (filter: FilterWithId) => void;
+  onSave: (filter: FilterWithId) => Promise<void> | void;
 }
 
 // ============================================================================
@@ -59,6 +61,37 @@ const OPERATOR_OPTIONS: { value: Operator; label: string }[] = [
   { value: "in", label: "in (list)" },
 ];
 
+function initialScalarValue(filter: FilterWithId): string {
+  if (filter.operator === "between") return "";
+  if (filter.operator === "in" && Array.isArray(filter.value)) {
+    return (filter.value as unknown[]).map(String).join(", ");
+  }
+  if (Array.isArray(filter.value)) return "";
+  return String(filter.value ?? "");
+}
+
+function initialBetweenValue(filter: FilterWithId): {
+  low: string;
+  high: string;
+} {
+  if (
+    filter.operator !== "between" ||
+    !filter.value ||
+    typeof filter.value !== "object" ||
+    Array.isArray(filter.value)
+  ) {
+    return { low: "", high: "" };
+  }
+
+  const value = filter.value as InsightFilterBetweenValue;
+  return { low: String(value.low ?? ""), high: String(value.high ?? "") };
+}
+
+function saveButtonLabel(isSaving: boolean, isNew: boolean): string {
+  if (!isSaving) return isNew ? "Add" : "Save";
+  return isNew ? "Adding..." : "Saving...";
+}
+
 // ============================================================================
 // FilterEditForm (inner; key-reset pattern from MetricEditDialog)
 // ============================================================================
@@ -66,7 +99,7 @@ const OPERATOR_OPTIONS: { value: Operator; label: string }[] = [
 interface FilterEditFormProps {
   filter: FilterWithId;
   combinedFields: CombinedField[];
-  onSave: (filter: FilterWithId) => void;
+  onSave: (filter: FilterWithId) => Promise<void> | void;
   onClose: () => void;
   isNew: boolean;
 }
@@ -82,31 +115,16 @@ function FilterEditForm({
   const [operator, setOperator] = useState<Operator>(filter.operator);
 
   // Scalar value state (also used for the `in` operator as comma-separated string)
-  const initialScalar = (() => {
-    if (filter.operator === "between") return "";
-    if (filter.operator === "in" && Array.isArray(filter.value)) {
-      return (filter.value as unknown[]).map(String).join(", ");
-    }
-    if (Array.isArray(filter.value)) return "";
-    return String(filter.value ?? "");
-  })();
-  const [scalarValue, setScalarValue] = useState(initialScalar);
+  const [scalarValue, setScalarValue] = useState(() =>
+    initialScalarValue(filter),
+  );
 
   // Between value state
-  const initialBetween = (() => {
-    if (
-      filter.operator === "between" &&
-      filter.value &&
-      typeof filter.value === "object" &&
-      !Array.isArray(filter.value)
-    ) {
-      const v = filter.value as InsightFilterBetweenValue;
-      return { low: String(v.low ?? ""), high: String(v.high ?? "") };
-    }
-    return { low: "", high: "" };
-  })();
+  const initialBetween = initialBetweenValue(filter);
   const [betweenLow, setBetweenLow] = useState(initialBetween.low);
   const [betweenHigh, setBetweenHigh] = useState(initialBetween.high);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   const selectedField = combinedFields.find(
     (f) => (f.columnName ?? f.name) === field,
@@ -147,22 +165,31 @@ function FilterEditForm({
   if (isIn) valuePlaceholder = "e.g. a, b, c";
   else if (inputType === "number") valuePlaceholder = "Enter a number";
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!isValid) return;
     // prepareFilterForSave stamps a fresh persisted id on a new filter (and
     // sources its client `_id` from it). Generated per save, not per dialog
     // mount — FilterEditDialog is permanently mounted, so a mount-scoped id
     // would hand every Add the same value and make the second filter overwrite
     // the first. An existing filter keeps its id/_id so edits route correctly.
-    onSave(
-      prepareFilterForSave({
-        ...filter,
-        field,
-        operator,
-        value: buildFilterValue(draft),
-      }),
-    );
-    onClose();
+    setError(null);
+    setIsSaving(true);
+    try {
+      await onSave(
+        prepareFilterForSave({
+          ...filter,
+          field,
+          operator,
+          value: buildFilterValue(draft),
+        }),
+      );
+      onClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setError(`Failed to save filter: ${message}`);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -177,6 +204,12 @@ function FilterEditForm({
       </DialogHeader>
 
       <div className="space-y-4 py-4">
+        {error && (
+          <Alert color="danger">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {/* Field picker */}
         <div className="space-y-2">
           <Label htmlFor="filter-field">Field</Label>
@@ -284,11 +317,17 @@ function FilterEditForm({
       </div>
 
       <DialogFooter>
-        <Button label="Cancel" variant="outline" onClick={onClose} />
         <Button
-          label={isNew ? "Add" : "Save"}
+          label="Cancel"
+          variant="outline"
+          onClick={onClose}
+          disabled={isSaving}
+        />
+        <Button
+          label={saveButtonLabel(isSaving, isNew)}
           onClick={handleSave}
-          disabled={!isValid}
+          disabled={isSaving || !isValid}
+          loading={isSaving}
         />
       </DialogFooter>
     </>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/FilterEditDialog.tsx
@@ -30,6 +30,7 @@ import {
   isFilterDraftValid,
 } from "./filter-value";
 import type { FilterWithId } from "./FiltersSection";
+import { useSaveDismissGuard, useSavingFlag } from "./use-save-dismiss-guard";
 
 // ============================================================================
 // Types
@@ -101,6 +102,7 @@ interface FilterEditFormProps {
   combinedFields: CombinedField[];
   onSave: (filter: FilterWithId) => Promise<void> | void;
   onClose: () => void;
+  onPendingChange: (pending: boolean) => void;
   isNew: boolean;
 }
 
@@ -109,6 +111,7 @@ function FilterEditForm({
   combinedFields,
   onSave,
   onClose,
+  onPendingChange,
   isNew,
 }: FilterEditFormProps) {
   const [field, setField] = useState<string>(filter.field);
@@ -124,7 +127,7 @@ function FilterEditForm({
   const [betweenLow, setBetweenLow] = useState(initialBetween.low);
   const [betweenHigh, setBetweenHigh] = useState(initialBetween.high);
   const [error, setError] = useState<string | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSaving, setIsSaving] = useSavingFlag(onPendingChange);
 
   const selectedField = combinedFields.find(
     (f) => (f.columnName ?? f.name) === field,
@@ -377,12 +380,22 @@ export function FilterEditDialog({
     return filter;
   })();
 
+  const { setPending, isPending } = useSaveDismissGuard();
+
+  // Escape and outside-click reach the shell directly, bypassing the disabled
+  // Cancel button. Dismissing a pending save lets a second editor open, and the
+  // first save's completion would then close it and discard that edit.
+  const handleDismiss = () => {
+    if (isPending()) return;
+    handleClose();
+  };
+
   const handleClose = () => {
     onOpenChange(false);
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen} onOpenChange={handleDismiss}>
       <DialogContent className="sm:max-w-md">
         {effectiveFilter && (
           <FilterEditForm
@@ -391,6 +404,7 @@ export function FilterEditDialog({
             combinedFields={combinedFields}
             onSave={onSave}
             onClose={handleClose}
+            onPendingChange={setPending}
             isNew={isNew}
           />
         )}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightConfigPanel.tsx
@@ -243,11 +243,10 @@ export function InsightConfigPanel({
    * matching an in-flight edit back to its predicate on save.
    *
    * `_id` is sourced from the filter's persisted `id` (generated on add by
-   * FilterEditDialog and preserved across persistence round-trips). This
-   * survives a subscription firing mid-edit — a concurrent reorder no longer
-   * shifts the id, so handleSaveFilter cannot misroute the save to the wrong
-   * filter. Filters created via the API/agent path without an `id` fall back to
-   * a content+index key; those aren't expected to be edited concurrently.
+   * FilterEditDialog and the API write boundary, then preserved across
+   * persistence round-trips). This survives a subscription firing mid-edit — a
+   * concurrent reorder no longer shifts the id, so handleSaveFilter cannot
+   * misroute the save to the wrong filter.
    */
   const filtersWithIds = useMemo(
     (): FilterWithId[] => withFilterIds(insight.filters),
@@ -300,18 +299,13 @@ export function InsightConfigPanel({
     async (field: CombinedField, newName: string) => {
       // Update the display name in the source DataTable
       // This only changes the user-facing name, not the underlying columnName
-      try {
-        await patchDataTableArray({
-          dataTableId: field.sourceTableId,
-          kind: "fields",
-          mode: "update",
-          itemId: field.id,
-          value: { name: newName },
-        });
-      } catch (error) {
-        console.error("Failed to rename field:", error);
-        alert("Failed to rename field. Please try again.");
-      }
+      await patchDataTableArray({
+        dataTableId: field.sourceTableId,
+        kind: "fields",
+        mode: "update",
+        itemId: field.id,
+        value: { name: newName },
+      });
     },
     [patchDataTableArray],
   );
@@ -344,19 +338,19 @@ export function InsightConfigPanel({
   );
 
   const handleAddMetric = useCallback(
-    (metric: InsightMetric) => {
+    async (metric: InsightMetric) => {
       const updated = [...(insight.metrics ?? []), metric];
-      updateInsight(insight.id, { metrics: updated });
+      await updateInsight(insight.id, { metrics: updated });
     },
     [insight.id, insight.metrics, updateInsight],
   );
 
   const handleEditMetric = useCallback(
-    (updatedMetric: InsightMetric) => {
+    async (updatedMetric: InsightMetric) => {
       const updated = (insight.metrics ?? []).map((m) =>
         m.id === updatedMetric.id ? updatedMetric : m,
       );
-      updateInsight(insight.id, { metrics: updated });
+      await updateInsight(insight.id, { metrics: updated });
     },
     [insight.id, insight.metrics, updateInsight],
   );
@@ -391,9 +385,9 @@ export function InsightConfigPanel({
   );
 
   const handleSaveFilter = useCallback(
-    (saved: FilterWithId) => {
+    async (saved: FilterWithId) => {
       const updated = applyFilterSave(filtersWithIds, saved);
-      updateInsightLegacy({
+      await updateInsightLegacy({
         id: insight.id,
         updates: { filters: stripFilterIds(updated) },
       });

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightMetricEditorModal.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightMetricEditorModal.tsx
@@ -1,5 +1,7 @@
 import type { DataTable, InsightMetric, UUID } from "@dashframe/types";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Dialog,
   DialogContent,
@@ -25,11 +27,35 @@ type AggregationType =
   | "max"
   | "count_distinct";
 
+export function metricColumnNameForSave(
+  aggregation: AggregationType,
+  columnName: string,
+): string | undefined {
+  return aggregation === "count" && !columnName
+    ? undefined
+    : columnName || undefined;
+}
+
+export function metricFormulaPreview(
+  aggregation: AggregationType,
+  columnName: string,
+): string {
+  if (aggregation === "count" && !columnName) {
+    return "count(*)";
+  }
+
+  if (!columnName) {
+    return `${aggregation}(?)`;
+  }
+
+  return `${aggregation}(${columnName})`;
+}
+
 interface InsightMetricEditorModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   dataTable: DataTable;
-  onSave: (metric: InsightMetric) => void;
+  onSave: (metric: InsightMetric) => Promise<void> | void;
 }
 
 /**
@@ -43,12 +69,14 @@ function InsightMetricForm({
   onClose,
 }: {
   dataTable: DataTable;
-  onSave: (metric: InsightMetric) => void;
+  onSave: (metric: InsightMetric) => Promise<void> | void;
   onClose: () => void;
 }) {
   const [customName, setCustomName] = useState<string | null>(null);
   const [aggregation, setAggregation] = useState<AggregationType>("count");
   const [columnName, setColumnName] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   // Get available fields (exclude internal _ prefixed)
   const availableFields = useMemo(
@@ -98,7 +126,7 @@ function InsightMetricForm({
   const name = customName ?? autoGenerateName();
   const setName = (next: string) => setCustomName(next);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!name.trim()) return;
 
     // Generate unique ID
@@ -108,25 +136,21 @@ function InsightMetricForm({
       id,
       name: name.trim(),
       sourceTable: dataTable.id,
-      columnName: aggregation === "count" ? undefined : columnName || undefined,
+      columnName: metricColumnNameForSave(aggregation, columnName),
       aggregation,
     };
 
-    onSave(metric);
-    onClose();
-  };
-
-  // Generate formula preview
-  const getFormulaPreview = () => {
-    if (aggregation === "count" && !columnName) {
-      return "count(*)";
+    setError(null);
+    setIsSaving(true);
+    try {
+      await onSave(metric);
+      onClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setError(`Failed to save metric: ${message}`);
+    } finally {
+      setIsSaving(false);
     }
-
-    if (!columnName) {
-      return `${aggregation}(?)`;
-    }
-
-    return `${aggregation}(${columnName})`;
   };
 
   // Check if field selection is required
@@ -148,6 +172,12 @@ function InsightMetricForm({
       </DialogHeader>
 
       <div className="space-y-4 py-4">
+        {error && (
+          <Alert color="danger">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {/* Aggregation Type */}
         <div className="space-y-2">
           <Label htmlFor="aggregation">Aggregation type</Label>
@@ -216,17 +246,23 @@ function InsightMetricForm({
             Formula preview
           </p>
           <code className="font-mono text-sm text-neutral-fg">
-            {getFormulaPreview()}
+            {metricFormulaPreview(aggregation, columnName)}
           </code>
         </div>
       </div>
 
       <DialogFooter>
-        <Button label="Cancel" variant="outline" onClick={onClose} />
         <Button
-          label="Add metric"
+          label="Cancel"
+          variant="outline"
+          onClick={onClose}
+          disabled={isSaving}
+        />
+        <Button
+          label={isSaving ? "Adding metric..." : "Add metric"}
           onClick={handleSave}
-          disabled={!name.trim() || (needsField && !columnName)}
+          disabled={isSaving || !name.trim() || (needsField && !columnName)}
+          loading={isSaving}
         />
       </DialogFooter>
     </>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightMetricEditorModal.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightMetricEditorModal.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@wystack/ui-react";
 import { useMemo, useState } from "react";
+import { useSaveDismissGuard, useSavingFlag } from "./use-save-dismiss-guard";
 
 type AggregationType =
   | "sum"
@@ -27,20 +28,24 @@ type AggregationType =
   | "max"
   | "count_distinct";
 
+// "Count (rows)" is `count(*)` by definition and the dialog offers no column
+// picker for it, so any column still held in state is invisible to the user.
+// Persisting it would emit `count(column)`, which silently skips null rows —
+// a different number than the one the label promises. The column is dropped
+// here as well as cleared on switch, so no caller can reintroduce it.
 export function metricColumnNameForSave(
   aggregation: AggregationType,
   columnName: string,
 ): string | undefined {
-  return aggregation === "count" && !columnName
-    ? undefined
-    : columnName || undefined;
+  if (aggregation === "count") return undefined;
+  return columnName || undefined;
 }
 
 export function metricFormulaPreview(
   aggregation: AggregationType,
   columnName: string,
 ): string {
-  if (aggregation === "count" && !columnName) {
+  if (aggregation === "count") {
     return "count(*)";
   }
 
@@ -67,16 +72,18 @@ function InsightMetricForm({
   dataTable,
   onSave,
   onClose,
+  onPendingChange,
 }: {
   dataTable: DataTable;
   onSave: (metric: InsightMetric) => Promise<void> | void;
   onClose: () => void;
+  onPendingChange: (pending: boolean) => void;
 }) {
   const [customName, setCustomName] = useState<string | null>(null);
   const [aggregation, setAggregation] = useState<AggregationType>("count");
   const [columnName, setColumnName] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSaving, setIsSaving] = useSavingFlag(onPendingChange);
 
   // Get available fields (exclude internal _ prefixed)
   const availableFields = useMemo(
@@ -183,7 +190,14 @@ function InsightMetricForm({
           <Label htmlFor="aggregation">Aggregation type</Label>
           <Select
             value={aggregation}
-            onValueChange={(v) => setAggregation(v as AggregationType)}
+            onValueChange={(v) => {
+              const next = v as AggregationType;
+              setAggregation(next);
+              // The field picker is hidden for "Count (rows)"; leaving a
+              // previously chosen column in state would make it unreachable
+              // but still live.
+              if (next === "count") setColumnName("");
+            }}
           >
             <SelectTrigger id="aggregation">
               <SelectValue />
@@ -288,7 +302,12 @@ export function InsightMetricEditorModal({
 }: InsightMetricEditorModalProps) {
   const [sessionKey, setSessionKey] = useState(0);
 
+  const { setPending, isPending } = useSaveDismissGuard();
+
   const handleOpenChange = (open: boolean) => {
+    // A dismissal while a save is pending would let a second editor open and
+    // then be closed by the first save's completion.
+    if (!open && isPending()) return;
     if (open) {
       // Bump key so the inner form remounts fresh on each open.
       setSessionKey((k) => k + 1);
@@ -307,6 +326,7 @@ export function InsightMetricEditorModal({
             dataTable={dataTable}
             onSave={onSave}
             onClose={handleClose}
+            onPendingChange={setPending}
           />
         )}
       </DialogContent>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightMetricEditorModal.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightMetricEditorModal.tsx
@@ -1,4 +1,9 @@
-import type { DataTable, InsightMetric, UUID } from "@dashframe/types";
+import type {
+  AggregationType,
+  DataTable,
+  InsightMetric,
+  UUID,
+} from "@dashframe/types";
 import {
   Alert,
   AlertDescription,
@@ -18,43 +23,11 @@ import {
   SelectValue,
 } from "@wystack/ui-react";
 import { useMemo, useState } from "react";
+import {
+  metricColumnNameForSave,
+  metricFormulaPreview,
+} from "./metric-formula";
 import { useSaveDismissGuard, useSavingFlag } from "./use-save-dismiss-guard";
-
-type AggregationType =
-  | "sum"
-  | "avg"
-  | "count"
-  | "min"
-  | "max"
-  | "count_distinct";
-
-// "Count (rows)" is `count(*)` by definition and the dialog offers no column
-// picker for it, so any column still held in state is invisible to the user.
-// Persisting it would emit `count(column)`, which silently skips null rows —
-// a different number than the one the label promises. The column is dropped
-// here as well as cleared on switch, so no caller can reintroduce it.
-export function metricColumnNameForSave(
-  aggregation: AggregationType,
-  columnName: string,
-): string | undefined {
-  if (aggregation === "count") return undefined;
-  return columnName || undefined;
-}
-
-export function metricFormulaPreview(
-  aggregation: AggregationType,
-  columnName: string,
-): string {
-  if (aggregation === "count") {
-    return "count(*)";
-  }
-
-  if (!columnName) {
-    return `${aggregation}(?)`;
-  }
-
-  return `${aggregation}(${columnName})`;
-}
 
 interface InsightMetricEditorModalProps {
   isOpen: boolean;

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/MetricEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/MetricEditDialog.tsx
@@ -4,6 +4,8 @@ import type {
   InsightMetric,
 } from "@dashframe/types";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Dialog,
   DialogContent,
@@ -25,7 +27,7 @@ interface MetricEditDialogProps {
   metric: InsightMetric | null;
   dataTable: DataTable;
   onOpenChange: (open: boolean) => void;
-  onSave: (metric: InsightMetric) => void;
+  onSave: (metric: InsightMetric) => Promise<void> | void;
 }
 
 /**
@@ -40,7 +42,7 @@ function MetricEditForm({
 }: {
   metric: InsightMetric;
   dataTable: DataTable;
-  onSave: (metric: InsightMetric) => void;
+  onSave: (metric: InsightMetric) => Promise<void> | void;
   onClose: () => void;
 }) {
   const [name, setName] = useState(metric.name);
@@ -48,6 +50,8 @@ function MetricEditForm({
     metric.aggregation,
   );
   const [columnName, setColumnName] = useState<string>(metric.columnName ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   // Get available fields (exclude internal _ prefixed)
   const availableFields = useMemo(
@@ -69,7 +73,7 @@ function MetricEditForm({
     [availableFields],
   );
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!name.trim()) return;
 
     const updatedMetric: InsightMetric = {
@@ -82,8 +86,17 @@ function MetricEditForm({
       aggregation,
     };
 
-    onSave(updatedMetric);
-    onClose();
+    setError(null);
+    setIsSaving(true);
+    try {
+      await onSave(updatedMetric);
+      onClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setError(`Failed to save metric: ${message}`);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   // Generate formula preview
@@ -124,6 +137,12 @@ function MetricEditForm({
       </DialogHeader>
 
       <div className="space-y-4 py-4">
+        {error && (
+          <Alert color="danger">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         {/* Aggregation Type */}
         <div className="space-y-2">
           <Label htmlFor="edit-aggregation">Aggregation type</Label>
@@ -204,11 +223,22 @@ function MetricEditForm({
       </div>
 
       <DialogFooter>
-        <Button label="Cancel" variant="outline" onClick={onClose} />
         <Button
-          label="Save"
+          label="Cancel"
+          variant="outline"
+          onClick={onClose}
+          disabled={isSaving}
+        />
+        <Button
+          label={isSaving ? "Saving..." : "Save"}
           onClick={handleSave}
-          disabled={!name.trim() || (needsField && !columnName) || !hasChanges}
+          disabled={
+            isSaving ||
+            !name.trim() ||
+            (needsField && !columnName) ||
+            !hasChanges
+          }
+          loading={isSaving}
         />
       </DialogFooter>
     </>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/MetricEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/MetricEditDialog.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@wystack/ui-react";
 import { useMemo, useState } from "react";
+import { useSaveDismissGuard, useSavingFlag } from "./use-save-dismiss-guard";
 
 interface MetricEditDialogProps {
   metric: InsightMetric | null;
@@ -39,11 +40,13 @@ function MetricEditForm({
   dataTable,
   onSave,
   onClose,
+  onPendingChange,
 }: {
   metric: InsightMetric;
   dataTable: DataTable;
   onSave: (metric: InsightMetric) => Promise<void> | void;
   onClose: () => void;
+  onPendingChange: (pending: boolean) => void;
 }) {
   const [name, setName] = useState(metric.name);
   const [aggregation, setAggregation] = useState<AggregationType>(
@@ -51,7 +54,7 @@ function MetricEditForm({
   );
   const [columnName, setColumnName] = useState<string>(metric.columnName ?? "");
   const [error, setError] = useState<string | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSaving, setIsSaving] = useSavingFlag(onPendingChange);
 
   // Get available fields (exclude internal _ prefixed)
   const availableFields = useMemo(
@@ -262,6 +265,16 @@ export function MetricEditDialog({
   onOpenChange,
   onSave,
 }: MetricEditDialogProps) {
+  const { setPending, isPending } = useSaveDismissGuard();
+
+  // Escape and outside-click reach the shell directly, bypassing the disabled
+  // Cancel button. Dismissing a pending save lets a second editor open, and the
+  // first save's completion would then close it and discard that edit.
+  const handleDismiss = () => {
+    if (isPending()) return;
+    handleClose();
+  };
+
   const handleClose = () => {
     onOpenChange(false);
   };
@@ -269,7 +282,7 @@ export function MetricEditDialog({
   const isOpen = metric !== null;
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen} onOpenChange={handleDismiss}>
       <DialogContent className="sm:max-w-md">
         {metric && (
           <MetricEditForm
@@ -278,6 +291,7 @@ export function MetricEditDialog({
             dataTable={dataTable}
             onSave={onSave}
             onClose={handleClose}
+            onPendingChange={setPending}
           />
         )}
       </DialogContent>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/MetricEditDialog.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/MetricEditDialog.tsx
@@ -22,6 +22,10 @@ import {
   SelectValue,
 } from "@wystack/ui-react";
 import { useMemo, useState } from "react";
+import {
+  metricColumnNameForSave,
+  metricFormulaPreview,
+} from "./metric-formula";
 import { useSaveDismissGuard, useSavingFlag } from "./use-save-dismiss-guard";
 
 interface MetricEditDialogProps {
@@ -82,10 +86,7 @@ function MetricEditForm({
     const updatedMetric: InsightMetric = {
       ...metric,
       name: name.trim(),
-      columnName:
-        aggregation === "count" && !columnName
-          ? undefined
-          : columnName || undefined,
+      columnName: metricColumnNameForSave(aggregation, columnName),
       aggregation,
     };
 
@@ -102,19 +103,6 @@ function MetricEditForm({
     }
   };
 
-  // Generate formula preview
-  const getFormulaPreview = () => {
-    if (aggregation === "count" && !columnName) {
-      return "count(*)";
-    }
-
-    if (!columnName) {
-      return `${aggregation}(?)`;
-    }
-
-    return `${aggregation}(${columnName})`;
-  };
-
   // Check if field selection is required (not required for basic count)
   const needsField = aggregation !== "count";
 
@@ -124,11 +112,15 @@ function MetricEditForm({
       ? numericFields
       : availableFields;
 
-  // Check if anything changed
+  // Compare against what a save would actually write, not the raw field. A
+  // metric stored as `count` with a column predates the column being dropped
+  // for "Count (rows)"; saving repairs it, so the dialog must read as dirty on
+  // open and let the user commit the repair without inventing another edit.
   const hasChanges =
     name.trim() !== metric.name ||
     aggregation !== metric.aggregation ||
-    (columnName || undefined) !== (metric.columnName || undefined);
+    metricColumnNameForSave(aggregation, columnName) !==
+      (metric.columnName || undefined);
 
   return (
     <>
@@ -220,7 +212,7 @@ function MetricEditForm({
             Formula preview
           </p>
           <code className="font-mono text-sm text-neutral-fg">
-            {getFormulaPreview()}
+            {metricFormulaPreview(aggregation, columnName)}
           </code>
         </div>
       </div>

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
@@ -238,7 +238,11 @@ describe("insight config dialog saves", () => {
   // the label promises. Driven through the rendered dialog rather than the
   // helpers, because the defect is the transition the user performs.
   it("drops a previously chosen column when switching back to Count (rows)", async () => {
-    const user = userEvent.setup();
+    // `delay: null` removes userEvent's inter-event wait. This test drives nine
+    // interactions through Radix Selects, and at the default delay the total
+    // ran just over the 5s limit on CI's slower runner while passing locally.
+    // Dropping the delay changes pacing only — every interaction still happens.
+    const user = userEvent.setup({ delay: null });
     const onSave = vi.fn().mockResolvedValue(undefined);
 
     render(

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
@@ -1,0 +1,143 @@
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import type { DataTable, InsightMetric } from "@dashframe/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FieldRenameDialog } from "./FieldRenameDialog";
+import { FilterEditDialog } from "./FilterEditDialog";
+import {
+  InsightMetricEditorModal,
+  metricColumnNameForSave,
+  metricFormulaPreview,
+} from "./InsightMetricEditorModal";
+import { MetricEditDialog } from "./MetricEditDialog";
+
+const table = {
+  id: "table-1",
+  name: "Orders",
+  fields: [
+    {
+      id: "field-1",
+      name: "Amount",
+      columnName: "amount",
+      type: "number",
+    },
+  ],
+} as DataTable;
+
+const field = {
+  id: "field-1",
+  name: "Amount",
+  displayName: "Amount",
+  columnName: "amount",
+  type: "number",
+  sourceTableId: "table-1",
+} as CombinedField;
+
+const metric = {
+  id: "metric-1",
+  name: "Total amount",
+  sourceTable: table.id,
+  columnName: "amount",
+  aggregation: "sum",
+} as InsightMetric;
+
+const rejectedSave = () => Promise.reject(new Error("write failed"));
+
+describe("insight config dialog saves", () => {
+  it("keeps the add-metric dialog open and reports a rejected save", async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <InsightMetricEditorModal
+        isOpen
+        onOpenChange={onOpenChange}
+        dataTable={table}
+        onSave={rejectedSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add metric" }));
+
+    expect(
+      await screen.findByText("Failed to save metric: write failed"),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Add metric" })).toBeTruthy();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the edit-metric dialog open and reports a rejected save", async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <MetricEditDialog
+        metric={metric}
+        dataTable={table}
+        onOpenChange={onOpenChange}
+        onSave={rejectedSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Revenue" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("Failed to save metric: write failed"),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Edit metric" })).toBeTruthy();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the filter dialog open and reports a rejected save", async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <FilterEditDialog
+        filter="new"
+        combinedFields={[field]}
+        onOpenChange={onOpenChange}
+        onSave={rejectedSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "100" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(
+      await screen.findByText("Failed to save filter: write failed"),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Add filter" })).toBeTruthy();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the field-rename dialog open and reports a rejected save", async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <FieldRenameDialog
+        field={field}
+        onOpenChange={onOpenChange}
+        onSave={rejectedSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Revenue" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText("Failed to rename field: write failed"),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Rename field" })).toBeTruthy();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps a count metric's saved payload equal to its preview", () => {
+    expect(metricFormulaPreview("count", "amount")).toBe("count(amount)");
+    expect(metricColumnNameForSave("count", "amount")).toBe("amount");
+  });
+});

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
@@ -1,6 +1,7 @@
 import type { CombinedField } from "@/lib/insights/compute-combined-fields";
 import type { DataTable, InsightMetric } from "@dashframe/types";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { FieldRenameDialog } from "./FieldRenameDialog";
 import { FilterEditDialog } from "./FilterEditDialog";
@@ -136,8 +137,161 @@ describe("insight config dialog saves", () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
+  // Disabling Cancel is not enough: Escape and an outside click reach the
+  // dialog shell's `onOpenChange` directly. Dismissing a pending save lets a
+  // second editor open, and the first promise's `onClose` then closes *that*
+  // one, discarding the edit.
+  it.each([
+    [
+      "add-metric",
+      (onOpenChange: () => void, onSave: () => Promise<void>) => (
+        <InsightMetricEditorModal
+          isOpen
+          onOpenChange={onOpenChange}
+          dataTable={table}
+          onSave={onSave}
+        />
+      ),
+      "Add metric",
+      () => undefined,
+    ],
+    [
+      "filter",
+      (onOpenChange: () => void, onSave: () => Promise<void>) => (
+        <FilterEditDialog
+          filter="new"
+          combinedFields={[field]}
+          onOpenChange={onOpenChange}
+          onSave={onSave}
+        />
+      ),
+      "Add",
+      () =>
+        fireEvent.change(screen.getByLabelText("Value"), {
+          target: { value: "100" },
+        }),
+    ],
+    [
+      "edit-metric",
+      (onOpenChange: () => void, onSave: () => Promise<void>) => (
+        <MetricEditDialog
+          metric={metric}
+          dataTable={table}
+          onOpenChange={onOpenChange}
+          onSave={onSave}
+        />
+      ),
+      "Save",
+      () =>
+        fireEvent.change(screen.getByLabelText("Display name"), {
+          target: { value: "Revenue" },
+        }),
+    ],
+    [
+      "field-rename",
+      (onOpenChange: () => void, onSave: () => Promise<void>) => (
+        <FieldRenameDialog
+          field={field}
+          onOpenChange={onOpenChange}
+          onSave={onSave}
+        />
+      ),
+      "Save",
+      () =>
+        fireEvent.change(screen.getByLabelText("Display name"), {
+          target: { value: "Revenue" },
+        }),
+    ],
+  ])(
+    "ignores an Escape dismissal while the %s save is in flight",
+    async (_name, renderDialog, submitLabel, prime) => {
+      const onOpenChange = vi.fn();
+      let release: () => void = () => undefined;
+      const onSave = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve;
+          }),
+      );
+
+      render(renderDialog(onOpenChange, onSave));
+
+      prime();
+      fireEvent.click(screen.getByRole("button", { name: submitLabel }));
+      await waitFor(() => expect(onSave).toHaveBeenCalled());
+
+      fireEvent.keyDown(document.activeElement ?? document.body, {
+        key: "Escape",
+        code: "Escape",
+      });
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+      // Once the save settles the dialog closes normally.
+      release();
+      await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    },
+  );
+
+  // The column picker is hidden for "Count (rows)", so a column chosen under a
+  // previous aggregation would be invisible state — and saving it emits
+  // `count(column)`, which skips null rows and reports a smaller number than
+  // the label promises. Driven through the rendered dialog rather than the
+  // helpers, because the defect is the transition the user performs.
+  it("drops a previously chosen column when switching back to Count (rows)", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InsightMetricEditorModal
+        isOpen
+        onOpenChange={vi.fn()}
+        dataTable={table}
+        onSave={onSave}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Aggregation type"));
+    await user.click(await screen.findByRole("option", { name: "Sum" }));
+
+    await user.click(screen.getByLabelText("Field"));
+    await user.click(
+      await screen.findByRole("option", { name: "Amount (number)" }),
+    );
+    expect(screen.getByText("sum(amount)")).toBeTruthy();
+
+    await user.click(screen.getByLabelText("Aggregation type"));
+    await user.click(
+      await screen.findByRole("option", { name: "Count (rows)" }),
+    );
+
+    expect(screen.getByText("count(*)")).toBeTruthy();
+
+    // Switching away again must not resurrect the column: the picker comes
+    // back empty, so the user re-chooses rather than inheriting hidden state.
+    await user.click(screen.getByLabelText("Aggregation type"));
+    await user.click(await screen.findByRole("option", { name: "Sum" }));
+    expect(screen.getByText("Select a field")).toBeTruthy();
+    expect(screen.getByText("sum(?)")).toBeTruthy();
+
+    await user.click(screen.getByLabelText("Aggregation type"));
+    await user.click(
+      await screen.findByRole("option", { name: "Count (rows)" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add metric" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      aggregation: "count",
+      columnName: undefined,
+    });
+  });
+
+  // Defence in depth for the same defect: even if a caller reaches the helper
+  // with a stale column, `count` is `count(*)` unconditionally, and the saved
+  // payload matches the preview the user was shown.
   it("keeps a count metric's saved payload equal to its preview", () => {
-    expect(metricFormulaPreview("count", "amount")).toBe("count(amount)");
-    expect(metricColumnNameForSave("count", "amount")).toBe("amount");
+    expect(metricFormulaPreview("count", "amount")).toBe("count(*)");
+    expect(metricColumnNameForSave("count", "amount")).toBeUndefined();
   });
 });

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
@@ -5,11 +5,11 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { FieldRenameDialog } from "./FieldRenameDialog";
 import { FilterEditDialog } from "./FilterEditDialog";
+import { InsightMetricEditorModal } from "./InsightMetricEditorModal";
 import {
-  InsightMetricEditorModal,
   metricColumnNameForSave,
   metricFormulaPreview,
-} from "./InsightMetricEditorModal";
+} from "./metric-formula";
 import { MetricEditDialog } from "./MetricEditDialog";
 
 const table = {
@@ -281,6 +281,46 @@ describe("insight config dialog saves", () => {
     await user.click(screen.getByRole("button", { name: "Add metric" }));
 
     expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      aggregation: "count",
+      columnName: undefined,
+    });
+  });
+
+  // The edit dialog reaches the same bad state by a different route: it never
+  // switches aggregation, it *initializes* from a metric already stored as
+  // `count` with a column. The picker is hidden, so the column is invisible,
+  // yet the old save preserved it and kept emitting `count(column)`.
+  it("repairs a stored count metric that still carries a column", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const stored = {
+      id: "metric-2",
+      name: "Orders",
+      sourceTable: table.id,
+      columnName: "amount",
+      aggregation: "count",
+    } as InsightMetric;
+
+    render(
+      <MetricEditDialog
+        metric={stored}
+        dataTable={table}
+        onOpenChange={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+
+    // What the user sees must match what the label promises.
+    expect(screen.getByText("count(*)")).toBeTruthy();
+    expect(screen.queryByLabelText("Field")).toBeNull();
+
+    // Saving is available without inventing an unrelated edit, because the
+    // payload genuinely differs from what is stored.
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
     expect(onSave.mock.calls[0][0]).toMatchObject({
       aggregation: "count",
       columnName: undefined,

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
@@ -188,4 +188,43 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
     expect(list.find((f) => f.id === "uuid-A")?.value).toBe(1);
     expect(list.find((f) => f.id === "uuid-B")?.value).toBe("north");
   });
+
+  it("keeps a legacy id-less filter's identity stable across a refetch", () => {
+    // Rows stored before filters carried persisted ids. Hydration runs again on
+    // every subscription update, so an identity minted per hydration would
+    // differ between the list the dialog opened from and the list its save
+    // merges into, and the save would append a duplicate instead of updating.
+    const stored = [{ field: "amount", operator: "eq" as const, value: 1 }];
+
+    const opened = withFilterIds(stored)[0]!;
+    const afterRefetch = withFilterIds(stored);
+
+    const saved = prepareFilterForSave({ ...opened, value: 2 });
+    const merged = applyFilterSave(afterRefetch, saved);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.value).toBe(2);
+    // The derived identity is promoted to the persisted id, so the next write
+    // stores it and the row stops being legacy.
+    expect(merged[0]!.id).toBe(opened._id);
+  });
+
+  it("keeps legacy identities stable when the stored order changes", () => {
+    // A concurrent update can reorder the array. Identity must follow the
+    // predicate, not its index, or the edit misroutes to its neighbour.
+    const a = { field: "amount", operator: "eq" as const, value: 1 };
+    const b = { field: "region", operator: "eq" as const, value: "north" };
+
+    const opened = withFilterIds([a, b])[0]!;
+    const reordered = withFilterIds([b, a]);
+
+    const merged = applyFilterSave(
+      reordered,
+      prepareFilterForSave({ ...opened, value: 2 }),
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged.find((f) => f.field === "amount")?.value).toBe(2);
+    expect(merged.find((f) => f.field === "region")?.value).toBe("north");
+  });
 });

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
@@ -18,19 +18,19 @@ import type { FilterWithId } from "./FiltersSection";
  */
 
 describe("deriveFilterId", () => {
-  it("uses the persisted id when present", () => {
+  it("uses the persisted id", () => {
     const f: InsightFilter = {
       id: "uuid-1",
       field: "amount",
       operator: "eq",
       value: 1,
     };
-    expect(deriveFilterId(f, 3)).toBe("uuid-1");
+    expect(deriveFilterId(f)).toBe("uuid-1");
   });
 
-  it("falls back to a content+index key when id is absent", () => {
+  it("rejects a filter without a persisted id", () => {
     const f: InsightFilter = { field: "amount", operator: "eq", value: 1 };
-    expect(deriveFilterId(f, 2)).toBe("amount-eq-2");
+    expect(() => deriveFilterId(f)).toThrow("missing its persisted id");
   });
 });
 
@@ -81,23 +81,28 @@ describe("applyFilterSave with a stable persisted id", () => {
     expect(result[1]._id).toBe("uuid-new");
   });
 
-  it("with index-based fallback ids, a reorder would misroute (regression guard)", () => {
-    // This documents WHY persisted ids matter: without them, the same reorder
-    // scenario fails to find the edited filter and appends a duplicate.
-    const original: InsightFilter[] = [
+  it("keeps an API-created filter idempotent after reorder", () => {
+    // The API receives id-less filters from an agent, stamps persisted ids, and
+    // the UI then derives `_id` solely from that stored identity.
+    const receivedByApi: InsightFilter[] = [
       { field: "region", operator: "eq", value: "north" },
       { field: "amount", operator: "gt", value: 100 },
     ];
-    const beforeEdit = withFilterIds(original); // ids: region-eq-0, amount-gt-1
-    const openedForEdit = beforeEdit[1]; // amount-gt-1
+    const persisted: InsightFilter[] = [
+      { ...receivedByApi[0], id: "api-region" },
+      { ...receivedByApi[1], id: "api-amount" },
+    ];
+    const beforeEdit = withFilterIds(persisted);
+    const openedForEdit = beforeEdit[1];
 
-    // Reorder to [amount, region] → amount is now index 0 → id amount-gt-0.
-    const reordered = withFilterIds([original[1], original[0]]);
+    const reordered = withFilterIds([persisted[1], persisted[0]]);
     const saved: FilterWithId = { ...openedForEdit, value: 200 };
     const result = applyFilterSave(reordered, saved);
 
-    // The stale id "amount-gt-1" no longer matches → duplicate appended.
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(2);
+    expect(result.filter((filter) => filter.id === "api-amount")).toEqual([
+      expect.objectContaining({ value: 200 }),
+    ]);
   });
 });
 
@@ -130,29 +135,25 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
     expect(reStamped._id).toBe("uuid-existing");
   });
 
-  it("edits an id-less (API-created) filter in place — backfills id, keeps _id", () => {
-    // Regression: an existing filter with no persisted `id` (its `_id` is the
-    // content+index fallback) must NOT have its `_id` overwritten on save, or
-    // applyFilterSave would fail to match and APPEND A DUPLICATE instead of
-    // updating. The persisted `id` is backfilled, but `_id` is preserved.
+  it("keeps an existing filter's stable id while editing", () => {
     const list = withFilterIds([
-      { field: "region", operator: "eq", value: "north" }, // no id → _id "region-eq-0"
+      { id: "uuid-region", field: "region", operator: "eq", value: "north" },
     ]);
     const openedForEdit = list[0];
-    expect(openedForEdit.id).toBeUndefined();
-    expect(openedForEdit._id).toBe("region-eq-0");
+    expect(openedForEdit.id).toBe("uuid-region");
+    expect(openedForEdit._id).toBe("uuid-region");
 
     const saved = prepareFilterForSave(
       { ...openedForEdit, value: "south" },
-      () => "uuid-backfilled",
+      () => "uuid-SHOULD-NOT-USE",
     );
-    expect(saved._id).toBe("region-eq-0"); // preserved for matching
-    expect(saved.id).toBe("uuid-backfilled"); // backfilled
+    expect(saved._id).toBe("uuid-region");
+    expect(saved.id).toBe("uuid-region");
 
     const result = applyFilterSave(list, saved);
     expect(result).toHaveLength(1); // updated in place, NOT duplicated
     expect(result[0].value).toBe("south");
-    expect(result[0].id).toBe("uuid-backfilled");
+    expect(result[0].id).toBe("uuid-region");
   });
 
   it("two consecutive Adds yield distinct ids — second does NOT overwrite first", () => {

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.test.ts
@@ -209,6 +209,58 @@ describe("prepareFilterForSave — distinct id per Add (data-loss guard)", () =>
     expect(merged[0]!.id).toBe(opened._id);
   });
 
+  it("gives byte-identical legacy predicates distinct identities", () => {
+    // Two rows can hold the same field/operator/value and still be separate
+    // entries. A purely content-derived identity would collapse them, and both
+    // `applyFilterSave` (map) and the panel's remove (filter) act on EVERY
+    // `_id` match — so editing one would edit both, and removing one would
+    // remove both. React would also see duplicate keys.
+    const same = { field: "amount", operator: "eq" as const, value: 1 };
+    const hydrated = withFilterIds([same, same]);
+
+    expect(hydrated).toHaveLength(2);
+    expect(hydrated[0]!._id).not.toBe(hydrated[1]!._id);
+
+    // Editing the first must leave the second alone.
+    const edited = applyFilterSave(
+      hydrated,
+      prepareFilterForSave({ ...hydrated[0]!, value: 2 }),
+    );
+    expect(edited).toHaveLength(2);
+    expect(edited[0]!.value).toBe(2);
+    expect(edited[1]!.value).toBe(1);
+
+    // Removing the second — the panel's `_id` filter — must leave the first.
+    const removed = hydrated.filter((f) => f._id !== hydrated[1]!._id);
+    expect(removed).toHaveLength(1);
+    expect(removed[0]!._id).toBe(hydrated[0]!._id);
+
+    // And the occurrence suffix is stable across a refetch, so a save opened
+    // from one hydration still merges into the next.
+    expect(withFilterIds([same, same]).map((f) => f._id)).toEqual(
+      hydrated.map((f) => f._id),
+    );
+  });
+
+  it("treats an empty stored id as absent rather than throwing", () => {
+    // `""` is not nullish, so it slips past a `??` fallback and then fails the
+    // emptiness check in `deriveFilterId` — a throw during render. The server
+    // rejects such values on write but cannot repair an already-stored row.
+    const stored = [
+      { id: "", field: "amount", operator: "eq" as const, value: 1 },
+    ];
+
+    const hydrated = withFilterIds(stored);
+    expect(hydrated).toHaveLength(1);
+    expect(hydrated[0]!._id).toBeTruthy();
+    expect(hydrated[0]!.id).toBe(hydrated[0]!._id);
+
+    // Saving promotes the derived identity, so the row stops being broken.
+    const saved = prepareFilterForSave({ ...hydrated[0]!, value: 2 });
+    expect(saved.id).toBe(hydrated[0]!._id);
+    expect(applyFilterSave(hydrated, saved)).toHaveLength(1);
+  });
+
   it("keeps legacy identities stable when the stored order changes", () => {
     // A concurrent update can reorder the array. Identity must follow the
     // predicate, not its index, or the edit misroutes to its neighbour.

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -33,9 +33,16 @@ export function deriveFilterId(filter: InsightFilter): string {
  * operation as doing it to both — `applyFilterSave` replaces every `_id` match
  * and `handleRemoveFilter` drops every match, so a shared identity would edit
  * or delete the pair. The occurrence index among *identical* predicates
- * disambiguates them without reintroducing array position: it is unchanged by
- * a refetch, and reordering two interchangeable predicates has no observable
- * effect anyway.
+ * disambiguates them: it is an ordinal within the identical group, not a
+ * position in the array, so it survives a plain refetch and any reordering.
+ *
+ * What it does NOT survive is a change in how many identical twins exist. If a
+ * concurrent write inserts or deletes one between the dialog opening and its
+ * save, the surviving twins renumber, the save's `_id` matches nothing, and
+ * `applyFilterSave` appends it as a new filter instead of updating the one the
+ * user edited. That window is only reachable for rows stored before filters
+ * carried ids, and only for byte-identical duplicates; a persisted `id` closes
+ * it, which is what saving any such row does. Tracked as issue #309.
  *
  * The `legacy:` prefix keeps these distinguishable from persisted ids, which
  * are UUIDs. Saving such a row promotes this value to its persisted `id`.

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -28,26 +28,52 @@ export function deriveFilterId(filter: InsightFilter): string {
  * which is the exact misroute persisted ids exist to prevent. Content is the
  * only source that is stable across both a refetch and a reorder.
  *
- * Two byte-identical predicates collapse to one identity. They are the same
- * predicate, so an edit routing to the first of them is the same outcome as
- * routing to the second; that is strictly better than appending a third.
+ * Byte-identical predicates must still get distinct identities. They remain
+ * separate list entries, and editing or removing one of them is not the same
+ * operation as doing it to both — `applyFilterSave` replaces every `_id` match
+ * and `handleRemoveFilter` drops every match, so a shared identity would edit
+ * or delete the pair. The occurrence index among *identical* predicates
+ * disambiguates them without reintroducing array position: it is unchanged by
+ * a refetch, and reordering two interchangeable predicates has no observable
+ * effect anyway.
  *
  * The `legacy:` prefix keeps these distinguishable from persisted ids, which
  * are UUIDs. Saving such a row promotes this value to its persisted `id`.
  */
-function legacyFilterId(filter: InsightFilter): string {
+function legacyFilterId(filter: InsightFilter, occurrence: number): string {
   const value = JSON.stringify(filter.value ?? null);
-  return `legacy:${filter.field}:${filter.operator}:${value}`;
+  return `legacy:${filter.field}:${filter.operator}:${value}#${occurrence}`;
+}
+
+/**
+ * A persisted id counts only if it is a non-empty string. An empty string is
+ * not nullish, so it would slip past a `??` fallback and then fail the
+ * emptiness check in `deriveFilterId`, throwing during render. The server
+ * rejects such values on write but cannot repair a row already stored with
+ * one.
+ */
+function persistedId(filter: InsightFilter): string | undefined {
+  return typeof filter.id === "string" && filter.id.length > 0
+    ? filter.id
+    : undefined;
 }
 
 /** Attach stable client ids to a persisted filter list. */
 export function withFilterIds(
   filters: InsightFilter[] | undefined,
 ): FilterWithId[] {
+  const seen = new Map<string, number>();
   return (filters ?? []).map((filter) => {
     // All API write paths stamp this id, so the fallback only covers rows
     // stored before they did.
-    const id = filter.id ?? legacyFilterId(filter);
+    const stored = persistedId(filter);
+    let id = stored;
+    if (id === undefined) {
+      const base = legacyFilterId(filter, 0);
+      const occurrence = seen.get(base) ?? 0;
+      seen.set(base, occurrence + 1);
+      id = legacyFilterId(filter, occurrence);
+    }
     return { ...filter, id, _id: deriveFilterId({ ...filter, id }) };
   });
 }
@@ -78,10 +104,10 @@ export function prepareFilterForSave(
   genId: () => string = () => crypto.randomUUID(),
 ): FilterWithId {
   if (filter._id === NEW_FILTER_ID) {
-    const id = filter.id ?? genId();
+    const id = persistedId(filter) ?? genId();
     return { ...filter, id, _id: id };
   }
-  return { ...filter, id: filter.id ?? filter._id };
+  return { ...filter, id: persistedId(filter) ?? filter._id };
 }
 
 /**

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -10,26 +10,32 @@ import type { FilterWithId } from "./FiltersSection";
  * reordered — does not shift identities and misroute an in-flight save.
  */
 
-/** Derive the stable client `_id` for a persisted filter at array position i. */
-export function deriveFilterId(filter: InsightFilter, index: number): string {
-  // Persisted id is the stable identity. Filters from the API/agent path may
-  // lack one; fall back to a content+index key (not edited concurrently).
-  return filter.id ?? `${filter.field}-${filter.operator}-${index}`;
+/** Derive the stable client `_id` from a filter's persisted identity. */
+export function deriveFilterId(filter: InsightFilter): string {
+  if (!filter.id) {
+    throw new Error("Filter is missing its persisted id");
+  }
+  return filter.id;
 }
 
 /** Attach stable client ids to a persisted filter list. */
 export function withFilterIds(
   filters: InsightFilter[] | undefined,
 ): FilterWithId[] {
-  return (filters ?? []).map((f, i) => ({ ...f, _id: deriveFilterId(f, i) }));
+  return (filters ?? []).map((filter) => {
+    // All API write paths persist this id. This defensive hydration only keeps
+    // legacy rows usable until their next save; it never derives identity from
+    // content or array position.
+    const id = filter.id ?? crypto.randomUUID();
+    return { ...filter, id, _id: deriveFilterId({ ...filter, id }) };
+  });
 }
 
 /**
  * Client `_id` sentinel for a not-yet-saved new-filter draft. Distinguishes a
  * brand-new filter (which must get a fresh identity and append) from an
  * existing row being edited (which must preserve its `_id` so the save routes
- * back to the same predicate — even if the existing filter has no persisted
- * `id`, e.g. one created via the API/agent path).
+ * back to the same predicate).
  */
 export const NEW_FILTER_ID = "__new__";
 
@@ -41,9 +47,8 @@ export const NEW_FILTER_ID = "__new__";
  *   Generating the id *here, per save* (not once per dialog mount) is what makes
  *   two consecutive Adds yield two distinct filters instead of the second
  *   overwriting the first.
- * - **Existing row** (any other `_id`): preserve `_id` so the save updates the
- *   matching predicate. Backfill a persisted `id` if it lacks one (API/agent
- *   filters), without disturbing the `_id` used for matching.
+ * - **Existing row** (any other `_id`): preserve its persisted identity so the
+ *   save updates the matching predicate.
  *
  * `genId` is injectable for tests; defaults to `crypto.randomUUID`.
  */
@@ -55,8 +60,7 @@ export function prepareFilterForSave(
     const id = filter.id ?? genId();
     return { ...filter, id, _id: id };
   }
-  // Existing row: keep _id for matching; backfill a persisted id if missing.
-  return { ...filter, id: filter.id ?? genId() };
+  return { ...filter, id: filter.id ?? filter._id };
 }
 
 /**

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -33,16 +33,22 @@ export function deriveFilterId(filter: InsightFilter): string {
  * operation as doing it to both — `applyFilterSave` replaces every `_id` match
  * and `handleRemoveFilter` drops every match, so a shared identity would edit
  * or delete the pair. The occurrence index among *identical* predicates
- * disambiguates them: it is an ordinal within the identical group, not a
- * position in the array, so it survives a plain refetch and any reordering.
+ * disambiguates them. It is an ordinal assigned by traversal order within the
+ * identical group, reassigned on every hydration — so a given `_id` is not
+ * bound to a particular row, only to a slot in that group. Since the members
+ * of the group are byte-identical, landing on a different member is not
+ * observable: whichever one the save replaces, the list ends up with the same
+ * contents.
  *
- * What it does NOT survive is a change in how many identical twins exist. If a
- * concurrent write inserts or deletes one between the dialog opening and its
- * save, the surviving twins renumber, the save's `_id` matches nothing, and
- * `applyFilterSave` appends it as a new filter instead of updating the one the
- * user edited. That window is only reachable for rows stored before filters
- * carried ids, and only for byte-identical duplicates; a persisted `id` closes
- * it, which is what saving any such row does. Tracked as issue #309.
+ * The one case that IS observable is a concurrent delete that shrinks the
+ * group below the saved ordinal. Then the `_id` matches nothing, and
+ * `applyFilterSave` appends the edit as a new filter instead of replacing one
+ * — the user gets a duplicate and their original is left unedited. Insertion
+ * is safe by the same argument as above: the group only grows, so every
+ * previous ordinal still resolves. This window is reachable only for rows
+ * stored before filters carried ids, and only for byte-identical duplicates;
+ * saving any such row promotes a persisted `id` and closes it for good.
+ * Tracked as issue #309.
  *
  * The `legacy:` prefix keeps these distinguishable from persisted ids, which
  * are UUIDs. Saving such a row promotes this value to its persisted `id`.

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -129,12 +129,17 @@ export function prepareFilterForSave(
 }
 
 /**
- * Merge a saved filter into the current list: update the row whose `_id`
- * matches, else append. For a filter with a persisted id, that id travels with
- * the filter rather than its index, so a concurrent reorder between open and
- * save cannot route the edit to the wrong predicate. The guarantee is weaker
- * for legacy identities and for concurrent deletes — see `legacyFilterId` and
- * issue #309.
+ * Merge a saved filter into the current list: replace every row whose `_id`
+ * matches, or append if none match.
+ *
+ * When the persisted id is unique within the current list, it travels with the
+ * filter rather than with its index, so a concurrent reorder between open and
+ * save cannot misroute the edit. Uniqueness is not enforced:
+ * `ensureInsightFilterIds` stamps an id only onto a filter that arrives without
+ * one, so a caller that supplies a duplicate keeps it, and a save then rewrites
+ * every predicate sharing that id. Legacy identities, duplicate persisted ids,
+ * and concurrent deletes are all weaker than the unique-id case — see
+ * `legacyFilterId` and issue #309.
  */
 export function applyFilterSave(
   current: FilterWithId[],

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -18,15 +18,36 @@ export function deriveFilterId(filter: InsightFilter): string {
   return filter.id;
 }
 
+/**
+ * Identity for a stored filter that predates persisted ids.
+ *
+ * Derived from the predicate's own content, never from array position, and
+ * never freshly generated: hydration runs again on every refetch, so a random
+ * id would differ between the list a dialog was opened from and the list its
+ * save merges into — `applyFilterSave` would miss and append a duplicate,
+ * which is the exact misroute persisted ids exist to prevent. Content is the
+ * only source that is stable across both a refetch and a reorder.
+ *
+ * Two byte-identical predicates collapse to one identity. They are the same
+ * predicate, so an edit routing to the first of them is the same outcome as
+ * routing to the second; that is strictly better than appending a third.
+ *
+ * The `legacy:` prefix keeps these distinguishable from persisted ids, which
+ * are UUIDs. Saving such a row promotes this value to its persisted `id`.
+ */
+function legacyFilterId(filter: InsightFilter): string {
+  const value = JSON.stringify(filter.value ?? null);
+  return `legacy:${filter.field}:${filter.operator}:${value}`;
+}
+
 /** Attach stable client ids to a persisted filter list. */
 export function withFilterIds(
   filters: InsightFilter[] | undefined,
 ): FilterWithId[] {
   return (filters ?? []).map((filter) => {
-    // All API write paths persist this id. This defensive hydration only keeps
-    // legacy rows usable until their next save; it never derives identity from
-    // content or array position.
-    const id = filter.id ?? crypto.randomUUID();
+    // All API write paths stamp this id, so the fallback only covers rows
+    // stored before they did.
+    const id = filter.id ?? legacyFilterId(filter);
     return { ...filter, id, _id: deriveFilterId({ ...filter, id }) };
   });
 }

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -21,12 +21,11 @@ export function deriveFilterId(filter: InsightFilter): string {
 /**
  * Identity for a stored filter that predates persisted ids.
  *
- * Derived from the predicate's own content, never from array position, and
- * never freshly generated: hydration runs again on every refetch, so a random
- * id would differ between the list a dialog was opened from and the list its
- * save merges into — `applyFilterSave` would miss and append a duplicate,
- * which is the exact misroute persisted ids exist to prevent. Content is the
- * only source that is stable across both a refetch and a reorder.
+ * Derived from the predicate's content plus its occurrence position among
+ * identical predicates — never from its absolute array index, and never
+ * freshly generated: hydration runs again on every refetch, so a random id
+ * would differ between the list a dialog was opened from and the list its save
+ * merges into, and `applyFilterSave` would miss and append instead of update.
  *
  * Byte-identical predicates must still get distinct identities. They remain
  * separate list entries, and editing or removing one of them is not the same
@@ -44,16 +43,20 @@ export function deriveFilterId(filter: InsightFilter): string {
  * then saved from an edit opened on the first A yields `[A', X, A]` where
  * following the logical row would have yielded `[A, X, A']`.
  *
- * Only a delete that shrinks the group past the saved ordinal produces the
- * no-match case: then `applyFilterSave` appends the edit as a new filter
- * instead of replacing one, so the user gets a duplicate and their original is
- * left unedited. Both windows are reachable only for rows stored before
- * filters carried ids, and only for byte-identical duplicates; saving any such
- * row promotes a persisted `id` and closes them for good. Tracked as issue
+ * That ordinal transfer is specific to legacy byte-identical duplicates, and
+ * saving any such row promotes a persisted `id`, which closes it for good.
+ *
+ * The other failure is NOT legacy-specific. `applyFilterSave` appends whenever
+ * the current list lacks the saved `_id`, so any concurrent delete of the row
+ * being edited — legacy or persisted, duplicate or not — makes the save
+ * resurrect it rather than update it. For legacy identities, deleting enough
+ * identical members reaches the same state by renumbering. Tracked as issue
  * #309.
  *
- * The `legacy:` prefix keeps these distinguishable from persisted ids, which
- * are UUIDs. Saving such a row promotes this value to its persisted `id`.
+ * The `legacy:` prefix distinguishes these fallback identities from freshly
+ * generated UUIDs. It is not a marker of being unsaved: saving a legacy row
+ * persists this `legacy:` value as its `id`, so a persisted id is not
+ * necessarily a UUID.
  */
 function legacyFilterId(filter: InsightFilter, occurrence: number): string {
   const value = JSON.stringify(filter.value ?? null);
@@ -127,9 +130,11 @@ export function prepareFilterForSave(
 
 /**
  * Merge a saved filter into the current list: update the row whose `_id`
- * matches, else append. Matching on the persisted-id-derived `_id` means a
- * concurrent reorder between open and save cannot route the edit to the wrong
- * predicate — the id travels with the filter, not its index.
+ * matches, else append. For a filter with a persisted id, that id travels with
+ * the filter rather than its index, so a concurrent reorder between open and
+ * save cannot route the edit to the wrong predicate. The guarantee is weaker
+ * for legacy identities and for concurrent deletes — see `legacyFilterId` and
+ * issue #309.
  */
 export function applyFilterSave(
   current: FilterWithId[],

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/filter-id.ts
@@ -34,21 +34,23 @@ export function deriveFilterId(filter: InsightFilter): string {
  * and `handleRemoveFilter` drops every match, so a shared identity would edit
  * or delete the pair. The occurrence index among *identical* predicates
  * disambiguates them. It is an ordinal assigned by traversal order within the
- * identical group, reassigned on every hydration — so a given `_id` is not
- * bound to a particular row, only to a slot in that group. Since the members
- * of the group are byte-identical, landing on a different member is not
- * observable: whichever one the save replaces, the list ends up with the same
- * contents.
+ * identical group and reassigned on every hydration, so it identifies a SLOT,
+ * not a logical row. Reordering or inserting identical predicates can transfer
+ * that ordinal to another row. `applyFilterSave` still resolves and replaces
+ * one entry rather than appending, but the transfer can become observable
+ * after editing, because `map` preserves array position: the changed predicate
+ * may land at a different position relative to the non-identical filters
+ * around it. `[A, X, A]` reordered to `[A, X, A]` (the two A's swapped) and
+ * then saved from an edit opened on the first A yields `[A', X, A]` where
+ * following the logical row would have yielded `[A, X, A']`.
  *
- * The one case that IS observable is a concurrent delete that shrinks the
- * group below the saved ordinal. Then the `_id` matches nothing, and
- * `applyFilterSave` appends the edit as a new filter instead of replacing one
- * — the user gets a duplicate and their original is left unedited. Insertion
- * is safe by the same argument as above: the group only grows, so every
- * previous ordinal still resolves. This window is reachable only for rows
- * stored before filters carried ids, and only for byte-identical duplicates;
- * saving any such row promotes a persisted `id` and closes it for good.
- * Tracked as issue #309.
+ * Only a delete that shrinks the group past the saved ordinal produces the
+ * no-match case: then `applyFilterSave` appends the edit as a new filter
+ * instead of replacing one, so the user gets a duplicate and their original is
+ * left unedited. Both windows are reachable only for rows stored before
+ * filters carried ids, and only for byte-identical duplicates; saving any such
+ * row promotes a persisted `id` and closes them for good. Tracked as issue
+ * #309.
  *
  * The `legacy:` prefix keeps these distinguishable from persisted ids, which
  * are UUIDs. Saving such a row promotes this value to its persisted `id`.

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/metric-formula.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/metric-formula.ts
@@ -1,0 +1,35 @@
+import type { AggregationType } from "@dashframe/types";
+
+/**
+ * Shared by the add and edit metric dialogs. Both render the same formula
+ * preview and both build the same save payload, so the two must agree on what
+ * a column means per aggregation — when they each carried their own copy, the
+ * add path was fixed and the edit path silently kept the old behaviour.
+ *
+ * "Count (rows)" is `count(*)` by definition and neither dialog offers a column
+ * picker for it, so any column still in state is invisible to the user.
+ * Persisting it emits `count(column)`, which skips null rows — a different
+ * number than the label promises. Use `count_distinct` to count values.
+ */
+export function metricColumnNameForSave(
+  aggregation: AggregationType,
+  columnName: string,
+): string | undefined {
+  if (aggregation === "count") return undefined;
+  return columnName || undefined;
+}
+
+export function metricFormulaPreview(
+  aggregation: AggregationType,
+  columnName: string,
+): string {
+  if (aggregation === "count") {
+    return "count(*)";
+  }
+
+  if (!columnName) {
+    return `${aggregation}(?)`;
+  }
+
+  return `${aggregation}(${columnName})`;
+}

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/use-save-dismiss-guard.ts
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/use-save-dismiss-guard.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Keeps a dialog on screen while its save is in flight.
+ *
+ * Disabling the Cancel button is not enough: Escape and an outside click both
+ * reach the dialog shell's `onOpenChange` directly. Dismissing a pending save
+ * lets the user open a second editor, and when the first promise settles its
+ * `onClose` clears the shared parent state and closes the *second* dialog,
+ * discarding that edit.
+ *
+ * The inner form owns the saving flag, so it reports transitions up through
+ * `setPending`; the shell checks `isPending()` before honouring a dismissal.
+ * A ref rather than state, because a dismissal can arrive in the same tick as
+ * the transition that set it.
+ *
+ * Candidate for extraction into `@wystack/ui-react` — the four insight config
+ * dialogs are the same shell shape, and nothing here is insight-specific.
+ */
+export function useSaveDismissGuard(): {
+  setPending: (pending: boolean) => void;
+  isPending: () => boolean;
+} {
+  const pendingRef = useRef(false);
+  const setPending = useCallback((pending: boolean) => {
+    pendingRef.current = pending;
+  }, []);
+  const isPending = useCallback(() => pendingRef.current, []);
+  return { setPending, isPending };
+}
+
+/**
+ * The saving flag for a dialog's inner form, mirrored to the shell's dismiss
+ * guard. Drop-in for `useState(false)` at each form's `isSaving`, so the two
+ * cannot drift apart.
+ */
+export function useSavingFlag(
+  onPendingChange?: (pending: boolean) => void,
+): readonly [boolean, (pending: boolean) => void] {
+  const [isSaving, setIsSavingState] = useState(false);
+  const setIsSaving = useCallback(
+    (pending: boolean) => {
+      setIsSavingState(pending);
+      onPendingChange?.(pending);
+    },
+    [onPendingChange],
+  );
+  return [isSaving, setIsSaving] as const;
+}

--- a/packages/app/vitest.setup.ts
+++ b/packages/app/vitest.setup.ts
@@ -27,6 +27,20 @@ class MemoryStorage implements Storage {
   }
 }
 
+/**
+ * jsdom implements neither the Pointer Capture API nor `scrollIntoView`, and
+ * Radix's `Select` calls both while opening its listbox. Without them a test
+ * cannot drive any Radix dropdown at all — the trigger throws before the
+ * content mounts. These are no-op shims, not behaviour: they only let the
+ * component reach the state a user would see.
+ */
+if (typeof Element !== "undefined") {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => undefined;
+  Element.prototype.releasePointerCapture ??= () => undefined;
+  Element.prototype.scrollIntoView ??= () => undefined;
+}
+
 const memory = new MemoryStorage();
 Object.defineProperty(globalThis, "localStorage", {
   value: memory,


### PR DESCRIPTION
Filter rows in the insight config panel were keyed by array index. A subscription update arriving mid-edit could reorder or remove a predicate, and the save would then land on whichever filter now occupied that slot — the wrong one. The four config dialogs also closed on click rather than on success, so a write that never landed looked like it had.

Tracked internally as TASK-685.

## Changes

- **Filter identity is the persisted `id`, not the array index.** Every server write boundary that can store filters — `updateInsight`, the artifact patch path, and the command path — now stamps an id, so a filter created through the API/agent path carries one before it is ever persisted.
- **Rows stored before ids existed get a content-derived identity**, not a fresh UUID. Hydration re-runs on every refetch; a random id would differ between the list a dialog opened from and the list its save merged into, so the merge would miss and append a duplicate — the exact misroute this ticket exists to close. Content is stable across both a refetch and a reorder, and is promoted to the persisted `id` on the next save. Array position is still never used.
- **The four config dialogs await their save and close only on success**, leaving the dialog open with its error visible and the user's input intact when the write fails.
- The command path guards rather than asserts on `filters`: the definition shape types it as optional, so an absent key is a real case there and in the artifact patch path.

## Screenshots

### Qa308 Dialog Light
![Qa308 Dialog Light](https://github.com/youhaowei/DashFrame/releases/download/pr-308-screenshots/qa308-dialog-light.png)

### Qa308 Dialog Dark
![Qa308 Dialog Dark](https://github.com/youhaowei/DashFrame/releases/download/pr-308-screenshots/qa308-dialog-dark.png)

### Qa308 Edit Repair After Light
![Qa308 Edit Repair After Light](https://github.com/youhaowei/DashFrame/releases/download/pr-308-screenshots/qa308-edit-repair-after-light.png)

_Screenshots via pr-screenshots (prerelease `pr-308-screenshots`, not in git)._
## Verification

Full local review gate. `bun run check` 4/4 PASS, `bun run format:check` clean.

Behavioral QA in the running Electron app against a scratch project (CSV import → insight → filters), six checks, all at runtime:

1. Two consecutive Adds produce two distinct filters — no overwrite.
2. Editing the first filter updates it in place; count and sibling unchanged.
3. Editing the second filter routes to the second — proving it is not simply always-first.
4. With `/api/**` blocked, Save leaves the dialog open, shows `Failed to save filter`, and preserves the edit.
5. Unblocking and retrying succeeds and closes the dialog.
6. After a full app reload, both filters persist and an edit still routes correctly against freshly-hydrated state.

The two new `filter-id` regression tests were mutation-tested: reverting the fallback to `crypto.randomUUID()` makes both fail, and the nine pre-existing tests still pass.

Second reviewer: grok (the change was written by Codex, so a different family read it). Its one substantive finding — that the legacy hydration path was reachable and re-minted identity per refetch — is the fix described above.

**Coverage boundary:** the dialog tests pin the four dialogs; the `InsightConfigPanel` parent handlers are verified by source inspection and the runtime checks above, not by unit tests. `handleFiltersReorder` and `handleRemoveFilter` still drop their promises — pre-existing and outside this ticket's scope.



