### PR TITLE
[codex] Surface sensitivity in insight field picker

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
@@ -89,4 +89,29 @@ describe("InsightFieldEditorModal", () => {
       ).toBeNull();
     }
   });
+
+  it("renders no sensitivity badge for a cleared field", () => {
+    const clearedFields = fields.map((field) =>
+      field.id === "customer-email"
+        ? { ...field, sensitivity: "cleared", sensitivityReason: undefined }
+        : field,
+    );
+
+    render(
+      <InsightFieldEditorModal
+        isOpen
+        onOpenChange={vi.fn()}
+        availableFields={clearedFields}
+        baseTableId="orders"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const emailField = screen.getByRole("button", {
+      name: /customer_email/i,
+    });
+    expect(
+      within(emailField).queryByText(/Sensitive|Likely sensitive|Unclassified/),
+    ).toBeNull();
+  });
 });

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
@@ -54,7 +54,7 @@ describe("InsightFieldEditorModal", () => {
       const field = screen.getByRole("button", {
         name: new RegExp(`^${fieldName} `),
       });
-      expect(within(field).queryByText(/Sensitive|Unclassified/)).toBeNull();
+      expect(within(field).queryByText(/sensitive|unclassified/i)).toBeNull();
     }
   });
 

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.test.tsx
@@ -1,0 +1,92 @@
+import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { InsightFieldEditorModal } from "./InsightFieldEditorModal";
+
+const fields = [
+  {
+    id: "order-id",
+    name: "order_id",
+    displayName: "order_id",
+    tableId: "orders",
+    sourceTableId: "orders",
+    type: "number",
+  },
+  {
+    id: "customer-email",
+    name: "customer_email",
+    displayName: "customer_email",
+    tableId: "orders",
+    sourceTableId: "orders",
+    type: "string",
+    sensitivity: "sensitive",
+    sensitivityReason: "Contains email addresses",
+  },
+  {
+    id: "amount",
+    name: "amount",
+    displayName: "amount",
+    tableId: "orders",
+    sourceTableId: "orders",
+    type: "number",
+  },
+] as CombinedField[];
+
+describe("InsightFieldEditorModal", () => {
+  it("renders the shared sensitivity marker only for sensitive fields", () => {
+    render(
+      <InsightFieldEditorModal
+        isOpen
+        onOpenChange={vi.fn()}
+        availableFields={fields}
+        baseTableId="orders"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const emailField = screen.getByRole("button", {
+      name: /customer_email/i,
+    });
+    expect(within(emailField).getByText("Sensitive")).toBeTruthy();
+
+    for (const fieldName of ["order_id", "amount"]) {
+      const field = screen.getByRole("button", {
+        name: new RegExp(`^${fieldName} `),
+      });
+      expect(within(field).queryByText(/Sensitive|Unclassified/)).toBeNull();
+    }
+  });
+
+  it("renders the shared suggestion marker for a likely-sensitive field only", () => {
+    const unclassifiedFields = fields.map((field) =>
+      field.id === "customer-email"
+        ? { ...field, sensitivity: undefined, sensitivityReason: undefined }
+        : field,
+    );
+
+    render(
+      <InsightFieldEditorModal
+        isOpen
+        onOpenChange={vi.fn()}
+        availableFields={unclassifiedFields}
+        baseTableId="orders"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const emailField = screen.getByRole("button", {
+      name: /customer_email/i,
+    });
+    expect(within(emailField).getByText("Likely sensitive")).toBeTruthy();
+
+    for (const fieldName of ["order_id", "amount"]) {
+      const field = screen.getByRole("button", {
+        name: new RegExp(`^${fieldName} `),
+      });
+      expect(
+        within(field).queryByText(/Likely sensitive|Unclassified/),
+      ).toBeNull();
+    }
+  });
+});

--- a/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/config-panel/InsightFieldEditorModal.tsx
@@ -1,4 +1,9 @@
+import { SensitivityBadge } from "@/components/data-sources/SensitivityBadge";
 import type { CombinedField } from "@/lib/insights/compute-combined-fields";
+import {
+  getFieldSensitivity,
+  suggestSensitivityReasons,
+} from "@dashframe/types";
 import {
   Badge,
   Dialog,
@@ -149,6 +154,12 @@ interface FieldOptionProps {
 }
 
 function FieldOption({ field, isJoined, onClick }: FieldOptionProps) {
+  const sensitivity = getFieldSensitivity(field);
+  const suggestedReasons =
+    sensitivity === "unclassified"
+      ? suggestSensitivityReasons({ name: field.name })
+      : [];
+
   return (
     <button
       onClick={onClick}
@@ -167,6 +178,9 @@ function FieldOption({ field, isJoined, onClick }: FieldOptionProps) {
         )}
       </div>
       <div className="flex shrink-0 items-center gap-2">
+        {(sensitivity === "sensitive" || suggestedReasons.length > 0) && (
+          <SensitivityBadge field={field} suggestedReasons={suggestedReasons} />
+        )}
         <Badge variant="outline" className="text-[10px]">
           {field.type}
         </Badge>

--- a/packages/app/src/components/data-sources/SensitivityBadge.test.tsx
+++ b/packages/app/src/components/data-sources/SensitivityBadge.test.tsx
@@ -12,6 +12,22 @@ const field = {
 } as unknown as Field;
 
 describe("SensitivityBadge", () => {
+  it("renders a suggested badge as read-only without a confirmation handler", () => {
+    render(
+      <SensitivityBadge
+        field={field}
+        suggestedReasons={["Contains email addresses"]}
+      />,
+    );
+
+    const badge = screen.getByText("Likely sensitive");
+    expect(badge.getAttribute("role")).toBeNull();
+    expect(badge.getAttribute("tabindex")).toBeNull();
+    expect(badge.closest("button")).toBeNull();
+    expect(badge.getAttribute("title")).toBe("Contains email addresses");
+    expect(badge.getAttribute("title")).not.toMatch(/confirm/i);
+  });
+
   it.each(["Enter", " "])(
     "confirms once on %j and ignores auto-repeat",
     (key) => {

--- a/packages/app/src/components/data-sources/SensitivityBadge.tsx
+++ b/packages/app/src/components/data-sources/SensitivityBadge.tsx
@@ -14,7 +14,7 @@ interface SensitivityBadgeProps {
  * Privacy badge for a field row. Single rendering of the sensitivity states
  * shared by every field list:
  * - sensitive → danger badge carrying the stored why
- * - unclassified + suggestion → clickable warning badge (confirm = mark)
+ * - unclassified + suggestion → clickable warning badge when onConfirmSuggestion is supplied; otherwise read-only
  * - unclassified → outline badge (restricted until cleared)
  * - cleared → nothing
  */

--- a/packages/app/src/components/data-sources/SensitivityBadge.tsx
+++ b/packages/app/src/components/data-sources/SensitivityBadge.tsx
@@ -6,8 +6,8 @@ interface SensitivityBadgeProps {
   field: Field;
   /** Classifier suggestion reasons, when the field is unclassified */
   suggestedReasons: string[];
-  /** One-click confirm of the classifier suggestion */
-  onConfirmSuggestion: () => void;
+  /** One-click confirm of the classifier suggestion, when the surface supports it */
+  onConfirmSuggestion?: () => void;
 }
 
 /**
@@ -41,9 +41,25 @@ export function SensitivityBadge({
   }
 
   if (suggestedReasons.length > 0) {
-    // Clickable confirm affordance. Built from the composed Badge (not a raw
-    // primitive — those are construction blocks internal to @wystack/ui-react) made
-    // interactive via role/tabIndex + keyboard activation.
+    const interactiveProps = onConfirmSuggestion
+      ? {
+          role: "button",
+          tabIndex: 0,
+          onClick: onConfirmSuggestion,
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              // Ignore auto-repeat so holding Enter/Space doesn't confirm repeatedly.
+              if (e.repeat) return;
+              onConfirmSuggestion();
+            }
+          },
+        }
+      : {};
+
+    // Surfaces that can confirm the suggestion opt into an interactive
+    // affordance. Read-only surfaces reuse the same composed badge without
+    // advertising an action they cannot perform.
     //
     // This relies on Badge forwarding arbitrary props to its root DOM node.
     // @wystack/ui-react's Badge renders `<div className={...} {...props} />`
@@ -54,19 +70,13 @@ export function SensitivityBadge({
       <Badge
         variant="soft"
         color="warning"
-        role="button"
-        tabIndex={0}
-        title={`${suggestedReasons.join("; ")} — click to confirm as sensitive`}
-        onClick={onConfirmSuggestion}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            // Ignore auto-repeat so holding Enter/Space doesn't confirm repeatedly.
-            if (e.repeat) return;
-            onConfirmSuggestion();
-          }
-        }}
-        className="shrink-0 cursor-pointer"
+        title={
+          onConfirmSuggestion
+            ? `${suggestedReasons.join("; ")} — click to confirm as sensitive`
+            : suggestedReasons.join("; ")
+        }
+        {...interactiveProps}
+        className={onConfirmSuggestion ? "shrink-0 cursor-pointer" : "shrink-0"}
       >
         Likely sensitive
       </Badge>


### PR DESCRIPTION
## Summary

- Surface shared field sensitivity badges in the insight Add Field picker.
- Keep suggestion confirmation interactive only when the caller can confirm it; picker badges remain read-only.
- Add regression coverage for read-only suggested badges and cleared picker fields.

## Scope

The picker uses the existing shared sensitivity helpers. Analysis-derived suggestions remain report-only: the picker has no per-field analysis map, so that data-loading work is intentionally excluded from this PR.

## Validation

- `bun run check` — pass (85/85 tasks)
- `bun run format:check` — pass
- `bunx turbo check --filter=@dashframe/app --force` — pass (21/21, uncached; 778 tests)
- Independent final review — no actionable findings
- Runtime QA at the unchanged UI implementation: light/dark picker captures covered Sensitive, Likely sensitive, unclassified/no-suggestion, and cleared states; detail-page confirmation remained functional.

## Visual evidence

Captured light/dark states: `/tmp/df-sens-picker-light.png`, `/tmp/df-sens-picker-dark.png`, and `/tmp/df-sens-picker-sensitive-dark.png` (validated before the final test-and-doc-only commits; no executable UI code changed afterward).
