### PR TITLE
fix(server): correct stale comments and error copy about serve's vault-class coverage

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -182,11 +182,17 @@ export interface DashframeServerOptions {
    */
   insecure?: boolean;
   /**
-   * Optional native engine for the dedicated Arrow IPC data path. When supplied
-   * (desktop / `dashframe serve` with the native engine), `POST /data/arrow`
-   * streams `application/vnd.apache.arrow.stream` for a compiled query — the
-   * binary path that never rides WyStack RPC. Web try-it omits it: the
-   * result already lives in renderer WASM, so there is no server data path.
+   * Optional native engine for the dedicated Arrow IPC data path. When
+   * supplied, `POST /data/arrow` streams `application/vnd.apache.arrow.stream`
+   * for a compiled query — the binary path that never rides WyStack RPC.
+   *
+   * Desktop is the only caller that supplies this today — Electron main
+   * constructs the native engine and passes it in. `dashframe serve`'s CLI
+   * composition (`createStandaloneServerOptions`) never sets it, so the Arrow
+   * data path stays unmounted there; wiring it in is the first slice of the
+   * unified data-plane work (see `@dashframe/engine-server`'s native-engine
+   * doc comment). Web try-it also omits it: the result already lives in
+   * renderer WASM, so there is no server data path.
    */
   arrowEngine?: ArrowQueryRunner;
   /**

--- a/apps/server/src/functions/utils.test.ts
+++ b/apps/server/src/functions/utils.test.ts
@@ -57,12 +57,17 @@ describe("withClassBoundaryMessage", () => {
     ).resolves.toEqual(expect.any(String));
   });
 
-  it("keeps the registry throw as the cause", async () => {
+  // Asserts the translated message on `storeCredential`'s own path, not just
+  // on `withClassBoundaryMessage` in isolation. A change that stopped
+  // `storeCredential` routing through the wrapper would leak the registry's
+  // internal wording to operators while every other test here still passed.
+  it("translates on storeCredential's real path, and keeps the registry throw as the cause", async () => {
     const error = await storeCredential(
       unbackedVault(),
       "pretend-credential",
       "hint",
     ).catch((thrown: unknown) => thrown);
+    expect((error as Error).message).toMatch(/requires the desktop app/);
     expect((error as Error).cause).toBeInstanceOf(Error);
     expect(((error as Error).cause as Error).message).toMatch(
       /No backend configured for class/,

--- a/apps/server/src/functions/utils.test.ts
+++ b/apps/server/src/functions/utils.test.ts
@@ -18,24 +18,48 @@ import { describe, expect, it } from "vitest";
 
 import { storeCredential, withClassBoundaryMessage } from "./utils";
 
-/** A vault shaped exactly like the one `dashframe serve` composes. */
+/**
+ * A vault shaped exactly like the one `dashframe serve` composes today:
+ * `serve-token` and `connector-key` both have a backend, `assistant-provider`
+ * deliberately does not (apps/server/src/index.ts's
+ * createStandaloneSecretServices). `assistant-provider` is the one class this
+ * test suite can still exercise the class-boundary translation with.
+ */
 function serveScopedVault(): SecretVault {
   const registry = new SecretRegistry();
   registry.register("test", new TestBackend());
   registry.setClassDefault(CREDENTIAL_CLASS.ServeToken, "test");
+  registry.setClassDefault(CREDENTIAL_CLASS.ConnectorKey, "test");
+  return new SecretVault(registry, new InMemoryMappingStore());
+}
+
+/** A vault with no backend registered for any class, `connector-key` included. */
+function unbackedVault(): SecretVault {
+  const registry = new SecretRegistry();
   return new SecretVault(registry, new InMemoryMappingStore());
 }
 
 describe("withClassBoundaryMessage", () => {
   it("translates the registry's class-boundary throw for a serve-scoped vault", async () => {
     await expect(
+      withClassBoundaryMessage(() =>
+        serveScopedVault().store("pretend-credential", {
+          class: CREDENTIAL_CLASS.AssistantProvider,
+          locatorHint: "hint",
+        }),
+      ),
+    ).rejects.toThrow(/requires the desktop app/);
+  });
+
+  it("succeeds storing a connector-key credential on a serve-scoped vault (has a backend)", async () => {
+    await expect(
       storeCredential(serveScopedVault(), "pretend-credential", "hint"),
-    ).rejects.toThrow(/require the desktop app/);
+    ).resolves.toEqual(expect.any(String));
   });
 
   it("keeps the registry throw as the cause", async () => {
     const error = await storeCredential(
-      serveScopedVault(),
+      unbackedVault(),
       "pretend-credential",
       "hint",
     ).catch((thrown: unknown) => thrown);

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -198,12 +198,18 @@ export async function storeCredential(
  * Translate the vault registry's "no backend for class X" throw into an
  * operator-legible one.
  *
- * `dashframe serve` composes a vault that is scoped to `serve-token` only —
- * `connector-key` and `assistant-provider` deliberately have no backend there,
- * because their refs travel with the copiable project DB and must not land in a
- * host-local store. Without this, an operator trying to save a data-source
- * credential on serve gets a registry-internal message naming a class name they
- * have never heard of, which reads like a bug rather than the boundary it is.
+ * Wraps both credential-class writers that can hit an unregistered class on
+ * `dashframe serve`: `storeCredential` (`connector-key`) and
+ * `storeAssistantCredential` (`assistant-provider`). `dashframe serve` now
+ * composes a vault with backends for `serve-token` and `connector-key` —
+ * only `assistant-provider` has no backend there today, because its refs
+ * travel with the copiable project DB and must not land in a host-local
+ * store — but the message below stays class-agnostic rather than naming
+ * that gap by name, since either writer can hit this path and which class is
+ * unregistered is a composition-time fact, not one this function should
+ * assume. Without this translation, an operator hitting the gap gets a
+ * registry-internal message naming a class they have never heard of, which
+ * reads like a bug rather than the boundary it is.
  *
  * Matched on the registry's message text because it does not export a typed
  * error; the fallback re-throws untouched, so a miss degrades to today's
@@ -218,8 +224,8 @@ export async function withClassBoundaryMessage<T>(
     const message = error instanceof Error ? error.message : "";
     if (!/No backend configured for class/i.test(message)) throw error;
     throw new Error(
-      "dashframe serve stores only access credentials; data-source and " +
-        "assistant credentials require the desktop app.",
+      "dashframe serve cannot store this type of credential — it requires " +
+        "the desktop app.",
       { cause: error },
     );
   }

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -211,6 +211,13 @@ export async function storeCredential(
  * registry-internal message naming a class they have never heard of, which
  * reads like a bug rather than the boundary it is.
  *
+ * The message does name a host, deliberately: `serve` is the only composition
+ * that leaves a class unbacked, so naming it buys the operator an actionable
+ * direction ("use the desktop app") that a host-agnostic wording would lose.
+ * Desktop registers a backend for all three classes (apps/desktop/src/main.ts's
+ * secret-services setup), so this branch is unreachable there. If a host ever
+ * ships with a partial registry, this message has to stop naming `serve`.
+ *
  * Matched on the registry's message text because it does not export a typed
  * error; the fallback re-throws untouched, so a miss degrades to today's
  * behavior rather than swallowing an unrelated failure.


### PR DESCRIPTION
## Summary

Three places described `dashframe serve`'s vault scope wrongly, all encoding the same false belief: that serve cannot store connector credentials.

It can. `createStandaloneSecretServices` registers backends for both `serve-token` and `connector-key`; only `assistant-provider` has none, because its refs travel with the copiable project DB and must not land in a host-local store.

**The docblock** on `withClassBoundaryMessage` claimed the vault was scoped to `serve-token` only. Corrected, and it now records why the thrown message stays class-agnostic: either writer can hit that path, and which class is unregistered is a composition-time fact this function should not assume.

**The operator-facing error** said "dashframe serve stores only access credentials; data-source and assistant credentials require the desktop app" — which told an operator something false about data-source credentials. It now reads:

> dashframe serve cannot store this type of credential — it requires the desktop app.

**The test fixture** was the most consequential of the three. `serveScopedVault()` registered only `serve-token`, so `storeCredential` threw and the test asserted that error — pinning the same wrong model the comment did. It would have kept passing if someone removed real connector-key support. The fixture now matches what serve actually composes, the boundary case moves to `assistant-provider` (the genuinely unbacked class), and a new positive test asserts connector-key **succeeds**, which is the assertion that would have caught the original defect.

Separately, the `arrowEngine` docblock in `app.ts` claimed the option was reachable via "desktop / `dashframe serve` with the native engine". The CLI's `createStandaloneServerOptions` never sets it and no flag exists for it — the docblock contradicted the file's own top-of-file comment. Corrected to state that desktop is the only current caller, pointing at the unified-data-plane doc comment in `@dashframe/engine-server` for why.

No control-flow change: the diff is comments, one thrown-message string, and the test fixture.

## Testing

- `bun run check` — PASS; `bun run format:check` — PASS.
- **Behavioral QA, reproduced independently of the author.** A real `dashframe serve` on loopback with `DASHFRAME_SECRET_KEY` set (keyed vault, matching production), then `POST /api/saveAssistantProviderConfig` with an api-key credential. Response body:
  ```json
  {"error":"dashframe serve cannot store this type of credential — it requires the desktop app."}
  ```
  That is the actual HTTP error an operator's client receives, not a test assertion.
- Every factual claim in the new comments was checked against source: `arrowEngine` never set in `apps/server/src/index.ts`, set at `apps/desktop/src/main.ts:390`, and the `@dashframe/engine-server` doc comment the new text points at exists and says what is claimed.
- Second reviewer: independent Codex session, no findings, verdict verified to cite the commit sha and all three changed files by name rather than an empty diff.

## Screenshots

No UI change.
