### PR TITLE
[codex] Wire native DuckDB into headless serve

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -31,12 +31,14 @@
  */
 // Import from the transport-only subpath, NOT the package barrel: the barrel
 // re-exports NativeDuckDBEngine, whose module top-level-imports the native
-// `@duckdb/node-api` addon. The `dashframe serve` path imports this app without
-// passing `arrowEngine`, so pulling the native binding eagerly would break
-// startup on platforms without it. arrow-data-path has no native dependency.
+// `@duckdb/node-api` addon. Runtime composers load that platform binding only
+// when they start (`dashframe serve` does so dynamically); importing this
+// deployment-agnostic app factory remains safe. arrow-data-path has no native
+// dependency.
 import {
   createArrowDataPath,
   type ArrowQueryRunner,
+  type ArrowTableRegistrar,
 } from "@dashframe/engine-server/arrow-data-path";
 import { schema, type ApiAccessCredentials } from "@dashframe/server-core";
 import { serve as nodeServe } from "@hono/node-server";
@@ -186,15 +188,11 @@ export interface DashframeServerOptions {
    * supplied, `POST /data/arrow` streams `application/vnd.apache.arrow.stream`
    * for a compiled query — the binary path that never rides WyStack RPC.
    *
-   * Desktop is the only caller that supplies this today — Electron main
-   * constructs the native engine and passes it in. `dashframe serve`'s CLI
-   * composition (`createStandaloneServerOptions`) never sets it, so the Arrow
-   * data path stays unmounted there; wiring it in is the first slice of the
-   * unified data-plane work (see `@dashframe/engine-server`'s native-engine
-   * doc comment). Web try-it also omits it: the result already lives in
-   * renderer WASM, so there is no server data path.
+   * Desktop and `dashframe serve` both construct the native engine and pass it
+   * here. Keeping construction at the runtime edge lets this shared factory be
+   * imported without eagerly loading a platform native addon.
    */
-  arrowEngine?: ArrowQueryRunner;
+  arrowEngine?: ArrowQueryRunner & Partial<ArrowTableRegistrar>;
   /**
    * Optional hook fired after every SUCCESSFUL artifact-DB write mutation.
    * Called once per committed write (after the DB transaction commits, never

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   printHelp,
   resolveDataDir,
   resolveProjectDirectory,
+  shutdownStandaloneResources,
 } from "./index";
 
 describe("dashframe serve CLI", () => {
@@ -81,6 +82,58 @@ describe("dashframe serve CLI", () => {
         })),
       ).rejects.toThrow(/Native DuckDB is required.*connect failed/);
       expect(dispose).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("standalone shutdown", () => {
+    function resources(close: ProjectHandle["close"]) {
+      return {
+        project: { close },
+        server: { stop: vi.fn() },
+        engine: { dispose: vi.fn().mockResolvedValue(undefined) },
+      };
+    }
+
+    it("exits zero after a durable final snapshot", async () => {
+      const exit = vi.fn();
+      await shutdownStandaloneResources(
+        resources(vi.fn().mockResolvedValue({ snapshotError: null })),
+        exit,
+      );
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    it("exits nonzero when the final snapshot fails", async () => {
+      const exit = vi.fn();
+      const error = new Error("snapshot write failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      try {
+        await shutdownStandaloneResources(
+          resources(vi.fn().mockResolvedValue({ snapshotError: error })),
+          exit,
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    it("exits nonzero when closing the project rejects", async () => {
+      const exit = vi.fn();
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      try {
+        await shutdownStandaloneResources(
+          resources(vi.fn().mockRejectedValue(new Error("close failed"))),
+          exit,
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+      expect(exit).toHaveBeenCalledWith(1);
     });
   });
 

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   assertAccessRootOutsideProject,
   assertBindIsSafe,
+  createStandaloneArrowEngine,
   createStandaloneSecretServices,
   createStandaloneServerOptions,
   parseArgs,
@@ -21,6 +22,68 @@ import {
 } from "./index";
 
 describe("dashframe serve CLI", () => {
+  describe("native engine composition", () => {
+    it("loads and initializes the server-native engine", async () => {
+      const initialize = vi.fn().mockResolvedValue(undefined);
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const queryArrow = vi.fn();
+      const registerArrowTable = vi.fn();
+
+      const engine = await createStandaloneArrowEngine(async () => ({
+        NativeDuckDBEngine: class {
+          initialize = initialize;
+          dispose = dispose;
+          queryArrow = queryArrow;
+          registerArrowTable = registerArrowTable;
+        },
+      }));
+
+      expect(initialize).toHaveBeenCalledOnce();
+      expect(engine.queryArrow).toBe(queryArrow);
+      expect(dispose).not.toHaveBeenCalled();
+    });
+
+    it("loads the installed native binding through the lazy runtime import", async () => {
+      const engine = await createStandaloneArrowEngine();
+      try {
+        const arrow = await engine.queryArrow(
+          "SELECT 1::INTEGER AS server_native",
+        );
+        expect(arrow.byteLength).toBeGreaterThan(0);
+      } finally {
+        await engine.dispose();
+      }
+    });
+
+    it("fails clearly when the native binding cannot load", async () => {
+      await expect(
+        createStandaloneArrowEngine(async () => {
+          throw new Error("native module not found");
+        }),
+      ).rejects.toThrow(
+        "Native DuckDB is required by dashframe serve but failed to initialize: native module not found",
+      );
+    });
+
+    it("disposes a partially initialized engine before failing startup", async () => {
+      const dispose = vi.fn().mockResolvedValue(undefined);
+
+      await expect(
+        createStandaloneArrowEngine(async () => ({
+          NativeDuckDBEngine: class {
+            async initialize() {
+              throw new Error("connect failed");
+            }
+            dispose = dispose;
+            queryArrow = vi.fn();
+            registerArrowTable = vi.fn();
+          },
+        })),
+      ).rejects.toThrow(/Native DuckDB is required.*connect failed/);
+      expect(dispose).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("parseArgs", () => {
     it("should parse the serve subcommand with project, bind, and token", () => {
       expect(
@@ -286,14 +349,20 @@ describe("dashframe serve CLI", () => {
           touchSnapshot: vi.fn(),
           flushSnapshot: vi.fn(),
         } as unknown as ProjectHandle;
+        const arrowEngine = {
+          queryArrow: vi.fn(),
+          registerArrowTable: vi.fn(),
+        };
         const options = createStandaloneServerOptions(
           { token: "plaintext-token" },
           project,
           services,
+          arrowEngine,
         );
         expect(options.vault).toBe(services.vault);
         expect(options.accessCredentials).toBe(services.accessCredentials);
         expect(options.authToken).toBe("plaintext-token");
+        expect(options.arrowEngine).toBe(arrowEngine);
 
         // Named access tokens and connector credentials share the composed,
         // encrypted standalone vault. No other credential class is routed to
@@ -348,6 +417,7 @@ describe("dashframe serve CLI", () => {
         { token: "plaintext-token" },
         project,
         services,
+        { queryArrow: vi.fn(), registerArrowTable: vi.fn() },
       );
       expect(options.vault).toBeUndefined();
       expect(options.accessCredentials).toBeUndefined();

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -473,33 +473,54 @@ function closeOnSignal(
   const close = async () => {
     if (closing) return;
     closing = true;
-    try {
-      server.stop();
-    } catch (error) {
-      console.error("[dashframe] error stopping server:", error);
-    }
-    try {
-      await engine.dispose();
-    } catch (error) {
-      console.error("[dashframe] error disposing native DuckDB engine:", error);
-    }
-    try {
-      const result = await project.close();
-      if (!result.snapshotError) {
-        process.exit(0);
-        return;
-      }
+    await shutdownStandaloneResources({ project, server, engine });
+  };
+  process.on("SIGINT", () => void close());
+  process.on("SIGTERM", () => void close());
+}
+
+export interface StandaloneShutdownResources {
+  project: Pick<ProjectHandle, "close">;
+  server: Pick<DashframeServer, "stop">;
+  engine: Pick<StandaloneArrowEngine, "dispose">;
+}
+
+/**
+ * Drain standalone runtime resources and terminate with an honest status.
+ * Snapshot durability is part of a successful shutdown: a reported final
+ * snapshot failure or a rejected project close exits nonzero even though the
+ * server and native engine were already stopped successfully.
+ */
+export async function shutdownStandaloneResources(
+  resources: StandaloneShutdownResources,
+  exit: (code: number) => void = (code) => process.exit(code),
+): Promise<void> {
+  try {
+    resources.server.stop();
+  } catch (error) {
+    console.error("[dashframe] error stopping server:", error);
+  }
+  try {
+    await resources.engine.dispose();
+  } catch (error) {
+    console.error("[dashframe] error disposing native DuckDB engine:", error);
+  }
+
+  let exitCode = 0;
+  try {
+    const result = await resources.project.close();
+    if (result.snapshotError) {
+      exitCode = 1;
       console.error(
         "[dashframe] close-time snapshot failed (data may not be persisted):",
         result.snapshotError,
       );
-    } catch (error) {
-      console.error("[dashframe] error closing project DB:", error);
     }
-    process.exit(0);
-  };
-  process.on("SIGINT", () => void close());
-  process.on("SIGTERM", () => void close());
+  } catch (error) {
+    exitCode = 1;
+    console.error("[dashframe] error closing project DB:", error);
+  }
+  exit(exitCode);
 }
 
 async function disposeEngineAfterStartupFailure(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -6,6 +6,10 @@
  * by an on-disk DashFrame project. Web dev can point `VITE_WYSTACK_URL` at the
  * printed URL.
  */
+import type {
+  ArrowQueryRunner,
+  ArrowTableRegistrar,
+} from "@dashframe/engine-server/arrow-data-path";
 import {
   ApiAccessCredentials,
   CREDENTIAL_CLASS,
@@ -258,6 +262,50 @@ export interface StandaloneSecretServices {
   accessCredentials?: ApiAccessCredentials;
 }
 
+interface StandaloneArrowEngine extends ArrowQueryRunner, ArrowTableRegistrar {
+  initialize(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+interface NativeEngineModule {
+  NativeDuckDBEngine: new () => StandaloneArrowEngine;
+}
+
+type LoadNativeEngineModule = () => Promise<NativeEngineModule>;
+
+/**
+ * Load and initialize the native engine only when `dashframe serve` starts.
+ *
+ * Keeping the value import dynamic preserves the server app's transport-only
+ * import boundary: code that imports `@dashframe/server/app` for tests or an
+ * alternate host does not load a platform native addon. The standalone CLI,
+ * however, has one supported execution engine. If the binding is absent or
+ * cannot initialize, startup fails explicitly; there is no WASM fallback.
+ */
+export async function createStandaloneArrowEngine(
+  loadModule: LoadNativeEngineModule = () => import("@dashframe/engine-server"),
+): Promise<StandaloneArrowEngine> {
+  let engine: StandaloneArrowEngine | undefined;
+  try {
+    const { NativeDuckDBEngine } = await loadModule();
+    engine = new NativeDuckDBEngine();
+    await engine.initialize();
+    return engine;
+  } catch (error) {
+    try {
+      await engine?.dispose();
+    } catch {
+      // Preserve the startup failure as the operator-facing cause. Disposal is
+      // best-effort here; NativeDuckDBEngine also releases partial init state.
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Native DuckDB is required by dashframe serve but failed to initialize: ${reason}`,
+      { cause: error },
+    );
+  }
+}
+
 /** Resolve host-local storage independently from the copiable project path. */
 export function resolveDataDir(
   opts: CliOptions,
@@ -396,6 +444,7 @@ export function createStandaloneServerOptions(
   opts: CliOptions,
   project: ProjectHandle,
   secretServices: StandaloneSecretServices,
+  arrowEngine: ArrowQueryRunner & ArrowTableRegistrar,
 ): DashframeServerOptions {
   return {
     db: project.db,
@@ -403,6 +452,7 @@ export function createStandaloneServerOptions(
     port: opts.port,
     corsOrigin: opts.corsOrigin,
     authToken: opts.token,
+    arrowEngine,
     ...secretServices,
     // Drive the debounced snapshot scheduler on the headless serve path too, so
     // `dashframe serve` gets the same crash-durability guarantee as desktop.
@@ -414,23 +464,74 @@ export function createStandaloneServerOptions(
   };
 }
 
-function closeOnSignal(project: ProjectHandle, server: DashframeServer): void {
+function closeOnSignal(
+  project: ProjectHandle,
+  server: DashframeServer,
+  engine: StandaloneArrowEngine,
+): void {
   let closing = false;
   const close = async () => {
     if (closing) return;
     closing = true;
-    server.stop();
-    const result = await project.close();
-    if (result.snapshotError) {
+    try {
+      server.stop();
+    } catch (error) {
+      console.error("[dashframe] error stopping server:", error);
+    }
+    try {
+      await engine.dispose();
+    } catch (error) {
+      console.error("[dashframe] error disposing native DuckDB engine:", error);
+    }
+    try {
+      const result = await project.close();
+      if (!result.snapshotError) {
+        process.exit(0);
+        return;
+      }
       console.error(
         "[dashframe] close-time snapshot failed (data may not be persisted):",
         result.snapshotError,
       );
+    } catch (error) {
+      console.error("[dashframe] error closing project DB:", error);
     }
     process.exit(0);
   };
   process.on("SIGINT", () => void close());
   process.on("SIGTERM", () => void close());
+}
+
+async function disposeEngineAfterStartupFailure(
+  engine: StandaloneArrowEngine | undefined,
+): Promise<void> {
+  try {
+    await engine?.dispose();
+  } catch (error) {
+    console.error(
+      "[dashframe] error disposing native DuckDB engine after startup failure:",
+      error,
+    );
+  }
+}
+
+async function closeProjectAfterStartupFailure(
+  project: ProjectHandle,
+): Promise<void> {
+  try {
+    const result = await project.close();
+    if (result.snapshotError) {
+      console.error(
+        "[dashframe] close-time snapshot failed after startup failure:",
+        result.snapshotError,
+      );
+    }
+  } catch (error) {
+    console.error(
+      "[dashframe] error closing project DB after startup failure:",
+      error,
+    );
+  }
 }
 
 export async function main(args = process.argv.slice(2)): Promise<void> {
@@ -483,11 +584,21 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
     );
   }
 
-  const server = await createDashframeServer(
-    createStandaloneServerOptions(opts, project, secretServices),
-  );
+  let engine: StandaloneArrowEngine | undefined;
+  let server: DashframeServer;
+  try {
+    engine = await createStandaloneArrowEngine();
+    console.log("[dashframe] native DuckDB engine ready");
+    server = await createDashframeServer(
+      createStandaloneServerOptions(opts, project, secretServices, engine),
+    );
+  } catch (error) {
+    await disposeEngineAfterStartupFailure(engine);
+    await closeProjectAfterStartupFailure(project);
+    throw error;
+  }
 
-  closeOnSignal(project, server);
+  closeOnSignal(project, server, engine);
 
   console.log(`[dashframe] project: ${project.dir}`);
   // Enabled/disabled only — never key material, and never a key ID derived

--- a/packages/engine-server/src/arrow-data-path.test.ts
+++ b/packages/engine-server/src/arrow-data-path.test.ts
@@ -69,6 +69,18 @@ describe("Arrow data path — auth + IPC roundtrip (Stage 5)", () => {
     expect(engine.calls).toHaveLength(0);
   });
 
+  it("rejects a tokenless text/plain query before SQL execution", async () => {
+    const engine = fakeEngine();
+    const app = createArrowDataPath({ engine });
+    const res = await app.request("/arrow", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: JSON.stringify({ sql: "SELECT 1" }),
+    });
+    expect(res.status).toBe(415);
+    expect(engine.calls).toHaveLength(0);
+  });
+
   it("threads params to the engine so parameterized queries are not silently dropped", async () => {
     const engine = fakeEngine();
     const app = createArrowDataPath({ engine, authToken: TOKEN });

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -240,6 +240,17 @@ export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
+    // A tokenless loopback server still needs a browser-origin boundary. CORS
+    // prevents a hostile page from reading a response, but a safelisted
+    // `text/plain` request can be sent without preflight and would execute SQL
+    // before the browser blocks that response. Requiring JSON forces a
+    // cross-origin browser to preflight, where the server's CORS policy can
+    // reject the origin before this handler executes.
+    const contentType = c.req.header("content-type")?.split(";", 1)[0]?.trim();
+    if (contentType?.toLowerCase() !== "application/json") {
+      return c.json({ error: "Content-Type must be application/json" }, 415);
+    }
+
     let body: RequestBody;
     try {
       body = (await c.req.json()) as RequestBody;

--- a/packages/engine-server/src/index.ts
+++ b/packages/engine-server/src/index.ts
@@ -13,9 +13,8 @@
  *   - Stage 4 Cache     — `ParquetCache` + `CacheWriteGate` seam (sensitivity gate, see #67)
  *   - Stage 5 Transport — `createArrowDataPath` (dedicated Arrow IPC HTTP path)
  *
- * Desktop already constructs Stage 3+5 in Electron main. Headless `serve` accepts
- * an optional `arrowEngine` but does not construct one yet — that wiring is the
- * first unified-plane slice.
+ * Desktop constructs Stage 3+5 in Electron main; headless `serve` constructs
+ * the same engine lazily at its runtime edge and injects it into the same path.
  *
  * Native module: this package depends on `@duckdb/node-api`, which must be
  * externalized from the Electron main bundle (and asar-unpacked if packaged).

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -7,10 +7,9 @@
  * `@dashframe/engine-browser` is a **backup / local-first** path, not a second
  * peer `QueryEngine` and not the long-term web default.
  *
- * Wiring today: Electron main constructs this engine and mounts Stage 5. Headless
- * `serve` does not pass it yet — that is the first slice of the unified data-plane
- * work (wire `arrowEngine` into serve). Cloud remote compute is not a binding;
- * this class is the intended seam there too once that tier exists.
+ * Electron main and headless `serve` both construct this engine and mount Stage
+ * 5. Cloud remote compute is not a binding; this class is the intended seam
+ * there too once that tier exists.
  *
  * Beyond the row-shaped `QueryEngine.query`, it exposes `queryArrow` — the
  * Arrow IPC bytes the dedicated data path (Stage 5) streams. Arrow encoding is


### PR DESCRIPTION
## Summary
- lazily load and initialize `NativeDuckDBEngine` when `dashframe serve` starts
- inject it into the existing Arrow data path, including query and table-registration routes
- fail clearly when the native binding is unavailable and dispose native/project resources on startup failure or shutdown
- keep browser WASM policy and web consumer migration out of this slice; no mode, switch, fallback, or bridge was added

## Validation
- `TURBO_CONCURRENCY=1 bun run check` — 85/85 tasks; all four checks PASS
- `bun run format:check` — PASS
- focused server index tests — 28/28 PASS
- engine-server tests — 79/79 PASS
- behavioral QA: real `dashframe serve` returned Arrow IPC from `POST /data/arrow`, decoded `{ answer: 42, engine: "server-native" }`; `POST /data/tables/qa_frame` registered and queried the same frame; invalid SQL returned 500
- local code review — no open findings
- independent second review — initial web-policy overclaim fixed by narrowing the diff; final re-review: no findings