### PR TITLE
test(app): de-flake config dialog save test and correct its comment

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/config-dialog-save.test.tsx
@@ -237,11 +237,20 @@ describe("insight config dialog saves", () => {
   // `count(column)`, which skips null rows and reports a smaller number than
   // the label promises. Driven through the rendered dialog rather than the
   // helpers, because the defect is the transition the user performs.
+  // The 20s budget is deliberate, and this test is the only one in the package
+  // that needs it. It drives eleven interactions through Radix Selects — each
+  // one a full userEvent pointer sequence against a portalled listbox — which
+  // costs ~600ms of CPU alone and ~900ms when the suite's other workers are
+  // competing for cores. That is the honest cost of the test, not a hang: every
+  // interaction completes, and profiling shows the time spread evenly across
+  // them with no dominant step. The default 5s left under 6x headroom, and CI
+  // runs 85 turbo tasks on a 4-core runner, so a contended run reaches 4.3s and
+  // the test times out (PR #313's `check` job). 20s is ~20x the in-suite cost
+  // and still fails fast on a real hang.
   it("drops a previously chosen column when switching back to Count (rows)", async () => {
-    // `delay: null` removes userEvent's inter-event wait. This test drives nine
-    // interactions through Radix Selects, and at the default delay the total
-    // ran just over the 5s limit on CI's slower runner while passing locally.
-    // Dropping the delay changes pacing only — every interaction still happens.
+    // `delay: null` removes userEvent's inter-event wait, which is why the work
+    // above is ~600ms rather than several seconds. It changes pacing only —
+    // every interaction still happens.
     const user = userEvent.setup({ delay: null });
     const onSave = vi.fn().mockResolvedValue(undefined);
 
@@ -289,7 +298,7 @@ describe("insight config dialog saves", () => {
       aggregation: "count",
       columnName: undefined,
     });
-  });
+  }, 20_000);
 
   // The edit dialog reaches the same bad state by a different route: it never
   // switches aggregation, it *initializes* from a metric already stored as


### PR DESCRIPTION
De-flakes the one test in `config-dialog-save.test.tsx` that has been intermittently
failing CI on unrelated PRs, and corrects a comment that misstated why an earlier fix
was applied.

## Changes

- Give the save-flow test an explicit `20_000`ms timeout. It is a genuine outlier:
  it drives 11 sequential `user.click` interactions and takes ~570ms uncontended,
  against ~178ms for the next-slowest test in the file. Under CI contention on a
  4-core runner that clears vitest's 5000ms default. The bump is disclosed here
  rather than hidden in a global config change.
- Rewrite the comment block above it. The previous wording implied that the
  `delay: null` change in `ee7f930b` had fixed the CI timeout. It had not — the
  timeout kept recurring after that commit, most recently on #313. A comment that
  misstates behavior is a defect; this one would have sent the next person
  investigating the flake down the wrong path.

No production code changes — one test file, 14 insertions / 5 deletions.

## Screenshots

No UI change.

## Verification

- `bun run check` — all four summary lines PASS, no SKIP.
- `bun run format:check` — clean.
- Stability: 10/10 passes with the target test run under artificial CPU contention
  (100 concurrent `yes` processes), well beyond what CI's runner produces. Load
  processes confirmed reaped afterwards.
- Independently verified by a separate session that re-ran the gate and the load
  test itself rather than trusting the authoring lane's report, and confirmed the
  corrected comment against `git show ee7f930b`.

## Follow-up note (not filed as a ticket)

`packages/app/vitest.config.ts` declares no `testTimeout`, so the whole package runs
on vitest's 5000ms default. Raising it globally would mask real hangs, so the
per-test bump above is the right scope for this flake — but if more tests in this
package start crossing the line, a considered package-level value is the better fix
than a spread of per-test overrides. Not user-visible, so no ticket.
