### PR TITLE
[codex] Fix responsive dashboard clipping and edit mode

### DIFF
--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.test.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.test.tsx
@@ -1,0 +1,81 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addItem: vi.fn(async () => {}),
+  dashboard: {
+    id: "dashboard",
+    name: "Dashboard",
+    createdAt: 0,
+    items: [],
+    controls: [],
+  },
+  editingAvailabilityCallback: undefined as
+    | ((isAvailable: boolean) => void)
+    | undefined,
+  navigate: vi.fn(),
+}));
+
+vi.mock("@wystack/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/client")>();
+  return {
+    ...actual,
+    useQuery: (ref: { _path: string }) => ({
+      data: ref._path === "listDashboards" ? [mocks.dashboard] : [],
+      isFetching: false,
+      isLoading: false,
+    }),
+    useMutation: () => ({ mutateAsync: mocks.addItem }),
+  };
+});
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/components/assistant/artifact-context", () => ({
+  useBindArtifact: () => {},
+}));
+
+vi.mock("@/components/dashboards/DashboardGrid", () => ({
+  DashboardGrid: (props: {
+    onEditingAvailabilityChange?: (isAvailable: boolean) => void;
+  }) => {
+    mocks.editingAvailabilityCallback = props.onEditingAvailabilityChange;
+    return <div>grid</div>;
+  },
+}));
+
+import DashboardDetailContent from "./DashboardDetailContent";
+
+describe("DashboardDetailContent editing availability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.editingAvailabilityCallback = undefined;
+  });
+
+  it("closes an open add-widget dialog when editing becomes unavailable", () => {
+    render(<DashboardDetailContent dashboardId="dashboard" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Dashboard" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Widget" }));
+    expect(screen.getByRole("dialog", { name: "Add Widget" })).toBeTruthy();
+
+    act(() => {
+      mocks.editingAvailabilityCallback?.(false);
+    });
+
+    expect(screen.queryByRole("dialog", { name: "Add Widget" })).toBeNull();
+    expect(
+      screen.getByText("Editing unavailable: dashboard needs a wider area.", {
+        exact: true,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Edit Dashboard" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(mocks.addItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.test.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useLayoutEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   editingAvailabilityCallback: undefined as
     | ((isAvailable: boolean) => void)
     | undefined,
+  gridAvailabilityOnMount: null as boolean | null,
+  isFetching: false,
   navigate: vi.fn(),
 }));
 
@@ -22,7 +25,7 @@ vi.mock("@wystack/client", async (importOriginal) => {
     ...actual,
     useQuery: (ref: { _path: string }) => ({
       data: ref._path === "listDashboards" ? [mocks.dashboard] : [],
-      isFetching: false,
+      isFetching: mocks.isFetching,
       isLoading: false,
     }),
     useMutation: () => ({ mutateAsync: mocks.addItem }),
@@ -41,7 +44,16 @@ vi.mock("@/components/dashboards/DashboardGrid", () => ({
   DashboardGrid: (props: {
     onEditingAvailabilityChange?: (isAvailable: boolean) => void;
   }) => {
-    mocks.editingAvailabilityCallback = props.onEditingAvailabilityChange;
+    const { onEditingAvailabilityChange } = props;
+    mocks.editingAvailabilityCallback = onEditingAvailabilityChange;
+    useLayoutEffect(() => {
+      if (mocks.gridAvailabilityOnMount !== null) {
+        onEditingAvailabilityChange?.(mocks.gridAvailabilityOnMount);
+      }
+      return () => {
+        mocks.editingAvailabilityCallback = undefined;
+      };
+    }, [onEditingAvailabilityChange]);
     return <div>grid</div>;
   },
 }));
@@ -52,6 +64,13 @@ describe("DashboardDetailContent editing availability", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.editingAvailabilityCallback = undefined;
+    mocks.gridAvailabilityOnMount = null;
+    mocks.isFetching = false;
+    mocks.dashboard.name = "Dashboard";
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
   });
 
   it("keeps editing unavailable until the grid reports its first measurement", () => {
@@ -106,5 +125,67 @@ describe("DashboardDetailContent editing availability", () => {
         .hasAttribute("disabled"),
     ).toBe(true);
     expect(mocks.addItem).not.toHaveBeenCalled();
+  });
+
+  it("fails closed across a refetch and narrow grid remount", () => {
+    mocks.gridAvailabilityOnMount = true;
+    const view = render(<DashboardDetailContent dashboardId="dashboard" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Dashboard" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Widget" }));
+    expect(screen.getByRole("dialog", { name: "Add Widget" })).toBeTruthy();
+
+    mocks.isFetching = true;
+    mocks.gridAvailabilityOnMount = null;
+    view.rerender(<DashboardDetailContent dashboardId="dashboard" />);
+
+    expect(screen.getByText("Loading dashboard...")).toBeTruthy();
+    expect(screen.queryByRole("dialog", { name: "Add Widget" })).toBeNull();
+
+    mocks.isFetching = false;
+    view.rerender(<DashboardDetailContent dashboardId="dashboard" />);
+
+    expect(screen.queryByRole("button", { name: "Done Editing" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Add Widget" })).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Edit Dashboard" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+
+    act(() => {
+      mocks.editingAvailabilityCallback?.(false);
+    });
+
+    expect(
+      screen.getByText("Editing unavailable: dashboard needs a wider area.", {
+        exact: true,
+      }),
+    ).toBeTruthy();
+    expect(mocks.addItem).not.toHaveBeenCalled();
+  });
+
+  it("lets a long unbroken dashboard name shrink inside a 320px header", () => {
+    mocks.dashboard.name = "W".repeat(80);
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 320,
+    });
+
+    render(<DashboardDetailContent dashboardId="dashboard" />);
+
+    const heading = screen.getByRole("heading", { name: mocks.dashboard.name });
+    const titleRegion = heading.parentElement;
+    const leadingRegion = titleRegion?.parentElement;
+    const header = heading.closest<HTMLElement>(".dashboard-detail-header");
+    expect(header?.classList.contains("flex-wrap")).toBe(true);
+    expect(header?.classList.contains("min-w-0")).toBe(true);
+    expect(leadingRegion?.classList.contains("min-w-0")).toBe(true);
+    expect(titleRegion?.classList.contains("min-w-0")).toBe(true);
+    expect(heading.classList.contains("break-words")).toBe(true);
+    expect(heading.classList.contains("[overflow-wrap:anywhere]")).toBe(true);
+    expect(
+      header?.contains(screen.getByRole("button", { name: "Edit Dashboard" })),
+    ).toBe(true);
   });
 });

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.test.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.test.tsx
@@ -54,8 +54,37 @@ describe("DashboardDetailContent editing availability", () => {
     mocks.editingAvailabilityCallback = undefined;
   });
 
+  it("keeps editing unavailable until the grid reports its first measurement", () => {
+    render(<DashboardDetailContent dashboardId="dashboard" />);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Edit Dashboard" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen.queryByText("Editing unavailable: dashboard needs a wider area.", {
+        exact: true,
+      }),
+    ).toBeNull();
+
+    act(() => {
+      mocks.editingAvailabilityCallback?.(true);
+    });
+
+    expect(
+      screen
+        .getByRole("button", { name: "Edit Dashboard" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+  });
+
   it("closes an open add-widget dialog when editing becomes unavailable", () => {
     render(<DashboardDetailContent dashboardId="dashboard" />);
+
+    act(() => {
+      mocks.editingAvailabilityCallback?.(true);
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Edit Dashboard" }));
     fireEvent.click(screen.getByRole("button", { name: "Add Widget" }));

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -27,7 +27,7 @@ import {
   FileIcon,
   PlusIcon,
 } from "@wystack/ui-react/icons";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 interface DashboardDetailContentProps {
@@ -123,6 +123,7 @@ export default function DashboardDetailContent({
 
   // ── Local UI state ────────────────────────────────────────────────────────
   const [isEditable, setIsEditable] = useState(false);
+  const [isEditingAvailable, setIsEditingAvailable] = useState(false);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isAddPending, setIsAddPending] = useState(false);
   const [addType, setAddType] = useState<DashboardItemType>("visualization");
@@ -139,6 +140,16 @@ export default function DashboardDetailContent({
       navigate({ to: "/dashboards" });
     }
   }, [isLoading, isFetching, dashboard, navigate]);
+
+  const handleEditingAvailabilityChange = useCallback(
+    (isAvailable: boolean) => {
+      setIsEditingAvailable(isAvailable);
+      if (!isAvailable) {
+        setIsEditable(false);
+      }
+    },
+    [],
+  );
 
   // Show loading state until we have the dashboard (or any fetch is in progress)
   if (isLoading || isFetching || !dashboard) {
@@ -191,7 +202,7 @@ export default function DashboardDetailContent({
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="dashboard-detail flex h-full flex-col">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-neutral-border/60 px-6 py-4">
         <div className="flex items-center gap-4">
@@ -211,28 +222,36 @@ export default function DashboardDetailContent({
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {isEditable ? (
-            <Button
-              icon={CheckIcon}
-              label="Done Editing"
-              onClick={() => setIsEditable(false)}
-            />
-          ) : (
-            <Button
-              variant="outline"
-              icon={EditIcon}
-              label="Edit Dashboard"
-              onClick={() => setIsEditable(true)}
-            />
-          )}
-          {isEditable && (
-            <Button
-              color="secondary"
-              icon={PlusIcon}
-              label="Add Widget"
-              onClick={() => setIsAddOpen(true)}
-            />
+        <div className="dashboard-edit-controls flex flex-col items-end gap-1">
+          <div className="dashboard-edit-actions flex items-center gap-2">
+            {isEditable ? (
+              <Button
+                icon={CheckIcon}
+                label="Done Editing"
+                onClick={() => setIsEditable(false)}
+              />
+            ) : (
+              <Button
+                variant="outline"
+                icon={EditIcon}
+                label="Edit Dashboard"
+                onClick={() => setIsEditable(true)}
+                disabled={!isEditingAvailable}
+              />
+            )}
+            {isEditable && (
+              <Button
+                color="secondary"
+                icon={PlusIcon}
+                label="Add Widget"
+                onClick={() => setIsAddOpen(true)}
+              />
+            )}
+          </div>
+          {!isEditingAvailable && (
+            <p className="dashboard-editing-unavailable text-xs text-neutral-fg-subtle">
+              Editing unavailable: dashboard needs a wider area.
+            </p>
           )}
         </div>
       </div>
@@ -252,6 +271,7 @@ export default function DashboardDetailContent({
         <DashboardGrid
           dashboard={dashboard}
           isEditable={isEditable}
+          onEditingAvailabilityChange={handleEditingAvailabilityChange}
           controlTransientValues={controlTransientValues}
         />
       </div>

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -148,6 +148,7 @@ export default function DashboardDetailContent({
       setIsEditingAvailable(isAvailable);
       if (!isAvailable) {
         setIsEditable(false);
+        setIsAddOpen(false);
       }
     },
     [],
@@ -163,6 +164,11 @@ export default function DashboardDetailContent({
   }
 
   const handleAddItem = async () => {
+    if (!isEditingAvailable) {
+      setIsAddOpen(false);
+      return;
+    }
+
     // Compute the bottom of the current layout so the new widget is appended
     // below all existing items. Using Infinity here would serialize to null in
     // JSON and cause the server-side position validator to reject the mutation.
@@ -357,7 +363,9 @@ export default function DashboardDetailContent({
               label="Add Widget"
               onClick={handleAddItem}
               disabled={
-                isAddPending || (addType === "visualization" && !selectedVizId)
+                !isEditingAvailable ||
+                isAddPending ||
+                (addType === "visualization" && !selectedVizId)
               }
             />
           </div>

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -123,7 +123,9 @@ export default function DashboardDetailContent({
 
   // ── Local UI state ────────────────────────────────────────────────────────
   const [isEditable, setIsEditable] = useState(false);
-  const [isEditingAvailable, setIsEditingAvailable] = useState(false);
+  // DashboardGrid starts at WidthProvider's wide seed and reports the first
+  // measured resize, so the header must start from the same availability.
+  const [isEditingAvailable, setIsEditingAvailable] = useState(true);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isAddPending, setIsAddPending] = useState(false);
   const [addType, setAddType] = useState<DashboardItemType>("visualization");
@@ -202,7 +204,10 @@ export default function DashboardDetailContent({
   };
 
   return (
-    <div className="dashboard-detail flex h-full flex-col">
+    <div
+      className="dashboard-detail flex h-full flex-col"
+      data-editing-available={isEditingAvailable}
+    >
       {/* Header */}
       <div className="flex items-center justify-between border-b border-neutral-border/60 px-6 py-4">
         <div className="flex items-center gap-4">

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -123,9 +123,10 @@ export default function DashboardDetailContent({
 
   // ── Local UI state ────────────────────────────────────────────────────────
   const [isEditable, setIsEditable] = useState(false);
-  // DashboardGrid starts at WidthProvider's wide seed and reports the first
-  // measured resize, so the header must start from the same availability.
-  const [isEditingAvailable, setIsEditingAvailable] = useState(true);
+  // DashboardGrid reports availability only after its first width measurement.
+  const [isEditingAvailable, setIsEditingAvailable] = useState<boolean | null>(
+    null,
+  );
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isAddPending, setIsAddPending] = useState(false);
   const [addType, setAddType] = useState<DashboardItemType>("visualization");
@@ -247,7 +248,7 @@ export default function DashboardDetailContent({
                 icon={EditIcon}
                 label="Edit Dashboard"
                 onClick={() => setIsEditable(true)}
-                disabled={!isEditingAvailable}
+                disabled={isEditingAvailable !== true}
               />
             )}
             {isEditable && (
@@ -259,7 +260,7 @@ export default function DashboardDetailContent({
               />
             )}
           </div>
-          {!isEditingAvailable && (
+          {isEditingAvailable === false && (
             <p className="dashboard-editing-unavailable text-xs text-neutral-fg-subtle">
               Editing unavailable: dashboard needs a wider area.
             </p>

--- a/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
+++ b/packages/app/src/app/dashboards/[dashboardId]/_components/DashboardDetailContent.tsx
@@ -131,6 +131,16 @@ export default function DashboardDetailContent({
   const [isAddPending, setIsAddPending] = useState(false);
   const [addType, setAddType] = useState<DashboardItemType>("visualization");
   const [selectedVizId, setSelectedVizId] = useState<string>("");
+  const editingSessionKey =
+    isLoading || isFetching || !dashboard ? null : dashboardId;
+  const [activeEditingSessionKey, setActiveEditingSessionKey] =
+    useState(editingSessionKey);
+  if (activeEditingSessionKey !== editingSessionKey) {
+    setActiveEditingSessionKey(editingSessionKey);
+    setIsEditingAvailable(null);
+    setIsEditable(false);
+    setIsAddOpen(false);
+  }
 
   // Redirect if not found — but only once any in-flight fetch has settled.
   // Guard on isFetching as well as isLoading: TanStack Query sets isLoading=false
@@ -216,8 +226,8 @@ export default function DashboardDetailContent({
       data-editing-available={isEditingAvailable}
     >
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-neutral-border/60 px-6 py-4">
-        <div className="flex items-center gap-4">
+      <div className="dashboard-detail-header flex min-w-0 flex-wrap items-start justify-between gap-4 border-b border-neutral-border/60 px-6 py-4">
+        <div className="flex min-w-0 flex-1 items-center gap-4">
           <Button
             variant="ghost"
             icon={ArrowLeftIcon}
@@ -225,8 +235,8 @@ export default function DashboardDetailContent({
             label="Back to dashboards"
             onClick={() => navigate({ to: "/dashboards" })}
           />
-          <div>
-            <h1 className="text-xl font-semibold tracking-tight text-neutral-fg">
+          <div className="min-w-0 flex-1">
+            <h1 className="break-words text-xl font-semibold tracking-tight text-neutral-fg [overflow-wrap:anywhere]">
               {dashboard.name}
             </h1>
             <p className="text-sm text-neutral-fg-subtle">
@@ -234,7 +244,7 @@ export default function DashboardDetailContent({
             </p>
           </div>
         </div>
-        <div className="dashboard-edit-controls flex flex-col items-end gap-1">
+        <div className="dashboard-edit-controls flex max-w-full shrink-0 flex-col items-end gap-1">
           <div className="dashboard-edit-actions flex items-center gap-2">
             {isEditable ? (
               <Button

--- a/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
@@ -47,7 +47,7 @@ const dashboard = {
       content: "First",
       x: 0,
       y: 0,
-      width: 4,
+      width: 2,
       height: 4,
     },
   ],
@@ -142,4 +142,23 @@ describe("DashboardGrid editing availability", () => {
     );
     expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
   });
+
+  it.each([601, 481, 321])(
+    "projects a stored width-2 item to the full non-lg grid span at %ipx",
+    (width) => {
+      mocks.currentWidth = width;
+
+      const { container } = render(
+        <DashboardGrid dashboard={dashboard} isEditable={false} />,
+      );
+
+      const gridItem = container.querySelector<HTMLElement>(".react-grid-item");
+      expect(gridItem).not.toBeNull();
+      // Full column span inside RGL's 16px horizontal container padding.
+      expect(Number.parseFloat(gridItem?.style.width ?? "")).toBeCloseTo(
+        width - 32,
+      );
+      expect(gridItem?.style.transform).toContain("translate(16px");
+    },
+  );
 });

--- a/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import type { ComponentType } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -29,10 +29,6 @@ vi.mock("react-grid-layout", async (importOriginal) => {
       ),
   };
 });
-
-vi.mock("./DashboardItem", () => ({
-  DashboardItem: () => <div>item</div>,
-}));
 
 import { DashboardGrid } from "./DashboardGrid";
 
@@ -159,6 +155,58 @@ describe("DashboardGrid editing availability", () => {
         width - 32,
       );
       expect(gridItem?.style.transform).toContain("translate(16px");
+
+      // Keep the real DashboardItem -> MarkdownWidget path in this suite so
+      // the full-width projection cannot pass while its content seam overflows.
+      const markdownContent = gridItem?.querySelector<HTMLElement>(".prose");
+      expect(markdownContent?.textContent).toContain("First");
+      expect(markdownContent?.classList.contains("max-w-none")).toBe(true);
+      expect(markdownContent?.classList.contains("overflow-auto")).toBe(true);
+      expect(
+        markdownContent
+          ?.closest("[data-slot='surface']")
+          ?.classList.contains("overflow-hidden"),
+      ).toBe(true);
     },
   );
+
+  it("stacks a reversed stored row in desktop reading order", () => {
+    mocks.currentWidth = 601;
+    const reversedDashboard = {
+      ...dashboard,
+      items: [
+        {
+          ...dashboard.items[0],
+          id: "right",
+          content: "Right widget",
+          x: 6,
+        },
+        {
+          ...dashboard.items[0],
+          id: "left",
+          content: "Left widget",
+          x: 0,
+        },
+      ],
+    };
+
+    render(<DashboardGrid dashboard={reversedDashboard} isEditable={false} />);
+
+    const leftItem = screen
+      .getByText("Left widget")
+      .closest<HTMLElement>(".react-grid-item");
+    const rightItem = screen
+      .getByText("Right widget")
+      .closest<HTMLElement>(".react-grid-item");
+    expect(leftItem).not.toBeNull();
+    expect(rightItem).not.toBeNull();
+
+    const verticalOffset = (item: HTMLElement | null) => {
+      const match = item?.style.transform.match(
+        /translate\([^,]+,\s*(-?[\d.]+)px\)/,
+      );
+      return Number(match?.[1]);
+    };
+    expect(verticalOffset(leftItem)).toBeLessThan(verticalOffset(rightItem));
+  });
 });

--- a/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
@@ -60,7 +60,7 @@ describe("DashboardGrid editing availability", () => {
     mocks.updateItems.mockClear();
   });
 
-  it("tracks same-breakpoint width changes from a wide initial render", () => {
+  it("tracks same-breakpoint width changes after the first measurement", () => {
     const view = render(
       <DashboardGrid
         dashboard={dashboard}
@@ -68,8 +68,7 @@ describe("DashboardGrid editing availability", () => {
         onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
       />,
     );
-    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
-    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(1);
+    expect(mocks.onEditingAvailabilityChange).not.toHaveBeenCalled();
 
     mocks.currentWidth = 1000;
     view.rerender(
@@ -80,7 +79,7 @@ describe("DashboardGrid editing availability", () => {
       />,
     );
     expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
-    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(2);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(1);
 
     mocks.currentWidth = 960;
     view.rerender(

--- a/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import type { ComponentType } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   currentWidth: 1280,
@@ -58,6 +58,26 @@ describe("DashboardGrid editing availability", () => {
     mocks.currentWidth = 1280;
     mocks.onEditingAvailabilityChange.mockClear();
     mocks.updateItems.mockClear();
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () => new DOMRect(0, 0, mocks.currentWidth, 0),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a first measurement matching WidthProvider's seed", () => {
+    render(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledOnce();
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
   });
 
   it("tracks same-breakpoint width changes after the first measurement", () => {
@@ -68,7 +88,8 @@ describe("DashboardGrid editing availability", () => {
         onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
       />,
     );
-    expect(mocks.onEditingAvailabilityChange).not.toHaveBeenCalled();
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(1);
 
     mocks.currentWidth = 1000;
     view.rerender(
@@ -79,7 +100,7 @@ describe("DashboardGrid editing availability", () => {
       />,
     );
     expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
-    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(1);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(2);
 
     mocks.currentWidth = 960;
     view.rerender(

--- a/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
@@ -69,8 +69,30 @@ describe("DashboardGrid editing availability", () => {
       />,
     );
     expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(1);
 
     mocks.currentWidth = 1000;
+    view.rerender(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenCalledTimes(2);
+
+    mocks.currentWidth = 960;
+    view.rerender(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(false);
+
+    mocks.currentWidth = 961;
     view.rerender(
       <DashboardGrid
         dashboard={dashboard}

--- a/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.responsive.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentWidth: 1280,
+  onEditingAvailabilityChange: vi.fn(),
+  updateItems: vi.fn(async () => {}),
+}));
+
+vi.mock("@wystack/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/client")>();
+  return {
+    ...actual,
+    useMutation: () => ({ mutateAsync: mocks.updateItems }),
+  };
+});
+
+// Exercise Responsive from the installed library. Only replace WidthProvider
+// so the test can deterministically drive the container width RGL receives.
+vi.mock("react-grid-layout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-grid-layout")>();
+  return {
+    ...actual,
+    WidthProvider:
+      (Grid: ComponentType<Record<string, unknown>>) =>
+      (props: Record<string, unknown>) => (
+        <Grid {...props} width={mocks.currentWidth} />
+      ),
+  };
+});
+
+vi.mock("./DashboardItem", () => ({
+  DashboardItem: () => <div>item</div>,
+}));
+
+import { DashboardGrid } from "./DashboardGrid";
+
+const dashboard = {
+  id: "dashboard",
+  name: "Dashboard",
+  createdAt: 0,
+  items: [
+    {
+      id: "first",
+      type: "markdown" as const,
+      content: "First",
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4,
+    },
+  ],
+};
+
+describe("DashboardGrid editing availability", () => {
+  beforeEach(() => {
+    mocks.currentWidth = 1280;
+    mocks.onEditingAvailabilityChange.mockClear();
+    mocks.updateItems.mockClear();
+  });
+
+  it("tracks same-breakpoint width changes from a wide initial render", () => {
+    const view = render(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
+
+    mocks.currentWidth = 1000;
+    view.rerender(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
+
+    mocks.currentWidth = 800;
+    view.rerender(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(false);
+
+    mocks.currentWidth = 1000;
+    view.rerender(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable={false}
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/packages/app/src/components/dashboards/DashboardGrid.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.test.tsx
@@ -75,6 +75,28 @@ describe("DashboardGrid canonical layout persistence", () => {
       />,
     );
     expect(mocks.gridProps?.onLayoutChange).toBeUndefined();
+    expect(mocks.gridProps?.layouts).toMatchObject({
+      lg: [
+        { i: "first", x: 0, w: 4 },
+        { i: "second", x: 4, w: 4 },
+      ],
+      md: [
+        { i: "first", x: 0, w: 10 },
+        { i: "second", x: 0, w: 10 },
+      ],
+      sm: [
+        { i: "first", x: 0, w: 6 },
+        { i: "second", x: 0, w: 6 },
+      ],
+      xs: [
+        { i: "first", x: 0, w: 4 },
+        { i: "second", x: 0, w: 4 },
+      ],
+      xxs: [
+        { i: "first", x: 0, w: 2 },
+        { i: "second", x: 0, w: 2 },
+      ],
+    });
 
     act(() => {
       (mocks.gridProps?.onWidthChange as (width: number) => void)(800);

--- a/packages/app/src/components/dashboards/DashboardGrid.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -25,10 +25,6 @@ vi.mock("react-grid-layout", () => ({
     mocks.gridProps = props;
     return <div>{props.children as React.ReactNode}</div>;
   },
-}));
-
-vi.mock("./DashboardItem", () => ({
-  DashboardItem: () => <div>item</div>,
 }));
 
 import { DashboardGrid } from "./DashboardGrid";
@@ -131,5 +127,31 @@ describe("DashboardGrid canonical layout persistence", () => {
         { itemId: "second", updates: { x: 7, y: 3, width: 4, height: 4 } },
       ],
     });
+  });
+
+  it("shuts down an unsaved markdown edit at the 960px boundary", () => {
+    render(<DashboardGrid dashboard={dashboard} isEditable />);
+
+    act(() => {
+      (mocks.gridProps?.onWidthChange as (width: number) => void)(1000);
+    });
+    const editButton = document
+      .querySelector(".lucide-pencil")
+      ?.closest("button");
+    expect(editButton).not.toBeNull();
+    fireEvent.click(editButton as HTMLButtonElement);
+    fireEvent.change(screen.getByPlaceholderText("Enter markdown..."), {
+      target: { value: "Unsaved draft" },
+    });
+    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+
+    act(() => {
+      (mocks.gridProps?.onWidthChange as (width: number) => void)(960);
+    });
+
+    expect(screen.queryByPlaceholderText("Enter markdown...")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.getByText("First")).toBeTruthy();
+    expect(mocks.updateItems).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/components/dashboards/DashboardGrid.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   gridProps: null as Record<string, unknown> | null,
   updateItems: vi.fn(async () => {}),
+  onEditingAvailabilityChange: vi.fn(),
 }));
 
 // Partial-mock the WyStack client: keep `createApi` (so `api` builds real
@@ -62,17 +63,27 @@ describe("DashboardGrid canonical layout persistence", () => {
   beforeEach(() => {
     mocks.gridProps = null;
     mocks.updateItems.mockClear();
+    mocks.onEditingAvailabilityChange.mockClear();
   });
 
   it("ignores responsive projections and batches an intentional desktop edit", () => {
-    render(<DashboardGrid dashboard={dashboard} isEditable />);
+    render(
+      <DashboardGrid
+        dashboard={dashboard}
+        isEditable
+        onEditingAvailabilityChange={mocks.onEditingAvailabilityChange}
+      />,
+    );
     expect(mocks.gridProps?.onLayoutChange).toBeUndefined();
 
     act(() => {
       (mocks.gridProps?.onBreakpointChange as (breakpoint: string) => void)(
-        "xs",
+        "md",
       );
     });
+    expect(mocks.gridProps?.isDraggable).toBe(false);
+    expect(mocks.gridProps?.isResizable).toBe(false);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(false);
     act(() => {
       (mocks.gridProps?.onDragStop as (layout: unknown[]) => void)([
         { i: "first", x: 0, y: 0, w: 2, h: 4 },
@@ -85,6 +96,9 @@ describe("DashboardGrid canonical layout persistence", () => {
         "lg",
       );
     });
+    expect(mocks.gridProps?.isDraggable).toBe(true);
+    expect(mocks.gridProps?.isResizable).toBe(true);
+    expect(mocks.onEditingAvailabilityChange).toHaveBeenLastCalledWith(true);
     act(() => {
       (mocks.gridProps?.onDragStop as (layout: unknown[]) => void)([
         { i: "first", x: 1, y: 2, w: 4, h: 4 },

--- a/packages/app/src/components/dashboards/DashboardGrid.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.test.tsx
@@ -77,9 +77,7 @@ describe("DashboardGrid canonical layout persistence", () => {
     expect(mocks.gridProps?.onLayoutChange).toBeUndefined();
 
     act(() => {
-      (mocks.gridProps?.onBreakpointChange as (breakpoint: string) => void)(
-        "md",
-      );
+      (mocks.gridProps?.onWidthChange as (width: number) => void)(800);
     });
     expect(mocks.gridProps?.isDraggable).toBe(false);
     expect(mocks.gridProps?.isResizable).toBe(false);
@@ -92,9 +90,7 @@ describe("DashboardGrid canonical layout persistence", () => {
     expect(mocks.updateItems).not.toHaveBeenCalled();
 
     act(() => {
-      (mocks.gridProps?.onBreakpointChange as (breakpoint: string) => void)(
-        "lg",
-      );
+      (mocks.gridProps?.onWidthChange as (width: number) => void)(1000);
     });
     expect(mocks.gridProps?.isDraggable).toBe(true);
     expect(mocks.gridProps?.isResizable).toBe(true);

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -59,9 +59,11 @@ export function DashboardGrid({
   const { mutateAsync: saveLayout } = useMutation(api.updateDashboardItems);
   // WidthProvider renders Responsive at its 1280px seed before its observer
   // measures the element, and Responsive does not call onWidthChange on mount.
-  // Seed the matching wide state; every observed resize then supplies the same
-  // measured width RGL uses to choose its layout.
-  const [isEditingAvailable, setIsEditingAvailable] = useState(true);
+  // Do not expose that unmeasured seed as editing availability: every observed
+  // resize supplies the measured width RGL uses to choose its layout.
+  const [isEditingAvailable, setIsEditingAvailable] = useState<boolean | null>(
+    null,
+  );
 
   const handleWidthChange = useCallback(
     (width: number) => {
@@ -81,7 +83,9 @@ export function DashboardGrid({
   );
 
   useEffect(() => {
-    onEditingAvailabilityChange?.(isEditingAvailable);
+    if (isEditingAvailable !== null) {
+      onEditingAvailabilityChange?.(isEditingAvailable);
+    }
   }, [isEditingAvailable, onEditingAvailabilityChange]);
 
   const layouts = useMemo(() => {
@@ -207,15 +211,15 @@ export function DashboardGrid({
       breakpoints={DASHBOARD_GRID_BREAKPOINTS}
       cols={DASHBOARD_GRID_COLUMNS}
       rowHeight={60}
-      isDraggable={isEditable && isEditingAvailable}
-      isResizable={isEditable && isEditingAvailable}
+      isDraggable={isEditable && isEditingAvailable === true}
+      isResizable={isEditable && isEditingAvailable === true}
       draggableHandle=".grid-drag-handle"
       onWidthChange={handleWidthChange}
       onDragStop={persistCanonicalLayout}
       onResizeStop={persistCanonicalLayout}
       margin={[16, 16]}
       resizeHandle={
-        isEditable && isEditingAvailable ? (
+        isEditable && isEditingAvailable === true ? (
           <div className="absolute -right-2 -bottom-2 z-50 flex h-6 w-6 cursor-se-resize items-center justify-center text-neutral-fg-subtle/40 transition-colors hover:text-neutral-fg-subtle">
             <svg
               width="24"
@@ -240,7 +244,7 @@ export function DashboardGrid({
           <DashboardItem
             item={item}
             dashboardId={dashboard.id}
-            isEditable={isEditable && isEditingAvailable}
+            isEditable={isEditable && isEditingAvailable === true}
             effectiveOverrides={effectiveOverridesMap.get(item.id)}
             controls={dashboard.controls ?? []}
           />

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -13,13 +13,13 @@ import { DashboardItem } from "./DashboardItem";
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
-// At 960px, a common 6-column chart is about 456px wide and even a minW: 2
+// Above 960px, a common 6-column chart is about 456px wide and even a minW: 2
 // item is about 141px: (960 - 13 * 16) / 12 * 2 + 16. The previous 720px
 // floor yielded roughly 101px for that minimum item.
-const EDITABLE_GRID_MIN_WIDTH = 960;
+const EDITABLE_GRID_BREAKPOINT = 960;
 
 const DASHBOARD_GRID_BREAKPOINTS = {
-  lg: EDITABLE_GRID_MIN_WIDTH,
+  lg: EDITABLE_GRID_BREAKPOINT,
   md: 600,
   sm: 480,
   xs: 320,
@@ -63,9 +63,22 @@ export function DashboardGrid({
   // measured width RGL uses to choose its layout.
   const [isEditingAvailable, setIsEditingAvailable] = useState(true);
 
-  const handleWidthChange = useCallback((width: number) => {
-    setIsEditingAvailable(width >= EDITABLE_GRID_MIN_WIDTH);
-  }, []);
+  const handleWidthChange = useCallback(
+    (width: number) => {
+      // RGL selects a breakpoint only when width is strictly greater than its
+      // configured value, so availability must use the same boundary.
+      const isAvailable = width > EDITABLE_GRID_BREAKPOINT;
+      if (isAvailable === isEditingAvailable) {
+        // Report same-breakpoint measurements too. Parent state setters bail
+        // out when the capability is unchanged, while consumers can verify
+        // that RGL delivered the width event.
+        onEditingAvailabilityChange?.(isAvailable);
+        return;
+      }
+      setIsEditingAvailable(isAvailable);
+    },
+    [isEditingAvailable, onEditingAvailabilityChange],
+  );
 
   useEffect(() => {
     onEditingAvailabilityChange?.(isEditingAvailable);

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -6,7 +6,14 @@ import type {
   InsightFilter,
 } from "@dashframe/types";
 import { useMutation } from "@wystack/client";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Responsive, WidthProvider, type Layout } from "react-grid-layout";
 import { toast } from "sonner";
 import { DashboardItem } from "./DashboardItem";
@@ -37,7 +44,7 @@ const DASHBOARD_GRID_COLUMNS = {
 interface DashboardGridProps {
   dashboard: Dashboard;
   isEditable: boolean;
-  /** Receives availability from the grid's own WidthProvider measurement. */
+  /** Receives availability after the grid container has been measured. */
   onEditingAvailabilityChange?: (isAvailable: boolean) => void;
   /**
    * View-local transient values for controls (from the viewer's session).
@@ -53,14 +60,14 @@ export function DashboardGrid({
   onEditingAvailabilityChange,
   controlTransientValues,
 }: DashboardGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   // Destructure the stable `mutateAsync` — the `useMutation` result object is a
   // fresh reference every render, so depending on it would defeat the
   // `onLayoutChange` memoization. `mutateAsync` is referentially stable.
   const { mutateAsync: saveLayout } = useMutation(api.updateDashboardItems);
+  // Keep availability unknown until the container itself has been measured.
   // WidthProvider renders Responsive at its 1280px seed before its observer
   // measures the element, and Responsive does not call onWidthChange on mount.
-  // Do not expose that unmeasured seed as editing availability: every observed
-  // resize supplies the measured width RGL uses to choose its layout.
   const [isEditingAvailable, setIsEditingAvailable] = useState<boolean | null>(
     null,
   );
@@ -81,6 +88,16 @@ export function DashboardGrid({
     },
     [isEditingAvailable, onEditingAvailabilityChange],
   );
+
+  useLayoutEffect(() => {
+    const width = containerRef.current?.getBoundingClientRect().width ?? 0;
+    if (width > 0) {
+      setIsEditingAvailable(width > EDITABLE_GRID_BREAKPOINT);
+    }
+    // RGL's onWidthChange owns subsequent measurements. This direct first
+    // measurement covers the case where the real width equals WidthProvider's
+    // seed and RGL consequently emits no change event.
+  }, []);
 
   useEffect(() => {
     if (isEditingAvailable !== null) {
@@ -205,51 +222,53 @@ export function DashboardGrid({
   }, [dashboard.controls, dashboard.items, controlTransientValues]);
 
   return (
-    <ResponsiveGridLayout
-      className="layout"
-      layouts={layouts}
-      breakpoints={DASHBOARD_GRID_BREAKPOINTS}
-      cols={DASHBOARD_GRID_COLUMNS}
-      rowHeight={60}
-      isDraggable={isEditable && isEditingAvailable === true}
-      isResizable={isEditable && isEditingAvailable === true}
-      draggableHandle=".grid-drag-handle"
-      onWidthChange={handleWidthChange}
-      onDragStop={persistCanonicalLayout}
-      onResizeStop={persistCanonicalLayout}
-      margin={[16, 16]}
-      resizeHandle={
-        isEditable && isEditingAvailable === true ? (
-          <div className="absolute -right-2 -bottom-2 z-50 flex h-6 w-6 cursor-se-resize items-center justify-center text-neutral-fg-subtle/40 transition-colors hover:text-neutral-fg-subtle">
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 8C20 14.6274 14.6274 20 8 20"
-                stroke="currentColor"
-                strokeWidth="3"
-                strokeLinecap="round"
-              />
-            </svg>
+    <div ref={containerRef}>
+      <ResponsiveGridLayout
+        className="layout"
+        layouts={layouts}
+        breakpoints={DASHBOARD_GRID_BREAKPOINTS}
+        cols={DASHBOARD_GRID_COLUMNS}
+        rowHeight={60}
+        isDraggable={isEditable && isEditingAvailable === true}
+        isResizable={isEditable && isEditingAvailable === true}
+        draggableHandle=".grid-drag-handle"
+        onWidthChange={handleWidthChange}
+        onDragStop={persistCanonicalLayout}
+        onResizeStop={persistCanonicalLayout}
+        margin={[16, 16]}
+        resizeHandle={
+          isEditable && isEditingAvailable === true ? (
+            <div className="absolute -right-2 -bottom-2 z-50 flex h-6 w-6 cursor-se-resize items-center justify-center text-neutral-fg-subtle/40 transition-colors hover:text-neutral-fg-subtle">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20 8C20 14.6274 14.6274 20 8 20"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </div>
+          ) : undefined
+        }
+      >
+        {dashboard.items.map((item) => (
+          <div key={item.id}>
+            <DashboardItem
+              item={item}
+              dashboardId={dashboard.id}
+              isEditable={isEditable && isEditingAvailable === true}
+              effectiveOverrides={effectiveOverridesMap.get(item.id)}
+              controls={dashboard.controls ?? []}
+            />
           </div>
-        ) : undefined
-      }
-    >
-      {dashboard.items.map((item) => (
-        <div key={item.id}>
-          <DashboardItem
-            item={item}
-            dashboardId={dashboard.id}
-            isEditable={isEditable && isEditingAvailable === true}
-            effectiveOverrides={effectiveOverridesMap.get(item.id)}
-            controls={dashboard.controls ?? []}
-          />
-        </div>
-      ))}
-    </ResponsiveGridLayout>
+        ))}
+      </ResponsiveGridLayout>
+    </div>
   );
 }

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -13,8 +13,13 @@ import { DashboardItem } from "./DashboardItem";
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
+// At 960px, a common 6-column chart is about 456px wide and even a minW: 2
+// item is about 141px: (960 - 13 * 16) / 12 * 2 + 16. The previous 720px
+// floor yielded roughly 101px for that minimum item.
+const EDITABLE_GRID_MIN_WIDTH = 960;
+
 const DASHBOARD_GRID_BREAKPOINTS = {
-  lg: 720,
+  lg: EDITABLE_GRID_MIN_WIDTH,
   md: 600,
   sm: 480,
   xs: 320,
@@ -28,8 +33,6 @@ const DASHBOARD_GRID_COLUMNS = {
   xs: 4,
   xxs: 2,
 };
-
-const EDITABLE_BREAKPOINT = "lg";
 
 interface DashboardGridProps {
   dashboard: Dashboard;
@@ -54,8 +57,15 @@ export function DashboardGrid({
   // fresh reference every render, so depending on it would defeat the
   // `onLayoutChange` memoization. `mutateAsync` is referentially stable.
   const { mutateAsync: saveLayout } = useMutation(api.updateDashboardItems);
-  const [activeBreakpoint, setActiveBreakpoint] = useState<string | null>(null);
-  const isEditingAvailable = activeBreakpoint === EDITABLE_BREAKPOINT;
+  // WidthProvider renders Responsive at its 1280px seed before its observer
+  // measures the element, and Responsive does not call onWidthChange on mount.
+  // Seed the matching wide state; every observed resize then supplies the same
+  // measured width RGL uses to choose its layout.
+  const [isEditingAvailable, setIsEditingAvailable] = useState(true);
+
+  const handleWidthChange = useCallback((width: number) => {
+    setIsEditingAvailable(width >= EDITABLE_GRID_MIN_WIDTH);
+  }, []);
 
   useEffect(() => {
     onEditingAvailabilityChange?.(isEditingAvailable);
@@ -187,7 +197,7 @@ export function DashboardGrid({
       isDraggable={isEditable && isEditingAvailable}
       isResizable={isEditable && isEditingAvailable}
       draggableHandle=".grid-drag-handle"
-      onBreakpointChange={setActiveBreakpoint}
+      onWidthChange={handleWidthChange}
       onDragStop={persistCanonicalLayout}
       onResizeStop={persistCanonicalLayout}
       margin={[16, 16]}

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -41,6 +41,11 @@ const DASHBOARD_GRID_COLUMNS = {
   xxs: 2,
 };
 
+const compareGridPosition = (
+  left: { id: string; x: number; y: number },
+  right: { id: string; x: number; y: number },
+) => left.y - right.y || left.x - right.x || left.id.localeCompare(right.id);
+
 interface DashboardGridProps {
   dashboard: Dashboard;
   isEditable: boolean;
@@ -118,7 +123,14 @@ export function DashboardGrid({
     }));
 
     const fullWidthLayout = (cols: number) =>
-      lgLayout.map((item) => ({ ...item, x: 0, w: cols }));
+      [...lgLayout]
+        .sort(
+          (left, right) =>
+            left.y - right.y ||
+            left.x - right.x ||
+            left.i.localeCompare(right.i),
+        )
+        .map((item) => ({ ...item, x: 0, w: cols }));
 
     return {
       lg: lgLayout,
@@ -128,6 +140,11 @@ export function DashboardGrid({
       xxs: fullWidthLayout(DASHBOARD_GRID_COLUMNS.xxs),
     };
   }, [dashboard.items]);
+
+  const itemsInReadingOrder = useMemo(
+    () => [...dashboard.items].sort(compareGridPosition),
+    [dashboard.items],
+  );
 
   const persistCanonicalLayout = useCallback(
     (currentLayout: Layout[]) => {
@@ -231,7 +248,7 @@ export function DashboardGrid({
           ) : undefined
         }
       >
-        {dashboard.items.map((item) => (
+        {itemsInReadingOrder.map((item) => (
           <div key={item.id}>
             <DashboardItem
               item={item}

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -6,16 +6,36 @@ import type {
   InsightFilter,
 } from "@dashframe/types";
 import { useMutation } from "@wystack/client";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Responsive, WidthProvider, type Layout } from "react-grid-layout";
 import { toast } from "sonner";
 import { DashboardItem } from "./DashboardItem";
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
+const DASHBOARD_GRID_BREAKPOINTS = {
+  lg: 720,
+  md: 600,
+  sm: 480,
+  xs: 320,
+  xxs: 0,
+};
+
+const DASHBOARD_GRID_COLUMNS = {
+  lg: 12,
+  md: 10,
+  sm: 6,
+  xs: 4,
+  xxs: 2,
+};
+
+const EDITABLE_BREAKPOINT = "lg";
+
 interface DashboardGridProps {
   dashboard: Dashboard;
   isEditable: boolean;
+  /** Receives availability from the grid's own WidthProvider measurement. */
+  onEditingAvailabilityChange?: (isAvailable: boolean) => void;
   /**
    * View-local transient values for controls (from the viewer's session).
    * These are layered on top of saved `control.defaultValue` without mutating
@@ -27,13 +47,19 @@ interface DashboardGridProps {
 export function DashboardGrid({
   dashboard,
   isEditable,
+  onEditingAvailabilityChange,
   controlTransientValues,
 }: DashboardGridProps) {
   // Destructure the stable `mutateAsync` — the `useMutation` result object is a
   // fresh reference every render, so depending on it would defeat the
   // `onLayoutChange` memoization. `mutateAsync` is referentially stable.
   const { mutateAsync: saveLayout } = useMutation(api.updateDashboardItems);
-  const [activeBreakpoint, setActiveBreakpoint] = useState("lg");
+  const [activeBreakpoint, setActiveBreakpoint] = useState<string | null>(null);
+  const isEditingAvailable = activeBreakpoint === EDITABLE_BREAKPOINT;
+
+  useEffect(() => {
+    onEditingAvailabilityChange?.(isEditingAvailable);
+  }, [isEditingAvailable, onEditingAvailabilityChange]);
 
   const layouts = useMemo(() => {
     // Base layout from stored positions (designed for lg: 12 cols)
@@ -87,7 +113,7 @@ export function DashboardGrid({
 
   const persistCanonicalLayout = useCallback(
     (currentLayout: Layout[]) => {
-      if (!isEditable || activeBreakpoint !== "lg") return;
+      if (!isEditable || !isEditingAvailable) return;
       const patches = currentLayout.flatMap((layoutItem) => {
         const item = dashboard.items.find(
           (candidate) => candidate.id === layoutItem.i,
@@ -122,7 +148,7 @@ export function DashboardGrid({
         );
       }
     },
-    [activeBreakpoint, dashboard.id, dashboard.items, isEditable, saveLayout],
+    [dashboard.id, dashboard.items, isEditable, isEditingAvailable, saveLayout],
   );
 
   // Pre-compute effective overrides for every item.  Merges the item's own
@@ -155,18 +181,18 @@ export function DashboardGrid({
     <ResponsiveGridLayout
       className="layout"
       layouts={layouts}
-      breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
-      cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
+      breakpoints={DASHBOARD_GRID_BREAKPOINTS}
+      cols={DASHBOARD_GRID_COLUMNS}
       rowHeight={60}
-      isDraggable={isEditable && activeBreakpoint === "lg"}
-      isResizable={isEditable && activeBreakpoint === "lg"}
+      isDraggable={isEditable && isEditingAvailable}
+      isResizable={isEditable && isEditingAvailable}
       draggableHandle=".grid-drag-handle"
       onBreakpointChange={setActiveBreakpoint}
       onDragStop={persistCanonicalLayout}
       onResizeStop={persistCanonicalLayout}
       margin={[16, 16]}
       resizeHandle={
-        isEditable ? (
+        isEditable && isEditingAvailable ? (
           <div className="absolute -right-2 -bottom-2 z-50 flex h-6 w-6 cursor-se-resize items-center justify-center text-neutral-fg-subtle/40 transition-colors hover:text-neutral-fg-subtle">
             <svg
               width="24"
@@ -191,7 +217,7 @@ export function DashboardGrid({
           <DashboardItem
             item={item}
             dashboardId={dashboard.id}
-            isEditable={isEditable}
+            isEditable={isEditable && isEditingAvailable}
             effectiveOverrides={effectiveOverridesMap.get(item.id)}
             controls={dashboard.controls ?? []}
           />

--- a/packages/app/src/components/dashboards/DashboardGrid.tsx
+++ b/packages/app/src/components/dashboards/DashboardGrid.tsx
@@ -117,41 +117,15 @@ export function DashboardGrid({
       minH: 2,
     }));
 
-    // Scale layouts for smaller breakpoints to prevent overflow
-    // md: 10 cols - slight scale down
-    const mdLayout = lgLayout.map((item) => ({
-      ...item,
-      x: Math.min(item.x, 10 - Math.min(item.w, 10)),
-      w: Math.min(item.w, 10),
-    }));
-
-    // sm: 6 cols - items stack more vertically
-    const smLayout = lgLayout.map((item) => ({
-      ...item,
-      x: 0,
-      w: Math.min(item.w, 6),
-    }));
-
-    // xs: 4 cols - full width items
-    const xsLayout = lgLayout.map((item) => ({
-      ...item,
-      x: 0,
-      w: Math.min(item.w, 4),
-    }));
-
-    // xxs: 2 cols - single column stacked layout
-    const xxsLayout = lgLayout.map((item) => ({
-      ...item,
-      x: 0,
-      w: 2,
-    }));
+    const fullWidthLayout = (cols: number) =>
+      lgLayout.map((item) => ({ ...item, x: 0, w: cols }));
 
     return {
       lg: lgLayout,
-      md: mdLayout,
-      sm: smLayout,
-      xs: xsLayout,
-      xxs: xxsLayout,
+      md: fullWidthLayout(DASHBOARD_GRID_COLUMNS.md),
+      sm: fullWidthLayout(DASHBOARD_GRID_COLUMNS.sm),
+      xs: fullWidthLayout(DASHBOARD_GRID_COLUMNS.xs),
+      xxs: fullWidthLayout(DASHBOARD_GRID_COLUMNS.xxs),
     };
   }, [dashboard.items]);
 

--- a/packages/app/src/components/dashboards/DashboardItem.test.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mutateAsync: vi.fn(async () => {}),
+}));
+
+vi.mock("@wystack/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wystack/client")>();
+  return {
+    ...actual,
+    useMutation: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+  };
+});
+
+import { DashboardItem } from "./DashboardItem";
+
+const item = {
+  id: "markdown",
+  type: "markdown" as const,
+  content: "Canonical content",
+  x: 0,
+  y: 0,
+  width: 4,
+  height: 4,
+};
+
+describe("DashboardItem markdown editing", () => {
+  beforeEach(() => {
+    mocks.mutateAsync.mockClear();
+  });
+
+  it("discards an open draft when dashboard editing becomes unavailable", () => {
+    const view = render(
+      <DashboardItem item={item} dashboardId="dashboard" isEditable />,
+    );
+
+    const editButton = view.container
+      .querySelector(".lucide-pencil")
+      ?.closest("button");
+    expect(editButton).not.toBeNull();
+    fireEvent.click(editButton as HTMLButtonElement);
+    fireEvent.change(screen.getByPlaceholderText("Enter markdown..."), {
+      target: { value: "Unsaved draft" },
+    });
+
+    view.rerender(
+      <DashboardItem item={item} dashboardId="dashboard" isEditable={false} />,
+    );
+
+    expect(screen.queryByPlaceholderText("Enter markdown...")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.getByText("Canonical content")).toBeDefined();
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+
+    view.rerender(
+      <DashboardItem item={item} dashboardId="dashboard" isEditable />,
+    );
+
+    expect(screen.queryByPlaceholderText("Enter markdown...")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.getByText("Canonical content")).toBeDefined();
+  });
+});

--- a/packages/app/src/components/dashboards/DashboardItem.tsx
+++ b/packages/app/src/components/dashboards/DashboardItem.tsx
@@ -52,6 +52,11 @@ export function DashboardItem({
   ...props
 }: DashboardItemProps) {
   const [isEditingContent, setIsEditingContent] = useState(false);
+  const [wasEditable, setWasEditable] = useState(isEditable);
+  if (wasEditable !== isEditable) {
+    setWasEditable(isEditable);
+    setIsEditingContent(false);
+  }
   const { mutateAsync: updateItem, isPending: isSavingContent } = useMutation(
     api.updateDashboardItem,
   );
@@ -135,7 +140,7 @@ export function DashboardItem({
           {item.type === "markdown" ? (
             <MarkdownWidget
               content={item.content || ""}
-              isEditing={isEditingContent}
+              isEditing={isEditable && isEditingContent}
               onSave={handleSaveContent}
               onCancel={() => setIsEditingContent(false)}
               isSaving={isSavingContent}

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -36,3 +36,23 @@ body,
   opacity: 0.4 !important;
   border-radius: var(--radius) !important;
 }
+
+.dashboard-detail {
+  container-type: inline-size;
+  container-name: dashboard-detail;
+}
+
+@container dashboard-detail (max-width: 44.99rem) {
+  .dashboard-edit-controls {
+    align-items: stretch;
+  }
+
+  .dashboard-edit-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .dashboard-editing-unavailable {
+    text-align: right;
+  }
+}

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -37,10 +37,6 @@ body,
   border-radius: var(--radius) !important;
 }
 
-.dashboard-detail {
-  container-type: inline-size;
-}
-
 .dashboard-detail[data-editing-available="false"] .dashboard-edit-controls {
   align-items: stretch;
 }

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -39,20 +39,18 @@ body,
 
 .dashboard-detail {
   container-type: inline-size;
-  container-name: dashboard-detail;
 }
 
-@container dashboard-detail (max-width: 44.99rem) {
-  .dashboard-edit-controls {
-    align-items: stretch;
-  }
+.dashboard-detail[data-editing-available="false"] .dashboard-edit-controls {
+  align-items: stretch;
+}
 
-  .dashboard-edit-actions {
-    flex-wrap: wrap;
-    justify-content: flex-end;
-  }
+.dashboard-detail[data-editing-available="false"] .dashboard-edit-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
 
+.dashboard-detail[data-editing-available="false"]
   .dashboard-editing-unavailable {
-    text-align: right;
-  }
+  text-align: right;
 }


### PR DESCRIPTION
## Changes

- prevent dashboard widget content and controls from clipping at narrow widths by projecting the responsive grid into a full-width reading-order stack
- measure the real grid container before paint and keep editing fail-closed until availability is known
- disable and exit edit mode at measured widths of 960px or less, including closing open add-widget and markdown-content editors
- cover initial measurement, breakpoint transitions, real dashboard-item rendering, editor teardown, reading order, and loading/refetch resets

## Screenshots

### Light — wide editable
![Light — wide editable](https://github.com/youhaowei/DashFrame/releases/download/pr-324-screenshots/light-wide-editable.png)

### Light — narrow unavailable
![Light — narrow unavailable](https://github.com/youhaowei/DashFrame/releases/download/pr-324-screenshots/light-narrow-unavailable.png)

### Dark — wide editable
![Dark — wide editable](https://github.com/youhaowei/DashFrame/releases/download/pr-324-screenshots/dark-wide-editable.png)

### Dark — narrow unavailable
![Dark — narrow unavailable](https://github.com/youhaowei/DashFrame/releases/download/pr-324-screenshots/dark-narrow-unavailable.png)

### Dark — markdown editor open
![Dark — markdown editor open](https://github.com/youhaowei/DashFrame/releases/download/pr-324-screenshots/dark-markdown-editor-open.png)

### Dark — editor closed after narrowing
![Dark — editor closed after narrowing](https://github.com/youhaowei/DashFrame/releases/download/pr-324-screenshots/markdown-editor-closed-after-narrow.png)

_Screenshots via pr-screenshots (prerelease `pr-324-screenshots`, not in git)._

## Verification

- Exact reviewed HEAD: `8a87833ee9fb674ae849e52f589bf57afadb5e60`
- `bun run check` — PASS (85/85 tasks)
- `bun run format:check` — PASS
- `bun run --cwd packages/app test -- src/app/dashboards/'[dashboardId]'/_components/DashboardDetailContent.test.tsx src/components/dashboards/DashboardGrid.responsive.test.tsx src/components/dashboards/DashboardGrid.test.tsx src/components/dashboards/DashboardItem.test.tsx` — PASS (4 files, 13 tests)
- independent Grok focused regression review of `771def217a7c580b730b1535ba440dca8324d8c7..8a87833ee9fb674ae849e52f589bf57afadb5e60` — PASS, no findings
- running-app QA: PASS on documented web+server fallback at real grid widths 320/480/600/920/1312px. Real visualization Chart/Table controls and content remained unclipped; wide→narrow exited editing and closed the markdown textarea/Save action; narrow→wide restored editing; all 130 relevant API calls returned 200 with no page errors. Electron CDP was attempted first but repeatedly exited with SIGTERM, so the complete acceptance flow used the repository-documented web surface.
