### PR TITLE
fix(scripts): install dependencies when provisioning a worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,12 @@ cd "$worktree"
 
 `scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch-slug>`
 (forward-slashes and colons in the branch name become dashes, lowercase) if not
-already there, populates and heals submodule checkouts, and prints the path. If
+already there, populates and heals submodule checkouts, runs `bun install`, and
+prints the path — the path it prints is ready to work in, with no separate
+install step. (`git worktree add` copies tracked files only, so without that a
+fresh worktree has no `node_modules` at all: no Electron binary, no vitest, and
+no resolvable `@wystack/*` imports.) You still need `bun run build:wystack`
+before the `@wystack/*` **built** output exists. If
 it fails, STOP — do not improvise another location.
 
 **Enforcement:** `.husky/pre-commit` blocks commits on a non-default branch in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,12 +164,19 @@ cd "$worktree"
 `scripts/ensure-worktree.sh` creates `~/worktrees/dashframe/<branch-slug>`
 (forward-slashes and colons in the branch name become dashes, lowercase) if not
 already there, populates and heals submodule checkouts, runs `bun install`, and
-prints the path — the path it prints is ready to work in, with no separate
+prints the path — a newly created worktree is ready to work in, with no separate
 install step. (`git worktree add` copies tracked files only, so without that a
 fresh worktree has no `node_modules` at all: no Electron binary, no vitest, and
 no resolvable `@wystack/*` imports.) You still need `bun run build:wystack`
-before the `@wystack/*` **built** output exists. If
-it fails, STOP — do not improvise another location.
+before the `@wystack/*` **built** output exists.
+
+On an **existing** worktree the install is a best-effort refresh, not a
+guarantee: it runs unfrozen, and a failure warns and still prints the path,
+because you may have edited a manifest without regenerating the lockfile and
+withholding the path would strand the work already in that tree. Read the
+warning — dependencies there may be stale.
+
+If it fails, STOP — do not improvise another location.
 
 **Enforcement:** `.husky/pre-commit` blocks commits on a non-default branch in
 the main checkout. Bypass with `ALLOW_MAIN_CHECKOUT_COMMIT=1` only when you

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,11 +170,18 @@ fresh worktree has no `node_modules` at all: no Electron binary, no vitest, and
 no resolvable `@wystack/*` imports.) You still need `bun run build:wystack`
 before the `@wystack/*` **built** output exists.
 
-On an **existing** worktree the install is a best-effort refresh, not a
-guarantee: it runs unfrozen, and a failure warns and still prints the path,
-because you may have edited a manifest without regenerating the lockfile and
-withholding the path would strand the work already in that tree. Read the
-warning — dependencies there may be stale.
+The install happens **once per worktree**, on first provision, and it runs
+`--frozen-lockfile` so bootstrapping can never rewrite `bun.lock`. An
+already-provisioned worktree is handed back untouched — re-running the script
+is free and safe. That matters if you use `bun link` to point an `@wystack/*`
+package at a checkout elsewhere: an install would silently undo the link (see
+`README.md`), so the script does not run one behind your back. Refresh
+dependencies yourself with `bun install` when you have changed a manifest.
+
+If the first provision fails — no `bun` on `PATH`, or a lockfile that does not
+match the branch — the script exits non-zero and leaves the worktree in place.
+Re-running it resumes the install rather than treating the half-provisioned
+tree as ready.
 
 If it fails, STOP — do not improvise another location.
 

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -13,12 +13,12 @@
 #     caller must cd into that path.  The main checkout's HEAD and current
 #     branch are never switched — verified by an assertion before this
 #     script hands back control.
+#   - Installs dependencies once, the first time a worktree is provisioned, so
+#     the path it prints means "ready to work in".  An already-provisioned
+#     worktree is handed back untouched.  See install_dependencies.
 #   - Hard-fails (exit 1) on any provisioning or validation failure — this is
 #     fail-closed by design so that a briefed agent cannot silently proceed in
-#     main.  The one deliberate exception is the dependency refresh on an
-#     ALREADY-EXISTING worktree: that warns and still prints the path, because
-#     withholding the path from a worktree that already holds the agent's work
-#     strands it.  See install_dependencies.
+#     main.
 #
 # ENV:
 #   WORKTREE_BASE  Override the base directory (default: ~/worktrees/<project>)
@@ -106,7 +106,7 @@ init_unpopulated_submodules() {
   done
 }
 
-# install_dependencies <worktree_path> <mode: create|reuse>
+# install_dependencies <worktree_path>
 # A fresh worktree has no node_modules at all: `git worktree add` copies
 # tracked files only, and nothing else in this script installs. Every agent
 # that then tries to run the app or the test suite hits a different symptom of
@@ -115,58 +115,73 @@ init_unpopulated_submodules() {
 # is `bun install`. Doing it here makes the printed path mean "ready to work
 # in", which is what every caller already assumes it means.
 #
-# Idempotent and near-free when the worktree is already installed, so this
-# also heals the reuse path.
+# It installs EXACTLY ONCE per worktree, gated on a marker in the worktree's
+# private gitdir, and both halves of that are load-bearing.
 #
-# The two modes differ because the cost of refusing differs. On `create` the
+# Installing once, rather than on every call, is what keeps the script safe to
+# re-run. `bun install` is not inert on an already-provisioned tree: every
+# `@wystack/*` dependency is `workspace:*`, so an install silently re-resolves
+# it to the in-repo submodule and undoes any `bun link` pointing at an external
+# checkout (README.md, submodule workflow). Refreshing on reuse would mean the
+# sanctioned bootstrap command quietly dismantles a developer's linked setup
+# every time they ran it. A worktree that is already provisioned is left alone.
+#
+# Gating on a marker, rather than on `node_modules` existing, is what keeps the
+# frozen contract honest. `git worktree add` succeeds before the install runs,
+# so a failed first provision leaves a real worktree on disk with a half-built
+# or absent node_modules. Keying off the directory would classify that as
+# "already provisioned" and hand it back; keying off a marker written only
+# after a clean install means the retry is still a first provision, and gets
+# the same fail-closed frozen install the original attempt did.
+#
+# The install is frozen because provisioning must never rewrite `bun.lock`: the
 # worktree is a fresh checkout of a committed tree, so the lockfile matches by
-# construction: `--frozen-lockfile` costs nothing, catches a genuinely broken
-# lockfile, and guarantees provisioning never leaves `bun.lock` modified in a
-# brand-new worktree. Failing there strands nobody — no work exists in it yet.
-#
-# On `reuse` an agent is already working in the tree and may legitimately have
-# edited a manifest without regenerating the lockfile. Enforcing frozen there
-# would make the sanctioned bootstrap refuse to hand back a worktree that
-# already exists and is the only place their work lives — a loop with no exit,
-# since teardown needs the path too. So reuse installs unfrozen, and an install
-# failure warns rather than exits: the caller still gets the path, and a stale
-# node_modules is a recoverable state where a withheld path is not.
+# construction, and a mismatch is a genuine defect on the branch rather than
+# something to paper over. Failing here strands nobody — no work exists in a
+# tree that has never been successfully provisioned.
 install_dependencies() {
   _idep_wt="$1"
-  _idep_mode="$2"
 
-  # A missing bun is the same class of failure as a failed install, so it takes
-  # the same mode-dependent exit: fatal while provisioning a tree that holds no
-  # work yet, a warning once the tree is the agent's only copy of it.
+  _idep_gitdir=$(cd "$_idep_wt" && git rev-parse --absolute-git-dir 2>/dev/null) || {
+    echo "ERROR [ensure-worktree]: cannot resolve the gitdir for '$_idep_wt'." >&2
+    exit 1
+  }
+  _idep_marker="$_idep_gitdir/ensure-worktree-provisioned"
+
+  # Already provisioned: leave it completely alone. No install, so nothing can
+  # clobber a `bun link` or a hand-edited node_modules.
+  [ -f "$_idep_marker" ] && return
+
+  # Backfill the marker for a worktree that predates it. Without this, the
+  # first run after this change treats every existing worktree as unprovisioned
+  # and forces a frozen install on a tree whose manifests an agent may already
+  # have edited — exiting 1 and withholding the path to the only copy of their
+  # work. An existing node_modules is sufficient evidence that someone
+  # installed here. The residual risk runs the safe direction: if a failed
+  # first provision did leave a partial node_modules behind, the cost is
+  # skipping an install and surfacing the ordinary missing-dependency error,
+  # which is recoverable, rather than stranding a worktree, which is not.
+  if [ -d "$_idep_wt/node_modules" ]; then
+    : >"$_idep_marker"
+    return
+  fi
+
   if ! command -v bun >/dev/null 2>&1; then
-    if [ "$_idep_mode" = "create" ]; then
-      echo "ERROR [ensure-worktree]: 'bun' is not on PATH; cannot install dependencies in '$_idep_wt'." >&2
-      echo "  Install bun (see AGENTS.md) and re-run." >&2
-      exit 1
-    fi
-    echo "WARNING [ensure-worktree]: 'bun' is not on PATH; skipping the dependency refresh in '$_idep_wt'." >&2
-    echo "  Returning the path anyway — your work lives there. Dependencies may be stale;" >&2
-    echo "  install bun (see AGENTS.md) and re-run before running the app or tests." >&2
-    return
+    echo "ERROR [ensure-worktree]: 'bun' is not on PATH; cannot provision '$_idep_wt'." >&2
+    echo "  Install bun (see AGENTS.md) and re-run — this worktree has never been" >&2
+    echo "  successfully provisioned, so re-running resumes where this left off." >&2
+    exit 1
   fi
 
-  if [ "$_idep_mode" = "create" ]; then
-    echo "[ensure-worktree] installing dependencies (bun install --frozen-lockfile)..." >&2
-    if ! (cd "$_idep_wt" && bun install --frozen-lockfile >&2); then
-      echo "ERROR [ensure-worktree]: 'bun install --frozen-lockfile' failed in the new worktree '$_idep_wt'." >&2
-      echo "  The lockfile does not match the manifests on this branch. Fix it and re-run;" >&2
-      echo "  this script is safe to re-run on an existing worktree." >&2
-      exit 1
-    fi
-    return
+  echo "[ensure-worktree] installing dependencies (bun install --frozen-lockfile)..." >&2
+  if ! (cd "$_idep_wt" && bun install --frozen-lockfile >&2); then
+    echo "ERROR [ensure-worktree]: 'bun install --frozen-lockfile' failed in '$_idep_wt'." >&2
+    echo "  The lockfile does not match the manifests on this branch. Fix it and re-run;" >&2
+    echo "  the worktree is left in place and re-running retries the install." >&2
+    exit 1
   fi
 
-  echo "[ensure-worktree] refreshing dependencies (bun install)..." >&2
-  if ! (cd "$_idep_wt" && bun install >&2); then
-    echo "WARNING [ensure-worktree]: 'bun install' failed in the existing worktree '$_idep_wt'." >&2
-    echo "  Returning the path anyway — your work lives there. Dependencies may be stale;" >&2
-    echo "  resolve the install error inside the worktree before running the app or tests." >&2
-  fi
+  : >"$_idep_marker"
 }
 
 # assert_submodule_pins_pushed <rev>
@@ -318,7 +333,7 @@ if [ "$git_dir" != "$git_common_dir" ]; then
   # Print the worktree root for the caller to cd into (in case they're in a subdir).
   _wt_top=$(git rev-parse --show-toplevel)
   init_unpopulated_submodules "$_wt_top"
-  install_dependencies "$_wt_top" reuse
+  install_dependencies "$_wt_top"
   echo "$_wt_top"
   exit 0
 fi
@@ -375,7 +390,7 @@ if [ -d "$worktree_path" ]; then
   # early-return path for a caller already inside a worktree is unguarded for
   # the same reason.
   init_unpopulated_submodules "$worktree_path"
-  install_dependencies "$worktree_path" reuse
+  install_dependencies "$worktree_path"
   echo "$worktree_path"
   exit 0
 fi
@@ -468,6 +483,6 @@ fi
 assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
 
 init_unpopulated_submodules "$worktree_path"
-install_dependencies "$worktree_path" create
+install_dependencies "$worktree_path"
 
 echo "$worktree_path"

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -102,7 +102,7 @@ init_unpopulated_submodules() {
   done
 }
 
-# install_dependencies <worktree_path>
+# install_dependencies <worktree_path> <mode: create|reuse>
 # A fresh worktree has no node_modules at all: `git worktree add` copies
 # tracked files only, and nothing else in this script installs. Every agent
 # that then tries to run the app or the test suite hits a different symptom of
@@ -112,10 +112,24 @@ init_unpopulated_submodules() {
 # in", which is what every caller already assumes it means.
 #
 # Idempotent and near-free when the worktree is already installed, so this
-# also heals the reuse path. A failure is fatal: handing back a path whose
-# dependencies are missing is the exact situation this exists to prevent.
+# also heals the reuse path.
+#
+# The two modes differ because the cost of refusing differs. On `create` the
+# worktree is a fresh checkout of a committed tree, so the lockfile matches by
+# construction: `--frozen-lockfile` costs nothing, catches a genuinely broken
+# lockfile, and guarantees provisioning never leaves `bun.lock` modified in a
+# brand-new worktree. Failing there strands nobody — no work exists in it yet.
+#
+# On `reuse` an agent is already working in the tree and may legitimately have
+# edited a manifest without regenerating the lockfile. Enforcing frozen there
+# would make the sanctioned bootstrap refuse to hand back a worktree that
+# already exists and is the only place their work lives — a loop with no exit,
+# since teardown needs the path too. So reuse installs unfrozen, and an install
+# failure warns rather than exits: the caller still gets the path, and a stale
+# node_modules is a recoverable state where a withheld path is not.
 install_dependencies() {
   _idep_wt="$1"
+  _idep_mode="$2"
 
   if ! command -v bun >/dev/null 2>&1; then
     echo "ERROR [ensure-worktree]: 'bun' is not on PATH; cannot install dependencies in '$_idep_wt'." >&2
@@ -123,11 +137,22 @@ install_dependencies() {
     exit 1
   fi
 
-  echo "[ensure-worktree] installing dependencies (bun install)..." >&2
-  if ! (cd "$_idep_wt" && bun install --frozen-lockfile >&2); then
-    echo "ERROR [ensure-worktree]: 'bun install' failed in '$_idep_wt'." >&2
-    echo "  Resolve the install error and re-run; this script retries on an existing worktree." >&2
-    exit 1
+  if [ "$_idep_mode" = "create" ]; then
+    echo "[ensure-worktree] installing dependencies (bun install --frozen-lockfile)..." >&2
+    if ! (cd "$_idep_wt" && bun install --frozen-lockfile >&2); then
+      echo "ERROR [ensure-worktree]: 'bun install --frozen-lockfile' failed in the new worktree '$_idep_wt'." >&2
+      echo "  The lockfile does not match the manifests on this branch. Fix it and re-run;" >&2
+      echo "  this script is safe to re-run on an existing worktree." >&2
+      exit 1
+    fi
+    return
+  fi
+
+  echo "[ensure-worktree] refreshing dependencies (bun install)..." >&2
+  if ! (cd "$_idep_wt" && bun install >&2); then
+    echo "WARNING [ensure-worktree]: 'bun install' failed in the existing worktree '$_idep_wt'." >&2
+    echo "  Returning the path anyway — your work lives there. Dependencies may be stale;" >&2
+    echo "  resolve the install error inside the worktree before running the app or tests." >&2
   fi
 }
 
@@ -280,7 +305,7 @@ if [ "$git_dir" != "$git_common_dir" ]; then
   # Print the worktree root for the caller to cd into (in case they're in a subdir).
   _wt_top=$(git rev-parse --show-toplevel)
   init_unpopulated_submodules "$_wt_top"
-  install_dependencies "$_wt_top"
+  install_dependencies "$_wt_top" reuse
   echo "$_wt_top"
   exit 0
 fi
@@ -337,7 +362,7 @@ if [ -d "$worktree_path" ]; then
   # early-return path for a caller already inside a worktree is unguarded for
   # the same reason.
   init_unpopulated_submodules "$worktree_path"
-  install_dependencies "$worktree_path"
+  install_dependencies "$worktree_path" reuse
   echo "$worktree_path"
   exit 0
 fi
@@ -430,6 +455,6 @@ fi
 assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
 
 init_unpopulated_submodules "$worktree_path"
-install_dependencies "$worktree_path"
+install_dependencies "$worktree_path" create
 
 echo "$worktree_path"

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -13,8 +13,12 @@
 #     caller must cd into that path.  The main checkout's HEAD and current
 #     branch are never switched — verified by an assertion before this
 #     script hands back control.
-#   - Hard-fails (exit 1) if anything goes wrong — this is fail-closed by
-#     design so that a briefed agent cannot silently proceed in main.
+#   - Hard-fails (exit 1) on any provisioning or validation failure — this is
+#     fail-closed by design so that a briefed agent cannot silently proceed in
+#     main.  The one deliberate exception is the dependency refresh on an
+#     ALREADY-EXISTING worktree: that warns and still prints the path, because
+#     withholding the path from a worktree that already holds the agent's work
+#     strands it.  See install_dependencies.
 #
 # ENV:
 #   WORKTREE_BASE  Override the base directory (default: ~/worktrees/<project>)

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -135,10 +135,19 @@ install_dependencies() {
   _idep_wt="$1"
   _idep_mode="$2"
 
+  # A missing bun is the same class of failure as a failed install, so it takes
+  # the same mode-dependent exit: fatal while provisioning a tree that holds no
+  # work yet, a warning once the tree is the agent's only copy of it.
   if ! command -v bun >/dev/null 2>&1; then
-    echo "ERROR [ensure-worktree]: 'bun' is not on PATH; cannot install dependencies in '$_idep_wt'." >&2
-    echo "  Install bun (see AGENTS.md) and re-run; this script is safe to re-run on an existing worktree." >&2
-    exit 1
+    if [ "$_idep_mode" = "create" ]; then
+      echo "ERROR [ensure-worktree]: 'bun' is not on PATH; cannot install dependencies in '$_idep_wt'." >&2
+      echo "  Install bun (see AGENTS.md) and re-run." >&2
+      exit 1
+    fi
+    echo "WARNING [ensure-worktree]: 'bun' is not on PATH; skipping the dependency refresh in '$_idep_wt'." >&2
+    echo "  Returning the path anyway — your work lives there. Dependencies may be stale;" >&2
+    echo "  install bun (see AGENTS.md) and re-run before running the app or tests." >&2
+    return
   fi
 
   if [ "$_idep_mode" = "create" ]; then

--- a/scripts/ensure-worktree.sh
+++ b/scripts/ensure-worktree.sh
@@ -102,6 +102,35 @@ init_unpopulated_submodules() {
   done
 }
 
+# install_dependencies <worktree_path>
+# A fresh worktree has no node_modules at all: `git worktree add` copies
+# tracked files only, and nothing else in this script installs. Every agent
+# that then tries to run the app or the test suite hits a different symptom of
+# the same cause — a missing Electron binary, an unresolvable `@wystack/*`
+# import, `vitest: command not found` — and has to rediscover that the answer
+# is `bun install`. Doing it here makes the printed path mean "ready to work
+# in", which is what every caller already assumes it means.
+#
+# Idempotent and near-free when the worktree is already installed, so this
+# also heals the reuse path. A failure is fatal: handing back a path whose
+# dependencies are missing is the exact situation this exists to prevent.
+install_dependencies() {
+  _idep_wt="$1"
+
+  if ! command -v bun >/dev/null 2>&1; then
+    echo "ERROR [ensure-worktree]: 'bun' is not on PATH; cannot install dependencies in '$_idep_wt'." >&2
+    echo "  Install bun (see AGENTS.md) and re-run; this script is safe to re-run on an existing worktree." >&2
+    exit 1
+  fi
+
+  echo "[ensure-worktree] installing dependencies (bun install)..." >&2
+  if ! (cd "$_idep_wt" && bun install --frozen-lockfile >&2); then
+    echo "ERROR [ensure-worktree]: 'bun install' failed in '$_idep_wt'." >&2
+    echo "  Resolve the install error and re-run; this script retries on an existing worktree." >&2
+    exit 1
+  fi
+}
+
 # assert_submodule_pins_pushed <rev>
 # Refuse to provision a worktree whose submodule pins point at commits no
 # submodule remote has.
@@ -251,6 +280,7 @@ if [ "$git_dir" != "$git_common_dir" ]; then
   # Print the worktree root for the caller to cd into (in case they're in a subdir).
   _wt_top=$(git rev-parse --show-toplevel)
   init_unpopulated_submodules "$_wt_top"
+  install_dependencies "$_wt_top"
   echo "$_wt_top"
   exit 0
 fi
@@ -307,6 +337,7 @@ if [ -d "$worktree_path" ]; then
   # early-return path for a caller already inside a worktree is unguarded for
   # the same reason.
   init_unpopulated_submodules "$worktree_path"
+  install_dependencies "$worktree_path"
   echo "$worktree_path"
   exit 0
 fi
@@ -399,5 +430,6 @@ fi
 assert_main_checkout_unchanged "$repo_root" "$main_head_before" "$main_branch_before"
 
 init_unpopulated_submodules "$worktree_path"
+install_dependencies "$worktree_path"
 
 echo "$worktree_path"


### PR DESCRIPTION
## Summary

`scripts/ensure-worktree.sh` provisions dependencies, so the path it prints means "ready to work in".

`git worktree add` copies tracked files only, so a fresh worktree has no `node_modules` at all. Every agent that then tried to run the app or the tests hit a different symptom of the same cause — a missing Electron binary, an unresolvable `@wystack/*` import, `vitest: command not found` — and had to rediscover that the answer was `bun install`. The bootstrap step every brief already runs now handles it.

The install happens **exactly once per worktree**, gated on a marker in the worktree's private gitdir. Both halves of that are load-bearing, and review is what established why:

**Why once, not every call.** `bun install` is not inert on a provisioned tree. Every `@wystack/*` dependency is `workspace:*`, so an install re-resolves it to the in-repo submodule and silently undoes a `bun link` pointing at an external checkout — a contract this repo documents in `README.md`. An earlier revision of this branch refreshed on every invocation, which meant the sanctioned bootstrap command dismantled a developer's linked setup every time they ran it. A provisioned worktree is now handed back untouched.

**Why a marker, not a `node_modules` check.** `git worktree add` succeeds before the install runs, so a failed first provision leaves a real worktree on disk with an absent or half-built `node_modules`. Keying off the directory would classify that as "already provisioned" and hand it back. Keying off a marker written only after a clean install means the retry is still a first provision, and gets the same fail-closed frozen install the original attempt did.

The install is `--frozen-lockfile`: a fresh checkout of a committed tree matches its lockfile by construction, so provisioning must never rewrite `bun.lock`, and a mismatch is a real defect on the branch rather than something to paper over.

Worktrees that predate the marker are backfilled from an existing `node_modules`. Without that, the first run after this lands would force a frozen install onto a tree whose manifests an agent may already have edited — exiting non-zero and withholding the path to the only copy of their work.

## Testing

- `bun run check` — 4/4 arms PASS; `bun run format:check` clean; `shellcheck` and `sh -n` clean.
- Behavioral verification of each path, in a real worktree:
  - **Fresh provision** installs with `--frozen-lockfile`, writes the marker, and leaves `bun.lock` unmodified.
  - **Already provisioned** returns the path in 0.07s with no install — nothing that could clobber a `bun link`.
  - **Failed first provision** (`bun` off `PATH`) exits 1, leaves the worktree on disk, and writes no marker; the retry is still a frozen first provision, not an unfrozen reuse.
  - **Pre-marker worktree** is backfilled and returns the path with `bun` off `PATH` entirely, proving no install is attempted.
- The independent second reviewer reproduced the fresh-provision, marker-write, and no-second-install behavior in a disposable git repo.

## Screenshots

No UI change.
