### PR TITLE
[codex] Persist server snapshots and serve queries natively

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -404,6 +404,8 @@ app
         // this, the gate degrades to the debounced-schedule path and the crash
         // window reopens. The narrow callback preserves the no-import boundary.
         flushSnapshot: () => project.flushSnapshot(),
+        flushSnapshotRetentionWindow: () =>
+          project.flushSnapshotRetentionWindow(),
         // Inject the fully-composed SecretVault. The server RECEIVES this vault;
         // it never instantiates a backend itself. Control-plane mutations
         // (create/update DataSource) call vault.store → ref; reads call

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import {
+  FileDataFrameStorage,
   NativeDuckDBEngine,
   selectEngineBinding,
 } from "@dashframe/engine-server";
@@ -380,6 +381,9 @@ app
 
       server = await createDashframeServer({
         db: project.db,
+        dataFrameStorage: new FileDataFrameStorage(
+          path.join(project.dir, "dataframes"),
+        ),
         accessCredentials: new ApiAccessCredentials(accessVault, accessRoot),
         corsOrigin,
         // Vault path passes a ref (no plaintext at the server); the

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -3,6 +3,7 @@ import "@dashframe/app/globals.css";
 import type { AppRouterContext, ProviderWrapper } from "@dashframe/app";
 import {
   ChartEngineProvider,
+  configureServerDataPlane,
   createWyStackRuntime,
   resolveWyStackConfig,
 } from "@dashframe/app";
@@ -53,57 +54,25 @@ async function bootstrap() {
   const config = await resolveWyStackConfig();
   const { Provider } = createWyStackRuntime(config);
 
-  // Attempt to build a native connector via the Electron IPC bridge.
-  // `window.dashframe` is only present in the Electron renderer (contextBridge).
-  // In web tier / tests this will be undefined — safe to ignore.
-  let nativeConnector: ReturnType<typeof createNativeConnector> | null = null;
-  let engineError: string | null = null;
-
-  const desktop = (
-    globalThis as {
-      dashframe?: { getServerInfo(): Promise<{ url: string; token: string }> };
-    }
-  ).dashframe;
-  if (desktop?.getServerInfo) {
-    try {
-      const info = await desktop.getServerInfo();
-      if (info?.url && info?.token) {
-        nativeConnector = createNativeConnector({
-          serverUrl: info.url,
-          token: info.token,
-        });
-      } else {
-        engineError = "Native engine not available — server info missing.";
-      }
-    } catch (err) {
-      // Failed to reach the loopback server; charts will show a degraded banner.
-      engineError =
-        err instanceof Error
-          ? `Native engine unavailable: ${err.message}`
-          : "Native engine unavailable — unknown error.";
-      console.error("[DashFrame] Failed to build native connector:", err);
-    }
+  if (!config.token) {
+    throw new Error(
+      "Desktop server info omitted its loopback token; native data plane unavailable",
+    );
   }
+  const nativeConnector = createNativeConnector({
+    serverUrl: config.url,
+    token: config.token,
+  });
 
-  // Bind the upload callback ONCE here, not inside the providerWrapper body.
-  // providerWrapper is rendered as a React component, so any object/function
-  // created in its body would be a fresh reference every render. That fresh
-  // reference flows through ChartEngineProvider context into useInsightView's
-  // chart-query effect dependency array, re-firing the effect on every render
-  // (→ setState → re-render → infinite loop, which crashes the renderer on the
-  // visualization route). A stable, module-lifetime callback breaks the loop.
-  const uploadArrowTable = nativeConnector
-    ? (name: string, arrowBytes: Uint8Array) =>
-        nativeConnector.uploadArrowTable(name, arrowBytes)
-    : null;
+  configureServerDataPlane({
+    serverUrl: config.url,
+    token: config.token,
+    connector: nativeConnector,
+  });
 
   const providerWrapper: ProviderWrapper = ({ children }) => (
     <Provider>
-      <ChartEngineProvider
-        connector={nativeConnector}
-        engineError={engineError}
-        uploadArrowTable={uploadArrowTable}
-      >
+      <ChartEngineProvider connector={nativeConnector}>
         {children}
       </ChartEngineProvider>
     </Provider>

--- a/apps/renderer/src/nativeConnector.test.ts
+++ b/apps/renderer/src/nativeConnector.test.ts
@@ -7,7 +7,7 @@
  *   than hanging forever.
  * - Happy path: a valid query returns a decoded flechette Table.
  * - Table upload: uploadArrowTable posts with Arrow content-type.
- * - Server frame registration: only the persisted handle and table name cross.
+ * - Server snapshot registration: only the DataFrame ID and table name cross.
  * - Error mapping: non-2xx responses are surfaced as human-readable throws.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -62,6 +62,40 @@ describe("createNativeConnector — abort timeout", () => {
     ).rejects.toThrow("Native engine timed out");
 
     // Advance past the 10-second timeout
+    await vi.advanceTimersByTimeAsync(11_000);
+    await queryPromise;
+  });
+
+  it("times out when response headers arrive but the Arrow body stalls", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init: RequestInit) =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () =>
+            new Promise<ArrayBuffer>((_resolve, reject) => {
+              (init.signal as AbortSignal | undefined)?.addEventListener(
+                "abort",
+                () =>
+                  reject(
+                    new DOMException(
+                      "The operation was aborted.",
+                      "AbortError",
+                    ),
+                  ),
+              );
+            }),
+        } as Response),
+      ),
+    );
+    const connector = createNativeConnector({
+      serverUrl: SERVER_URL,
+      token: TOKEN,
+    });
+    const queryPromise = expect(
+      connector.query({ sql: "SELECT 1" }),
+    ).rejects.toThrow("Native engine timed out");
+
     await vi.advanceTimersByTimeAsync(11_000);
     await queryPromise;
   });
@@ -147,7 +181,7 @@ describe("createNativeConnector — error handling", () => {
     ).rejects.toThrow(/Failed to upload table/);
   });
 
-  it("registers a persisted server frame by handle without an Arrow body", async () => {
+  it("registers a persisted server snapshot by DataFrame ID without an Arrow body", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/apps/renderer/src/nativeConnector.test.ts
+++ b/apps/renderer/src/nativeConnector.test.ts
@@ -7,6 +7,7 @@
  *   than hanging forever.
  * - Happy path: a valid query returns a decoded flechette Table.
  * - Table upload: uploadArrowTable posts with Arrow content-type.
+ * - Server frame registration: only the persisted handle and table name cross.
  * - Error mapping: non-2xx responses are surfaced as human-readable throws.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -144,5 +145,31 @@ describe("createNativeConnector — error handling", () => {
     await expect(
       connector.uploadArrowTable("df_test", new Uint8Array([0])),
     ).rejects.toThrow(/Failed to upload table/);
+  });
+
+  it("registers a persisted server frame by handle without an Arrow body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const connector = createNativeConnector({
+      serverUrl: SERVER_URL,
+      token: TOKEN,
+    });
+
+    await connector.registerServerFrame(
+      "0d44d605-f3be-46b6-a492-e912231cbedf",
+      "df_report",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${SERVER_URL}/data/frames/0d44d605-f3be-46b6-a492-e912231cbedf/tables/df_report`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${TOKEN}`,
+        }),
+      }),
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).not.toHaveProperty("body");
   });
 });

--- a/apps/renderer/src/nativeConnector.test.ts
+++ b/apps/renderer/src/nativeConnector.test.ts
@@ -201,6 +201,7 @@ describe("createNativeConnector — error handling", () => {
         method: "POST",
         headers: expect.objectContaining({
           Authorization: `Bearer ${TOKEN}`,
+          "Content-Type": "application/json",
         }),
       }),
     );

--- a/apps/renderer/src/nativeConnector.ts
+++ b/apps/renderer/src/nativeConnector.ts
@@ -4,19 +4,18 @@
  * Builds a Mosaic Connector that routes all chart-compute queries to the
  * native DuckDB engine via the loopback Arrow IPC endpoint (`POST /data/arrow`).
  *
- * This is the desktop-tier half of the surface-scoped engine selection:
- *   - Desktop:  this connector → loopback server → native DuckDB
- *   - Web/WASM: no connector; VisualizationSetup falls back to DuckDB-WASM
+ * Desktop uses this loopback connector; web composes the same server protocol
+ * through the shared app connector. Neither activates a WASM fallback.
  *
  * No `isElectron` checks in components — the connector is injected through
  * ChartEngineProvider by the renderer's bootstrap (main.tsx) only when the
  * desktop IPC surface is present.
  *
- * ## Table upload
+ * ## Retained table upload
  *
- * Before chart queries can run against a DataFrame table, that table must be
- * uploaded to the native engine's in-memory store via `POST /data/tables/:name`.
- * Call `uploadArrowTable(name, arrowBytes)` before issuing chart queries.
+ * `uploadArrowTable` remains available for browser-owned local frames, but the
+ * active data plane loads through the shared server connection. Durable project
+ * frames use `registerServerFrame`, so their bytes never cross the renderer.
  *
  * ## Arrow IPC decoding — flechette, not apache-arrow
  *
@@ -81,6 +80,7 @@ export interface NativeMosaicConnector {
    * Must be called before issuing chart queries that reference this table.
    */
   uploadArrowTable(name: string, arrowBytes: Uint8Array): Promise<void>;
+  registerServerFrame(frameId: string, tableName: string): Promise<void>;
 }
 
 /**
@@ -155,8 +155,28 @@ export function createNativeConnector(
     }
   }
 
+  async function registerServerFrame(
+    frameId: string,
+    tableName: string,
+  ): Promise<void> {
+    const endpoint = `${serverUrl}/data/frames/${encodeURIComponent(frameId)}/tables/${encodeURIComponent(tableName)}`;
+    const res = await fetchWithTimeout(endpoint, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Failed to register server frame (${res.status}): ${await res.text()}`,
+      );
+    }
+  }
+
   // Cast through unknown: TypeScript can't narrow the overloaded query
   // signatures to a single implementation, but the runtime dispatches
   // correctly based on q.type.
-  return { query, uploadArrowTable } as unknown as NativeMosaicConnector;
+  return {
+    query,
+    uploadArrowTable,
+    registerServerFrame,
+  } as unknown as NativeMosaicConnector;
 }

--- a/apps/renderer/src/nativeConnector.ts
+++ b/apps/renderer/src/nativeConnector.ts
@@ -39,14 +39,16 @@ const LOOPBACK_TIMEOUT_MS = 10_000;
  * Maps an `AbortError` to a human-readable "timed out" message so the engine-
  * error UI surface always has something useful to show.
  */
-async function fetchWithTimeout(
+async function requestWithTimeout<T>(
   url: string,
   init: RequestInit,
-): Promise<Response> {
+  consume: (response: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), LOOPBACK_TIMEOUT_MS);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    return await consume(response);
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error(
@@ -104,33 +106,28 @@ export function createNativeConnector(
   async function query(q: { type?: string; sql: string }): Promise<unknown> {
     const type = q.type ?? "arrow";
 
-    const res = await fetchWithTimeout(arrowEndpoint, {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({ type, sql: q.sql }),
-    });
-
-    if (!res.ok) {
-      // Keep loopback errors out of the UI — surface as a human-readable throw.
-      const text = await res.text().catch(() => String(res.status));
-      throw new Error(`Native engine query failed (${res.status}): ${text}`);
-    }
-
-    if (type === "exec") {
-      // exec: no result body, nothing to return.
-      return undefined;
-    }
-
-    if (type === "json") {
-      // json: server returns a JSON array of row objects.
-      return (await res.json()) as Record<string, unknown>[];
-    }
-
-    // arrow (default): server returns raw Arrow IPC bytes. Decode into a
-    // flechette Table — the surface vgplot consumes (toColumns() etc.).
-    // useDate matches Mosaic's own decodeIPC default.
-    const buf = await res.arrayBuffer();
-    return tableFromIPC(new Uint8Array(buf), { useDate: true });
+    return requestWithTimeout(
+      arrowEndpoint,
+      {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ type, sql: q.sql }),
+      },
+      async (res) => {
+        if (!res.ok) {
+          const text = await res.text().catch(() => String(res.status));
+          throw new Error(
+            `Native engine query failed (${res.status}): ${text}`,
+          );
+        }
+        if (type === "exec") return undefined;
+        if (type === "json") {
+          return (await res.json()) as Record<string, unknown>[];
+        }
+        const buf = await res.arrayBuffer();
+        return tableFromIPC(new Uint8Array(buf), { useDate: true });
+      },
+    );
   }
 
   async function uploadArrowTable(
@@ -138,21 +135,25 @@ export function createNativeConnector(
     arrowBytes: Uint8Array,
   ): Promise<void> {
     const tableEndpoint = `${serverUrl}/data/tables/${encodeURIComponent(name)}`;
-    const res = await fetchWithTimeout(tableEndpoint, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": ARROW_CONTENT_TYPE,
+    await requestWithTimeout(
+      tableEndpoint,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": ARROW_CONTENT_TYPE,
+        },
+        body: arrowBytes,
       },
-      body: arrowBytes,
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => String(res.status));
-      throw new Error(
-        `Failed to upload table "${name}" (${res.status}): ${text}`,
-      );
-    }
+      async (res) => {
+        if (!res.ok) {
+          const text = await res.text().catch(() => String(res.status));
+          throw new Error(
+            `Failed to upload table "${name}" (${res.status}): ${text}`,
+          );
+        }
+      },
+    );
   }
 
   async function registerServerFrame(
@@ -160,15 +161,17 @@ export function createNativeConnector(
     tableName: string,
   ): Promise<void> {
     const endpoint = `${serverUrl}/data/frames/${encodeURIComponent(frameId)}/tables/${encodeURIComponent(tableName)}`;
-    const res = await fetchWithTimeout(endpoint, {
-      method: "POST",
-      headers: authHeaders(),
-    });
-    if (!res.ok) {
-      throw new Error(
-        `Failed to register server frame (${res.status}): ${await res.text()}`,
-      );
-    }
+    await requestWithTimeout(
+      endpoint,
+      { method: "POST", headers: authHeaders() },
+      async (res) => {
+        if (!res.ok) {
+          throw new Error(
+            `Failed to register server frame (${res.status}): ${await res.text()}`,
+          );
+        }
+      },
+    );
   }
 
   // Cast through unknown: TypeScript can't narrow the overloaded query

--- a/apps/server/src/app-context.ts
+++ b/apps/server/src/app-context.ts
@@ -20,9 +20,11 @@ export interface AppContext {
   cleanupDereferencedServerFrames?: (
     before: ReadonlySet<string>,
   ) => Promise<void>;
+  unregisterServerFrames?: (ids: readonly string[]) => Promise<void>;
   draftController?: DraftController;
   onWrite?: () => void;
   flushSnapshot?: () => Promise<void>;
+  flushSnapshotRetentionWindow?: () => Promise<void>;
   googleOAuth?: GoogleOAuthConfig;
   mode?: string;
   draftId?: string;

--- a/apps/server/src/app-context.ts
+++ b/apps/server/src/app-context.ts
@@ -21,6 +21,7 @@ export interface AppContext {
     before: ReadonlySet<string>,
   ) => Promise<void>;
   unregisterServerFrames?: (ids: readonly string[]) => Promise<void>;
+  markServerFrameCleanupHandled?: () => void;
   draftController?: DraftController;
   onWrite?: () => void;
   flushSnapshot?: () => Promise<void>;

--- a/apps/server/src/app-context.ts
+++ b/apps/server/src/app-context.ts
@@ -1,3 +1,4 @@
+import type { DataFrameStorage } from "@dashframe/engine";
 import type { ApiAccessCredentials, ArtifactDb } from "@dashframe/server-core";
 import type { Principal } from "@wystack/identity";
 import type { SecretVault } from "@wystack/secret-vault";
@@ -14,6 +15,11 @@ export interface AppContext {
   vault?: SecretVault;
   wyStackApp?: WyStackApp;
   artifactDb?: ArtifactDb;
+  dataFrameStorage?: DataFrameStorage;
+  captureServerFrameReferences?: () => Promise<ReadonlySet<string>>;
+  cleanupDereferencedServerFrames?: (
+    before: ReadonlySet<string>,
+  ) => Promise<void>;
   draftController?: DraftController;
   onWrite?: () => void;
   flushSnapshot?: () => Promise<void>;

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -10,9 +10,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  duckdbColumnsToArrowIpc,
+  FileDataFrameStorage,
+  NativeDuckDBEngine,
+} from "@dashframe/engine-server";
+import {
   ApiAccessCredentials,
   CREDENTIAL_CLASS,
   openProject,
+  schema,
   type ProjectHandle,
 } from "@dashframe/server-core";
 import {
@@ -23,15 +29,17 @@ import {
   TestBackend,
 } from "@wystack/secret-vault";
 import { applyCommands } from "@wystack/server";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   assertBindAuthorized,
   buildDashframeApp,
   createDashframeServer,
+  createDraftController,
   type DashframeServer,
 } from "./app";
-import type { ProjectInfoResult } from "./functions";
+import { functions, type ProjectInfoResult } from "./functions";
 import { cmd } from "./functions/commands";
 import { LOCAL_USER_ID } from "./permissions";
 
@@ -53,6 +61,17 @@ function makeSecretServices(rootDir: string): {
 
 function makeAccessCredentials(rootDir: string): ApiAccessCredentials {
   return makeSecretServices(rootDir).accessCredentials;
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await predicate())) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for state");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 }
 
 function waitForWsAuth(
@@ -816,6 +835,351 @@ describe("createDashframeServer", () => {
   });
 });
 
+describe("committed native frame cleanup", () => {
+  let root: string;
+  let project: ProjectHandle | null;
+  let server: DashframeServer | null;
+  let storage: FileDataFrameStorage;
+  let engine: NativeDuckDBEngine;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dashframe-native-cleanup-"));
+    project = null;
+    server = null;
+    storage = new FileDataFrameStorage(join(root, "frames"));
+    engine = new NativeDuckDBEngine();
+  });
+
+  afterEach(async () => {
+    server?.stop();
+    await engine.dispose();
+    await project?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  async function seedRegisteredFrame(value: string): Promise<{
+    frameId: string;
+    sourceId: string;
+    tableId: string;
+    tableName: string;
+  }> {
+    const frameId = crypto.randomUUID();
+    const sourceId = crypto.randomUUID();
+    const tableId = crypto.randomUUID();
+    const tableName = `df_${frameId.replaceAll("-", "_")}`;
+    const arrow = duckdbColumnsToArrowIpc([
+      { name: "value", typeId: 17, values: [value] },
+    ]);
+    await storage.save(frameId, arrow);
+    await project!.db.insert(schema.dataSources).values({
+      id: sourceId,
+      name: "Source",
+      kind: "csv",
+      storage: "live",
+      config: {},
+      createdBy: { kind: "user" },
+    });
+    await project!.db.insert(schema.dataFrames).values({
+      id: frameId,
+      storage: { type: "file", key: frameId },
+      fieldIds: [],
+      name: "Frame",
+      sourceId,
+      definitionId: tableId,
+    });
+    await project!.db.insert(schema.dataTables).values({
+      id: tableId,
+      dataSourceId: sourceId,
+      name: "Table",
+      table: "source.csv",
+      fields: [],
+      metrics: [],
+      dataFrameId: frameId,
+    });
+    return { frameId, sourceId, tableId, tableName };
+  }
+
+  async function registerFrame(frameId: string, tableName: string) {
+    const response = await fetch(
+      `${server!.url}/data/frames/${frameId}/tables/${tableName}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+    );
+    expect(response.status).toBe(200);
+  }
+
+  async function registerRawTable(
+    tableName: string,
+    value: string,
+  ): Promise<Response> {
+    const arrow = duckdbColumnsToArrowIpc([
+      { name: "value", typeId: 17, values: [value] },
+    ]);
+    return fetch(`${server!.url}/data/tables/${tableName}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.apache.arrow.stream" },
+      body: arrow,
+    });
+  }
+
+  function failNextNativeDrop(): void {
+    const connection = (
+      engine as unknown as {
+        connection: { run(sql: string): Promise<unknown> };
+      }
+    ).connection;
+    vi.spyOn(connection, "run").mockRejectedValueOnce(
+      new Error("injected transient native DROP failure"),
+    );
+  }
+
+  it("reports committed deletion, fires onWrite, and eventually retries native unregister", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const seeded = await seedRegisteredFrame("old");
+    const onWrite = vi.fn();
+    server = await createDashframeServer({
+      db: project.db,
+      dataFrameStorage: storage,
+      arrowEngine: engine,
+      flushSnapshotRetentionWindow: async () => {},
+      onWrite,
+    });
+    await registerFrame(seeded.frameId, seeded.tableName);
+    onWrite.mockClear();
+    failNextNativeDrop();
+
+    const ws = new WebSocket(`${server.url.replace(/^http/, "ws")}/api/ws`);
+    const subscriptionId = "deleted-table-invalidation";
+    let markSubscribed!: () => void;
+    const subscribed = new Promise<void>((resolve) => {
+      markSubscribed = resolve;
+    });
+    let markInvalidated!: () => void;
+    const invalidated = new Promise<void>((resolve) => {
+      markInvalidated = resolve;
+    });
+    ws.onopen = () => ws.send(JSON.stringify({ type: "auth", token: null }));
+    ws.onmessage = (event) => {
+      const message = JSON.parse(String(event.data)) as {
+        type?: string;
+        id?: string;
+      };
+      if (message.type === "authenticated") {
+        ws.send(
+          JSON.stringify({
+            type: "subscribe",
+            id: subscriptionId,
+            path: "listDataTables",
+            args: {},
+          }),
+        );
+      } else if (
+        message.type === "subscribed" &&
+        message.id === subscriptionId
+      ) {
+        markSubscribed();
+      } else if (
+        message.type === "invalidate" &&
+        message.id === subscriptionId
+      ) {
+        markInvalidated();
+      }
+    };
+    await subscribed;
+
+    const response = await fetch(`${server.url}/api/removeDataTable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: seeded.tableId }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()) as unknown).not.toHaveProperty(
+      "data.deletedArrowKeys",
+    );
+    expect(await storage.exists(seeded.frameId)).toBe(false);
+    expect(
+      (await project.db.select().from(schema.dataFrames)).find(
+        (row) => row.id === seeded.frameId,
+      ),
+    ).toBeUndefined();
+    expect(onWrite).toHaveBeenCalledTimes(1);
+    await invalidated;
+    ws.close();
+    await waitUntil(() => !engine.hasTable(seeded.tableName));
+  });
+
+  it("never lets an old unregister retry drop a re-registered table generation", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const seeded = await seedRegisteredFrame("old");
+    server = await createDashframeServer({
+      db: project.db,
+      dataFrameStorage: storage,
+      arrowEngine: engine,
+      flushSnapshotRetentionWindow: async () => {},
+    });
+    await registerFrame(seeded.frameId, seeded.tableName);
+    failNextNativeDrop();
+
+    const deleted = await fetch(`${server.url}/api/removeDataTable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: seeded.tableId }),
+    });
+    expect(deleted.status).toBe(200);
+
+    const replacement = duckdbColumnsToArrowIpc([
+      { name: "value", typeId: 17, values: ["new"] },
+    ]);
+    await storage.save(seeded.frameId, replacement);
+    const replacementTableId = crypto.randomUUID();
+    await project.db.insert(schema.dataFrames).values({
+      id: seeded.frameId,
+      storage: { type: "file", key: seeded.frameId },
+      fieldIds: [],
+      name: "Replacement",
+      sourceId: seeded.sourceId,
+      definitionId: replacementTableId,
+    });
+    await project.db.insert(schema.dataTables).values({
+      id: replacementTableId,
+      dataSourceId: seeded.sourceId,
+      name: "Replacement table",
+      table: "replacement.csv",
+      fields: [],
+      metrics: [],
+      dataFrameId: seeded.frameId,
+    });
+    await registerFrame(seeded.frameId, seeded.tableName);
+
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    expect(engine.hasTable(seeded.tableName)).toBe(true);
+    expect(
+      (await engine.query(`SELECT value FROM "${seeded.tableName}"`)).rows,
+    ).toEqual([{ value: "new" }]);
+  });
+
+  it("serializes a retry already in flight before a successful newer registration", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const seeded = await seedRegisteredFrame("old");
+    server = await createDashframeServer({
+      db: project.db,
+      dataFrameStorage: storage,
+      arrowEngine: engine,
+      flushSnapshotRetentionWindow: async () => {},
+    });
+    await registerFrame(seeded.frameId, seeded.tableName);
+
+    const nativeUnregister = engine.unregisterTable.bind(engine);
+    let unregisterCalls = 0;
+    let markRetryStarted!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    let releaseRetry!: () => void;
+    const retryBlocked = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    vi.spyOn(engine, "unregisterTable").mockImplementation(async (name) => {
+      unregisterCalls += 1;
+      if (unregisterCalls === 1) {
+        throw new Error("injected initial native DROP failure");
+      }
+      if (unregisterCalls === 2) {
+        markRetryStarted();
+        await retryBlocked;
+      }
+      await nativeUnregister(name);
+    });
+
+    const deleted = await fetch(`${server.url}/api/removeDataTable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: seeded.tableId }),
+    });
+    expect(deleted.status).toBe(200);
+    await retryStarted;
+
+    const registering = registerRawTable(seeded.tableName, "new");
+    releaseRetry();
+    expect((await registering).status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(engine.hasTable(seeded.tableName)).toBe(true);
+    expect(
+      (await engine.query(`SELECT value FROM "${seeded.tableName}"`)).rows,
+    ).toEqual([{ value: "new" }]);
+  });
+
+  it("keeps the previous cleanup retry alive when same-name replacement registration fails", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const seeded = await seedRegisteredFrame("old");
+    server = await createDashframeServer({
+      db: project.db,
+      dataFrameStorage: storage,
+      arrowEngine: engine,
+      flushSnapshotRetentionWindow: async () => {},
+    });
+    await registerFrame(seeded.frameId, seeded.tableName);
+    failNextNativeDrop();
+
+    const deleted = await fetch(`${server.url}/api/removeDataTable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: seeded.tableId }),
+    });
+    expect(deleted.status).toBe(200);
+    expect(engine.hasTable(seeded.tableName)).toBe(true);
+
+    vi.spyOn(engine, "registerArrowTable").mockRejectedValueOnce(
+      new Error("injected same-name replacement registration failure"),
+    );
+    const registration = await registerRawTable(
+      seeded.tableName,
+      "replacement",
+    );
+    expect(registration.status).toBe(500);
+
+    await waitUntil(() => !engine.hasTable(seeded.tableName));
+  });
+
+  it("cancels pending unregister retries when the server stops", async () => {
+    project = await openProject({ dir: join(root, "proj") });
+    const seeded = await seedRegisteredFrame("old");
+    server = await createDashframeServer({
+      db: project.db,
+      dataFrameStorage: storage,
+      arrowEngine: engine,
+      flushSnapshotRetentionWindow: async () => {},
+    });
+    await registerFrame(seeded.frameId, seeded.tableName);
+    const connection = (
+      engine as unknown as {
+        connection: { run(sql: string): Promise<unknown> };
+      }
+    ).connection;
+    const drop = vi
+      .spyOn(connection, "run")
+      .mockRejectedValue(new Error("persistent native DROP failure"));
+
+    const deleted = await fetch(`${server.url}/api/removeDataTable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: seeded.tableId }),
+    });
+    expect(deleted.status).toBe(200);
+    expect(drop).toHaveBeenCalledTimes(1);
+
+    server.stop();
+    server = null;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(drop).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("write → subscription invalidation", () => {
   /**
    * Guards the RE-MIRROR POINT documented in app.ts's `call` wrapper.
@@ -1272,6 +1636,179 @@ describe("buildDashframeApp — vault injection seam", () => {
       apiKey: "threaded-key",
     });
     expect(id).toBeTruthy();
+  });
+
+  it("rejects every public draft mutation dispatch before handler effects while preserving query overlays", async () => {
+    const definition = functions.createDataSource;
+    const originalHandler = definition.handler;
+    let handlerDispatches = 0;
+    definition.handler = async (
+      ...args: Parameters<typeof originalHandler>
+    ) => {
+      handlerDispatches++;
+      return originalHandler(...args);
+    };
+    const { vault } = makeTestVault();
+    let storeCallCount = 0;
+    let onWriteCalls = 0;
+    const realStore = vault.store.bind(vault);
+    vault.store = async (...args: Parameters<typeof vault.store>) => {
+      storeCallCount++;
+      return realStore(...args);
+    };
+    try {
+      const app = await buildDashframeApp({
+        db: project.db,
+        vault,
+        onWrite: () => onWriteCalls++,
+      });
+      const controller = createDraftController(app, project.db);
+      const draftId = await controller.openDraft();
+      const [metadataBefore] = await project.db
+        .select()
+        .from(schema.draftMetadata)
+        .where(eq(schema.draftMetadata.draftId, draftId));
+      const principal = { kind: "user" as const, userId: LOCAL_USER_ID };
+      const context = { draftId, principal };
+      const rejectedCallId = crypto.randomUUID();
+      const rejectedRunHandlerId = crypto.randomUUID();
+      const rejectedDraftTrackerId = crypto.randomUUID();
+      const rejectedReplayId = crypto.randomUUID();
+      const rejection =
+        /Direct draft mutation "createDataSource" is not allowed; use draftBatch or DraftController\.appendToDraft/;
+
+      await expect(
+        app.call(
+          "createDataSource",
+          {
+            id: rejectedCallId,
+            type: "notion",
+            name: "call must not reach handler",
+            apiKey: "must-not-be-stored",
+          },
+          context,
+        ),
+      ).rejects.toThrow(rejection);
+      await expect(
+        app.runHandler(
+          "createDataSource",
+          {
+            id: rejectedRunHandlerId,
+            type: "notion",
+            name: "runHandler must not reach handler",
+            apiKey: "must-not-be-stored",
+          },
+          app.createTracked(),
+          context,
+        ),
+      ).rejects.toThrow(rejection);
+      await expect(
+        app.runHandler(
+          "createDataSource",
+          {
+            id: rejectedDraftTrackerId,
+            type: "notion",
+            name: "draft tracker must not reach handler",
+            apiKey: "must-not-be-stored",
+          },
+          app.createTracked().withDraft(draftId),
+          { principal },
+        ),
+      ).rejects.toThrow(rejection);
+
+      const reflectedDispatchSymbol =
+        Reflect.ownKeys(app).find(
+          (key): key is symbol =>
+            typeof key === "symbol" &&
+            key.description === "dashframe.draftControllerDispatch",
+        ) ?? Symbol("dashframe.draftControllerDispatch");
+      const replayedAuthorization = {
+        [reflectedDispatchSymbol]: Reflect.get(app, reflectedDispatchSymbol),
+      };
+      await expect(
+        app.call(
+          "createDataSource",
+          {
+            id: rejectedReplayId,
+            type: "notion",
+            name: "reflected capability replay must not reach handler",
+            apiKey: "must-not-be-stored",
+          },
+          { ...context, ...replayedAuthorization },
+        ),
+      ).rejects.toThrow(rejection);
+      expect(
+        Reflect.ownKeys(app).some(
+          (key) =>
+            typeof key === "symbol" &&
+            key.description === "dashframe.draftControllerDispatch",
+        ),
+      ).toBe(false);
+
+      const rejectedShadows = await project.db
+        .select()
+        .from(schema.dataSourcesDraft)
+        .where(eq(schema.dataSourcesDraft.draftId, draftId));
+      const rejectedLog = await project.db
+        .select()
+        .from(schema.draftCommandLog)
+        .where(eq(schema.draftCommandLog.draftId, draftId));
+      const [metadataAfter] = await project.db
+        .select()
+        .from(schema.draftMetadata)
+        .where(eq(schema.draftMetadata.draftId, draftId));
+      expect(rejectedShadows).toHaveLength(0);
+      expect(rejectedLog).toHaveLength(0);
+      expect(metadataAfter).toEqual(metadataBefore);
+      expect(handlerDispatches).toBe(0);
+      expect(storeCallCount).toBe(0);
+      expect(onWriteCalls).toBe(0);
+
+      const draftedId = crypto.randomUUID();
+      await controller.appendToDraft(
+        draftId,
+        [
+          cmd("CreateDataSource", {
+            id: draftedId,
+            type: "csv",
+            name: "query-visible draft",
+          }),
+        ],
+        { principal },
+      );
+      expect(handlerDispatches).toBe(1);
+
+      const { result: callQuery } = await app.call(
+        "getDataSource",
+        { id: draftedId },
+        context,
+      );
+      const runHandlerQuery = await app.runHandler(
+        "getDataSource",
+        { id: draftedId },
+        app.createTracked(),
+        context,
+      );
+      const draftTrackerQuery = await app.runHandler(
+        "getDataSource",
+        { id: draftedId },
+        app.createTracked().withDraft(draftId),
+        { principal },
+      );
+      const { result: canonical } = await app.call("getDataSource", {
+        id: draftedId,
+      });
+      const expectedDraft = expect.objectContaining({
+        id: draftedId,
+        name: "query-visible draft",
+      });
+      expect(callQuery).toEqual(expectedDraft);
+      expect(runHandlerQuery).toEqual(expectedDraft);
+      expect(draftTrackerQuery).toEqual(expectedDraft);
+      expect(canonical).toBeNull();
+    } finally {
+      definition.handler = originalHandler;
+    }
   });
 });
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -35,12 +35,14 @@
 // when they start (`dashframe serve` does so dynamically); importing this
 // deployment-agnostic app factory remains safe. arrow-data-path has no native
 // dependency.
+import type { DataFrameStorage } from "@dashframe/engine";
 import {
   createArrowDataPath,
   type ArrowQueryRunner,
   type ArrowTableRegistrar,
 } from "@dashframe/engine-server/arrow-data-path";
 import { schema, type ApiAccessCredentials } from "@dashframe/server-core";
+import type { UUID } from "@dashframe/types";
 import { serve as nodeServe } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import type { DraftDrizzleTracker, DrizzleTracker } from "@wystack/db";
@@ -147,6 +149,8 @@ function allowLocalhostOrigin(origin: string): string | undefined {
 export interface DashframeServerOptions {
   /** Project artifact DB — a Drizzle/PGLite instance (e.g. `ProjectHandle.db`). */
   db: object;
+  /** Durable Arrow frame store owned by the selected project. */
+  dataFrameStorage?: DataFrameStorage;
   /** Bind host. Default `127.0.0.1` (loopback). */
   hostname?: string;
   /** Bind port. Default `0` — the OS assigns an ephemeral port. */
@@ -451,6 +455,7 @@ export function withDraftSeam(
  */
 export async function buildDashframeApp(opts: {
   db: object;
+  dataFrameStorage?: DataFrameStorage;
   vault?: SecretVault;
   onWrite?: () => void;
   accessCredentials?: ApiAccessCredentials;
@@ -463,12 +468,34 @@ export async function buildDashframeApp(opts: {
     expectedPermissionIds,
   });
 
+  if (opts.dataFrameStorage != null) {
+    // No requests can be in flight yet, so startup is the safe point to repair
+    // a crash-interrupted delete and remove files with no persisted owner.
+    await removeUnreferencedServerFrames(
+      opts.db as ArtifactDb,
+      opts.dataFrameStorage,
+    );
+  }
+
   const { vault, onWrite } = opts;
 
   // Build the static context additions once so every call shares the same object
   // reference (vault identity is stable for the server lifetime).
   const staticContext: AppContext = {
     getServerEndpoint: opts.getServerEndpoint ?? (() => undefined),
+    ...(opts.dataFrameStorage != null
+      ? {
+          dataFrameStorage: opts.dataFrameStorage,
+          captureServerFrameReferences: () =>
+            referencedServerFrameIds(opts.db as ArtifactDb),
+          cleanupDereferencedServerFrames: (before: ReadonlySet<string>) =>
+            removeDereferencedServerFrames(
+              opts.db as ArtifactDb,
+              opts.dataFrameStorage!,
+              before,
+            ),
+        }
+      : {}),
     ...(opts.accessCredentials != null
       ? { accessCredentials: opts.accessCredentials }
       : {}),
@@ -498,10 +525,25 @@ export async function buildDashframeApp(opts: {
       const merged = { ...(context ?? {}), ...staticContext };
       const tracked = rawApp.createTracked();
       const effective = withDraftSeam(tracked, merged);
+      const framesBefore =
+        opts.dataFrameStorage != null
+          ? await referencedServerFrameIds(opts.db as ArtifactDb)
+          : undefined;
       const result = await rawApp.runHandler(path, args, effective, merged);
       // `tracked` and `effective` share the same tracker sets (withDraft reuses
       // the base tracker), so tablesWritten reflects the write either way.
       const tablesWritten = tracked.tablesWritten;
+      if (
+        opts.dataFrameStorage != null &&
+        framesBefore != null &&
+        tablesWritten.size > 0
+      ) {
+        await removeDereferencedServerFrames(
+          opts.db as ArtifactDb,
+          opts.dataFrameStorage,
+          framesBefore,
+        );
+      }
       if (onWrite != null && tablesWritten.size > 0) {
         try {
           onWrite();
@@ -521,6 +563,54 @@ export async function buildDashframeApp(opts: {
       return rawApp.runHandler(path, args, effective, merged);
     },
   };
+}
+
+async function removeUnreferencedServerFrames(
+  db: ArtifactDb,
+  storage: DataFrameStorage,
+): Promise<void> {
+  const referenced = await referencedServerFrameIds(db);
+  await storage.recoverStagedDeletes?.([...referenced] as UUID[]);
+  const ids = await storage.list();
+  await Promise.all(
+    ids.filter((id) => !referenced.has(id)).map((id) => storage.delete(id)),
+  );
+}
+
+async function removeDereferencedServerFrames(
+  db: ArtifactDb,
+  storage: DataFrameStorage,
+  before: ReadonlySet<string>,
+): Promise<void> {
+  const after = await referencedServerFrameIds(db);
+  const results = await Promise.allSettled(
+    [...before]
+      .filter((id) => !after.has(id))
+      .map((id) => storage.delete(id as UUID)),
+  );
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    console.error(
+      `[dashframe] ${failures.length} dereferenced server frame(s) could not be removed; startup recovery will retry`,
+      failures.map(({ reason }) => reason),
+    );
+  }
+}
+
+async function referencedServerFrameIds(db: ArtifactDb): Promise<Set<string>> {
+  const rows = (await db.select().from(schema.dataFrames)) as Array<{
+    storage: unknown;
+  }>;
+  return new Set(
+    rows.flatMap((row) => {
+      const location = row.storage as { type?: string; key?: string };
+      return location.type === "file" && typeof location.key === "string"
+        ? [location.key]
+        : [];
+    }),
+  );
 }
 
 /**
@@ -665,6 +755,7 @@ export async function createDashframeServer(
   // to fire `opts.onWrite` after every successful mutation.
   const vaultWrapped = await buildDashframeApp({
     db: opts.db,
+    dataFrameStorage: opts.dataFrameStorage,
     vault: opts.vault,
     onWrite: opts.onWrite,
     accessCredentials: opts.accessCredentials,
@@ -822,6 +913,7 @@ export async function createDashframeServer(
       "/data",
       createArrowDataPath({
         engine: opts.arrowEngine,
+        dataFrameStorage: opts.dataFrameStorage,
         ...(opts.authRef && opts.vault
           ? { authRef: opts.authRef, vault: opts.vault }
           : { authToken: opts.authToken }),

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -53,7 +53,7 @@ import {
 } from "@wystack/secret-vault";
 import { createRoutes, type WyStackApp } from "@wystack/server";
 import type { Table } from "drizzle-orm";
-import { getTableName } from "drizzle-orm";
+import { eq as drizzleEq, getTableName } from "drizzle-orm";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { createHash, timingSafeEqual } from "node:crypto";
@@ -74,6 +74,7 @@ import {
 } from "./connector-setup/oauth-provider";
 import { captureCommandCredentials } from "./credential-release";
 import {
+  consumeOperatedDraftDispatch,
   createDraftController,
   type DraftController,
 } from "./draft-controller";
@@ -274,6 +275,149 @@ export interface DashframeServer {
   stop(): void;
 }
 
+const NATIVE_UNREGISTER_MAX_ATTEMPTS = 3;
+const NATIVE_UNREGISTER_RETRY_MS = 250;
+
+/**
+ * Owns native table registration generations and bounded post-commit cleanup.
+ *
+ * A generation advances only after registration succeeds. Cleanup captures the
+ * current generation and re-checks it inside the same per-name operation queue
+ * used by registration. Therefore a failed replacement leaves the prior
+ * generation's cleanup live, while a successful replacement makes stale
+ * cleanup a no-op before it can drop the newer table.
+ */
+class NativeTableLifecycle {
+  readonly engine: ArrowQueryRunner & Partial<ArrowTableRegistrar>;
+  private readonly generations = new Map<string, number>();
+  private readonly operations = new Map<string, Promise<void>>();
+  private readonly retryTimers = new Map<
+    string,
+    { generation: number; timer: ReturnType<typeof setTimeout> }
+  >();
+  private closed = false;
+
+  constructor(
+    private readonly native: ArrowQueryRunner & Partial<ArrowTableRegistrar>,
+  ) {
+    this.engine = {
+      queryArrow: (sql, params) => native.queryArrow(sql, params),
+      ...(typeof native.registerArrowTable === "function"
+        ? {
+            registerArrowTable: (name: string, arrow: Uint8Array) =>
+              this.register(name, arrow),
+          }
+        : {}),
+      ...(typeof native.unregisterTable === "function"
+        ? { unregisterTable: (name: string) => this.unregisterCurrent(name) }
+        : {}),
+    };
+  }
+
+  async unregisterCommittedFrames(ids: readonly string[]): Promise<void> {
+    if (typeof this.native.unregisterTable !== "function") return;
+    await Promise.all(
+      ids.map((id) => {
+        const name = `df_${id.replaceAll("-", "_")}`;
+        return this.tryUnregister(name, this.generation(name), 1);
+      }),
+    );
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const { timer } of this.retryTimers.values()) clearTimeout(timer);
+    this.retryTimers.clear();
+  }
+
+  private generation(name: string): number {
+    return this.generations.get(name) ?? 0;
+  }
+
+  private async register(name: string, arrow: Uint8Array): Promise<void> {
+    if (this.closed) throw new Error("Native table lifecycle is closed");
+    await this.enqueue(name, async () => {
+      if (this.closed) throw new Error("Native table lifecycle is closed");
+      await this.native.registerArrowTable!(name, arrow);
+      this.generations.set(name, this.generation(name) + 1);
+      this.cancelRetry(name);
+    });
+  }
+
+  private async unregisterCurrent(name: string): Promise<void> {
+    if (typeof this.native.unregisterTable !== "function") return;
+    const generation = this.generation(name);
+    await this.enqueue(name, async () => {
+      if (this.closed || this.generation(name) !== generation) return;
+      await this.native.unregisterTable!(name);
+    });
+  }
+
+  private async tryUnregister(
+    name: string,
+    generation: number,
+    attempt: number,
+  ): Promise<void> {
+    try {
+      await this.enqueue(name, async () => {
+        if (this.closed || this.generation(name) !== generation) return;
+        await this.native.unregisterTable!(name);
+      });
+    } catch (error) {
+      if (this.closed || this.generation(name) !== generation) return;
+      if (attempt >= NATIVE_UNREGISTER_MAX_ATTEMPTS) {
+        console.error(
+          `[dashframe] native table ${name} remains registered after ${attempt} cleanup attempts`,
+          error,
+        );
+        return;
+      }
+      console.error(
+        `[dashframe] native table ${name} unregister failed after durable frame deletion; retrying (${attempt + 1}/${NATIVE_UNREGISTER_MAX_ATTEMPTS})`,
+        error,
+      );
+      this.scheduleRetry(name, generation, attempt + 1);
+    }
+  }
+
+  private scheduleRetry(
+    name: string,
+    generation: number,
+    attempt: number,
+  ): void {
+    this.cancelRetry(name);
+    const timer = setTimeout(() => {
+      const pending = this.retryTimers.get(name);
+      if (pending?.generation !== generation) return;
+      this.retryTimers.delete(name);
+      this.tryUnregister(name, generation, attempt).catch((error) => {
+        console.error("[dashframe] native unregister retry failed", error);
+      });
+    }, NATIVE_UNREGISTER_RETRY_MS);
+    this.retryTimers.set(name, { generation, timer });
+  }
+
+  private cancelRetry(name: string): void {
+    const pending = this.retryTimers.get(name);
+    if (pending) clearTimeout(pending.timer);
+    this.retryTimers.delete(name);
+  }
+
+  private enqueue(name: string, operation: () => Promise<void>): Promise<void> {
+    const previous = this.operations.get(name) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const settled = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.operations.set(name, settled);
+    settled.then(() => {
+      if (this.operations.get(name) === settled) this.operations.delete(name);
+    });
+    return current;
+  }
+}
+
 /**
  * Pull a draft handle out of a handler context. A `draftId` in the context bag
  * means "execute this write into the draft overlay, not canonical." Returns the
@@ -439,9 +583,8 @@ export function withDraftSeam(
  *
  *   2. The draft controller's `appendToDraft` — routes writes through a
  *      `withDraft(draftId)` handle, so every `ctx.db.into/update/delete` lands in
- *      `<table>__draft` shadow tables. Draft writes are not canonical; `onWrite`
- *      drives canonical snapshot persistence and must NOT fire for draft-overlay
- *      writes.
+ *      `<table>__draft` shadow tables. This wrapper must not fire `onWrite` per
+ *      handler: the owning draft RPC aggregates the whole durable transition.
  *
  * When the controller's `publishDraft` replays the log via
  * `applyCommands(app, log, { mode: 'commit' })` and returns a `CommitResult` with
@@ -520,11 +663,11 @@ export async function buildDashframeApp(opts: {
       : {}),
   };
 
-  // The draft seam wraps `call` itself (not just runHandler): `rawApp.call`
-  // mints its own fresh DrizzleTracker internally, so a draftId-bearing `call` would
-  // otherwise hit canonical. We mirror rawApp.call's composition (fresh tracked
-  // → runHandler → result shape) but pass the draft-scoped handle when a draftId
-  // is present, leaving the no-draft path identical to rawApp.call.
+  // One shared dispatcher backs both public handler entry points. `call` asks it
+  // to mint a tracker lazily; `runHandler` supplies one. Draft-mutation safety is
+  // therefore decided once, before tracker creation or a supplied tracker's use,
+  // and before withDraftSeam or handler dispatch. DraftController marks its
+  // operated shadow+log transition through a module-private async scope.
   //
   // EQUIVALENCE (load-bearing): rawApp.call is a THIN composition — `const t =
   // createTracked(); const result = await runHandler(path, args, t, context);
@@ -534,25 +677,71 @@ export async function buildDashframeApp(opts: {
   // on the no-draft path. RE-MIRROR POINT: if a wystack upgrade adds logic INSIDE
   // rawApp.call, this wrapper must be updated to match — it cannot delegate to
   // rawApp.call because that path mints an internal tracker the seam can't reach.
-  return {
+  async function dispatchHandler(
+    path: string,
+    args: unknown,
+    context: Record<string, unknown> | undefined,
+    suppliedTracker?: DrizzleTracker | DraftDrizzleTracker,
+    beforeHandler?: () => Promise<void>,
+  ): Promise<{
+    result: unknown;
+    tracked: DrizzleTracker | DraftDrizzleTracker;
+  }> {
+    const merged = { ...(context ?? {}), ...staticContext };
+    const isSuppliedDraftTracker =
+      suppliedTracker !== undefined && !("withDraft" in suppliedTracker);
+    const isDraftScoped =
+      draftIdFromContext(merged) !== undefined || isSuppliedDraftTracker;
+    const isDraftMutation =
+      rawApp.functions.get(path)?.type === "mutation" && isDraftScoped;
+    const isOperatedDraftMutation =
+      isDraftMutation &&
+      suppliedTracker !== undefined &&
+      consumeOperatedDraftDispatch(path, suppliedTracker);
+    if (isDraftMutation && !isOperatedDraftMutation) {
+      throw new Error(
+        `Direct draft mutation "${path}" is not allowed; use draftBatch or ` +
+          "DraftController.appendToDraft so shadow state and the command log remain atomic",
+      );
+    }
+
+    const tracked = suppliedTracker ?? rawApp.createTracked();
+    await beforeHandler?.();
+    const effective = withDraftSeam(tracked, merged);
+    const result = await rawApp.runHandler(path, args, effective, merged);
+    return { result, tracked };
+  }
+
+  const app: WyStackApp = {
     ...rawApp,
     async call(path, args, context) {
-      // Static context wins over per-request context: spread per-request first
-      // so static keys (vault) cannot be shadowed by a crafted request context.
-      const merged = { ...(context ?? {}), ...staticContext };
-      const tracked = rawApp.createTracked();
-      const effective = withDraftSeam(tracked, merged);
-      const framesBefore =
-        opts.dataFrameStorage != null
-          ? await referencedServerFrameIds(opts.db as ArtifactDb)
-          : undefined;
-      const result = await rawApp.runHandler(path, args, effective, merged);
+      let serverFrameCleanupHandled = false;
+      const dispatchContext = {
+        ...(context ?? {}),
+        markServerFrameCleanupHandled: () => {
+          serverFrameCleanupHandled = true;
+        },
+      };
+      let framesBefore: Set<string> | undefined;
+      const { result, tracked } = await dispatchHandler(
+        path,
+        args,
+        dispatchContext,
+        undefined,
+        async () => {
+          framesBefore =
+            opts.dataFrameStorage != null
+              ? await referencedServerFrameIds(opts.db as ArtifactDb)
+              : undefined;
+        },
+      );
       // `tracked` and `effective` share the same tracker sets (withDraft reuses
       // the base tracker), so tablesWritten reflects the write either way.
       const tablesWritten = tracked.tablesWritten;
       if (
         opts.dataFrameStorage != null &&
         framesBefore != null &&
+        !serverFrameCleanupHandled &&
         tablesWritten.size > 0
       ) {
         await removeDereferencedServerFrames(
@@ -577,11 +766,10 @@ export async function buildDashframeApp(opts: {
       };
     },
     async runHandler(path, args, tracked, context) {
-      const merged = { ...(context ?? {}), ...staticContext };
-      const effective = withDraftSeam(tracked, merged);
-      return rawApp.runHandler(path, args, effective, merged);
+      return (await dispatchHandler(path, args, context, tracked)).result;
     },
   };
+  return app;
 }
 
 async function removeUnreferencedServerFrames(
@@ -590,6 +778,14 @@ async function removeUnreferencedServerFrames(
   flushSnapshotRetentionWindow: (() => Promise<void>) | undefined,
 ): Promise<void> {
   const referenced = await referencedServerFrameIds(db);
+  const pendingDeletes =
+    (await storage.hasPendingDataFrameDeletes?.()) ?? false;
+  const storedIds = await storage.list();
+  const hasUnreferencedFrames = storedIds.some((id) => !referenced.has(id));
+  if (!pendingDeletes && !hasUnreferencedFrames) {
+    await storage.recoverStagedDeletes?.([...referenced] as UUID[]);
+    return;
+  }
   if (flushSnapshotRetentionWindow == null) {
     console.error(
       "[dashframe] no retained-snapshot flush hook; leaving server frame cleanup for a configured startup",
@@ -661,7 +857,17 @@ async function optsUnregisterSuccessful(
   const removed = ids.filter(
     (_, index) => results[index]?.status === "fulfilled",
   );
-  if (removed.length > 0) await unregister?.(removed);
+  if (removed.length === 0 || unregister == null) return;
+  try {
+    await unregister(removed);
+  } catch (error) {
+    // File deletion is already committed. A runtime-native cleanup failure
+    // cannot make the durable mutation untrue or suppress its onWrite hook.
+    console.error(
+      "[dashframe] native unregister failed after durable frame deletion; runtime cleanup will retry when configured",
+      error,
+    );
+  }
 }
 
 async function referencedServerFrameIds(db: ArtifactDb): Promise<Set<string>> {
@@ -743,6 +949,9 @@ export async function createDashframeServer(
   const userId = LOCAL_USER_ID;
   const serverState: { endpoint?: string } = {};
   const googleOAuth = opts.googleOAuth ?? readOptionalGoogleOAuthConfig();
+  const nativeTables = opts.arrowEngine
+    ? new NativeTableLifecycle(opts.arrowEngine)
+    : undefined;
 
   // Resolve the auth context builder: vault-backed ref takes priority over
   // plaintext token. Both produce the same (req) → context shape for WyStack.
@@ -825,14 +1034,8 @@ export async function createDashframeServer(
     onWrite: opts.onWrite,
     flushSnapshot: opts.flushSnapshot,
     flushSnapshotRetentionWindow: opts.flushSnapshotRetentionWindow,
-    unregisterServerFrames: async (ids) => {
-      if (typeof opts.arrowEngine?.unregisterTable !== "function") return;
-      await Promise.all(
-        ids.map((id) =>
-          opts.arrowEngine!.unregisterTable!(`df_${id.replaceAll("-", "_")}`),
-        ),
-      );
-    },
+    unregisterServerFrames: (ids) =>
+      nativeTables?.unregisterCommittedFrames(ids) ?? Promise.resolve(),
     accessCredentials: opts.accessCredentials,
     getServerEndpoint: () => serverState.endpoint,
     googleOAuth,
@@ -983,12 +1186,23 @@ export async function createDashframeServer(
   // Mount the dedicated Arrow IPC data path *before* the WyStack catch-all
   // route, so `/data/arrow` is served by the binary path, not WyStack. This is
   // the hard metadata/data boundary: WyStack frames never carry Arrow bytes.
-  if (opts.arrowEngine) {
+  if (nativeTables) {
     honoApp.route(
       "/data",
       createArrowDataPath({
-        engine: opts.arrowEngine,
+        engine: nativeTables.engine,
         dataFrameStorage: opts.dataFrameStorage,
+        isFrameAvailable: async (id) => {
+          const rows = await (opts.db as ArtifactDb)
+            .select({ storage: schema.dataFrames.storage })
+            .from(schema.dataFrames)
+            .where(drizzleEq(schema.dataFrames.id, id))
+            .limit(1);
+          const location = rows[0]?.storage as
+            | { type?: string; key?: string }
+            | undefined;
+          return location?.type === "file" && location.key === id;
+        },
         ...(opts.authRef && opts.vault
           ? { authRef: opts.authRef, vault: opts.vault }
           : { authToken: opts.authToken }),
@@ -1043,7 +1257,10 @@ export async function createDashframeServer(
   return {
     url: `http://${hostname}:${port}`,
     port,
-    stop: () => server.close(),
+    stop: () => {
+      nativeTables?.close();
+      server.close();
+    },
   };
 }
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -226,6 +226,8 @@ export interface DashframeServerOptions {
    * debounced `onWrite` behaviour in that case (existing semantics).
    */
   flushSnapshot?: () => Promise<void>;
+  /** Drain retained DB snapshots before deleting snapshot-owned frame bytes. */
+  flushSnapshotRetentionWindow?: () => Promise<void>;
   /** Google OAuth client settings used by resumable connector setup. */
   googleOAuth?: GoogleOAuthConfig;
   /**
@@ -458,6 +460,9 @@ export async function buildDashframeApp(opts: {
   dataFrameStorage?: DataFrameStorage;
   vault?: SecretVault;
   onWrite?: () => void;
+  flushSnapshot?: () => Promise<void>;
+  flushSnapshotRetentionWindow?: () => Promise<void>;
+  unregisterServerFrames?: (ids: readonly string[]) => Promise<void>;
   accessCredentials?: ApiAccessCredentials;
   getServerEndpoint?: () => string | undefined;
   googleOAuth?: GoogleOAuthConfig;
@@ -474,6 +479,7 @@ export async function buildDashframeApp(opts: {
     await removeUnreferencedServerFrames(
       opts.db as ArtifactDb,
       opts.dataFrameStorage,
+      opts.flushSnapshotRetentionWindow,
     );
   }
 
@@ -493,6 +499,8 @@ export async function buildDashframeApp(opts: {
               opts.db as ArtifactDb,
               opts.dataFrameStorage!,
               before,
+              opts.flushSnapshotRetentionWindow,
+              opts.unregisterServerFrames,
             ),
         }
       : {}),
@@ -501,6 +509,15 @@ export async function buildDashframeApp(opts: {
       : {}),
     ...(vault != null ? { vault } : {}),
     ...(opts.googleOAuth != null ? { googleOAuth: opts.googleOAuth } : {}),
+    ...(opts.flushSnapshot != null
+      ? { flushSnapshot: opts.flushSnapshot }
+      : {}),
+    ...(opts.flushSnapshotRetentionWindow != null
+      ? { flushSnapshotRetentionWindow: opts.flushSnapshotRetentionWindow }
+      : {}),
+    ...(opts.unregisterServerFrames != null
+      ? { unregisterServerFrames: opts.unregisterServerFrames }
+      : {}),
   };
 
   // The draft seam wraps `call` itself (not just runHandler): `rawApp.call`
@@ -542,6 +559,8 @@ export async function buildDashframeApp(opts: {
           opts.db as ArtifactDb,
           opts.dataFrameStorage,
           framesBefore,
+          opts.flushSnapshotRetentionWindow,
+          opts.unregisterServerFrames,
         );
       }
       if (onWrite != null && tablesWritten.size > 0) {
@@ -568,26 +587,61 @@ export async function buildDashframeApp(opts: {
 async function removeUnreferencedServerFrames(
   db: ArtifactDb,
   storage: DataFrameStorage,
+  flushSnapshotRetentionWindow: (() => Promise<void>) | undefined,
 ): Promise<void> {
   const referenced = await referencedServerFrameIds(db);
+  if (flushSnapshotRetentionWindow == null) {
+    console.error(
+      "[dashframe] no retained-snapshot flush hook; leaving server frame cleanup for a configured startup",
+    );
+    return;
+  }
+  await flushSnapshotRetentionWindow();
   await storage.recoverStagedDeletes?.([...referenced] as UUID[]);
   const ids = await storage.list();
-  await Promise.all(
+  const results = await Promise.allSettled(
     ids.filter((id) => !referenced.has(id)).map((id) => storage.delete(id)),
   );
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    console.error(
+      `[dashframe] ${failures.length} unreferenced server frame(s) could not be removed at startup; the next start will retry`,
+      failures.map(({ reason }) => reason),
+    );
+  }
 }
 
 async function removeDereferencedServerFrames(
   db: ArtifactDb,
   storage: DataFrameStorage,
   before: ReadonlySet<string>,
+  flushSnapshotRetentionWindow: (() => Promise<void>) | undefined,
+  unregister: ((ids: readonly string[]) => Promise<void>) | undefined,
 ): Promise<void> {
   const after = await referencedServerFrameIds(db);
+  const dereferenced = [...before].filter((id) => !after.has(id));
+  if (dereferenced.length === 0) return;
+  if (flushSnapshotRetentionWindow == null) {
+    console.error(
+      "[dashframe] no retained-snapshot flush hook; leaving dereferenced server frames for startup recovery",
+    );
+    return;
+  }
+  try {
+    await flushSnapshotRetentionWindow();
+  } catch (error) {
+    console.error(
+      "[dashframe] snapshot flush failed; leaving dereferenced server frames for startup recovery",
+      error,
+    );
+    return;
+  }
   const results = await Promise.allSettled(
-    [...before]
-      .filter((id) => !after.has(id))
-      .map((id) => storage.delete(id as UUID)),
+    dereferenced.map((id) => storage.delete(id as UUID)),
   );
+  await optsUnregisterSuccessful(results, dereferenced, unregister);
   const failures = results.filter(
     (result): result is PromiseRejectedResult => result.status === "rejected",
   );
@@ -599,10 +653,21 @@ async function removeDereferencedServerFrames(
   }
 }
 
+async function optsUnregisterSuccessful(
+  results: PromiseSettledResult<void>[],
+  ids: string[],
+  unregister: ((ids: readonly string[]) => Promise<void>) | undefined,
+): Promise<void> {
+  const removed = ids.filter(
+    (_, index) => results[index]?.status === "fulfilled",
+  );
+  if (removed.length > 0) await unregister?.(removed);
+}
+
 async function referencedServerFrameIds(db: ArtifactDb): Promise<Set<string>> {
-  const rows = (await db.select().from(schema.dataFrames)) as Array<{
-    storage: unknown;
-  }>;
+  const rows = (await db
+    .select({ storage: schema.dataFrames.storage })
+    .from(schema.dataFrames)) as Array<{ storage: unknown }>;
   return new Set(
     rows.flatMap((row) => {
       const location = row.storage as { type?: string; key?: string };
@@ -758,6 +823,16 @@ export async function createDashframeServer(
     dataFrameStorage: opts.dataFrameStorage,
     vault: opts.vault,
     onWrite: opts.onWrite,
+    flushSnapshot: opts.flushSnapshot,
+    flushSnapshotRetentionWindow: opts.flushSnapshotRetentionWindow,
+    unregisterServerFrames: async (ids) => {
+      if (typeof opts.arrowEngine?.unregisterTable !== "function") return;
+      await Promise.all(
+        ids.map((id) =>
+          opts.arrowEngine!.unregisterTable!(`df_${id.replaceAll("-", "_")}`),
+        ),
+      );
+    },
     accessCredentials: opts.accessCredentials,
     getServerEndpoint: () => serverState.endpoint,
     googleOAuth,

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -80,6 +80,7 @@ import {
   type WyStackApp,
 } from "@wystack/server";
 import { eq, getTableName, sql } from "drizzle-orm";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 import {
   assertPublishLogHasNoLateBound,
@@ -87,6 +88,37 @@ import {
 } from "./draft-late-bound";
 import { computeLogSignature } from "./draft-log-signature";
 import { assertKnownCommandPaths } from "./functions/commands";
+
+type OperatedDraftDispatch = {
+  consumed: boolean;
+  path: string;
+  tracker: Parameters<WyStackApp["runHandler"]>[2];
+};
+
+const operatedDraftDispatchScope =
+  new AsyncLocalStorage<OperatedDraftDispatch>();
+
+/**
+ * @internal Consumes the single dispatch opened by DraftController. The scope
+ * and its enter operation stay module-private, so importing this check cannot
+ * mint, copy, or replay authorization.
+ */
+export function consumeOperatedDraftDispatch(
+  path: string,
+  tracker: Parameters<WyStackApp["runHandler"]>[2],
+): boolean {
+  const dispatch = operatedDraftDispatchScope.getStore();
+  if (
+    dispatch == null ||
+    dispatch.consumed ||
+    dispatch.path !== path ||
+    dispatch.tracker !== tracker
+  ) {
+    return false;
+  }
+  dispatch.consumed = true;
+  return true;
+}
 
 /**
  * The closed set of `<table>__draft` shadows a draft can touch. Discard
@@ -1153,11 +1185,19 @@ export function createDraftController(
           // producing it only after the batch-level check already passed.
           assertKnownCommandPaths([captured.command], "appendToDraft");
           captureRollbacks.push(captured.rollback);
-          const value = await app.runHandler(
-            captured.command.path,
-            captured.command.args,
-            baseDb,
-            draftContext,
+          const value = await operatedDraftDispatchScope.run(
+            {
+              consumed: false,
+              path: captured.command.path,
+              tracker: baseDb,
+            },
+            () =>
+              app.runHandler(
+                captured.command.path,
+                captured.command.args,
+                baseDb,
+                draftContext,
+              ),
           );
           ranSnapshots.push(structuredClone(captured.command) as DraftCommand);
           results.push({ id: captured.command.id, value });

--- a/apps/server/src/functions/app-artifacts.test.ts
+++ b/apps/server/src/functions/app-artifacts.test.ts
@@ -276,6 +276,82 @@ describe("privacy floor — no raw sampleValues persist in artifact DB", () => {
       lastRefreshedAt: refreshedAt,
     });
   });
+
+  it("rejects a client-authored server frame alias on insert", async () => {
+    const id = crypto.randomUUID();
+    await expect(
+      call("putDataFrameEntry", {
+        entry: {
+          ...makeDataFrameEntry(id),
+          storage: { type: "file", key: crypto.randomUUID() },
+        },
+      }),
+    ).rejects.toThrow("Server frame storage is server-owned");
+    expect(await db.select().from(dataFrames)).toEqual([]);
+  });
+
+  it("rejects client-authored file storage even when key matches the row id", async () => {
+    const id = crypto.randomUUID();
+    await expect(
+      call("putDataFrameEntry", {
+        entry: {
+          ...makeDataFrameEntry(id),
+          storage: { type: "file", key: id },
+        },
+      }),
+    ).rejects.toThrow("Server frame storage is server-owned");
+  });
+
+  it("does not let a public update convert a server-owned frame", async () => {
+    const id = crypto.randomUUID();
+    await db.insert(dataFrames).values({
+      id,
+      storage: { type: "file", key: id },
+      fieldIds: [],
+      name: "server frame",
+    });
+
+    await expect(
+      call("updateDataFrameEntry", {
+        id,
+        updates: { storage: { type: "indexeddb", key: `arrow-${id}` } },
+      }),
+    ).rejects.toThrow("Server frame storage cannot be changed");
+    expect((await db.select().from(dataFrames))[0]?.storage).toEqual({
+      type: "file",
+      key: id,
+    });
+  });
+
+  it("does not let public put replace a server-owned frame's storage", async () => {
+    const id = crypto.randomUUID();
+    await db.insert(dataFrames).values({
+      id,
+      storage: { type: "file", key: id },
+      fieldIds: [],
+      name: "server frame",
+    });
+    await expect(
+      call("putDataFrameEntry", {
+        entry: makeDataFrameEntry(id),
+      }),
+    ).rejects.toThrow("Server frame storage cannot be changed");
+  });
+
+  it("rejects changing a DataFrame to another server frame's key", async () => {
+    const id = crypto.randomUUID();
+    await call("putDataFrameEntry", { entry: makeDataFrameEntry(id) });
+
+    await expect(
+      call("updateDataFrameEntry", {
+        id,
+        updates: { storage: { type: "file", key: crypto.randomUUID() } },
+      }),
+    ).rejects.toThrow("Server frame storage is server-owned");
+
+    const [stored] = await db.select().from(dataFrames);
+    expect(stored?.storage).toEqual({ type: "indexeddb", key: `arrow-${id}` });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -423,17 +423,25 @@ const removeDataSource = wy.procedure
     // keychain side-effect outside the DB transaction. A preview executes then
     // rolls back: the row (with its refs) survives, so its credential must too.
     const source = await ctx.db.from(dataSources).where(eq("id", id)).first();
-    const ownedTables = (await ctx.db
-      .from(dataTables)
-      .where(eq("dataSourceId", id))
-      .all()) as DataTableRow[];
-    const ownedFrames = await framesForDefinitions(
-      ctx,
-      ownedTables.map((table) => table.id),
-    );
-    const staged = await stageServerFrames(ctx, ownedFrames);
+    let staged: StagedServerFrame[] = [];
     try {
       await ctx.db.transaction(async (tx) => {
+        const ownedTables = (await tx
+          .from(dataTables)
+          .where(eq("dataSourceId", id))
+          .all()) as DataTableRow[];
+        const candidateFrames = await framesByIds(
+          { ...ctx, db: tx },
+          ownedTables.flatMap((table) =>
+            table.dataFrameId ? [table.dataFrameId] : [],
+          ),
+        );
+        const ownedFrames = await framesUnreferencedOutsideTables(
+          { ...ctx, db: tx },
+          candidateFrames,
+          new Set(ownedTables.map((table) => table.id)),
+        );
+        staged = await stageServerFrames(ctx, ownedFrames);
         for (const frame of ownedFrames) {
           await tx.from(dataFrames).where(eq("id", frame.id)).delete();
         }
@@ -553,10 +561,23 @@ const removeDataTable = wy.procedure
   .input({ id: uuid })
   .mutation(async (ctx, { id }): Promise<{ ok: true }> => {
     assertCanonicalFrameSideEffects(ctx);
-    const frames = await framesForDefinitions(ctx, [id]);
-    const staged = await stageServerFrames(ctx, frames);
+    let staged: StagedServerFrame[] = [];
     try {
       await ctx.db.transaction(async (tx) => {
+        const table = (await tx
+          .from(dataTables)
+          .where(eq("id", id))
+          .first()) as DataTableRow | undefined;
+        const candidates = await framesByIds(
+          { ...ctx, db: tx },
+          table?.dataFrameId ? [table.dataFrameId] : [],
+        );
+        const frames = await framesUnreferencedOutsideTables(
+          { ...ctx, db: tx },
+          candidates,
+          new Set([id]),
+        );
+        staged = await stageServerFrames(ctx, frames);
         for (const frame of frames) {
           await tx.from(dataFrames).where(eq("id", frame.id)).delete();
         }
@@ -656,6 +677,12 @@ const putDataFrameEntry = wy.procedure
   .input({ entry: jsonb })
   .mutation(async (ctx, { entry }): Promise<{ id: string }> => {
     const value = entry as DataFrameEntry;
+    const existing = (await ctx.db
+      .from(dataFrames)
+      .where(eq("id", value.id))
+      .first()) as DataFrameRow | undefined;
+    assertExistingServerFrameImmutable(existing, value.storage);
+    assertServerFrameOwnership(value.id, value.storage);
     // Strip raw sample values before persisting — privacy floor: the artifact
     // DB holds zero raw cell values. In-memory callers that need sampleValues
     // (e.g. the suggest-mode PII classifier) operate on the runtime object
@@ -678,10 +705,6 @@ const putDataFrameEntry = wy.procedure
       analysis: safeAnalysis,
       lastRefreshedAt: nullableDateFromEpoch(value.lastRefreshedAt),
     };
-    const existing = (await ctx.db
-      .from(dataFrames)
-      .where(eq("id", value.id))
-      .first()) as DataFrameRow | undefined;
     if (existing) {
       await ctx.db.from(dataFrames).where(eq("id", value.id)).update(row);
     } else {
@@ -694,6 +717,14 @@ const updateDataFrameEntry = wy.procedure
   .input({ id: uuid, updates: jsonb })
   .mutation(async (ctx, { id, updates }): Promise<{ ok: true }> => {
     const patch = updates as Partial<DataFrameEntry>;
+    if (patch.storage !== undefined) {
+      const existing = (await ctx.db
+        .from(dataFrames)
+        .where(eq("id", id))
+        .first()) as DataFrameRow | undefined;
+      assertExistingServerFrameImmutable(existing, patch.storage);
+      assertServerFrameOwnership(id, patch.storage);
+    }
     await ctx.db
       .from(dataFrames)
       .where(eq("id", id))
@@ -745,6 +776,10 @@ const removeDataFrameEntry = wy.procedure
     const staged = await stageServerFrames(ctx, row ? [row] : []);
     try {
       await ctx.db.transaction(async (tx) => {
+        await tx
+          .from(dataTables)
+          .where(eq("dataFrameId", id))
+          .update({ dataFrameId: null, lastFetchedAt: null });
         await tx.from(dataFrames).where(eq("id", id)).delete();
       });
     } catch (error) {
@@ -1189,12 +1224,12 @@ const listNotionDatabases = wy.procedure
   });
 
 /**
- * Serializable Notion inspection/materialization result. Inspection returns
- * schema only; reviewed materialization also returns an opaque frame handle.
+ * Serializable Notion inspection/import result. Inspection returns schema
+ * only; a reviewed import or refresh also returns the current DataFrame ID.
  * Row bytes never cross the client boundary.
  */
 type NotionQueryResult = {
-  frameHandle?: UUID;
+  dataFrameId?: UUID;
   fieldIds: string[];
   fields: Field[];
   rowCount: number;
@@ -1216,9 +1251,9 @@ async function persistConnectorFrame(
   if (!storage) {
     throw new Error("Server DataFrame storage is not configured");
   }
-  const frameHandle = randomUUID() as UUID;
+  const dataFrameId = randomUUID() as UUID;
   await storage.save(
-    frameHandle,
+    dataFrameId,
     new Uint8Array(Buffer.from(args.arrowBuffer, "base64")),
   );
   let stagedPrevious: StagedServerFrame[] = [];
@@ -1227,7 +1262,7 @@ async function persistConnectorFrame(
       // Ownership validation and replacement discovery belong inside the same
       // serialized DB transaction as the link update. Otherwise a concurrent
       // DeleteNode or refresh can invalidate an earlier read and leave an
-      // unowned or duplicate materialization behind.
+      // unowned or duplicate snapshot behind.
       const table = (await tx
         .from(dataTables)
         .where(eq("id", args.tableId))
@@ -1238,14 +1273,19 @@ async function persistConnectorFrame(
           `DataTable ${args.tableId} does not belong to DataSource ${args.dataSourceId}`,
         );
       }
-      const previous = (await tx
-        .from(dataFrames)
-        .where(eq("definitionId", args.tableId))
-        .all()) as DataFrameRow[];
+      const previousCandidates = await framesByIds(
+        { ...ctx, db: tx },
+        table.dataFrameId ? [table.dataFrameId] : [],
+      );
+      const previous = await framesUnreferencedOutsideTables(
+        { ...ctx, db: tx },
+        previousCandidates,
+        new Set([args.tableId]),
+      );
       stagedPrevious = await stageServerFrames(ctx, previous);
       await tx.into(dataFrames).insert({
-        id: frameHandle,
-        storage: { type: "file", key: frameHandle },
+        id: dataFrameId,
+        storage: { type: "file", key: dataFrameId },
         fieldIds: args.fieldIds,
         name: table.name,
         sourceId: args.dataSourceId,
@@ -1256,7 +1296,7 @@ async function persistConnectorFrame(
       });
       await tx.from(dataTables).where(eq("id", args.tableId)).update({
         fields: args.approvedFields,
-        dataFrameId: frameHandle,
+        dataFrameId,
         lastFetchedAt: new Date(),
       });
       for (const oldFrame of previous) {
@@ -1265,14 +1305,14 @@ async function persistConnectorFrame(
     });
   } catch (error) {
     await rollbackStagedServerFrames(ctx, stagedPrevious);
-    await storage.delete(frameHandle).catch(() => undefined);
+    await storage.delete(dataFrameId).catch(() => undefined);
     throw error;
   }
   await commitStagedServerFrames(ctx, stagedPrevious);
-  return frameHandle;
+  return dataFrameId;
 }
 
-function approvedFieldsForMaterialization(
+function approvedFieldsForSnapshot(
   value: unknown,
   fieldIds: readonly string[],
   resultFields: readonly Field[],
@@ -1280,10 +1320,10 @@ function approvedFieldsForMaterialization(
   if (
     resultFields.some((field) => getFieldSensitivity(field) === "sensitive")
   ) {
-    throw new Error("Sensitive remote columns cannot be materialized");
+    throw new Error("Sensitive remote columns cannot be imported");
   }
   if (!Array.isArray(value)) {
-    throw new Error("Reviewed fields are required before materialization");
+    throw new Error("Reviewed fields are required before import");
   }
   const byColumn = new Map<string, Field>();
   for (const candidate of value) {
@@ -1292,9 +1332,7 @@ function approvedFieldsForMaterialization(
     }
     const field = candidate as unknown as Field;
     if (getFieldSensitivity(field) !== "cleared") {
-      throw new Error(
-        "Every remote column must be reviewed before materialization",
-      );
+      throw new Error("Every remote column must be reviewed before import");
     }
     const column = field.columnName ?? field.name;
     if (typeof column !== "string" || !column) {
@@ -1376,6 +1414,24 @@ async function commitStagedServerFrames(
   staged: StagedServerFrame[],
 ): Promise<void> {
   if (staged.length === 0) return;
+  if (ctx.flushSnapshotRetentionWindow == null) {
+    console.error(
+      "[dashframe] no retained-snapshot flush hook; leaving staged server frame deletes for startup recovery",
+    );
+    return;
+  }
+  try {
+    // The metadata deletion must reach the durable project snapshot before the
+    // staged bytes are destroyed. Recovery can otherwise restore an older
+    // snapshot that still references a frame whose bytes no longer exist.
+    await ctx.flushSnapshotRetentionWindow();
+  } catch (error) {
+    console.error(
+      "[dashframe] snapshot flush failed; leaving staged server frame deletes for startup recovery",
+      error,
+    );
+    return;
+  }
   const storage = atomicStorage(ctx);
   const results = await Promise.allSettled(
     staged.map(({ token }) => storage.commitDelete(token)),
@@ -1383,10 +1439,38 @@ async function commitStagedServerFrames(
   const failures = results.filter(
     (result): result is PromiseRejectedResult => result.status === "rejected",
   );
+  const removedIds = staged.flatMap(({ token }, index) =>
+    results[index]?.status === "fulfilled" ? [token.split(".")[0]!] : [],
+  );
+  if (removedIds.length > 0) {
+    await ctx.unregisterServerFrames?.(removedIds);
+  }
   if (failures.length > 0) {
     console.error(
       `[dashframe] ${failures.length} staged server frame delete(s) could not be finalized; startup recovery will retry`,
       failures.map(({ reason }) => reason),
+    );
+  }
+}
+
+function assertServerFrameOwnership(
+  _id: string,
+  storage: DataFrameStorageLocation,
+): void {
+  if (storage.type === "file") {
+    throw new Error("Server frame storage is server-owned");
+  }
+}
+
+function assertExistingServerFrameImmutable(
+  existing: DataFrameRow | undefined,
+  _next: DataFrameStorageLocation,
+): void {
+  if (
+    (existing?.storage as DataFrameStorageLocation | undefined)?.type === "file"
+  ) {
+    throw new Error(
+      "Server frame storage cannot be changed through public RPC",
     );
   }
 }
@@ -1402,22 +1486,41 @@ async function rollbackStagedServerFrames(
   }
 }
 
-async function framesForDefinitions(
+async function framesByIds(
   ctx: DashframeFunctionContext,
-  definitionIds: UUID[],
+  ids: readonly string[],
 ): Promise<DataFrameRow[]> {
-  if (definitionIds.length === 0) return [];
-  const allRows = (await ctx.db.from(dataFrames).all()) as DataFrameRow[];
-  const definitions = new Set(definitionIds);
-  return allRows.filter(
-    (row) =>
-      row.definitionId != null && definitions.has(row.definitionId as UUID),
-  );
+  const rows: DataFrameRow[] = [];
+  for (const id of new Set(ids)) {
+    const row = (await ctx.db.from(dataFrames).where(eq("id", id)).first()) as
+      | DataFrameRow
+      | undefined;
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+async function framesUnreferencedOutsideTables(
+  ctx: DashframeFunctionContext,
+  frames: DataFrameRow[],
+  removedTableIds: ReadonlySet<string>,
+): Promise<DataFrameRow[]> {
+  const keep: DataFrameRow[] = [];
+  for (const frame of frames) {
+    const references = (await ctx.db
+      .from(dataTables)
+      .where(eq("dataFrameId", frame.id))
+      .all()) as DataTableRow[];
+    if (references.every((table) => removedTableIds.has(table.id))) {
+      keep.push(frame);
+    }
+  }
+  return keep;
 }
 
 /**
  * queryNotionDatabase — fetch rows from a specific Notion database server-side
- * and return schema for review or a reviewed server materialization.
+ * and return schema for review or persist a reviewed server snapshot.
  *
  * The credential resolves via the bound resolver inside `connector.query`; the
  * handler has no plaintext in scope and the client receives only data.
@@ -1430,13 +1533,13 @@ const queryNotionDatabase = wy.procedure
     // Optional cap on rows fetched for the preview. Bounds an unbounded Notion
     // database scan; the renderer passes a preview limit. Omitted = no cap.
     limit: int.optional(),
-    materialize: boolean.optional(),
+    snapshot: boolean.optional(),
     approvedFields: jsonb.optional(),
   })
   .mutation(
     async (
       ctx,
-      { dataSourceId, databaseId, tableId, limit, materialize, approvedFields },
+      { dataSourceId, databaseId, tableId, limit, snapshot, approvedFields },
     ): Promise<NotionQueryResult> => {
       const connector = await notionConnectorFor(ctx, dataSourceId);
       // Only a positive integer limit caps the fetch. Reject 0/negative — the
@@ -1449,13 +1552,13 @@ const queryNotionDatabase = wy.procedure
       // query() resolves the apiKey via the bound resolver internally and returns
       // a serializable result — no credential in scope here, no DataFrame built.
       const result = await connector.query(databaseId, tableId, pagination);
-      const frameHandle = materialize
+      const dataFrameId = snapshot
         ? await persistConnectorFrame(ctx, {
             arrowBuffer: result.arrowBuffer,
             dataSourceId,
             tableId,
             fieldIds: result.fieldIds,
-            approvedFields: approvedFieldsForMaterialization(
+            approvedFields: approvedFieldsForSnapshot(
               approvedFields,
               result.fieldIds,
               result.fields,
@@ -1464,7 +1567,7 @@ const queryNotionDatabase = wy.procedure
           })
         : undefined;
       return {
-        ...(frameHandle ? { frameHandle } : {}),
+        ...(dataFrameId ? { dataFrameId } : {}),
         fieldIds: result.fieldIds,
         fields: result.fields,
         rowCount: result.rowCount,
@@ -1524,11 +1627,11 @@ async function postgresConnectorFor(
 // ============================================================================
 
 /**
- * Serializable Postgres inspection/materialization result. The handle exists
- * only after reviewed fields pass the server privacy gate.
+ * Serializable Postgres inspection/import result. The DataFrame ID exists only
+ * after reviewed fields pass the server privacy gate and a snapshot is saved.
  */
 type PostgresQueryResult = {
-  frameHandle?: UUID;
+  dataFrameId?: UUID;
   fieldIds: string[];
   fields: Field[];
   rowCount: number;
@@ -1553,7 +1656,7 @@ const listPostgresTables = wy.procedure
 
 /**
  * queryPostgresTable — fetch rows from a Postgres table or run a SELECT
- * server-side and return schema for review or a reviewed materialization.
+ * server-side and return schema for review or persist a reviewed snapshot.
  *
  * The credential resolves via the bound resolver inside `connector.query`; the
  * handler has no plaintext in scope and the client receives only data.
@@ -1567,13 +1670,13 @@ const queryPostgresTable = wy.procedure
     tableId: uuid,
     /** Optional cap on rows fetched for the preview. */
     limit: int.optional(),
-    materialize: boolean.optional(),
+    snapshot: boolean.optional(),
     approvedFields: jsonb.optional(),
   })
   .mutation(
     async (
       ctx,
-      { dataSourceId, databaseId, tableId, limit, materialize, approvedFields },
+      { dataSourceId, databaseId, tableId, limit, snapshot, approvedFields },
     ): Promise<PostgresQueryResult> => {
       const connector = await postgresConnectorFor(ctx, dataSourceId);
       const pagination =
@@ -1581,13 +1684,13 @@ const queryPostgresTable = wy.procedure
           ? { pagination: { offset: 0, limit } }
           : undefined;
       const result = await connector.query(databaseId, tableId, pagination);
-      const frameHandle = materialize
+      const dataFrameId = snapshot
         ? await persistConnectorFrame(ctx, {
             arrowBuffer: result.arrowBuffer,
             dataSourceId,
             tableId,
             fieldIds: result.fieldIds,
-            approvedFields: approvedFieldsForMaterialization(
+            approvedFields: approvedFieldsForSnapshot(
               approvedFields,
               result.fieldIds,
               result.fields,
@@ -1596,7 +1699,7 @@ const queryPostgresTable = wy.procedure
           })
         : undefined;
       return {
-        ...(frameHandle ? { frameHandle } : {}),
+        ...(dataFrameId ? { dataFrameId } : {}),
         fieldIds: result.fieldIds,
         fields: result.fields,
         rowCount: result.rowCount,
@@ -1777,11 +1880,11 @@ const listGa4Properties = wy.procedure
   );
 
 /**
- * Serializable GA4 inspection/materialization result. Structurally identical
+ * Serializable GA4 inspection/import result. Structurally identical
  * to Postgres today, but deliberately kept per-connector here.
  */
 type Ga4QueryResult = {
-  frameHandle?: UUID;
+  dataFrameId?: UUID;
   fieldIds: string[];
   fields: Field[];
   rowCount: number;
@@ -1803,13 +1906,13 @@ const queryGa4Property = wy.procedure
     dataSourceId: uuid,
     tableId: uuid,
     limit: int.optional(),
-    materialize: boolean.optional(),
+    snapshot: boolean.optional(),
     approvedFields: jsonb.optional(),
   })
   .mutation(
     async (
       ctx,
-      { dataSourceId, tableId, limit, materialize, approvedFields },
+      { dataSourceId, tableId, limit, snapshot, approvedFields },
     ): Promise<Ga4QueryResult> => {
       const table = (await ctx.db
         .from(dataTables)
@@ -1827,13 +1930,13 @@ const queryGa4Property = wy.procedure
           ? { pagination: { offset: 0, limit } }
           : undefined;
       const result = await connector.query(table.table, tableId, pagination);
-      const frameHandle = materialize
+      const dataFrameId = snapshot
         ? await persistConnectorFrame(ctx, {
             arrowBuffer: result.arrowBuffer,
             dataSourceId,
             tableId,
             fieldIds: result.fieldIds,
-            approvedFields: approvedFieldsForMaterialization(
+            approvedFields: approvedFieldsForSnapshot(
               approvedFields,
               result.fieldIds,
               result.fields,
@@ -1842,7 +1945,7 @@ const queryGa4Property = wy.procedure
           })
         : undefined;
       return {
-        ...(frameHandle ? { frameHandle } : {}),
+        ...(dataFrameId ? { dataFrameId } : {}),
         fieldIds: result.fieldIds,
         fields: result.fields,
         rowCount: result.rowCount,

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -25,13 +25,15 @@ import type {
   VisualizationType,
 } from "@dashframe/types";
 import {
+  getFieldSensitivity,
   isUnmodifiedDraft,
   stripSampleValues,
   validateVisualizationEncoding,
 } from "@dashframe/types";
-import { eq, int, jsonb, text, uuid } from "@wystack/db";
+import { boolean, eq, int, jsonb, text, uuid } from "@wystack/db";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { isSecretRef } from "@wystack/secret-vault";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import type { DashframeFunctionContext } from "../app-context";
@@ -51,6 +53,7 @@ import { tsToMillis } from "./timestamps";
 import {
   applyCredentialField,
   flushThenReleaseRefs,
+  inDraftContext,
   isRecord,
   modeFromCtx,
   releaseCredentialRefs,
@@ -412,6 +415,7 @@ const getDataSourceByType = wy.procedure
 const removeDataSource = wy.procedure
   .input({ id: uuid })
   .mutation(async (ctx, { id }): Promise<{ ok: true }> => {
+    assertCanonicalFrameSideEffects(ctx);
     // Fetch the source config BEFORE deleting so we can release its SecretRefs.
     // vault-absent-with-a-ref is an error (fail-closed symmetry): a ref can only
     // exist because vault.store() succeeded, which requires a vault to be present.
@@ -419,14 +423,34 @@ const removeDataSource = wy.procedure
     // keychain side-effect outside the DB transaction. A preview executes then
     // rolls back: the row (with its refs) survives, so its credential must too.
     const source = await ctx.db.from(dataSources).where(eq("id", id)).first();
+    const ownedTables = (await ctx.db
+      .from(dataTables)
+      .where(eq("dataSourceId", id))
+      .all()) as DataTableRow[];
+    const ownedFrames = await framesForDefinitions(
+      ctx,
+      ownedTables.map((table) => table.id),
+    );
+    const staged = await stageServerFrames(ctx, ownedFrames);
+    try {
+      await ctx.db.transaction(async (tx) => {
+        for (const frame of ownedFrames) {
+          await tx.from(dataFrames).where(eq("id", frame.id)).delete();
+        }
+        await tx.from(dataTables).where(eq("dataSourceId", id)).delete();
+        await tx.from(dataSources).where(eq("id", id)).delete();
+      });
+    } catch (error) {
+      await rollbackStagedServerFrames(ctx, staged);
+      throw error;
+    }
+    await commitStagedServerFrames(ctx, staged);
     if (source && modeFromCtx(ctx) !== "preview") {
       await releaseCredentialRefs(
         (source.config ?? {}) as DataSourceConfig,
         vaultFromCtx(ctx),
       );
     }
-    await ctx.db.from(dataTables).where(eq("dataSourceId", id)).delete();
-    await ctx.db.from(dataSources).where(eq("id", id)).delete();
     return { ok: true };
   });
 
@@ -528,7 +552,21 @@ const refreshDataTable = wy.procedure
 const removeDataTable = wy.procedure
   .input({ id: uuid })
   .mutation(async (ctx, { id }): Promise<{ ok: true }> => {
-    await ctx.db.from(dataTables).where(eq("id", id)).delete();
+    assertCanonicalFrameSideEffects(ctx);
+    const frames = await framesForDefinitions(ctx, [id]);
+    const staged = await stageServerFrames(ctx, frames);
+    try {
+      await ctx.db.transaction(async (tx) => {
+        for (const frame of frames) {
+          await tx.from(dataFrames).where(eq("id", frame.id)).delete();
+        }
+        await tx.from(dataTables).where(eq("id", id)).delete();
+      });
+    } catch (error) {
+      await rollbackStagedServerFrames(ctx, staged);
+      throw error;
+    }
+    await commitStagedServerFrames(ctx, staged);
     return { ok: true };
   });
 
@@ -700,7 +738,20 @@ const updateDataFrameEntry = wy.procedure
 const removeDataFrameEntry = wy.procedure
   .input({ id: uuid })
   .mutation(async (ctx, { id }): Promise<{ ok: true }> => {
-    await ctx.db.from(dataFrames).where(eq("id", id)).delete();
+    assertCanonicalFrameSideEffects(ctx);
+    const row = (await ctx.db.from(dataFrames).where(eq("id", id)).first()) as
+      | DataFrameRow
+      | undefined;
+    const staged = await stageServerFrames(ctx, row ? [row] : []);
+    try {
+      await ctx.db.transaction(async (tx) => {
+        await tx.from(dataFrames).where(eq("id", id)).delete();
+      });
+    } catch (error) {
+      await rollbackStagedServerFrames(ctx, staged);
+      throw error;
+    }
+    await commitStagedServerFrames(ctx, staged);
     return { ok: true };
   });
 
@@ -1013,16 +1064,27 @@ const removeVisualization = wy.procedure
 const clearAllData = wy.procedure
   .input({})
   .mutation(async (ctx): Promise<{ ok: true }> => {
+    assertCanonicalFrameSideEffects(ctx);
     // One unconditional DELETE FROM per table (DrizzleTracker.delete() with no
     // .where() clears the whole table). Idempotent and a single statement
     // each — no per-row round-trips, no partial-clear retry hazard. FK-child
     // tables first so cascade order is satisfied even without DB-level FKs.
-    await ctx.db.from(dashboards).delete();
-    await ctx.db.from(visualizations).delete();
-    await ctx.db.from(insights).delete();
-    await ctx.db.from(dataFrames).delete();
-    await ctx.db.from(dataTables).delete();
-    await ctx.db.from(dataSources).delete();
+    const frames = (await ctx.db.from(dataFrames).all()) as DataFrameRow[];
+    const staged = await stageServerFrames(ctx, frames);
+    try {
+      await ctx.db.transaction(async (tx) => {
+        await tx.from(dashboards).delete();
+        await tx.from(visualizations).delete();
+        await tx.from(insights).delete();
+        await tx.from(dataFrames).delete();
+        await tx.from(dataTables).delete();
+        await tx.from(dataSources).delete();
+      });
+    } catch (error) {
+      await rollbackStagedServerFrames(ctx, staged);
+      throw error;
+    }
+    await commitStagedServerFrames(ctx, staged);
     return { ok: true };
   });
 
@@ -1127,20 +1189,235 @@ const listNotionDatabases = wy.procedure
   });
 
 /**
- * Serializable result of a Notion query — raw Arrow IPC buffer (base64) +
- * field ids + field definitions. The renderer materializes the browser
- * DataFrame from this; no plaintext and no live DataFrame crosses the boundary.
+ * Serializable Notion inspection/materialization result. Inspection returns
+ * schema only; reviewed materialization also returns an opaque frame handle.
+ * Row bytes never cross the client boundary.
  */
 type NotionQueryResult = {
-  arrowBuffer: string;
+  frameHandle?: UUID;
   fieldIds: string[];
   fields: Field[];
   rowCount: number;
 };
 
+async function persistConnectorFrame(
+  ctx: DashframeFunctionContext,
+  args: {
+    arrowBuffer: string;
+    dataSourceId: UUID;
+    tableId: UUID;
+    fieldIds: string[];
+    approvedFields: Field[];
+    rowCount: number;
+  },
+): Promise<UUID> {
+  assertCanonicalFrameSideEffects(ctx);
+  const storage = ctx.dataFrameStorage;
+  if (!storage) {
+    throw new Error("Server DataFrame storage is not configured");
+  }
+  const frameHandle = randomUUID() as UUID;
+  await storage.save(
+    frameHandle,
+    new Uint8Array(Buffer.from(args.arrowBuffer, "base64")),
+  );
+  let stagedPrevious: StagedServerFrame[] = [];
+  try {
+    await ctx.db.transaction(async (tx) => {
+      // Ownership validation and replacement discovery belong inside the same
+      // serialized DB transaction as the link update. Otherwise a concurrent
+      // DeleteNode or refresh can invalidate an earlier read and leave an
+      // unowned or duplicate materialization behind.
+      const table = (await tx
+        .from(dataTables)
+        .where(eq("id", args.tableId))
+        .first()) as DataTableRow | undefined;
+      if (!table) throw new Error(`DataTable ${args.tableId} not found`);
+      if (table.dataSourceId !== args.dataSourceId) {
+        throw new Error(
+          `DataTable ${args.tableId} does not belong to DataSource ${args.dataSourceId}`,
+        );
+      }
+      const previous = (await tx
+        .from(dataFrames)
+        .where(eq("definitionId", args.tableId))
+        .all()) as DataFrameRow[];
+      stagedPrevious = await stageServerFrames(ctx, previous);
+      await tx.into(dataFrames).insert({
+        id: frameHandle,
+        storage: { type: "file", key: frameHandle },
+        fieldIds: args.fieldIds,
+        name: table.name,
+        sourceId: args.dataSourceId,
+        definitionId: args.tableId,
+        rowCount: args.rowCount,
+        columnCount: args.fieldIds.length,
+        lastRefreshedAt: new Date(),
+      });
+      await tx.from(dataTables).where(eq("id", args.tableId)).update({
+        fields: args.approvedFields,
+        dataFrameId: frameHandle,
+        lastFetchedAt: new Date(),
+      });
+      for (const oldFrame of previous) {
+        await tx.from(dataFrames).where(eq("id", oldFrame.id)).delete();
+      }
+    });
+  } catch (error) {
+    await rollbackStagedServerFrames(ctx, stagedPrevious);
+    await storage.delete(frameHandle).catch(() => undefined);
+    throw error;
+  }
+  await commitStagedServerFrames(ctx, stagedPrevious);
+  return frameHandle;
+}
+
+function approvedFieldsForMaterialization(
+  value: unknown,
+  fieldIds: readonly string[],
+  resultFields: readonly Field[],
+): Field[] {
+  if (
+    resultFields.some((field) => getFieldSensitivity(field) === "sensitive")
+  ) {
+    throw new Error("Sensitive remote columns cannot be materialized");
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("Reviewed fields are required before materialization");
+  }
+  const byColumn = new Map<string, Field>();
+  for (const candidate of value) {
+    if (!isRecord(candidate) || typeof candidate.id !== "string") {
+      throw new Error("Reviewed fields are invalid");
+    }
+    const field = candidate as unknown as Field;
+    if (getFieldSensitivity(field) !== "cleared") {
+      throw new Error(
+        "Every remote column must be reviewed before materialization",
+      );
+    }
+    const column = field.columnName ?? field.name;
+    if (typeof column !== "string" || !column) {
+      throw new Error("Reviewed fields are invalid");
+    }
+    byColumn.set(column, field);
+  }
+  if (
+    resultFields.length !== fieldIds.length ||
+    resultFields.some((field, index) => field.id !== fieldIds[index]) ||
+    byColumn.size !== resultFields.length ||
+    resultFields.some((field) => !byColumn.has(field.columnName ?? field.name))
+  ) {
+    throw new Error("Reviewed fields do not match the remote result");
+  }
+  return resultFields.map((field) => {
+    const approved = byColumn.get(field.columnName ?? field.name)!;
+    return {
+      ...field,
+      sensitivity: approved.sensitivity,
+      sensitivityReason: approved.sensitivityReason,
+    };
+  });
+}
+
+type StagedServerFrame = { token: string };
+
+function assertCanonicalFrameSideEffects(ctx: DashframeFunctionContext): void {
+  if (modeFromCtx(ctx) === "preview" || inDraftContext(ctx)) {
+    throw new Error(
+      "Server frame side effects require a canonical commit context",
+    );
+  }
+}
+
+function atomicStorage(ctx: DashframeFunctionContext) {
+  const storage = ctx.dataFrameStorage;
+  if (
+    !storage?.stageDelete ||
+    !storage.commitDelete ||
+    !storage.rollbackDelete
+  ) {
+    throw new Error("Server DataFrame storage lacks atomic delete support");
+  }
+  return storage as Required<
+    Pick<typeof storage, "stageDelete" | "commitDelete" | "rollbackDelete">
+  > &
+    typeof storage;
+}
+
+async function stageServerFrames(
+  ctx: DashframeFunctionContext,
+  rows: DataFrameRow[],
+): Promise<StagedServerFrame[]> {
+  const fileRows = rows.filter(
+    (row) => (row.storage as DataFrameStorageLocation).type === "file",
+  );
+  if (fileRows.length === 0) return [];
+  const storage = atomicStorage(ctx);
+  const staged: StagedServerFrame[] = [];
+  try {
+    for (const row of fileRows) {
+      const location = row.storage as Extract<
+        DataFrameStorageLocation,
+        { type: "file" }
+      >;
+      const token = await storage.stageDelete(location.key as UUID);
+      if (token) staged.push({ token });
+    }
+    return staged;
+  } catch (error) {
+    await rollbackStagedServerFrames(ctx, staged);
+    throw error;
+  }
+}
+
+async function commitStagedServerFrames(
+  ctx: DashframeFunctionContext,
+  staged: StagedServerFrame[],
+): Promise<void> {
+  if (staged.length === 0) return;
+  const storage = atomicStorage(ctx);
+  const results = await Promise.allSettled(
+    staged.map(({ token }) => storage.commitDelete(token)),
+  );
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    console.error(
+      `[dashframe] ${failures.length} staged server frame delete(s) could not be finalized; startup recovery will retry`,
+      failures.map(({ reason }) => reason),
+    );
+  }
+}
+
+async function rollbackStagedServerFrames(
+  ctx: DashframeFunctionContext,
+  staged: StagedServerFrame[],
+): Promise<void> {
+  if (staged.length === 0) return;
+  const storage = atomicStorage(ctx);
+  for (const { token } of staged.toReversed()) {
+    await storage.rollbackDelete(token);
+  }
+}
+
+async function framesForDefinitions(
+  ctx: DashframeFunctionContext,
+  definitionIds: UUID[],
+): Promise<DataFrameRow[]> {
+  if (definitionIds.length === 0) return [];
+  const allRows = (await ctx.db.from(dataFrames).all()) as DataFrameRow[];
+  const definitions = new Set(definitionIds);
+  return allRows.filter(
+    (row) =>
+      row.definitionId != null && definitions.has(row.definitionId as UUID),
+  );
+}
+
 /**
  * queryNotionDatabase — fetch rows from a specific Notion database server-side
- * and return a serializable result the renderer can materialize.
+ * and return schema for review or a reviewed server materialization.
  *
  * The credential resolves via the bound resolver inside `connector.query`; the
  * handler has no plaintext in scope and the client receives only data.
@@ -1153,11 +1430,13 @@ const queryNotionDatabase = wy.procedure
     // Optional cap on rows fetched for the preview. Bounds an unbounded Notion
     // database scan; the renderer passes a preview limit. Omitted = no cap.
     limit: int.optional(),
+    materialize: boolean.optional(),
+    approvedFields: jsonb.optional(),
   })
   .mutation(
     async (
       ctx,
-      { dataSourceId, databaseId, tableId, limit },
+      { dataSourceId, databaseId, tableId, limit, materialize, approvedFields },
     ): Promise<NotionQueryResult> => {
       const connector = await notionConnectorFor(ctx, dataSourceId);
       // Only a positive integer limit caps the fetch. Reject 0/negative — the
@@ -1170,8 +1449,22 @@ const queryNotionDatabase = wy.procedure
       // query() resolves the apiKey via the bound resolver internally and returns
       // a serializable result — no credential in scope here, no DataFrame built.
       const result = await connector.query(databaseId, tableId, pagination);
+      const frameHandle = materialize
+        ? await persistConnectorFrame(ctx, {
+            arrowBuffer: result.arrowBuffer,
+            dataSourceId,
+            tableId,
+            fieldIds: result.fieldIds,
+            approvedFields: approvedFieldsForMaterialization(
+              approvedFields,
+              result.fieldIds,
+              result.fields,
+            ),
+            rowCount: result.rowCount,
+          })
+        : undefined;
       return {
-        arrowBuffer: result.arrowBuffer,
+        ...(frameHandle ? { frameHandle } : {}),
         fieldIds: result.fieldIds,
         fields: result.fields,
         rowCount: result.rowCount,
@@ -1231,12 +1524,11 @@ async function postgresConnectorFor(
 // ============================================================================
 
 /**
- * Serializable result of a Postgres query — raw Arrow IPC buffer (base64) +
- * field ids + field definitions. The renderer materializes the browser
- * DataFrame from this; no plaintext and no live DataFrame crosses the boundary.
+ * Serializable Postgres inspection/materialization result. The handle exists
+ * only after reviewed fields pass the server privacy gate.
  */
 type PostgresQueryResult = {
-  arrowBuffer: string;
+  frameHandle?: UUID;
   fieldIds: string[];
   fields: Field[];
   rowCount: number;
@@ -1261,7 +1553,7 @@ const listPostgresTables = wy.procedure
 
 /**
  * queryPostgresTable — fetch rows from a Postgres table or run a SELECT
- * server-side and return a serializable result the renderer can materialize.
+ * server-side and return schema for review or a reviewed materialization.
  *
  * The credential resolves via the bound resolver inside `connector.query`; the
  * handler has no plaintext in scope and the client receives only data.
@@ -1275,11 +1567,13 @@ const queryPostgresTable = wy.procedure
     tableId: uuid,
     /** Optional cap on rows fetched for the preview. */
     limit: int.optional(),
+    materialize: boolean.optional(),
+    approvedFields: jsonb.optional(),
   })
   .mutation(
     async (
       ctx,
-      { dataSourceId, databaseId, tableId, limit },
+      { dataSourceId, databaseId, tableId, limit, materialize, approvedFields },
     ): Promise<PostgresQueryResult> => {
       const connector = await postgresConnectorFor(ctx, dataSourceId);
       const pagination =
@@ -1287,8 +1581,22 @@ const queryPostgresTable = wy.procedure
           ? { pagination: { offset: 0, limit } }
           : undefined;
       const result = await connector.query(databaseId, tableId, pagination);
+      const frameHandle = materialize
+        ? await persistConnectorFrame(ctx, {
+            arrowBuffer: result.arrowBuffer,
+            dataSourceId,
+            tableId,
+            fieldIds: result.fieldIds,
+            approvedFields: approvedFieldsForMaterialization(
+              approvedFields,
+              result.fieldIds,
+              result.fields,
+            ),
+            rowCount: result.rowCount,
+          })
+        : undefined;
       return {
-        arrowBuffer: result.arrowBuffer,
+        ...(frameHandle ? { frameHandle } : {}),
         fieldIds: result.fieldIds,
         fields: result.fields,
         rowCount: result.rowCount,
@@ -1469,13 +1777,11 @@ const listGa4Properties = wy.procedure
   );
 
 /**
- * Serializable result of a GA4 property read. Structurally identical to
- * PostgresQueryResult today, and named separately on purpose: these two travel
- * different code paths and one gaining a field should not silently change the
- * other's contract.
+ * Serializable GA4 inspection/materialization result. Structurally identical
+ * to Postgres today, but deliberately kept per-connector here.
  */
 type Ga4QueryResult = {
-  arrowBuffer: string;
+  frameHandle?: UUID;
   fieldIds: string[];
   fields: Field[];
   rowCount: number;
@@ -1497,9 +1803,14 @@ const queryGa4Property = wy.procedure
     dataSourceId: uuid,
     tableId: uuid,
     limit: int.optional(),
+    materialize: boolean.optional(),
+    approvedFields: jsonb.optional(),
   })
   .mutation(
-    async (ctx, { dataSourceId, tableId, limit }): Promise<Ga4QueryResult> => {
+    async (
+      ctx,
+      { dataSourceId, tableId, limit, materialize, approvedFields },
+    ): Promise<Ga4QueryResult> => {
       const table = (await ctx.db
         .from(dataTables)
         .where(eq("id", tableId))
@@ -1516,8 +1827,22 @@ const queryGa4Property = wy.procedure
           ? { pagination: { offset: 0, limit } }
           : undefined;
       const result = await connector.query(table.table, tableId, pagination);
+      const frameHandle = materialize
+        ? await persistConnectorFrame(ctx, {
+            arrowBuffer: result.arrowBuffer,
+            dataSourceId,
+            tableId,
+            fieldIds: result.fieldIds,
+            approvedFields: approvedFieldsForMaterialization(
+              approvedFields,
+              result.fieldIds,
+              result.fields,
+            ),
+            rowCount: result.rowCount,
+          })
+        : undefined;
       return {
-        arrowBuffer: result.arrowBuffer,
+        ...(frameHandle ? { frameHandle } : {}),
         fieldIds: result.fieldIds,
         fields: result.fields,
         rowCount: result.rowCount,

--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -6,6 +6,7 @@ import { makeNotionConnector } from "@dashframe/connector-notion";
 import { makePostgresConnector } from "@dashframe/connector-postgres";
 // The canonical bound-resolver type — aliased for readability at the mint site.
 import type { SecretResolver as BoundSecretResolver } from "@dashframe/engine";
+import { inspectArrowIpc } from "@dashframe/engine-server/arrow-data-path";
 import { schema } from "@dashframe/server-core";
 import type {
   DataFrameAnalysis,
@@ -31,12 +32,14 @@ import {
   validateVisualizationEncoding,
 } from "@dashframe/types";
 import { boolean, eq, int, jsonb, text, uuid } from "@wystack/db";
+import { PermissionDeniedError } from "@wystack/permissions";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { isSecretRef } from "@wystack/secret-vault";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import type { DashframeFunctionContext } from "../app-context";
+import { permissions } from "../permissions";
 import { wy } from "../wystack";
 import {
   decodeInsight,
@@ -430,12 +433,20 @@ const removeDataSource = wy.procedure
           .from(dataTables)
           .where(eq("dataSourceId", id))
           .all()) as DataTableRow[];
-        const candidateFrames = await framesByIds(
-          { ...ctx, db: tx },
-          ownedTables.flatMap((table) =>
-            table.dataFrameId ? [table.dataFrameId] : [],
-          ),
-        );
+        const txCtx = { ...ctx, db: tx };
+        const candidateFrames = dedupeFrames([
+          ...(await framesByIds(
+            txCtx,
+            ownedTables.flatMap((table) =>
+              table.dataFrameId ? [table.dataFrameId] : [],
+            ),
+          )),
+          ...(await framesForDefinitions(
+            txCtx,
+            ownedTables.map((table) => table.id),
+          )),
+          ...(await framesForSources(txCtx, [id])),
+        ]);
         const ownedFrames = await framesUnreferencedOutsideTables(
           { ...ctx, db: tx },
           candidateFrames,
@@ -518,30 +529,64 @@ const addDataTable = wy.procedure
     },
   );
 
+async function updateDataTableRecord(
+  ctx: DashframeFunctionContext,
+  id: UUID,
+  patch: Partial<DataTable>,
+): Promise<{ ok: true }> {
+  const dbPatch = {
+    ...(patch.name !== undefined ? { name: patch.name } : {}),
+    ...(patch.table !== undefined ? { table: patch.table } : {}),
+    ...(patch.sourceSchema !== undefined
+      ? { sourceSchema: patch.sourceSchema }
+      : {}),
+    ...(patch.fields !== undefined ? { fields: patch.fields } : {}),
+    ...(patch.metrics !== undefined ? { metrics: patch.metrics } : {}),
+    ...(patch.dataFrameId !== undefined
+      ? { dataFrameId: patch.dataFrameId }
+      : {}),
+    ...(patch.lastFetchedAt !== undefined
+      ? { lastFetchedAt: dateFromEpoch(patch.lastFetchedAt) }
+      : {}),
+  };
+  if (patch.dataFrameId === undefined || !isCanonicalContext(ctx)) {
+    await ctx.db.from(dataTables).where(eq("id", id)).update(dbPatch);
+    return { ok: true };
+  }
+  let staged: StagedServerFrame[] = [];
+  try {
+    await ctx.db.transaction(async (tx) => {
+      const table = (await tx.from(dataTables).where(eq("id", id)).first()) as
+        | DataTableRow
+        | undefined;
+      const oldFrames =
+        table?.dataFrameId && table.dataFrameId !== patch.dataFrameId
+          ? await framesUnreferencedOutsideTables(
+              { ...ctx, db: tx },
+              await framesByIds({ ...ctx, db: tx }, [table.dataFrameId]),
+              new Set([id]),
+            )
+          : [];
+      staged = await stageServerFrames(ctx, oldFrames);
+      await tx.from(dataTables).where(eq("id", id)).update(dbPatch);
+      for (const frame of oldFrames) {
+        await tx.from(dataFrames).where(eq("id", frame.id)).delete();
+      }
+    });
+  } catch (error) {
+    await rollbackStagedServerFrames(ctx, staged);
+    throw error;
+  }
+  await commitStagedServerFrames(ctx, staged);
+  return { ok: true };
+}
+
 const updateDataTable = wy.procedure
   .input({ id: uuid, updates: jsonb })
-  .mutation(async (ctx, { id, updates }): Promise<{ ok: true }> => {
-    const patch = updates as Partial<DataTable>;
-    await ctx.db
-      .from(dataTables)
-      .where(eq("id", id))
-      .update({
-        ...(patch.name !== undefined ? { name: patch.name } : {}),
-        ...(patch.table !== undefined ? { table: patch.table } : {}),
-        ...(patch.sourceSchema !== undefined
-          ? { sourceSchema: patch.sourceSchema }
-          : {}),
-        ...(patch.fields !== undefined ? { fields: patch.fields } : {}),
-        ...(patch.metrics !== undefined ? { metrics: patch.metrics } : {}),
-        ...(patch.dataFrameId !== undefined
-          ? { dataFrameId: patch.dataFrameId }
-          : {}),
-        ...(patch.lastFetchedAt !== undefined
-          ? { lastFetchedAt: dateFromEpoch(patch.lastFetchedAt) }
-          : {}),
-      });
-    return { ok: true };
-  });
+  .mutation(
+    async (ctx, { id, updates }): Promise<{ ok: true }> =>
+      updateDataTableRecord(ctx, id, updates as Partial<DataTable>),
+  );
 
 // NOTE: silently no-ops on a missing id (0-row UPDATE returns { ok: true }).
 // The command path (`refreshDataTableCmd` in commands.ts) enforces existence
@@ -550,11 +595,10 @@ const updateDataTable = wy.procedure
 const refreshDataTable = wy.procedure
   .input({ id: uuid, dataFrameId: uuid })
   .mutation(async (ctx, { id, dataFrameId }): Promise<{ ok: true }> => {
-    await ctx.db
-      .from(dataTables)
-      .where(eq("id", id))
-      .update({ dataFrameId, lastFetchedAt: new Date() });
-    return { ok: true };
+    return updateDataTableRecord(ctx, id, {
+      dataFrameId,
+      lastFetchedAt: Date.now(),
+    });
   });
 
 const removeDataTable = wy.procedure
@@ -568,10 +612,14 @@ const removeDataTable = wy.procedure
           .from(dataTables)
           .where(eq("id", id))
           .first()) as DataTableRow | undefined;
-        const candidates = await framesByIds(
-          { ...ctx, db: tx },
-          table?.dataFrameId ? [table.dataFrameId] : [],
-        );
+        const txCtx = { ...ctx, db: tx };
+        const candidates = dedupeFrames([
+          ...(await framesByIds(
+            txCtx,
+            table?.dataFrameId ? [table.dataFrameId] : [],
+          )),
+          ...(await framesForDefinitions(txCtx, [id])),
+        ]);
         const frames = await framesUnreferencedOutsideTables(
           { ...ctx, db: tx },
           candidates,
@@ -1251,11 +1299,25 @@ async function persistConnectorFrame(
   if (!storage) {
     throw new Error("Server DataFrame storage is not configured");
   }
-  const dataFrameId = randomUUID() as UUID;
-  await storage.save(
-    dataFrameId,
-    new Uint8Array(Buffer.from(args.arrowBuffer, "base64")),
+  const arrow = new Uint8Array(Buffer.from(args.arrowBuffer, "base64"));
+  let ipc: ReturnType<typeof inspectArrowIpc>;
+  try {
+    ipc = inspectArrowIpc(arrow);
+  } catch {
+    throw new Error("Connector returned malformed Arrow IPC");
+  }
+  const expectedNames = args.approvedFields.map(
+    (field) => field.columnName ?? field.name,
   );
+  if (
+    ipc.rowCount !== args.rowCount ||
+    ipc.fieldNames.length !== expectedNames.length ||
+    ipc.fieldNames.some((name, index) => name !== expectedNames[index])
+  ) {
+    throw new Error("Connector Arrow schema does not match reviewed fields");
+  }
+  const dataFrameId = randomUUID() as UUID;
+  await storage.save(dataFrameId, arrow);
   let stagedPrevious: StagedServerFrame[] = [];
   try {
     await ctx.db.transaction(async (tx) => {
@@ -1312,6 +1374,51 @@ async function persistConnectorFrame(
   return dataFrameId;
 }
 
+async function connectorTableBinding(
+  ctx: DashframeFunctionContext,
+  dataSourceId: UUID,
+  tableId: UUID,
+): Promise<DataTableRow> {
+  const table = (await ctx.db
+    .from(dataTables)
+    .where(eq("id", tableId))
+    .first()) as DataTableRow | undefined;
+  if (!table) throw new Error(`DataTable ${tableId} not found`);
+  if (table.dataSourceId !== dataSourceId) {
+    throw new Error(
+      `DataTable ${tableId} does not belong to DataSource ${dataSourceId}`,
+    );
+  }
+  return table;
+}
+
+async function requireConnectorMaterializationPermission(
+  ctx: DashframeFunctionContext,
+  snapshot: boolean | undefined,
+): Promise<void> {
+  if (snapshot && !(await ctx.can(permissions.commands.commit))) {
+    throw new PermissionDeniedError(permissions.commands.commit.id);
+  }
+}
+
+const CONNECTOR_INSPECTION_ROW_LIMIT = 100;
+
+function connectorQueryOptions(
+  limit: number | undefined,
+  snapshot: boolean | undefined,
+): { pagination: { offset: number; limit: number } } | undefined {
+  const requestedLimit =
+    limit !== undefined && Number.isInteger(limit) && limit > 0
+      ? limit
+      : undefined;
+  const effectiveLimit = snapshot
+    ? requestedLimit
+    : (requestedLimit ?? CONNECTOR_INSPECTION_ROW_LIMIT);
+  return effectiveLimit === undefined
+    ? undefined
+    : { pagination: { offset: 0, limit: effectiveLimit } };
+}
+
 function approvedFieldsForSnapshot(
   value: unknown,
   fieldIds: readonly string[],
@@ -1361,11 +1468,15 @@ function approvedFieldsForSnapshot(
 type StagedServerFrame = { token: string };
 
 function assertCanonicalFrameSideEffects(ctx: DashframeFunctionContext): void {
-  if (modeFromCtx(ctx) === "preview" || inDraftContext(ctx)) {
+  if (!isCanonicalContext(ctx)) {
     throw new Error(
       "Server frame side effects require a canonical commit context",
     );
   }
+}
+
+function isCanonicalContext(ctx: DashframeFunctionContext): boolean {
+  return modeFromCtx(ctx) !== "preview" && !inDraftContext(ctx);
 }
 
 function atomicStorage(ctx: DashframeFunctionContext) {
@@ -1391,6 +1502,10 @@ async function stageServerFrames(
     (row) => (row.storage as DataFrameStorageLocation).type === "file",
   );
   if (fileRows.length === 0) return [];
+  // This handler owns staging + retained-snapshot finalization. Suppress the
+  // generic post-handler reconciliation so it does not flush retention and
+  // attempt the same cleanup a second time.
+  ctx.markServerFrameCleanupHandled?.();
   const storage = atomicStorage(ctx);
   const staged: StagedServerFrame[] = [];
   try {
@@ -1443,7 +1558,16 @@ async function commitStagedServerFrames(
     results[index]?.status === "fulfilled" ? [token.split(".")[0]!] : [],
   );
   if (removedIds.length > 0) {
-    await ctx.unregisterServerFrames?.(removedIds);
+    try {
+      await ctx.unregisterServerFrames?.(removedIds);
+    } catch (error) {
+      // Metadata and file deletion are durable at this point. Runtime-native
+      // cleanup must not turn that committed mutation into a reported failure.
+      console.error(
+        "[dashframe] native unregister failed after durable frame deletion; runtime cleanup will retry when configured",
+        error,
+      );
+    }
   }
   if (failures.length > 0) {
     console.error(
@@ -1500,6 +1624,46 @@ async function framesByIds(
   return rows;
 }
 
+async function framesForDefinitions(
+  ctx: DashframeFunctionContext,
+  definitionIds: readonly string[],
+): Promise<DataFrameRow[]> {
+  const ids = [...new Set(definitionIds)];
+  if (ids.length === 0) return [];
+  const rows: DataFrameRow[] = [];
+  for (const definitionId of ids) {
+    rows.push(
+      ...((await ctx.db
+        .from(dataFrames)
+        .where(eq("definitionId", definitionId))
+        .all()) as DataFrameRow[]),
+    );
+  }
+  return rows;
+}
+
+async function framesForSources(
+  ctx: DashframeFunctionContext,
+  sourceIds: readonly string[],
+): Promise<DataFrameRow[]> {
+  const ids = [...new Set(sourceIds)];
+  if (ids.length === 0) return [];
+  const rows: DataFrameRow[] = [];
+  for (const sourceId of ids) {
+    rows.push(
+      ...((await ctx.db
+        .from(dataFrames)
+        .where(eq("sourceId", sourceId))
+        .all()) as DataFrameRow[]),
+    );
+  }
+  return rows;
+}
+
+function dedupeFrames(rows: readonly DataFrameRow[]): DataFrameRow[] {
+  return [...new Map(rows.map((row) => [row.id, row])).values()];
+}
+
 async function framesUnreferencedOutsideTables(
   ctx: DashframeFunctionContext,
   frames: DataFrameRow[],
@@ -1530,8 +1694,8 @@ const queryNotionDatabase = wy.procedure
     dataSourceId: uuid,
     databaseId: text,
     tableId: uuid,
-    // Optional cap on rows fetched for the preview. Bounds an unbounded Notion
-    // database scan; the renderer passes a preview limit. Omitted = no cap.
+    // Optional cap on rows fetched for preview. Inspection defaults to a small
+    // server-side bound; an approved snapshot remains unbounded when omitted.
     limit: int.optional(),
     snapshot: boolean.optional(),
     approvedFields: jsonb.optional(),
@@ -1542,16 +1706,17 @@ const queryNotionDatabase = wy.procedure
       { dataSourceId, databaseId, tableId, limit, snapshot, approvedFields },
     ): Promise<NotionQueryResult> => {
       const connector = await notionConnectorFor(ctx, dataSourceId);
-      // Only a positive integer limit caps the fetch. Reject 0/negative — the
-      // client-side page loop treats `0 || Infinity` as unbounded, so a `limit: 0`
-      // would silently become a full-database scan (the cap's whole purpose).
-      const pagination =
-        limit !== undefined && Number.isInteger(limit) && limit > 0
-          ? { pagination: { offset: 0, limit } }
-          : undefined;
+      const table = await connectorTableBinding(ctx, dataSourceId, tableId);
+      if (databaseId !== table.table) {
+        throw new Error(
+          `DataTable ${tableId} is bound to remote resource ${table.table}`,
+        );
+      }
+      await requireConnectorMaterializationPermission(ctx, snapshot);
+      const pagination = connectorQueryOptions(limit, snapshot);
       // query() resolves the apiKey via the bound resolver internally and returns
       // a serializable result — no credential in scope here, no DataFrame built.
-      const result = await connector.query(databaseId, tableId, pagination);
+      const result = await connector.query(table.table, tableId, pagination);
       const dataFrameId = snapshot
         ? await persistConnectorFrame(ctx, {
             arrowBuffer: result.arrowBuffer,
@@ -1679,11 +1844,15 @@ const queryPostgresTable = wy.procedure
       { dataSourceId, databaseId, tableId, limit, snapshot, approvedFields },
     ): Promise<PostgresQueryResult> => {
       const connector = await postgresConnectorFor(ctx, dataSourceId);
-      const pagination =
-        limit !== undefined && Number.isInteger(limit) && limit > 0
-          ? { pagination: { offset: 0, limit } }
-          : undefined;
-      const result = await connector.query(databaseId, tableId, pagination);
+      const table = await connectorTableBinding(ctx, dataSourceId, tableId);
+      if (databaseId !== table.table) {
+        throw new Error(
+          `DataTable ${tableId} is bound to remote resource ${table.table}`,
+        );
+      }
+      await requireConnectorMaterializationPermission(ctx, snapshot);
+      const pagination = connectorQueryOptions(limit, snapshot);
+      const result = await connector.query(table.table, tableId, pagination);
       const dataFrameId = snapshot
         ? await persistConnectorFrame(ctx, {
             arrowBuffer: result.arrowBuffer,
@@ -1914,21 +2083,10 @@ const queryGa4Property = wy.procedure
       ctx,
       { dataSourceId, tableId, limit, snapshot, approvedFields },
     ): Promise<Ga4QueryResult> => {
-      const table = (await ctx.db
-        .from(dataTables)
-        .where(eq("id", tableId))
-        .first()) as DataTableRow | undefined;
-      if (!table) throw new Error(`DataTable ${tableId} not found`);
-      if (table.dataSourceId !== dataSourceId) {
-        throw new Error(
-          `DataTable ${tableId} does not belong to DataSource ${dataSourceId}`,
-        );
-      }
       const connector = await ga4ConnectorFor(ctx, dataSourceId);
-      const pagination =
-        limit !== undefined && Number.isInteger(limit) && limit > 0
-          ? { pagination: { offset: 0, limit } }
-          : undefined;
+      const table = await connectorTableBinding(ctx, dataSourceId, tableId);
+      await requireConnectorMaterializationPermission(ctx, snapshot);
+      const pagination = connectorQueryOptions(limit, snapshot);
       const result = await connector.query(table.table, tableId, pagination);
       const dataFrameId = snapshot
         ? await persistConnectorFrame(ctx, {

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -3731,6 +3731,40 @@ describe("command vocabulary", () => {
         0,
       );
     });
+
+    it("preserves an Insight-owned DataFrame while a DataTable still references it", async () => {
+      const { tableId } = await makeTable();
+      const insightId = id();
+      const frameId = id();
+      await commit(
+        cmd("CreateInsight", {
+          id: insightId,
+          name: "I",
+          source: { sourceType: "dataTable", sourceId: tableId },
+        }),
+      );
+      await db.insert(schema.dataFrames).values({
+        id: frameId,
+        storage: { type: "indexeddb", key: `arrow-${frameId}` },
+        fieldIds: [],
+        name: `Frame for ${insightId}`,
+        insightId,
+        createdAt: new Date(),
+      });
+      await db
+        .update(schema.dataTables)
+        .set({ dataFrameId: frameId })
+        .where(eq(schema.dataTables.id, tableId));
+
+      await commit(cmd("DeleteNode", { id: insightId }));
+
+      expect(
+        await db
+          .select()
+          .from(schema.dataFrames)
+          .where(eq(schema.dataFrames.id, frameId)),
+      ).toHaveLength(1);
+    });
   });
 
   describe("RenameNode (extended to Visualization and Dashboard)", () => {

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1967,10 +1967,10 @@ async function findOrphanedInsights(
  * so DataTable cleanup is handled by the caller passing the DataTable's
  * `dataFrameId` directly.
  *
- * The `dataFrames` table stores metadata only; the actual Arrow bytes live in
- * the renderer's IndexedDB. Deleting the metadata row here is the signal the
- * client-side `removeDataFrame` hook needs to clean up the Arrow bytes via
- * `deleteArrowData(storage.key)` (see `packages/app/src/data/data-frames.ts`).
+ * The `dataFrames` table stores metadata only. For server-file rows, the
+ * server app reconciles unreferenced files after the enclosing command
+ * transaction commits; a rolled-back batch therefore never loses live bytes.
+ * Retained IndexedDB rows are still cleaned by the client data-access hook.
  */
 async function deleteInsightDataFrames(
   ctx: { db: import("@wystack/db").DrizzleTracker },
@@ -1988,8 +1988,8 @@ async function deleteInsightDataFrames(
  *
  * Returns the deduplicated set of Insights that SOURCE or JOIN any of
  * `ownedTables` (these are the reference-boundary orphans). As a side-effect,
- * deletes the DataFrame metadata rows for each DataTable's Arrow result so the
- * client-side `removeDataFrame` hook can clean up Arrow bytes.
+ * deletes the DataFrame metadata rows for each DataTable's Arrow result. The
+ * server's post-commit reconciliation then removes unreferenced server files.
  *
  * The full insights table is fetched once (not once-per-table) so that N owned
  * tables do not produce N round-trips.
@@ -2230,7 +2230,7 @@ const deleteNode = wy.procedure
           (it) => it.visualizationId && ownedVizIds.has(it.visualizationId),
         );
       });
-      // Clean up DataFrame metadata so the client-side Arrow cleanup hook fires.
+      // Delete metadata; server-file cleanup runs after the command transaction.
       await deleteInsightDataFrames(ctx, id);
       // Delete the Insight — schema FK cascade removes its Visualizations.
       await ctx.db.from(insights).where(eq("id", id)).delete();

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -642,9 +642,10 @@ const createDataTable = wy.procedure
 async function requireDataTable(
   ctx: { db: import("@wystack/db").DrizzleTracker },
   id: string,
-): Promise<void> {
+): Promise<typeof dataTables.$inferSelect> {
   const row = await ctx.db.from(dataTables).where(eq("id", id)).first();
   if (!row) throw new Error(`Data table ${id} not found`);
+  return row;
 }
 
 /** SetDataTableSchema — replaces the discovered source schema slice. */
@@ -665,11 +666,28 @@ const refreshDataTable = wy.procedure
   .input({ id: uuid, dataFrameId: uuid })
   .authorize(permissions.commands.commit)
   .mutation(async (ctx, { id, dataFrameId }): Promise<{ ok: true }> => {
-    await requireDataTable(ctx, id);
+    const table = await requireDataTable(ctx, id);
+    let replacedFrameId: string | undefined;
+    if (
+      isCanonicalCommandContext(ctx) &&
+      table.dataFrameId &&
+      table.dataFrameId !== dataFrameId
+    ) {
+      const references = await ctx.db
+        .from(dataTables)
+        .where(eq("dataFrameId", table.dataFrameId))
+        .all();
+      if (references.every((reference) => reference.id === id)) {
+        replacedFrameId = table.dataFrameId;
+      }
+    }
     await ctx.db
       .from(dataTables)
       .where(eq("id", id))
       .update({ dataFrameId, lastFetchedAt: new Date() });
+    if (replacedFrameId) {
+      await ctx.db.from(dataFrames).where(eq("id", replacedFrameId)).delete();
+    }
     return { ok: true };
   });
 
@@ -2002,7 +2020,13 @@ async function deleteInsightDataFrames(
  * tables do not produce N round-trips.
  */
 async function deleteDataSourceDependents(
-  ctx: { db: import("@wystack/db").DrizzleTracker },
+  ctx: {
+    db: import("@wystack/db").DrizzleTracker;
+    mode?: string;
+    draftId?: string;
+    __publishReplay?: boolean;
+  },
+  sourceId: string,
   ownedTables: (typeof dataTables.$inferSelect)[],
 ): Promise<OrphanedNode[]> {
   // Fetch all insights once — avoids O(N) full-table scans inside the loop.
@@ -2027,20 +2051,95 @@ async function deleteDataSourceDependents(
     }
   }
 
-  // Clean up DataFrame metadata for each owned DataTable's Arrow result.
-  for (const t of ownedTables) {
-    if (t.dataFrameId) {
-      const references = await ctx.db
-        .from(dataTables)
-        .where(eq("dataFrameId", t.dataFrameId))
-        .all();
-      if (references.every((reference) => ownedTableIds.has(reference.id))) {
-        await ctx.db.from(dataFrames).where(eq("id", t.dataFrameId)).delete();
-      }
-    }
+  // Include both the current link and source/definition ownership metadata.
+  // A clear or replacement may have removed the link before an earlier
+  // cleanup completed; those rows still belong to this deletion lifecycle.
+  if (isCanonicalCommandContext(ctx)) {
+    await deleteOwnedSourceDataFrames(
+      ctx,
+      sourceId,
+      ownedTables,
+      ownedTableIds,
+    );
   }
 
   return orphanedNodes;
+}
+
+async function deleteOwnedSourceDataFrames(
+  ctx: { db: import("@wystack/db").DrizzleTracker },
+  sourceId: string,
+  ownedTables: (typeof dataTables.$inferSelect)[],
+  ownedTableIds: ReadonlySet<string>,
+): Promise<void> {
+  const candidates = new Map<string, typeof dataFrames.$inferSelect>();
+  for (const table of ownedTables) {
+    if (table.dataFrameId) {
+      const linked = await ctx.db
+        .from(dataFrames)
+        .where(eq("id", table.dataFrameId))
+        .first();
+      if (linked) candidates.set(linked.id, linked);
+    }
+    const defined = await ctx.db
+      .from(dataFrames)
+      .where(eq("definitionId", table.id))
+      .all();
+    for (const frame of defined) candidates.set(frame.id, frame);
+  }
+  const sourced = await ctx.db
+    .from(dataFrames)
+    .where(eq("sourceId", sourceId))
+    .all();
+  for (const frame of sourced) candidates.set(frame.id, frame);
+  for (const frame of candidates.values()) {
+    const references = await ctx.db
+      .from(dataTables)
+      .where(eq("dataFrameId", frame.id))
+      .all();
+    if (references.every((reference) => ownedTableIds.has(reference.id))) {
+      await ctx.db.from(dataFrames).where(eq("id", frame.id)).delete();
+    }
+  }
+}
+
+async function deleteCanonicalTableDataFrames(
+  ctx: { db: import("@wystack/db").DrizzleTracker },
+  table: typeof dataTables.$inferSelect,
+): Promise<void> {
+  const candidates = new Map<string, typeof dataFrames.$inferSelect>();
+  if (table.dataFrameId) {
+    const linked = await ctx.db
+      .from(dataFrames)
+      .where(eq("id", table.dataFrameId))
+      .first();
+    if (linked) candidates.set(linked.id, linked);
+  }
+  const defined = await ctx.db
+    .from(dataFrames)
+    .where(eq("definitionId", table.id))
+    .all();
+  for (const frame of defined) candidates.set(frame.id, frame);
+  for (const frame of candidates.values()) {
+    const references = await ctx.db
+      .from(dataTables)
+      .where(eq("dataFrameId", frame.id))
+      .all();
+    if (references.every((reference) => reference.id === table.id)) {
+      await ctx.db.from(dataFrames).where(eq("id", frame.id)).delete();
+    }
+  }
+}
+
+function isCanonicalCommandContext(ctx: {
+  mode?: string;
+  draftId?: string;
+  __publishReplay?: boolean;
+}): boolean {
+  return (
+    ctx.__publishReplay === true ||
+    (ctx.mode !== "preview" && ctx.draftId == null)
+  );
 }
 
 /**
@@ -2274,17 +2373,8 @@ const deleteNode = wy.procedure
       .first()) as typeof dataTables.$inferSelect | undefined;
     if (table) {
       const orphanedInsights = await findOrphanedInsights(ctx, id);
-      if (table.dataFrameId) {
-        const references = await ctx.db
-          .from(dataTables)
-          .where(eq("dataFrameId", table.dataFrameId))
-          .all();
-        if (references.every((reference) => reference.id === table.id)) {
-          await ctx.db
-            .from(dataFrames)
-            .where(eq("id", table.dataFrameId))
-            .delete();
-        }
+      if (isCanonicalCommandContext(ctx)) {
+        await deleteCanonicalTableDataFrames(ctx, table);
       }
       await ctx.db.from(dataTables).where(eq("id", id)).delete();
       return {
@@ -2307,7 +2397,11 @@ const deleteNode = wy.procedure
         .from(dataTables)
         .where(eq("dataSourceId", id))
         .all()) as (typeof dataTables.$inferSelect)[];
-      const orphanedNodes = await deleteDataSourceDependents(ctx, ownedTables);
+      const orphanedNodes = await deleteDataSourceDependents(
+        ctx,
+        id,
+        ownedTables,
+      );
       // PRE-RELEASE FLUSH GATE — collect credential refs from the config BEFORE
       // deleting the row, then delete the row, then flush a snapshot (so the
       // snapshot captures the "row deleted" state and can no longer reference

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -1960,12 +1960,9 @@ async function findOrphanedInsights(
 }
 
 /**
- * Delete all DataFrame metadata rows linked to the given node id (by
- * `insightId` column) and return their storage locations so the caller can
- * signal Arrow/IndexedDB cleanup. DataTable rows link via `dataFrameId` (a
- * nullable FK on the DataTable row itself), not a column on the DataFrame —
- * so DataTable cleanup is handled by the caller passing the DataTable's
- * `dataFrameId` directly.
+ * Delete DataFrame metadata owned by the Insight only when no DataTable still
+ * references it. DataTable-to-DataFrame links may legitimately cross the
+ * original owner boundary, so ownership alone is not a deletion signal.
  *
  * The `dataFrames` table stores metadata only. For server-file rows, the
  * server app reconciles unreferenced files after the enclosing command
@@ -1976,9 +1973,19 @@ async function deleteInsightDataFrames(
   ctx: { db: import("@wystack/db").DrizzleTracker },
   insightId: string,
 ): Promise<void> {
-  // Delete all DataFrame rows whose insightId matches — there should be at
-  // most one per Insight in practice, but the schema allows N.
-  await ctx.db.from(dataFrames).where(eq("insightId", insightId)).delete();
+  const owned = await ctx.db
+    .from(dataFrames)
+    .where(eq("insightId", insightId))
+    .all();
+  for (const frame of owned) {
+    const references = await ctx.db
+      .from(dataTables)
+      .where(eq("dataFrameId", frame.id))
+      .all();
+    if (references.length === 0) {
+      await ctx.db.from(dataFrames).where(eq("id", frame.id)).delete();
+    }
+  }
 }
 
 /**
@@ -2023,7 +2030,13 @@ async function deleteDataSourceDependents(
   // Clean up DataFrame metadata for each owned DataTable's Arrow result.
   for (const t of ownedTables) {
     if (t.dataFrameId) {
-      await ctx.db.from(dataFrames).where(eq("id", t.dataFrameId)).delete();
+      const references = await ctx.db
+        .from(dataTables)
+        .where(eq("dataFrameId", t.dataFrameId))
+        .all();
+      if (references.every((reference) => ownedTableIds.has(reference.id))) {
+        await ctx.db.from(dataFrames).where(eq("id", t.dataFrameId)).delete();
+      }
     }
   }
 
@@ -2262,10 +2275,16 @@ const deleteNode = wy.procedure
     if (table) {
       const orphanedInsights = await findOrphanedInsights(ctx, id);
       if (table.dataFrameId) {
-        await ctx.db
-          .from(dataFrames)
-          .where(eq("id", table.dataFrameId))
-          .delete();
+        const references = await ctx.db
+          .from(dataTables)
+          .where(eq("dataFrameId", table.dataFrameId))
+          .all();
+        if (references.every((reference) => reference.id === table.id)) {
+          await ctx.db
+            .from(dataFrames)
+            .where(eq("id", table.dataFrameId))
+            .delete();
+        }
       }
       await ctx.db.from(dataTables).where(eq("id", id)).delete();
       return {

--- a/apps/server/src/functions/connector-setup-ga4-pipeline.test.ts
+++ b/apps/server/src/functions/connector-setup-ga4-pipeline.test.ts
@@ -1,3 +1,4 @@
+import { FileDataFrameStorage } from "@dashframe/engine-server";
 import { openArtifactDb, schema } from "@dashframe/server-core";
 import {
   InMemoryMappingStore,
@@ -123,6 +124,7 @@ describe("GA4 connector setup pipeline", () => {
   async function makeApp(): Promise<WyStackApp> {
     const base = await buildDashframeApp({
       db,
+      dataFrameStorage: new FileDataFrameStorage(join(dir, "dataframes")),
       vault: makeVault(),
       googleOAuth: oauthConfig(),
       getServerEndpoint: () => "http://127.0.0.1:4567/api",
@@ -206,9 +208,23 @@ describe("GA4 connector setup pipeline", () => {
       { principal: user },
     );
     const tableId = (added.result as { id: string }).id;
-    const queried = await app.call(
+    const inspected = await app.call(
       "queryGa4Property",
       { dataSourceId: result.dataSourceId, tableId },
+      { principal: user },
+    );
+    expect(inspected.result).not.toHaveProperty("frameHandle");
+    const approvedFields = (
+      inspected.result as { fields: object[] }
+    ).fields.map((field) => ({ ...field, sensitivity: "cleared" }));
+    const queried = await app.call(
+      "queryGa4Property",
+      {
+        dataSourceId: result.dataSourceId,
+        tableId,
+        materialize: true,
+        approvedFields,
+      },
       { principal: user },
     );
     expect(queried.result).toMatchObject({
@@ -218,9 +234,10 @@ describe("GA4 connector setup pipeline", () => {
         { name: "activeUsers", type: "number" },
       ],
     });
-    expect(queried.result).toHaveProperty("arrowBuffer");
+    expect(queried.result).toHaveProperty("frameHandle");
+    expect(queried.result).not.toHaveProperty("arrowBuffer");
     expect(queried.result).toHaveProperty("fieldIds");
-    expect(googleFetch).toHaveBeenCalledTimes(4);
+    expect(googleFetch).toHaveBeenCalledTimes(5);
   });
 
   it("fails setup when the report probe is forbidden", async () => {

--- a/apps/server/src/functions/connector-setup-ga4-pipeline.test.ts
+++ b/apps/server/src/functions/connector-setup-ga4-pipeline.test.ts
@@ -213,7 +213,7 @@ describe("GA4 connector setup pipeline", () => {
       { dataSourceId: result.dataSourceId, tableId },
       { principal: user },
     );
-    expect(inspected.result).not.toHaveProperty("frameHandle");
+    expect(inspected.result).not.toHaveProperty("dataFrameId");
     const approvedFields = (
       inspected.result as { fields: object[] }
     ).fields.map((field) => ({ ...field, sensitivity: "cleared" }));
@@ -222,7 +222,7 @@ describe("GA4 connector setup pipeline", () => {
       {
         dataSourceId: result.dataSourceId,
         tableId,
-        materialize: true,
+        snapshot: true,
         approvedFields,
       },
       { principal: user },
@@ -234,7 +234,7 @@ describe("GA4 connector setup pipeline", () => {
         { name: "activeUsers", type: "number" },
       ],
     });
-    expect(queried.result).toHaveProperty("frameHandle");
+    expect(queried.result).toHaveProperty("dataFrameId");
     expect(queried.result).not.toHaveProperty("arrowBuffer");
     expect(queried.result).toHaveProperty("fieldIds");
     expect(googleFetch).toHaveBeenCalledTimes(5);

--- a/apps/server/src/functions/connector-setup-ga4-pipeline.test.ts
+++ b/apps/server/src/functions/connector-setup-ga4-pipeline.test.ts
@@ -214,9 +214,26 @@ describe("GA4 connector setup pipeline", () => {
       { principal: user },
     );
     expect(inspected.result).not.toHaveProperty("dataFrameId");
+    expect(
+      JSON.parse(String(runReportCalls().at(-1)?.[1]?.body)),
+    ).toMatchObject({ offset: "0", limit: "100" });
     const approvedFields = (
       inspected.result as { fields: object[] }
     ).fields.map((field) => ({ ...field, sensitivity: "cleared" }));
+    const reportCallsBeforeDeniedSnapshot = runReportCalls().length;
+    await expect(
+      app.call(
+        "queryGa4Property",
+        {
+          dataSourceId: result.dataSourceId,
+          tableId,
+          snapshot: true,
+          approvedFields,
+        },
+        { principal: { kind: "service", credentialId: "inspector" } },
+      ),
+    ).rejects.toThrow("Permission denied: commands.commit");
+    expect(runReportCalls()).toHaveLength(reportCallsBeforeDeniedSnapshot);
     const queried = await app.call(
       "queryGa4Property",
       {
@@ -227,6 +244,9 @@ describe("GA4 connector setup pipeline", () => {
       },
       { principal: user },
     );
+    expect(
+      JSON.parse(String(runReportCalls().at(-1)?.[1]?.body)),
+    ).toMatchObject({ offset: "0", limit: "10000" });
     expect(queried.result).toMatchObject({
       rowCount: 2,
       fields: [

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -236,6 +236,7 @@ const publishDraft = wy.procedure
 
       // Mark the replay as the sanctioned canonical-commit path so the credential
       // command handlers' direct-call guard accepts it (release is handled here).
+      const framesBefore = await ctx.captureServerFrameReferences?.();
       let result: Awaited<ReturnType<DraftController["publishDraft"]>>;
       try {
         result = await draftController.publishDraft(
@@ -266,6 +267,10 @@ const publishDraft = wy.procedure
           throw draftConflictError(err.conflictReport);
         }
         throw err;
+      }
+
+      if (framesBefore != null) {
+        await ctx.cleanupDereferencedServerFrames?.(framesBefore);
       }
 
       // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -270,7 +270,16 @@ const publishDraft = wy.procedure
       }
 
       if (framesBefore != null) {
-        await ctx.cleanupDereferencedServerFrames?.(framesBefore);
+        try {
+          await ctx.cleanupDereferencedServerFrames?.(framesBefore);
+        } catch (err) {
+          // The publish is already committed. Startup recovery retries cleanup,
+          // so never report the committed transition as a failed publish.
+          console.error(
+            "[dashframe] publishDraft: dereferenced server frame cleanup failed; startup recovery will retry",
+            err,
+          );
+        }
       }
 
       // Fire snapshot persistence. `buildDashframeApp`'s outer call wrapper does

--- a/apps/server/src/functions/notion-routes.test.ts
+++ b/apps/server/src/functions/notion-routes.test.ts
@@ -5,7 +5,7 @@
  *   - listNotionDatabases maps the connector's RemoteDatabase {id,name} to the
  *     renderer DTO {id,title} (the consumer renders/adds by `title`).
  *   - queryNotionDatabase persists Arrow server-side and returns an opaque
- *     frame handle plus schema metadata — no row bytes cross by default.
+ *     DataFrame ID plus schema metadata — no row bytes cross by default.
  *   - Both resolve the credential through the bound resolver (vault.withSecret)
  *     server-side, with no plaintext returned to the caller.
  *
@@ -24,9 +24,18 @@ import {
 } from "@wystack/secret-vault";
 import { applyCommands, type WyStackApp } from "@wystack/server";
 import { mkdtempSync, rmSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
 
 // Mock the connector so the routes resolve the credential via the bound
 // resolver but never hit the Notion network. The mock connect()/query() call
@@ -39,6 +48,7 @@ const approvedFields = [
   { id: "f1", name: "Name", type: "string", sensitivity: "cleared" },
   { id: "f2", name: "Status", type: "string", sensitivity: "cleared" },
 ];
+let returnedFields: Array<Record<string, unknown>> = [];
 
 vi.mock("@dashframe/connector-notion", () => ({
   makeNotionConnector: (
@@ -66,10 +76,7 @@ vi.mock("@dashframe/connector-notion", () => ({
       return auth(async () => ({
         arrowBuffer: "QVJST1cx", // base64 placeholder
         fieldIds: ["f1", "f2"],
-        fields: [
-          { id: "f1", name: "Name", type: "string" },
-          { id: "f2", name: "Status", type: "string" },
-        ],
+        fields: returnedFields,
         rowCount: 2,
       }));
     },
@@ -96,17 +103,28 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
   let vault: SecretVault;
   let backend: TestBackend;
   let frameStorage: FileDataFrameStorage;
+  let flushSnapshot: Mock<() => Promise<void>>;
+  let unregisterServerFrames: Mock<(ids: readonly string[]) => Promise<void>>;
 
   beforeEach(async () => {
     queryCalls.length = 0;
+    returnedFields = [
+      { id: "f1", name: "Name", type: "string" },
+      { id: "f2", name: "Status", type: "string" },
+    ];
     dir = mkdtempSync(join(tmpdir(), "dashframe-notion-routes-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault, backend } = makeTestVault());
     frameStorage = new FileDataFrameStorage(join(dir, "dataframes"));
+    flushSnapshot = vi.fn(async () => {});
+    unregisterServerFrames = vi.fn(async () => {});
     app = await buildDashframeApp({
       db,
       vault,
       dataFrameStorage: frameStorage,
+      flushSnapshot,
+      flushSnapshotRetentionWindow: flushSnapshot,
+      unregisterServerFrames,
     });
   });
 
@@ -158,7 +176,7 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
 
     // DTO the renderer consumes: title, not name.
     expect(result).toEqual([{ id: "db-1", title: "Roadmap" }]);
-    // The credential was materialized exactly once, server-side.
+    // The credential was imported exactly once, server-side.
     expect(backend.resolveCallCount).toBe(1);
   });
 
@@ -171,18 +189,18 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
 
-    // Serializable shape — opaque server frame handle + ids + fields + rowCount.
+    // Serializable shape — DataFrame ID + field ids + fields + rowCount.
     const r = result as {
-      frameHandle: string;
+      dataFrameId: string;
       fieldIds: string[];
       fields: unknown[];
       rowCount: number;
     };
-    expect(r.frameHandle).toMatch(/^[0-9a-f-]{36}$/);
+    expect(r.dataFrameId).toMatch(/^[0-9a-f-]{36}$/);
     expect(r).not.toHaveProperty("arrowBuffer");
     expect(r.fieldIds).toEqual(["f1", "f2"]);
     expect(r.fields).toHaveLength(2);
@@ -192,13 +210,13 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     expect(backend.resolveCallCount).toBe(1);
     expect(JSON.stringify(result)).not.toContain("secret_plaintext");
 
-    expect(await frameStorage.load(r.frameHandle)).toEqual(
+    expect(await frameStorage.load(r.dataFrameId)).toEqual(
       new Uint8Array(Buffer.from("QVJST1cx", "base64")),
     );
-    const frame = await app.call("getDataFrameEntry", { id: r.frameHandle });
+    const frame = await app.call("getDataFrameEntry", { id: r.dataFrameId });
     expect(frame.result).toMatchObject({
-      id: r.frameHandle,
-      storage: { type: "file", key: r.frameHandle },
+      id: r.dataFrameId,
+      storage: { type: "file", key: r.dataFrameId },
       definitionId: tableId,
       rowCount: 2,
       columnCount: 2,
@@ -215,13 +233,64 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       tableId,
     });
 
-    expect(result).not.toHaveProperty("frameHandle");
+    expect(result).not.toHaveProperty("dataFrameId");
     expect(await frameStorage.list()).toEqual([]);
     expect((await app.call("listDataFrames", {})).result).toEqual([]);
     expect(
       ((await app.call("getDataTable", { id: tableId })).result as DataTable)
         .dataFrameId,
     ).toBeUndefined();
+  });
+
+  it("rejects every unreviewed import shape before persistence", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const base = {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+    };
+    const expectNoPersistence = async () => {
+      expect(await frameStorage.list()).toEqual([]);
+      expect((await app.call("listDataFrames", {})).result).toEqual([]);
+      expect(
+        ((await app.call("getDataTable", { id: tableId })).result as DataTable)
+          .dataFrameId,
+      ).toBeUndefined();
+    };
+
+    await expect(app.call("queryNotionDatabase", base)).rejects.toThrow(
+      "Reviewed fields are required before import",
+    );
+    await expectNoPersistence();
+
+    await expect(
+      app.call("queryNotionDatabase", {
+        ...base,
+        approvedFields: approvedFields.map(
+          ({ sensitivity: _, ...field }) => field,
+        ),
+      }),
+    ).rejects.toThrow("Every remote column must be reviewed before import");
+    await expectNoPersistence();
+
+    await expect(
+      app.call("queryNotionDatabase", {
+        ...base,
+        approvedFields: approvedFields.slice(0, 1),
+      }),
+    ).rejects.toThrow("Reviewed fields do not match the remote result");
+    await expectNoPersistence();
+
+    returnedFields = [
+      { id: "f1", name: "Name", type: "string", sensitivity: "sensitive" },
+      { id: "f2", name: "Status", type: "string" },
+    ];
+    await expect(
+      app.call("queryNotionDatabase", { ...base, approvedFields }),
+    ).rejects.toThrow("Sensitive remote columns cannot be imported");
+    await expectNoPersistence();
   });
 
   it("forwards the preview row limit to connector.query as pagination", async () => {
@@ -248,27 +317,49 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
-    const firstHandle = (first.result as { frameHandle: string }).frameHandle;
+    const firstDataFrameId = (first.result as { dataFrameId: string })
+      .dataFrameId;
     const second = await app.call("queryNotionDatabase", {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
-    const secondHandle = (second.result as { frameHandle: string }).frameHandle;
+    const secondDataFrameId = (second.result as { dataFrameId: string })
+      .dataFrameId;
 
-    expect(await frameStorage.exists(firstHandle)).toBe(false);
-    expect(await frameStorage.exists(secondHandle)).toBe(true);
-    expect(await frameStorage.list()).toEqual([secondHandle]);
+    expect(await frameStorage.exists(firstDataFrameId)).toBe(false);
+    expect(await frameStorage.exists(secondDataFrameId)).toBe(true);
+    expect(await frameStorage.list()).toEqual([secondDataFrameId]);
     expect((await app.call("listDataFrames", {})).result).toHaveLength(1);
 
     await app.call("removeDataTable", { id: tableId });
-    expect(await frameStorage.exists(secondHandle)).toBe(false);
+    expect(await frameStorage.exists(secondDataFrameId)).toBe(false);
     expect((await app.call("listDataFrames", {})).result).toEqual([]);
+  });
+
+  it("does not retain an orphan when import races table deletion", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const [, removed] = await Promise.allSettled([
+      app.call("queryNotionDatabase", {
+        dataSourceId: id,
+        databaseId: "db-1",
+        tableId,
+        snapshot: true,
+        approvedFields,
+      }),
+      app.call("removeDataTable", { id: tableId }),
+    ]);
+
+    expect(removed.status).toBe("fulfilled");
+    expect((await app.call("getDataTable", { id: tableId })).result).toBeNull();
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+    expect(await frameStorage.list()).toEqual([]);
   });
 
   it("removes a server frame after DeleteNode commits", async () => {
@@ -278,10 +369,10 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
-    const handle = (queried.result as { frameHandle: string }).frameHandle;
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
 
     await app.call(
       "commitBatch",
@@ -295,8 +386,131 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       },
     );
 
-    expect(await frameStorage.exists(handle)).toBe(false);
+    expect(await frameStorage.exists(dataFrameId)).toBe(false);
+    expect(flushSnapshot).toHaveBeenCalled();
+    expect(unregisterServerFrames).toHaveBeenCalledWith([dataFrameId]);
     expect((await app.call("listDataFrames", {})).result).toEqual([]);
+  });
+
+  it("preserves a shared frame when one referencing DataTable is deleted", async () => {
+    const id = await seedNotionSource();
+    const ownerTableId = await seedNotionTable(id);
+    const otherTableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId: ownerTableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    await app.call("updateDataTable", {
+      id: otherTableId,
+      updates: { dataFrameId: dataFrameId },
+    });
+
+    await app.call(
+      "commitBatch",
+      { commands: [cmd("DeleteNode", { id: otherTableId })] },
+      {
+        wyStackApp: app,
+        artifactDb: db,
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      },
+    );
+
+    expect(await frameStorage.exists(dataFrameId)).toBe(true);
+    expect(
+      (await app.call("getDataFrameEntry", { id: dataFrameId })).result,
+    ).not.toBeNull();
+    expect(
+      (await app.call("getDataTable", { id: ownerTableId })).result,
+    ).toMatchObject({ dataFrameId: dataFrameId });
+  });
+
+  it("removes a shared frame when its final referencing DataTable is deleted", async () => {
+    const id = await seedNotionSource();
+    const ownerTableId = await seedNotionTable(id);
+    const otherTableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId: ownerTableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    await app.call("updateDataTable", {
+      id: otherTableId,
+      updates: { dataFrameId: dataFrameId },
+    });
+
+    const context = {
+      wyStackApp: app,
+      artifactDb: db,
+      principal: { kind: "user" as const, userId: LOCAL_USER_ID },
+    };
+    await app.call(
+      "commitBatch",
+      { commands: [cmd("DeleteNode", { id: ownerTableId })] },
+      context,
+    );
+
+    expect(await frameStorage.exists(dataFrameId)).toBe(true);
+    expect(
+      (await app.call("getDataFrameEntry", { id: dataFrameId })).result,
+    ).not.toBeNull();
+    expect(
+      (await app.call("getDataTable", { id: otherTableId })).result,
+    ).toMatchObject({ dataFrameId: dataFrameId });
+
+    await app.call(
+      "commitBatch",
+      { commands: [cmd("DeleteNode", { id: otherTableId })] },
+      context,
+    );
+
+    expect(await frameStorage.exists(dataFrameId)).toBe(false);
+    expect(
+      (await app.call("getDataFrameEntry", { id: dataFrameId })).result,
+    ).toBeNull();
+    expect(unregisterServerFrames).toHaveBeenCalledWith([dataFrameId]);
+  });
+
+  it("retains staged bytes when the durable snapshot flush fails", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    flushSnapshot.mockRejectedValue(new Error("injected snapshot failure"));
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await app.call(
+      "removeDataFrameEntry",
+      { id: dataFrameId },
+      { flushSnapshot, flushSnapshotRetentionWindow: flushSnapshot },
+    );
+
+    expect(
+      (await app.call("getDataFrameEntry", { id: dataFrameId })).result,
+    ).toBeNull();
+    expect(await frameStorage.exists(dataFrameId)).toBe(true);
+    expect(
+      (await app.call("getDataTable", { id: tableId })).result,
+    ).toMatchObject({ dataFrameId: undefined });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("leaving staged server frame deletes"),
+      expect.any(Error),
+    );
+    const trash = await readdir(join(dir, "dataframes", ".trash"));
+    expect(trash).toHaveLength(1);
+    log.mockRestore();
   });
 
   it("reports a committed DeleteNode and schedules its snapshot when file cleanup must retry", async () => {
@@ -306,16 +520,18 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
-    const handle = (queried.result as { frameHandle: string }).frameHandle;
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
     const onWrite = vi.fn();
     app = await buildDashframeApp({
       db,
       vault,
       dataFrameStorage: frameStorage,
       onWrite,
+      flushSnapshot: async () => {},
+      flushSnapshotRetentionWindow: async () => {},
     });
     const cleanup = vi
       .spyOn(frameStorage, "delete")
@@ -336,7 +552,7 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     ).resolves.toBeDefined();
 
     expect(onWrite).toHaveBeenCalled();
-    expect(await frameStorage.exists(handle)).toBe(true);
+    expect(await frameStorage.exists(dataFrameId)).toBe(true);
     expect((await app.call("listDataFrames", {})).result).toEqual([]);
     cleanup.mockRestore();
 
@@ -344,8 +560,89 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       db,
       vault,
       dataFrameStorage: frameStorage,
+      flushSnapshotRetentionWindow: async () => {},
     });
-    expect(await frameStorage.exists(handle)).toBe(false);
+    expect(await frameStorage.exists(dataFrameId)).toBe(false);
+  });
+
+  it("reports a committed DeleteNode when the post-commit ownership query must retry", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const onWrite = vi.fn();
+    const flushSnapshotRetentionWindow = vi.fn(async () => {});
+    app = await buildDashframeApp({
+      db,
+      vault,
+      dataFrameStorage: frameStorage,
+      onWrite,
+      flushSnapshot: async () => {},
+      flushSnapshotRetentionWindow,
+    });
+    flushSnapshotRetentionWindow.mockRejectedValueOnce(
+      new Error("injected post-commit snapshot failure"),
+    );
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      app.call(
+        "commitBatch",
+        { commands: [cmd("DeleteNode", { id: tableId })] },
+        {
+          wyStackApp: app,
+          artifactDb: db,
+          onWrite,
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        },
+      ),
+    ).resolves.toBeDefined();
+
+    expect(onWrite).toHaveBeenCalled();
+    expect((await app.call("getDataTable", { id: tableId })).result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("snapshot flush failed"),
+      expect.any(Error),
+    );
+    log.mockRestore();
+  });
+
+  it("starts with an unremovable orphan and retries it on the next startup", async () => {
+    const orphan = "11111111-1111-4111-8111-111111111111";
+    await frameStorage.save(orphan, new Uint8Array([1]));
+    const cleanup = vi
+      .spyOn(frameStorage, "delete")
+      .mockRejectedValueOnce(new Error("injected startup cleanup failure"));
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      buildDashframeApp({
+        db,
+        vault,
+        dataFrameStorage: frameStorage,
+        flushSnapshotRetentionWindow: async () => {},
+      }),
+    ).resolves.toBeDefined();
+    expect(await frameStorage.exists(orphan)).toBe(true);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("the next start will retry"),
+      expect.any(Array),
+    );
+
+    cleanup.mockRestore();
+    log.mockRestore();
+    await buildDashframeApp({
+      db,
+      vault,
+      dataFrameStorage: frameStorage,
+      flushSnapshotRetentionWindow: async () => {},
+    });
+    expect(await frameStorage.exists(orphan)).toBe(false);
   });
 
   it("restores a staged frame when the metadata transaction fails", async () => {
@@ -355,24 +652,28 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
-    const handle = (queried.result as { frameHandle: string }).frameHandle;
-    const transaction = vi
-      .spyOn(db, "transaction")
-      .mockRejectedValueOnce(new Error("injected transaction failure"));
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    await db.$client.exec(`
+      CREATE FUNCTION fail_frame_delete() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN RAISE EXCEPTION 'injected transaction failure'; END $$;
+      CREATE TRIGGER fail_frame_delete
+      BEFORE DELETE ON data_frames
+      FOR EACH ROW EXECUTE FUNCTION fail_frame_delete();
+    `);
 
     await expect(app.call("removeDataTable", { id: tableId })).rejects.toThrow(
-      "injected transaction failure",
+      'delete from "data_frames"',
     );
-    transaction.mockRestore();
+    await db.$client.exec(`DROP TRIGGER fail_frame_delete ON data_frames`);
 
-    expect(await frameStorage.exists(handle)).toBe(true);
+    expect(await frameStorage.exists(dataFrameId)).toBe(true);
     expect(
-      (await app.call("getDataFrameEntry", { id: handle })).result,
+      (await app.call("getDataFrameEntry", { id: dataFrameId })).result,
     ).toMatchObject({
-      id: handle,
+      id: dataFrameId,
       definitionId: tableId,
     });
   });
@@ -384,29 +685,33 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       dataSourceId: id,
       databaseId: "db-1",
       tableId,
-      materialize: true,
+      snapshot: true,
       approvedFields,
     });
-    const handle = (queried.result as { frameHandle: string }).frameHandle;
-    const transaction = vi
-      .spyOn(db, "transaction")
-      .mockRejectedValueOnce(new Error("injected replacement failure"));
+    const dataFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    await db.$client.exec(`
+      CREATE FUNCTION fail_frame_insert() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN RAISE EXCEPTION 'injected replacement failure'; END $$;
+      CREATE TRIGGER fail_frame_insert
+      BEFORE INSERT ON data_frames
+      FOR EACH ROW EXECUTE FUNCTION fail_frame_insert();
+    `);
 
     await expect(
       app.call("queryNotionDatabase", {
         dataSourceId: id,
         databaseId: "db-1",
         tableId,
-        materialize: true,
+        snapshot: true,
         approvedFields,
       }),
-    ).rejects.toThrow("injected replacement failure");
-    transaction.mockRestore();
+    ).rejects.toThrow('insert into "data_frames"');
+    await db.$client.exec(`DROP TRIGGER fail_frame_insert ON data_frames`);
 
-    expect(await frameStorage.list()).toEqual([handle]);
+    expect(await frameStorage.list()).toEqual([dataFrameId]);
     expect(
       (await app.call("getDataTable", { id: tableId })).result,
-    ).toMatchObject({ dataFrameId: handle });
+    ).toMatchObject({ dataFrameId: dataFrameId });
     expect((await app.call("listDataFrames", {})).result).toHaveLength(1);
   });
 

--- a/apps/server/src/functions/notion-routes.test.ts
+++ b/apps/server/src/functions/notion-routes.test.ts
@@ -4,8 +4,8 @@
  * Proves the route-level contract that the fail-closed tests don't reach:
  *   - listNotionDatabases maps the connector's RemoteDatabase {id,name} to the
  *     renderer DTO {id,title} (the consumer renders/adds by `title`).
- *   - queryNotionDatabase returns the serializable result {arrowBuffer,
- *     fieldIds, fields} unchanged — no live DataFrame crosses the boundary.
+ *   - queryNotionDatabase persists Arrow server-side and returns an opaque
+ *     frame handle plus schema metadata — no row bytes cross by default.
  *   - Both resolve the credential through the bound resolver (vault.withSecret)
  *     server-side, with no plaintext returned to the caller.
  *
@@ -13,7 +13,9 @@
  * invokes its bound resolver (proving the auth-blind path runs) and returns
  * fixed data. TestBackend is used ONLY in test setup — never in production code.
  */
+import { FileDataFrameStorage } from "@dashframe/engine-server";
 import { CREDENTIAL_CLASS, openArtifactDb } from "@dashframe/server-core";
+import type { DataTable } from "@dashframe/types";
 import {
   InMemoryMappingStore,
   SecretRegistry,
@@ -33,6 +35,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Captures the options the route forwards to connector.query (e.g. the preview
 // row limit) so a test can assert the wiring.
 const queryCalls: Array<{ databaseId: string; options?: unknown }> = [];
+const approvedFields = [
+  { id: "f1", name: "Name", type: "string", sensitivity: "cleared" },
+  { id: "f2", name: "Status", type: "string", sensitivity: "cleared" },
+];
 
 vi.mock("@dashframe/connector-notion", () => ({
   makeNotionConnector: (
@@ -60,16 +66,18 @@ vi.mock("@dashframe/connector-notion", () => ({
       return auth(async () => ({
         arrowBuffer: "QVJST1cx", // base64 placeholder
         fieldIds: ["f1", "f2"],
-        fields: [{ id: "f1" }, { id: "f2" }],
+        fields: [
+          { id: "f1", name: "Name", type: "string" },
+          { id: "f2", name: "Status", type: "string" },
+        ],
         rowCount: 2,
       }));
     },
   }),
 }));
 
-import { functions } from "../functions";
+import { buildDashframeApp } from "../app";
 import { LOCAL_USER_ID } from "../permissions";
-import { wy } from "../wystack";
 import { cmd } from "./commands";
 
 function makeTestVault(): { vault: SecretVault; backend: TestBackend } {
@@ -87,25 +95,19 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
   let app: WyStackApp;
   let vault: SecretVault;
   let backend: TestBackend;
+  let frameStorage: FileDataFrameStorage;
 
   beforeEach(async () => {
     queryCalls.length = 0;
     dir = mkdtempSync(join(tmpdir(), "dashframe-notion-routes-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault, backend } = makeTestVault());
-    const rawApp = await wy.build({ db, functions });
-    app = {
-      ...rawApp,
-      async call(path, args, ctx) {
-        return rawApp.call(path, args, { ...(ctx ?? {}), vault });
-      },
-      async runHandler(path, args, tracked, ctx) {
-        return rawApp.runHandler(path, args, tracked, {
-          ...(ctx ?? {}),
-          vault,
-        });
-      },
-    };
+    frameStorage = new FileDataFrameStorage(join(dir, "dataframes"));
+    app = await buildDashframeApp({
+      db,
+      vault,
+      dataFrameStorage: frameStorage,
+    });
   });
 
   afterEach(async () => {
@@ -137,6 +139,15 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     return id;
   }
 
+  async function seedNotionTable(dataSourceId: string): Promise<string> {
+    const added = await app.call("addDataTable", {
+      dataSourceId,
+      name: "Roadmap",
+      table: "db-1",
+    });
+    return (added.result as { id: string }).id;
+  }
+
   it("listNotionDatabases maps {id,name} → {id,title} and resolves via the vault", async () => {
     const id = await seedNotionSource();
     expect(backend.resolveCallCount).toBe(0);
@@ -153,23 +164,26 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
 
   it("queryNotionDatabase returns the serializable result and resolves via the vault", async () => {
     const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
     expect(backend.resolveCallCount).toBe(0);
 
     const { result } = await app.call("queryNotionDatabase", {
       dataSourceId: id,
       databaseId: "db-1",
-      tableId: crypto.randomUUID(),
+      tableId,
+      materialize: true,
+      approvedFields,
     });
 
-    // Serializable shape — raw Arrow buffer + ids + fields + rowCount, no live
-    // DataFrame. rowCount lets the renderer register frame metadata.
+    // Serializable shape — opaque server frame handle + ids + fields + rowCount.
     const r = result as {
-      arrowBuffer: string;
+      frameHandle: string;
       fieldIds: string[];
       fields: unknown[];
       rowCount: number;
     };
-    expect(typeof r.arrowBuffer).toBe("string");
+    expect(r.frameHandle).toMatch(/^[0-9a-f-]{36}$/);
+    expect(r).not.toHaveProperty("arrowBuffer");
     expect(r.fieldIds).toEqual(["f1", "f2"]);
     expect(r.fields).toHaveLength(2);
     expect(r.rowCount).toBe(2);
@@ -177,15 +191,47 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     // Credential resolved once, server-side; no plaintext in the payload.
     expect(backend.resolveCallCount).toBe(1);
     expect(JSON.stringify(result)).not.toContain("secret_plaintext");
+
+    expect(await frameStorage.load(r.frameHandle)).toEqual(
+      new Uint8Array(Buffer.from("QVJST1cx", "base64")),
+    );
+    const frame = await app.call("getDataFrameEntry", { id: r.frameHandle });
+    expect(frame.result).toMatchObject({
+      id: r.frameHandle,
+      storage: { type: "file", key: r.frameHandle },
+      definitionId: tableId,
+      rowCount: 2,
+      columnCount: 2,
+    });
+  });
+
+  it("inspection returns schema without persisting unreviewed row bytes", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+
+    const { result } = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+    });
+
+    expect(result).not.toHaveProperty("frameHandle");
+    expect(await frameStorage.list()).toEqual([]);
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+    expect(
+      ((await app.call("getDataTable", { id: tableId })).result as DataTable)
+        .dataFrameId,
+    ).toBeUndefined();
   });
 
   it("forwards the preview row limit to connector.query as pagination", async () => {
     const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
 
     await app.call("queryNotionDatabase", {
       dataSourceId: id,
       databaseId: "db-1",
-      tableId: crypto.randomUUID(),
+      tableId,
       limit: 250,
     });
 
@@ -195,13 +241,183 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     });
   });
 
+  it("replaces and removes the server frame with its owning table", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const first = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      materialize: true,
+      approvedFields,
+    });
+    const firstHandle = (first.result as { frameHandle: string }).frameHandle;
+    const second = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      materialize: true,
+      approvedFields,
+    });
+    const secondHandle = (second.result as { frameHandle: string }).frameHandle;
+
+    expect(await frameStorage.exists(firstHandle)).toBe(false);
+    expect(await frameStorage.exists(secondHandle)).toBe(true);
+    expect(await frameStorage.list()).toEqual([secondHandle]);
+    expect((await app.call("listDataFrames", {})).result).toHaveLength(1);
+
+    await app.call("removeDataTable", { id: tableId });
+    expect(await frameStorage.exists(secondHandle)).toBe(false);
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+  });
+
+  it("removes a server frame after DeleteNode commits", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      materialize: true,
+      approvedFields,
+    });
+    const handle = (queried.result as { frameHandle: string }).frameHandle;
+
+    await app.call(
+      "commitBatch",
+      {
+        commands: [cmd("DeleteNode", { id: tableId })],
+      },
+      {
+        wyStackApp: app,
+        artifactDb: db,
+        principal: { kind: "user", userId: LOCAL_USER_ID },
+      },
+    );
+
+    expect(await frameStorage.exists(handle)).toBe(false);
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+  });
+
+  it("reports a committed DeleteNode and schedules its snapshot when file cleanup must retry", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      materialize: true,
+      approvedFields,
+    });
+    const handle = (queried.result as { frameHandle: string }).frameHandle;
+    const onWrite = vi.fn();
+    app = await buildDashframeApp({
+      db,
+      vault,
+      dataFrameStorage: frameStorage,
+      onWrite,
+    });
+    const cleanup = vi
+      .spyOn(frameStorage, "delete")
+      .mockRejectedValueOnce(new Error("injected cleanup failure"));
+    onWrite.mockClear();
+
+    await expect(
+      app.call(
+        "commitBatch",
+        { commands: [cmd("DeleteNode", { id: tableId })] },
+        {
+          wyStackApp: app,
+          artifactDb: db,
+          onWrite,
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        },
+      ),
+    ).resolves.toBeDefined();
+
+    expect(onWrite).toHaveBeenCalled();
+    expect(await frameStorage.exists(handle)).toBe(true);
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+    cleanup.mockRestore();
+
+    app = await buildDashframeApp({
+      db,
+      vault,
+      dataFrameStorage: frameStorage,
+    });
+    expect(await frameStorage.exists(handle)).toBe(false);
+  });
+
+  it("restores a staged frame when the metadata transaction fails", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      materialize: true,
+      approvedFields,
+    });
+    const handle = (queried.result as { frameHandle: string }).frameHandle;
+    const transaction = vi
+      .spyOn(db, "transaction")
+      .mockRejectedValueOnce(new Error("injected transaction failure"));
+
+    await expect(app.call("removeDataTable", { id: tableId })).rejects.toThrow(
+      "injected transaction failure",
+    );
+    transaction.mockRestore();
+
+    expect(await frameStorage.exists(handle)).toBe(true);
+    expect(
+      (await app.call("getDataFrameEntry", { id: handle })).result,
+    ).toMatchObject({
+      id: handle,
+      definitionId: tableId,
+    });
+  });
+
+  it("keeps the prior frame and removes the new file when replacement fails", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      materialize: true,
+      approvedFields,
+    });
+    const handle = (queried.result as { frameHandle: string }).frameHandle;
+    const transaction = vi
+      .spyOn(db, "transaction")
+      .mockRejectedValueOnce(new Error("injected replacement failure"));
+
+    await expect(
+      app.call("queryNotionDatabase", {
+        dataSourceId: id,
+        databaseId: "db-1",
+        tableId,
+        materialize: true,
+        approvedFields,
+      }),
+    ).rejects.toThrow("injected replacement failure");
+    transaction.mockRestore();
+
+    expect(await frameStorage.list()).toEqual([handle]);
+    expect(
+      (await app.call("getDataTable", { id: tableId })).result,
+    ).toMatchObject({ dataFrameId: handle });
+    expect((await app.call("listDataFrames", {})).result).toHaveLength(1);
+  });
+
   it("omits pagination when no limit is given (unbounded fetch)", async () => {
     const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
 
     await app.call("queryNotionDatabase", {
       dataSourceId: id,
       databaseId: "db-1",
-      tableId: crypto.randomUUID(),
+      tableId,
     });
 
     expect(queryCalls).toHaveLength(1);
@@ -210,11 +426,12 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
 
   it("rejects a non-positive limit (limit: 0 must not become an unbounded scan)", async () => {
     const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
 
     await app.call("queryNotionDatabase", {
       dataSourceId: id,
       databaseId: "db-1",
-      tableId: crypto.randomUUID(),
+      tableId,
       limit: 0,
     });
 

--- a/apps/server/src/functions/notion-routes.test.ts
+++ b/apps/server/src/functions/notion-routes.test.ts
@@ -13,8 +13,15 @@
  * invokes its bound resolver (proving the auth-blind path runs) and returns
  * fixed data. TestBackend is used ONLY in test setup — never in production code.
  */
-import { FileDataFrameStorage } from "@dashframe/engine-server";
-import { CREDENTIAL_CLASS, openArtifactDb } from "@dashframe/server-core";
+import {
+  duckdbColumnsToArrowIpc,
+  FileDataFrameStorage,
+} from "@dashframe/engine-server";
+import {
+  CREDENTIAL_CLASS,
+  openArtifactDb,
+  schema,
+} from "@dashframe/server-core";
 import type { DataTable } from "@dashframe/types";
 import {
   InMemoryMappingStore,
@@ -23,6 +30,7 @@ import {
   TestBackend,
 } from "@wystack/secret-vault";
 import { applyCommands, type WyStackApp } from "@wystack/server";
+import { eq as drizzleEq } from "drizzle-orm";
 import { mkdtempSync, rmSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -44,11 +52,14 @@ import {
 // Captures the options the route forwards to connector.query (e.g. the preview
 // row limit) so a test can assert the wiring.
 const queryCalls: Array<{ databaseId: string; options?: unknown }> = [];
+const postgresQueryCalls: Array<{ databaseId: string; options?: unknown }> = [];
 const approvedFields = [
   { id: "f1", name: "Name", type: "string", sensitivity: "cleared" },
   { id: "f2", name: "Status", type: "string", sensitivity: "cleared" },
 ];
 let returnedFields: Array<Record<string, unknown>> = [];
+let returnedArrowBuffer = "";
+let pauseQuery: (() => Promise<void>) | undefined;
 
 vi.mock("@dashframe/connector-notion", () => ({
   makeNotionConnector: (
@@ -73,8 +84,9 @@ vi.mock("@dashframe/connector-notion", () => ({
     connect: async () => auth(async () => [{ id: "db-1", name: "Roadmap" }]),
     query: async (databaseId: string, _tableId: string, options?: unknown) => {
       queryCalls.push({ databaseId, options });
+      await pauseQuery?.();
       return auth(async () => ({
-        arrowBuffer: "QVJST1cx", // base64 placeholder
+        arrowBuffer: returnedArrowBuffer,
         fieldIds: ["f1", "f2"],
         fields: returnedFields,
         rowCount: 2,
@@ -83,7 +95,31 @@ vi.mock("@dashframe/connector-notion", () => ({
   }),
 }));
 
-import { buildDashframeApp } from "../app";
+vi.mock("@dashframe/connector-postgres", () => ({
+  makePostgresConnector: (
+    auth: <T>(use: (plaintext: string) => Promise<T>) => Promise<T>,
+  ) => ({
+    id: "postgres",
+    name: "Postgres",
+    description: "Postgres",
+    icon: "<svg></svg>",
+    sourceType: "database" as const,
+    getFormFields: () => [],
+    connect: async () =>
+      auth(async () => [{ id: "public.tasks", name: "Tasks" }]),
+    query: async (databaseId: string, _tableId: string, options?: unknown) => {
+      postgresQueryCalls.push({ databaseId, options });
+      return auth(async () => ({
+        arrowBuffer: returnedArrowBuffer,
+        fieldIds: ["f1", "f2"],
+        fields: returnedFields,
+        rowCount: 2,
+      }));
+    },
+  }),
+}));
+
+import { buildDashframeApp, createDraftController } from "../app";
 import { LOCAL_USER_ID } from "../permissions";
 import { cmd } from "./commands";
 
@@ -105,27 +141,46 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
   let frameStorage: FileDataFrameStorage;
   let flushSnapshot: Mock<() => Promise<void>>;
   let unregisterServerFrames: Mock<(ids: readonly string[]) => Promise<void>>;
+  let onWrite: Mock<() => void>;
 
   beforeEach(async () => {
     queryCalls.length = 0;
+    postgresQueryCalls.length = 0;
+    pauseQuery = undefined;
     returnedFields = [
       { id: "f1", name: "Name", type: "string" },
       { id: "f2", name: "Status", type: "string" },
     ];
+    returnedArrowBuffer = Buffer.from(
+      duckdbColumnsToArrowIpc([
+        { name: "Name", typeId: 17, values: ["One", "Two"] },
+        { name: "Status", typeId: 17, values: ["Open", "Done"] },
+      ]),
+    ).toString("base64");
     dir = mkdtempSync(join(tmpdir(), "dashframe-notion-routes-"));
     db = await openArtifactDb({ path: join(dir, "artifacts.db") });
     ({ vault, backend } = makeTestVault());
     frameStorage = new FileDataFrameStorage(join(dir, "dataframes"));
     flushSnapshot = vi.fn(async () => {});
     unregisterServerFrames = vi.fn(async () => {});
-    app = await buildDashframeApp({
+    onWrite = vi.fn();
+    const builtApp = await buildDashframeApp({
       db,
       vault,
       dataFrameStorage: frameStorage,
       flushSnapshot,
       flushSnapshotRetentionWindow: flushSnapshot,
       unregisterServerFrames,
+      onWrite,
     });
+    app = {
+      ...builtApp,
+      call: (path, args, context = {}) =>
+        builtApp.call(path, args, {
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+          ...context,
+        }),
+    };
   });
 
   afterEach(async () => {
@@ -164,6 +219,37 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       table: "db-1",
     });
     return (added.result as { id: string }).id;
+  }
+
+  async function seedPostgresSourceAndTable(): Promise<{
+    sourceId: string;
+    tableId: string;
+  }> {
+    const sourceId = crypto.randomUUID();
+    await applyCommands(
+      app,
+      [
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "postgres",
+          name: "Warehouse",
+          connectionString: "postgresql://user:pass@host/db",
+        }),
+      ],
+      {
+        mode: "commit",
+        context: {
+          vault,
+          principal: { kind: "user", userId: LOCAL_USER_ID },
+        },
+      },
+    );
+    const added = await app.call("addDataTable", {
+      dataSourceId: sourceId,
+      name: "Tasks",
+      table: "public.tasks",
+    });
+    return { sourceId, tableId: (added.result as { id: string }).id };
   }
 
   it("listNotionDatabases maps {id,name} → {id,title} and resolves via the vault", async () => {
@@ -209,9 +295,10 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     // Credential resolved once, server-side; no plaintext in the payload.
     expect(backend.resolveCallCount).toBe(1);
     expect(JSON.stringify(result)).not.toContain("secret_plaintext");
+    expect(queryCalls[0]?.options).toBeUndefined();
 
     expect(await frameStorage.load(r.dataFrameId)).toEqual(
-      new Uint8Array(Buffer.from("QVJST1cx", "base64")),
+      new Uint8Array(Buffer.from(returnedArrowBuffer, "base64")),
     );
     const frame = await app.call("getDataFrameEntry", { id: r.dataFrameId });
     expect(frame.result).toMatchObject({
@@ -340,6 +427,301 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     await app.call("removeDataTable", { id: tableId });
     expect(await frameStorage.exists(secondDataFrameId)).toBe(false);
     expect((await app.call("listDataFrames", {})).result).toEqual([]);
+  });
+
+  it("clearing a table link removes its old owned frame but preserves a shared frame", async () => {
+    const id = await seedNotionSource();
+    const ownerTableId = await seedNotionTable(id);
+    const sharedTableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId: ownerTableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const frameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    await app.call("updateDataTable", {
+      id: sharedTableId,
+      updates: { dataFrameId: frameId },
+    });
+
+    await app.call("updateDataTable", {
+      id: ownerTableId,
+      updates: { dataFrameId: null },
+    });
+    expect(await frameStorage.exists(frameId)).toBe(true);
+    expect(
+      (await app.call("getDataFrameEntry", { id: frameId })).result,
+    ).not.toBeNull();
+
+    flushSnapshot.mockClear();
+    await app.call("updateDataTable", {
+      id: sharedTableId,
+      updates: { dataFrameId: null },
+    });
+    expect(await frameStorage.exists(frameId)).toBe(false);
+    expect(
+      (await app.call("getDataFrameEntry", { id: frameId })).result,
+    ).toBeNull();
+    expect(flushSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("source deletion discovers an old source-owned frame after its table link was already cleared", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const frameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    // Recreate the pre-fix stranded state: metadata still owns the frame, but
+    // the table's current link no longer reveals it.
+    await db
+      .update(schema.dataTables)
+      .set({ dataFrameId: null })
+      .where(drizzleEq(schema.dataTables.id, tableId));
+
+    await app.call("removeDataSource", { id });
+    expect(await frameStorage.exists(frameId)).toBe(false);
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+    await expect(
+      buildDashframeApp({
+        db,
+        vault,
+        dataFrameStorage: frameStorage,
+        flushSnapshotRetentionWindow: async () => {},
+      }),
+    ).resolves.toBeDefined();
+    expect(await frameStorage.list()).toEqual([]);
+  });
+
+  it("canonical RefreshDataTable does not strand the replaced server frame", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const oldFrameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    const replacementId = crypto.randomUUID();
+
+    await app.call(
+      "commitBatch",
+      {
+        commands: [
+          cmd("RefreshDataTable", { id: tableId, dataFrameId: replacementId }),
+        ],
+      },
+      { wyStackApp: app, artifactDb: db },
+    );
+
+    expect(await frameStorage.exists(oldFrameId)).toBe(false);
+    expect(
+      (await app.call("getDataFrameEntry", { id: oldFrameId })).result,
+    ).toBeNull();
+    expect(
+      (await app.call("getDataTable", { id: tableId })).result,
+    ).toMatchObject({ dataFrameId: replacementId });
+  });
+
+  it("rejects malformed or schema-mismatched IPC before replacing a healthy frame", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const healthy = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const healthyId = (healthy.result as { dataFrameId: string }).dataFrameId;
+
+    const healthyIpc = Buffer.from(returnedArrowBuffer, "base64");
+    returnedArrowBuffer = healthyIpc
+      .subarray(0, Math.floor(healthyIpc.length / 2))
+      .toString("base64");
+    await expect(
+      app.call("queryNotionDatabase", {
+        dataSourceId: id,
+        databaseId: "db-1",
+        tableId,
+        snapshot: true,
+        approvedFields,
+      }),
+    ).rejects.toThrow("malformed Arrow IPC");
+    expect(await frameStorage.list()).toEqual([healthyId]);
+
+    returnedArrowBuffer = Buffer.from(
+      duckdbColumnsToArrowIpc([
+        { name: "Wrong", typeId: 17, values: ["One", "Two"] },
+        { name: "Status", typeId: 17, values: ["Open", "Done"] },
+      ]),
+    ).toString("base64");
+    await expect(
+      app.call("queryNotionDatabase", {
+        dataSourceId: id,
+        databaseId: "db-1",
+        tableId,
+        snapshot: true,
+        approvedFields,
+      }),
+    ).rejects.toThrow("schema does not match reviewed fields");
+    expect(await frameStorage.list()).toEqual([healthyId]);
+    expect(
+      (await app.call("getDataTable", { id: tableId })).result,
+    ).toMatchObject({ dataFrameId: healthyId });
+  });
+
+  it("validates the persisted remote binding before resolving credentials or querying", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    await expect(
+      app.call("queryNotionDatabase", {
+        dataSourceId: id,
+        databaseId: "attacker-selected-db",
+        tableId,
+      }),
+    ).rejects.toThrow("is bound to remote resource db-1");
+    expect(queryCalls).toEqual([]);
+    expect(backend.resolveCallCount).toBe(0);
+  });
+
+  it("enforces the persisted Postgres resource binding before credentials or query", async () => {
+    const { sourceId, tableId } = await seedPostgresSourceAndTable();
+    expect(backend.resolveCallCount).toBe(0);
+    await expect(
+      app.call("queryPostgresTable", {
+        dataSourceId: sourceId,
+        databaseId: "public.secrets",
+        tableId,
+      }),
+    ).rejects.toThrow("is bound to remote resource public.tasks");
+    expect(postgresQueryCalls).toEqual([]);
+    expect(backend.resolveCallCount).toBe(0);
+
+    await app.call("queryPostgresTable", {
+      dataSourceId: sourceId,
+      databaseId: "public.tasks",
+      tableId,
+    });
+    expect(postgresQueryCalls).toEqual([
+      {
+        databaseId: "public.tasks",
+        options: { pagination: { offset: 0, limit: 100 } },
+      },
+    ]);
+    expect(backend.resolveCallCount).toBe(1);
+  });
+
+  it("allows service inspection but requires commit permission before materialization", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const service = {
+      principal: { kind: "service", credentialId: "reader" },
+    };
+
+    await expect(
+      app.call(
+        "queryNotionDatabase",
+        { dataSourceId: id, databaseId: "db-1", tableId },
+        service,
+      ),
+    ).resolves.toBeDefined();
+    queryCalls.length = 0;
+    await expect(
+      app.call(
+        "queryNotionDatabase",
+        {
+          dataSourceId: id,
+          databaseId: "db-1",
+          tableId,
+          snapshot: true,
+          approvedFields,
+        },
+        service,
+      ),
+    ).rejects.toThrow("Permission denied: commands.commit");
+    expect(queryCalls).toEqual([]);
+    expect(await frameStorage.list()).toEqual([]);
+  });
+
+  it("cannot attach a materialized frame after table deletion commits", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    let release!: () => void;
+    let started!: () => void;
+    const queryStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    pauseQuery = async () => {
+      started();
+      await released;
+    };
+    const materialize = app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    await queryStarted;
+    await app.call("removeDataTable", { id: tableId });
+    release();
+
+    await expect(materialize).rejects.toThrow(`DataTable ${tableId} not found`);
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+    expect(await frameStorage.list()).toEqual([]);
+  });
+
+  it("executes frame-touching preview and draft batches without canonical side effects", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const frameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    const command = cmd("DeleteNode", { id: tableId });
+
+    await expect(
+      app.call(
+        "previewDiff",
+        { commands: [command] },
+        {
+          wyStackApp: app,
+          artifactDb: db,
+          principal: { kind: "service", credentialId: "previewer" },
+        },
+      ),
+    ).resolves.toBeDefined();
+    const controller = createDraftController(app, db);
+    const draftId = await controller.openDraft();
+    await expect(
+      controller.appendToDraft(draftId, [command], {
+        principal: { kind: "service", credentialId: "drafter" },
+      }),
+    ).resolves.toBeDefined();
+
+    expect(
+      (await app.call("getDataTable", { id: tableId })).result,
+    ).not.toBeNull();
+    expect(await frameStorage.exists(frameId)).toBe(true);
+    expect(
+      (await app.call("getDataFrameEntry", { id: frameId })).result,
+    ).not.toBeNull();
   });
 
   it("does not retain an orphan when import races table deletion", async () => {
@@ -565,6 +947,53 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     expect(await frameStorage.exists(dataFrameId)).toBe(false);
   });
 
+  it("publishDraft reports success and continues snapshot scheduling when post-commit cleanup fails", async () => {
+    const id = await seedNotionSource();
+    const tableId = await seedNotionTable(id);
+    const queried = await app.call("queryNotionDatabase", {
+      dataSourceId: id,
+      databaseId: "db-1",
+      tableId,
+      snapshot: true,
+      approvedFields,
+    });
+    const frameId = (queried.result as { dataFrameId: string }).dataFrameId;
+    const controller = createDraftController(app, db);
+    const draftId = await controller.openDraft();
+    await controller.appendToDraft(
+      draftId,
+      [cmd("DeleteNode", { id: tableId })],
+      { principal: { kind: "user", userId: LOCAL_USER_ID } },
+    );
+    const cleanup = vi
+      .spyOn(frameStorage, "delete")
+      .mockRejectedValueOnce(new Error("injected publish cleanup failure"));
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    onWrite.mockClear();
+    flushSnapshot.mockClear();
+
+    await expect(
+      app.call(
+        "publishDraft",
+        { draftId },
+        { draftController: controller, onWrite },
+      ),
+    ).resolves.toBeDefined();
+    expect((await app.call("getDataTable", { id: tableId })).result).toBeNull();
+    expect((await app.call("listDataFrames", {})).result).toEqual([]);
+    expect(await frameStorage.exists(frameId)).toBe(true);
+    expect(onWrite).toHaveBeenCalled();
+    expect(flushSnapshot).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "dereferenced server frame(s) could not be removed",
+      ),
+      expect.any(Array),
+    );
+    cleanup.mockRestore();
+    log.mockRestore();
+  });
+
   it("reports a committed DeleteNode when the post-commit ownership query must retry", async () => {
     const id = await seedNotionSource();
     const tableId = await seedNotionTable(id);
@@ -715,7 +1144,7 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     expect((await app.call("listDataFrames", {})).result).toHaveLength(1);
   });
 
-  it("omits pagination when no limit is given (unbounded fetch)", async () => {
+  it("applies a fail-safe inspection bound when no preview limit is given", async () => {
     const id = await seedNotionSource();
     const tableId = await seedNotionTable(id);
 
@@ -726,10 +1155,12 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
     });
 
     expect(queryCalls).toHaveLength(1);
-    expect(queryCalls[0]?.options).toBeUndefined();
+    expect(queryCalls[0]?.options).toEqual({
+      pagination: { offset: 0, limit: 100 },
+    });
   });
 
-  it("rejects a non-positive limit (limit: 0 must not become an unbounded scan)", async () => {
+  it("falls back to the inspection bound for a non-positive limit", async () => {
     const id = await seedNotionSource();
     const tableId = await seedNotionTable(id);
 
@@ -740,9 +1171,9 @@ describe("Notion data-plane routes — happy path (mocked connector)", () => {
       limit: 0,
     });
 
-    // limit: 0 is dropped (not forwarded as pagination), so the connector's
-    // page loop does not see `0 || Infinity` → full scan.
     expect(queryCalls).toHaveLength(1);
-    expect(queryCalls[0]?.options).toBeUndefined();
+    expect(queryCalls[0]?.options).toEqual({
+      pagination: { offset: 0, limit: 100 },
+    });
   });
 });

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -1230,10 +1230,15 @@ const commitBatch = wy.procedure
     if (ctx.vault !== undefined) handlerContext.vault = ctx.vault;
     if (ctx.principal !== undefined) handlerContext.principal = ctx.principal;
 
+    const framesBefore = await ctx.captureServerFrameReferences?.();
     const result = await applyCommands(wyStackApp, commands as Command[], {
       mode: "commit",
       context: handlerContext,
     });
+
+    if (framesBefore != null) {
+      await ctx.cleanupDereferencedServerFrames?.(framesBefore);
+    }
 
     if (result.tablesWritten.size > 0) {
       ctx.onWrite?.();

--- a/apps/server/src/functions/preview-diff.ts
+++ b/apps/server/src/functions/preview-diff.ts
@@ -1237,7 +1237,16 @@ const commitBatch = wy.procedure
     });
 
     if (framesBefore != null) {
-      await ctx.cleanupDereferencedServerFrames?.(framesBefore);
+      try {
+        await ctx.cleanupDereferencedServerFrames?.(framesBefore);
+      } catch (err) {
+        // applyCommands has committed. Cleanup is recoverable startup work and
+        // must not suppress snapshot scheduling, invalidation, or the response.
+        console.error(
+          "[dashframe] commitBatch: dereferenced server frame cleanup failed; startup recovery will retry",
+          err,
+        );
+      }
     }
 
     if (result.tablesWritten.size > 0) {

--- a/apps/server/src/functions/vault-control-plane.test.ts
+++ b/apps/server/src/functions/vault-control-plane.test.ts
@@ -664,6 +664,103 @@ describe("connector factory — mintBoundResolver fail-closed", () => {
       }),
     ).rejects.toThrow(/not a notion source/i);
   });
+
+  it("queryPostgresTable throws for a wrong-kind source before a missing table", async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-factory-pg-kind-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    const { vault } = makeTestVault();
+    const rawApp = await buildUserApp(db);
+    const id = crypto.randomUUID();
+    await db.insert(dataSources).values({
+      id,
+      kind: "csv",
+      name: "Not Postgres",
+      storage: "parquet",
+      config: {},
+      createdBy: { kind: "user" as const },
+    });
+
+    await expect(
+      rawApp.call(
+        "queryPostgresTable",
+        {
+          dataSourceId: id,
+          databaseId: "public.tasks",
+          tableId: crypto.randomUUID(),
+        },
+        { vault },
+      ),
+    ).rejects.toThrow(/not a postgres source/i);
+  });
+
+  it("queryPostgresTable throws without a vault before a missing table", async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-factory-pg-novault-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    const rawApp = await buildUserApp(db);
+    const id = crypto.randomUUID();
+    await db.insert(dataSources).values({
+      id,
+      kind: "postgres",
+      name: "Postgres without vault",
+      storage: "live",
+      config: {},
+      createdBy: { kind: "user" as const },
+    });
+
+    await expect(
+      rawApp.call("queryPostgresTable", {
+        dataSourceId: id,
+        databaseId: "public.tasks",
+        tableId: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow(/no vault/i);
+  });
+
+  it("queryGa4Property throws for a wrong-kind source before a missing table", async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-factory-ga4-kind-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    const { vault } = makeTestVault();
+    const rawApp = await buildUserApp(db);
+    const id = crypto.randomUUID();
+    await db.insert(dataSources).values({
+      id,
+      kind: "csv",
+      name: "Not GA4",
+      storage: "parquet",
+      config: {},
+      createdBy: { kind: "user" as const },
+    });
+
+    await expect(
+      rawApp.call(
+        "queryGa4Property",
+        { dataSourceId: id, tableId: crypto.randomUUID() },
+        { vault },
+      ),
+    ).rejects.toThrow(/not a Google Analytics source/i);
+  });
+
+  it("queryGa4Property throws without a vault before a missing table", async () => {
+    dir = mkdtempSync(join(tmpdir(), "dashframe-factory-ga4-novault-"));
+    db = await openArtifactDb({ path: join(dir, "artifacts.db") });
+    const rawApp = await buildUserApp(db);
+    const id = crypto.randomUUID();
+    await db.insert(dataSources).values({
+      id,
+      kind: "googleAnalytics",
+      name: "GA4 without vault",
+      storage: "live",
+      config: {},
+      createdBy: { kind: "user" as const },
+    });
+
+    await expect(
+      rawApp.call("queryGa4Property", {
+        dataSourceId: id,
+        tableId: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow(/no vault/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -1,3 +1,4 @@
+import { FileDataFrameStorage } from "@dashframe/engine-server/file-dataframe-storage";
 import {
   ApiAccessCredentials,
   CREDENTIAL_CLASS,
@@ -399,6 +400,7 @@ describe("dashframe serve CLI", () => {
 
         const project = {
           db: {},
+          dir: path.join(dataDir, "project"),
           touchSnapshot: vi.fn(),
           flushSnapshot: vi.fn(),
         } as unknown as ProjectHandle;
@@ -416,6 +418,7 @@ describe("dashframe serve CLI", () => {
         expect(options.accessCredentials).toBe(services.accessCredentials);
         expect(options.authToken).toBe("plaintext-token");
         expect(options.arrowEngine).toBe(arrowEngine);
+        expect(options.dataFrameStorage).toBeInstanceOf(FileDataFrameStorage);
 
         // Named access tokens and connector credentials share the composed,
         // encrypted standalone vault. No other credential class is routed to
@@ -463,6 +466,7 @@ describe("dashframe serve CLI", () => {
       expect(services).toEqual({});
       const project = {
         db: {},
+        dir: "/unused-project",
         touchSnapshot: vi.fn(),
         flushSnapshot: vi.fn(),
       } as unknown as ProjectHandle;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -464,6 +464,7 @@ export function createStandaloneServerOptions(
     // Durable counterpart: used by the pre-release gate before deleting a vault
     // ref so the snapshot that drops the ref is confirmed on disk first.
     flushSnapshot: () => project.flushSnapshot(),
+    flushSnapshotRetentionWindow: () => project.flushSnapshotRetentionWindow(),
     googleOAuth: readOptionalGoogleOAuthConfig(),
   };
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import type {
   ArrowQueryRunner,
   ArrowTableRegistrar,
 } from "@dashframe/engine-server/arrow-data-path";
+import { FileDataFrameStorage } from "@dashframe/engine-server/file-dataframe-storage";
 import {
   ApiAccessCredentials,
   CREDENTIAL_CLASS,
@@ -448,6 +449,9 @@ export function createStandaloneServerOptions(
 ): DashframeServerOptions {
   return {
     db: project.db,
+    dataFrameStorage: new FileDataFrameStorage(
+      path.join(project.dir, "dataframes"),
+    ),
     hostname: opts.hostname,
     port: opts.port,
     corsOrigin: opts.corsOrigin,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,13 @@
 import "@dashframe/app/globals.css";
 
 import type { AppRouterContext, ProviderWrapper } from "@dashframe/app";
-import { createWyStackRuntime, resolveWyStackConfig } from "@dashframe/app";
+import {
+  ChartEngineProvider,
+  configureServerDataPlane,
+  createServerConnector,
+  createWyStackRuntime,
+  resolveWyStackConfig,
+} from "@dashframe/app";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -39,13 +45,24 @@ function renderBootstrapError(error: unknown) {
 async function bootstrap() {
   const config = await resolveWyStackConfig();
   const { Provider } = createWyStackRuntime(config);
+  const connector = createServerConnector({
+    serverUrl: config.url,
+    ...(config.token ? { token: config.token } : {}),
+  });
+  configureServerDataPlane({
+    serverUrl: config.url,
+    connector,
+    ...(config.token ? { token: config.token } : {}),
+  });
 
   // WyStack Provider wraps PostHog so every data hook (and PostHogPageView's
   // router hooks) sees both contexts. The composed wrapper rides the
   // providerWrapper slot into the shared RouteRoot.
   const providerWrapper: ProviderWrapper = ({ children }) => (
     <Provider>
-      <WebProviders>{children}</WebProviders>
+      <ChartEngineProvider connector={connector}>
+        <WebProviders>{children}</WebProviders>
+      </ChartEngineProvider>
     </Provider>
   );
   router.update({ context: { providerWrapper } });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -154,6 +154,10 @@ export default defineConfig(({ mode }) => {
               changeOrigin: true,
               ws: true,
             },
+            "/data": {
+              target: wystackUrl,
+              changeOrigin: true,
+            },
           }
         : undefined,
     },

--- a/bun.lock
+++ b/bun.lock
@@ -457,6 +457,7 @@
         "@tanstack/react-router": "^1.169.2",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.12",
+        "@uwdata/flechette": "^2.2.5",
         "@uwdata/vgplot": "^0.21.1",
         "@wystack/client": "workspace:*",
         "@wystack/ui-core": "workspace:*",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,6 +48,7 @@
     "@tanstack/react-router": "^1.169.2",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.12",
+    "@uwdata/flechette": "^2.2.5",
     "@uwdata/vgplot": "^0.21.1",
     "apache-arrow": "^21.1.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -106,13 +106,13 @@ function remapAnalysisColumnNames(
 }
 
 import { useConfirmDialogStore } from "@/lib/stores/confirm-dialog-store";
+import type { DuckDBConnection } from "@dashframe/engine-browser";
 import type { ChartEncoding } from "@dashframe/types";
 import { fieldEncoding, metricEncoding } from "@dashframe/types";
-import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 
 /** Helper context for DataFrame analysis operations */
 interface AnalysisContext {
-  duckDBConnection: AsyncDuckDBConnection;
+  duckDBConnection: DuckDBConnection;
   updateAnalysis: (id: UUID, analysis: DataFrameAnalysis) => Promise<void>;
 }
 
@@ -889,7 +889,7 @@ export function InsightView({
   // For insights with joins, creates a view with joined data
   // For simple insights, returns the base table name
   const { viewName: chartTableName, isReady: isChartViewReady } =
-    useInsightView(insight);
+    useInsightView(insight, { dataTables: allDataTables });
 
   // Derived column-analysis: only return cached results if they match the
   // currently-active chart view. Otherwise treat as empty.

--- a/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
+++ b/packages/app/src/app/visualizations/[visualizationId]/_components/VisualizationPageContent.tsx
@@ -229,7 +229,7 @@ export default function VisualizationPageContent({
 
   // Get DuckDB view name for analysis (uses UUID-based column names)
   const { viewName: analysisViewName, isReady: isAnalysisViewReady } =
-    useInsightView(insightForView);
+    useInsightView(insightForView, { dataTables });
   const {
     columns: modelColumns,
     columnDisplayNames: modelColumnDisplayNames,

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -468,7 +468,7 @@ export function DataPickerContent({
         const queryResource = (snapshot = false, approvedFields?: Field[]) => {
           const snapshotRequest = snapshot
             ? { snapshot: true, approvedFields }
-            : {};
+            : { limit: 100 };
           if (remoteResourceState.connectorId === "notion") {
             return queryNotionDatabaseMutation({
               dataSourceId: remoteResourceState.sourceId,

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -1,5 +1,4 @@
 import { getConnectorById } from "@/lib/connectors/registry";
-import { removeDataFrame } from "@/lib/data-access/data-frames";
 import { handleFileConnectorResult } from "@/lib/local-csv-handler";
 import {
   connectRemoteSource,
@@ -10,17 +9,13 @@ import {
   reviewUnclassifiedRemoteFields,
   type RemoteFieldReviewRequest,
 } from "@/lib/remote-field-review";
-import {
-  materializeRemoteTable,
-  RemoteTableReplacementError,
-} from "@/lib/remote-table-materialization";
 import { useConfirmDialogStore, type ConfirmDialogConfig } from "@/lib/stores";
 import { api } from "@/wystack/api";
 import type {
   FileSourceConnector,
   RemoteApiConnector,
 } from "@dashframe/engine";
-import type { CreateDataSourceInput, UUID } from "@dashframe/types";
+import type { CreateDataSourceInput, Field, UUID } from "@dashframe/types";
 import {
   cmd,
   COMMAND_PATHS,
@@ -462,7 +457,6 @@ export function DataPickerContent({
       setMaterializingResourceId(resource.id);
       setError(null);
       let tableId: UUID | null = null;
-      let dataFrameId: UUID | null = null;
       try {
         tableId = (
           await addDataTable({
@@ -471,27 +465,38 @@ export function DataPickerContent({
             table: resource.id,
           })
         ).id;
-        let result;
-        if (remoteResourceState.connectorId === "notion") {
-          result = await queryNotionDatabaseMutation({
-            dataSourceId: remoteResourceState.sourceId,
-            databaseId: resource.id,
-            tableId,
-          });
-        } else if (remoteResourceState.connectorId === "postgres") {
-          result = await queryPostgresTableMutation({
-            dataSourceId: remoteResourceState.sourceId,
-            databaseId: resource.id,
-            tableId,
-          });
-        } else {
+        const queryResource = (
+          materialize = false,
+          approvedFields?: Field[],
+        ) => {
+          const materialization = materialize
+            ? { materialize: true, approvedFields }
+            : {};
+          if (remoteResourceState.connectorId === "notion") {
+            return queryNotionDatabaseMutation({
+              dataSourceId: remoteResourceState.sourceId,
+              databaseId: resource.id,
+              tableId: tableId!,
+              ...materialization,
+            });
+          }
+          if (remoteResourceState.connectorId === "postgres") {
+            return queryPostgresTableMutation({
+              dataSourceId: remoteResourceState.sourceId,
+              databaseId: resource.id,
+              tableId: tableId!,
+              ...materialization,
+            });
+          }
           // The property is read from the DataTable row just created above,
           // so it cannot drift from the resource the user picked.
-          result = await queryGa4PropertyMutation({
+          return queryGa4PropertyMutation({
             dataSourceId: remoteResourceState.sourceId,
-            tableId,
+            tableId: tableId!,
+            ...materialization,
           });
-        }
+        };
+        const result = await queryResource();
         const explicitlySensitive = result.fields.some(
           (field) => getFieldSensitivity(field) === "sensitive",
         );
@@ -510,20 +515,11 @@ export function DataPickerContent({
           return;
         }
 
-        const materialized = await materializeRemoteTable(
-          { id: tableId },
-          { ...result, fields: reviewedFields },
-          resource.title,
-        );
-        dataFrameId = materialized.dataFrameId;
+        await queryResource(true, reviewedFields);
         onTableSelect(tableId, resource.title);
-      } catch (cause) {
-        const preserveTable = cause instanceof RemoteTableReplacementError;
+      } catch {
         const cleanupResults = await Promise.allSettled([
-          ...(dataFrameId ? [removeDataFrame(dataFrameId)] : []),
-          ...(tableId && !preserveTable
-            ? [removeDataTable({ id: tableId })]
-            : []),
+          ...(tableId ? [removeDataTable({ id: tableId })] : []),
         ]);
         const cleanupFailed = cleanupResults.some(
           ({ status }) => status === "rejected",

--- a/packages/app/src/components/data-sources/DataPickerContent.tsx
+++ b/packages/app/src/components/data-sources/DataPickerContent.tsx
@@ -165,9 +165,9 @@ export function DataPickerContent({
   const [error, setError] = useState<string | null>(null);
   const [remoteResourceState, setRemoteResourceState] =
     useState<RemoteResourceState | null>(null);
-  const [materializingResourceId, setMaterializingResourceId] = useState<
-    string | null
-  >(null);
+  const [importingResourceId, setImportingResourceId] = useState<string | null>(
+    null,
+  );
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -454,7 +454,7 @@ export function DataPickerContent({
   const handleRemoteResourceSelect = useCallback(
     async (resource: { id: string; title: string }) => {
       if (!remoteResourceState) return;
-      setMaterializingResourceId(resource.id);
+      setImportingResourceId(resource.id);
       setError(null);
       let tableId: UUID | null = null;
       try {
@@ -465,19 +465,16 @@ export function DataPickerContent({
             table: resource.id,
           })
         ).id;
-        const queryResource = (
-          materialize = false,
-          approvedFields?: Field[],
-        ) => {
-          const materialization = materialize
-            ? { materialize: true, approvedFields }
+        const queryResource = (snapshot = false, approvedFields?: Field[]) => {
+          const snapshotRequest = snapshot
+            ? { snapshot: true, approvedFields }
             : {};
           if (remoteResourceState.connectorId === "notion") {
             return queryNotionDatabaseMutation({
               dataSourceId: remoteResourceState.sourceId,
               databaseId: resource.id,
               tableId: tableId!,
-              ...materialization,
+              ...snapshotRequest,
             });
           }
           if (remoteResourceState.connectorId === "postgres") {
@@ -485,7 +482,7 @@ export function DataPickerContent({
               dataSourceId: remoteResourceState.sourceId,
               databaseId: resource.id,
               tableId: tableId!,
-              ...materialization,
+              ...snapshotRequest,
             });
           }
           // The property is read from the DataTable row just created above,
@@ -493,7 +490,7 @@ export function DataPickerContent({
           return queryGa4PropertyMutation({
             dataSourceId: remoteResourceState.sourceId,
             tableId: tableId!,
-            ...materialization,
+            ...snapshotRequest,
           });
         };
         const result = await queryResource();
@@ -530,7 +527,7 @@ export function DataPickerContent({
             : "Couldn't import this table. Check the connection and try again.",
         );
       } finally {
-        setMaterializingResourceId(null);
+        setImportingResourceId(null);
       }
     },
     [
@@ -631,7 +628,7 @@ export function DataPickerContent({
                       label={resource.title}
                       variant="outline"
                       className="w-full justify-start"
-                      disabled={materializingResourceId !== null}
+                      disabled={importingResourceId !== null}
                       onClick={() => handleRemoteResourceSelect(resource)}
                     />
                   ))

--- a/packages/app/src/components/data-sources/DataSourceDisplay.tsx
+++ b/packages/app/src/components/data-sources/DataSourceDisplay.tsx
@@ -3,9 +3,12 @@ import {
   getConnectorById,
   useRegistryVersion,
 } from "@/lib/connectors/registry";
-import { materializeRemoteTable } from "@/lib/remote-table-materialization";
 import { api } from "@/wystack/api";
-import type { DataTable, Field } from "@dashframe/types";
+import {
+  getFieldSensitivity,
+  type DataTable,
+  type Field,
+} from "@dashframe/types";
 import { VirtualTable, type VirtualTableColumn } from "@dashframe/ui";
 import { useMutation, useQuery } from "@wystack/client";
 import {
@@ -554,17 +557,30 @@ function useNotionSync(
         return;
       }
 
-      // Persist the frame + fields BEFORE reporting success, so a reload finds
-      // the data and schema intact (not just a refreshed timestamp).
-      const materialized = await materializeRemoteTable(
-        selectedDataTable,
-        reviewedResult,
-        selectedDataTable.name,
-      );
+      if (
+        reviewedResult.fields.some(
+          (field) => getFieldSensitivity(field) !== "cleared",
+        )
+      ) {
+        throw new Error(
+          "Every remote column must be reviewed before materialization",
+        );
+      }
+
+      // Re-query only after the privacy gate. The server validates the reviewed
+      // schema against that result and commits bytes, schema, and linkage
+      // atomically; row bytes never transit the UI.
+      const materialized = await queryNotionDatabaseMutation({
+        dataSourceId: dataSource.id,
+        databaseId: selectedDataTable.table,
+        tableId: selectedDataTable.id,
+        materialize: true,
+        approvedFields: reviewedResult.fields,
+      });
 
       setNotionPreviewData({
         tableId: selectedDataTable.id,
-        rows: [], // row data lives in IndexedDB; preview shows column schema
+        rows: [], // row data stays in server storage; preview shows column schema
         columns,
         rowCount: materialized.rowCount,
       });

--- a/packages/app/src/components/data-sources/DataSourceDisplay.tsx
+++ b/packages/app/src/components/data-sources/DataSourceDisplay.tsx
@@ -37,7 +37,7 @@ interface DataSourceDisplayProps {
 
 // Preview data type for Notion sources.
 // rowCount is the actual fetched row count; undefined when only column schema
-// is available (e.g. the serializable query result carries no materialized rows).
+// is available (e.g. the serializable query result carries no snapshot rows).
 // tableId keys the preview to the data table it was synced from — stale preview
 // from a previously selected table is suppressed by comparing to selectedDataTable.id.
 interface PreviewData {
@@ -108,7 +108,7 @@ function getFilesDescription(fileCount: number): string {
 
 // Helper to get table stats description.
 // rowCount may be undefined when only the column schema has been fetched
-// (the serializable query result carries no materialized row count).
+// (the serializable query result carries no snapshot row count).
 function getTableStatsDescription(
   rowCount: number | undefined,
   columnCount: number | undefined,
@@ -518,7 +518,7 @@ function useNotionSync(
 
     setIsRefreshing(true);
     try {
-      // Sync materializes the FULL database (no row cap): the persisted table
+      // Refresh imports the FULL database (no row cap): the persisted table
       // must hold the whole source so it survives a reload intact. The server's
       // `limit` arg stays available for a future preview-only fetch.
       const result = await queryNotionDatabaseMutation({
@@ -562,19 +562,17 @@ function useNotionSync(
           (field) => getFieldSensitivity(field) !== "cleared",
         )
       ) {
-        throw new Error(
-          "Every remote column must be reviewed before materialization",
-        );
+        throw new Error("Every remote column must be reviewed before refresh");
       }
 
       // Re-query only after the privacy gate. The server validates the reviewed
       // schema against that result and commits bytes, schema, and linkage
       // atomically; row bytes never transit the UI.
-      const materialized = await queryNotionDatabaseMutation({
+      const refreshed = await queryNotionDatabaseMutation({
         dataSourceId: dataSource.id,
         databaseId: selectedDataTable.table,
         tableId: selectedDataTable.id,
-        materialize: true,
+        snapshot: true,
         approvedFields: reviewedResult.fields,
       });
 
@@ -582,7 +580,7 @@ function useNotionSync(
         tableId: selectedDataTable.id,
         rows: [], // row data stays in server storage; preview shows column schema
         columns,
-        rowCount: materialized.rowCount,
+        rowCount: refreshed.rowCount,
       });
 
       toast.success(successMsg(columns.length));

--- a/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
+++ b/packages/app/src/components/preview-diff/usePreviewComputeFill.ts
@@ -402,7 +402,7 @@ type ResolvedTables = {
  */
 async function ensureInsightDataFrames(
   insightLike: InsightLike,
-  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+  conn: import("@dashframe/engine-browser").DuckDBConnection,
   nodeIndex: DirectNodeIndex,
 ): Promise<ResolvedTables | null> {
   const baseTable = await resolveBaseTable(insightLike.baseTableId, nodeIndex);
@@ -463,7 +463,7 @@ function countCellToNumber(cell: unknown): number | null {
 async function computeRowCount(
   insightLike: InsightLike,
   tables: ResolvedTables,
-  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+  conn: import("@dashframe/engine-browser").DuckDBConnection,
 ): Promise<number | null> {
   const { baseTable, joinedTables } = tables;
 
@@ -514,7 +514,7 @@ const EMPTY_COMPUTE: PreviewCompute = {
 async function computeHead(
   insightLike: InsightLike,
   tables: ResolvedTables,
-  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+  conn: import("@dashframe/engine-browser").DuckDBConnection,
 ): Promise<Array<Record<string, unknown>>> {
   const { baseTable, joinedTables } = tables;
 
@@ -548,7 +548,7 @@ async function computeHead(
 async function computeNode(
   proposed: InsightLike,
   canonical: InsightLike | null,
-  conn: import("@duckdb/duckdb-wasm").AsyncDuckDBConnection,
+  conn: import("@dashframe/engine-browser").DuckDBConnection,
   nodeIndex: DirectNodeIndex,
 ): Promise<PreviewCompute> {
   const [proposedTables, canonicalTables] = await Promise.all([

--- a/packages/app/src/components/providers/ChartEngineProvider.tsx
+++ b/packages/app/src/components/providers/ChartEngineProvider.tsx
@@ -2,16 +2,11 @@
  * ChartEngineProvider — surface-scoped chart compute injection point.
  *
  * The visualization system (Mosaic + vgplot) needs a DuckDB connection to run
- * chart queries. Which DuckDB it talks to is surface-scoped:
- *   - web tier / WASM  — no override; VisualizationSetup uses the WASM engine.
- *   - desktop tier     — the host supplies a Mosaic Connector that routes
- *                        chart queries to the native DuckDB engine via the
- *                        loopback Arrow IPC endpoint.
+ * chart queries. Web and desktop hosts both inject a Mosaic Connector that
+ * routes those queries to native DuckDB through the server Arrow endpoint.
  *
  * The connector is injected here via context rather than via an `isElectron`
- * branch in components (see DESIGN.md anti-patterns). The desktop renderer
- * supplies a connector through its ProviderWrapper; the web host provides
- * nothing and VisualizationSetup falls back to WASM.
+ * branch in components (see DESIGN.md anti-patterns).
  *
  * The MosaicConnector shape mirrors `@uwdata/mosaic-core`'s `Connector`
  * interface, kept inline here so this package has no direct dep on mosaic-core.
@@ -36,8 +31,7 @@ export interface MosaicConnector {
 
 interface ChartEngineContextValue {
   /**
-   * When set, VisualizationSetup bypasses DuckDB-WASM and wires this
-   * connector into the Mosaic Coordinator instead.
+   * Server-native connector wired into the Mosaic Coordinator.
    */
   connector: MosaicConnector | null;
   /**
@@ -47,11 +41,8 @@ interface ChartEngineContextValue {
   engineError: string | null;
   /**
    * Upload a named Arrow IPC table to the native engine's in-memory store.
-   * Called by useInsightView before issuing chart queries that reference a
-   * DataFrame table — ensures the native engine has the same tables the
-   * renderer's WASM engine has.
-   *
-   * Only provided when a native connector is active; null on the WASM path.
+   * Retained as a dormant compatibility seam; the active server connection
+   * handles local imports directly and registers durable frames by handle.
    */
   uploadArrowTable:
     | ((name: string, arrowBytes: Uint8Array) => Promise<void>)
@@ -68,9 +59,7 @@ export interface ChartEngineProviderProps {
   connector: MosaicConnector | null;
   engineError?: string | null;
   /**
-   * Upload function for Arrow IPC table registration on the native engine.
-   * Should be provided alongside `connector` on the desktop path.
-   * Omit (or pass null) on the web/WASM path.
+   * Dormant Arrow upload seam. Active hosts omit it.
    */
   uploadArrowTable?:
     | ((name: string, arrowBytes: Uint8Array) => Promise<void>)
@@ -80,8 +69,7 @@ export interface ChartEngineProviderProps {
 
 /**
  * Provide a custom Mosaic Connector for chart compute.
- * Desktop hosts supply a native-engine-backed connector here.
- * Web hosts do not mount this provider; VisualizationSetup falls back to WASM.
+ * Both hosts supply a native-engine-backed connector here.
  */
 export function ChartEngineProvider({
   connector,
@@ -91,11 +79,8 @@ export function ChartEngineProvider({
 }: ChartEngineProviderProps) {
   // Memoize the context value. Without this, a fresh object literal every render
   // would change the context identity, forcing every useChartEngine() consumer
-  // to re-render. In useInsightView that re-render re-runs the chart-query
-  // effect (connector/uploadArrowTable are in its dep array) → setState →
-  // re-render → infinite loop, which crashes the renderer on the visualization
-  // route. The desktop host passes stable connector/uploadArrowTable references,
-  // so this memo holds steady once mounted.
+  // to re-render. Hosts pass stable connector references, so this memo holds
+  // steady once mounted.
   const value = useMemo(
     () => ({ connector, engineError, uploadArrowTable }),
     [connector, engineError, uploadArrowTable],
@@ -109,7 +94,7 @@ export function ChartEngineProvider({
 }
 
 /**
- * Read the surface-scoped chart engine connector (or null for WASM default).
+ * Read the server chart connector and frame registration seams.
  */
 export function useChartEngine(): ChartEngineContextValue {
   return useContext(ChartEngineContext);

--- a/packages/app/src/components/providers/ChartEngineProvider.tsx
+++ b/packages/app/src/components/providers/ChartEngineProvider.tsx
@@ -42,7 +42,7 @@ interface ChartEngineContextValue {
   /**
    * Upload a named Arrow IPC table to the native engine's in-memory store.
    * Retained as a dormant compatibility seam; the active server connection
-   * handles local imports directly and registers durable frames by handle.
+   * handles local imports directly and registers snapshots by DataFrame ID.
    */
   uploadArrowTable:
     | ((name: string, arrowBytes: Uint8Array) => Promise<void>)

--- a/packages/app/src/components/providers/DuckDBProvider.tsx
+++ b/packages/app/src/components/providers/DuckDBProvider.tsx
@@ -1,6 +1,9 @@
 import { clearInsightViewCache } from "@/hooks/useInsightView";
 import { getServerDataPlane } from "@/lib/server-data-plane";
-import { clearAllTableCaches } from "@dashframe/engine-browser";
+import {
+  clearAllTableCaches,
+  type DuckDBConnection,
+} from "@dashframe/engine-browser";
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import {
   createContext,
@@ -13,7 +16,7 @@ import {
 
 interface DuckDBContextValue {
   db: duckdb.AsyncDuckDB | null;
-  connection: duckdb.AsyncDuckDBConnection | null;
+  connection: DuckDBConnection | null;
   isInitialized: boolean;
   isLoading: boolean;
   error: Error | null;
@@ -45,7 +48,7 @@ export function DuckDBProvider({ children }: { children: React.ReactNode }) {
   /** Prevent duplicate initialization attempts */
   const initRef = useRef(false);
   /** Ref to track live connection for cleanup */
-  const connectionRef = useRef<duckdb.AsyncDuckDBConnection | null>(null);
+  const connectionRef = useRef<DuckDBConnection | null>(null);
   /** Ref to read current state values without triggering callback re-creation */
   const stateRef = useRef(state);
 
@@ -83,8 +86,7 @@ export function DuckDBProvider({ children }: { children: React.ReactNode }) {
       if (serverConnection) {
         clearAllTableCaches();
         clearInsightViewCache();
-        const connection =
-          serverConnection as unknown as duckdb.AsyncDuckDBConnection;
+        const connection = serverConnection;
         connectionRef.current = connection;
         setState({
           db: null,

--- a/packages/app/src/components/providers/DuckDBProvider.tsx
+++ b/packages/app/src/components/providers/DuckDBProvider.tsx
@@ -1,5 +1,5 @@
 import { clearInsightViewCache } from "@/hooks/useInsightView";
-import { initializeDuckDB } from "@/lib/duckdb/init";
+import { getServerDataPlane } from "@/lib/server-data-plane";
 import { clearAllTableCaches } from "@dashframe/engine-browser";
 import type * as duckdb from "@duckdb/duckdb-wasm";
 import {
@@ -30,15 +30,8 @@ const DuckDBContext = createContext<DuckDBContextValue>({
 });
 
 /**
- * DuckDB Provider that eagerly loads DuckDB in the background.
- * Initialization starts automatically during browser idle time (via requestIdleCallback),
- * so DuckDB is typically ready by the time components need it.
- *
- * This approach:
- * - Keeps ~10MB WASM bundle in a separate chunk (code splitting via dynamic import)
- * - Doesn't block initial page render
- * - Starts loading immediately but non-blocking
- * - Components show inline loading states while DuckDB initializes
+ * DuckDB Provider for the sole active v0.3 server-native data plane.
+ * The retained WASM implementation is deliberately not selected here.
  */
 export function DuckDBProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<Omit<DuckDBContextValue, "initDuckDB">>({
@@ -53,8 +46,6 @@ export function DuckDBProvider({ children }: { children: React.ReactNode }) {
   const initRef = useRef(false);
   /** Ref to track live connection for cleanup */
   const connectionRef = useRef<duckdb.AsyncDuckDBConnection | null>(null);
-  /** Ref to track live db instance for cleanup */
-  const dbRef = useRef<duckdb.AsyncDuckDB | null>(null);
   /** Ref to read current state values without triggering callback re-creation */
   const stateRef = useRef(state);
 
@@ -88,24 +79,25 @@ export function DuckDBProvider({ children }: { children: React.ReactNode }) {
     setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
     try {
-      const { db, connection } = await initializeDuckDB();
-
-      // Clear table caches since this is a fresh DuckDB instance
-      // Any previously cached tables no longer exist
-      clearAllTableCaches();
-      clearInsightViewCache();
-
-      // Store in refs for cleanup access
-      dbRef.current = db;
-      connectionRef.current = connection;
-
-      setState({
-        db,
-        connection,
-        isInitialized: true,
-        isLoading: false,
-        error: null,
-      });
+      const serverConnection = getServerDataPlane();
+      if (serverConnection) {
+        clearAllTableCaches();
+        clearInsightViewCache();
+        const connection =
+          serverConnection as unknown as duckdb.AsyncDuckDBConnection;
+        connectionRef.current = connection;
+        setState({
+          db: null,
+          connection,
+          isInitialized: true,
+          isLoading: false,
+          error: null,
+        });
+        return;
+      }
+      throw new Error(
+        "Native server data plane is not configured; DuckDB-WASM is suspended",
+      );
     } catch (err) {
       console.error("Failed to initialize DuckDB:", err);
       setState({
@@ -130,23 +122,14 @@ export function DuckDBProvider({ children }: { children: React.ReactNode }) {
       } catch (err) {
         console.warn("Failed to close DuckDB connection during cleanup:", err);
       }
-      try {
-        dbRef.current?.terminate();
-      } catch (err) {
-        console.warn(
-          "Failed to terminate DuckDB instance during cleanup:",
-          err,
-        );
-      }
       // Clear table caches since DuckDB instance is being destroyed
       clearAllTableCaches();
       clearInsightViewCache();
     };
   }, []);
 
-  // Eager background initialization - starts loading during browser idle time
-  // This improves UX by having DuckDB ready before user needs it,
-  // while not blocking initial page render
+  // Bind the server connection during browser idle time so initial rendering
+  // stays non-blocking while never activating the retained WASM engine.
   useEffect(() => {
     const startInit = () => {
       if (!initRef.current) {
@@ -186,8 +169,7 @@ export const useDuckDBContext = () => useContext(DuckDBContext);
 
 /**
  * Hook to access DuckDB connection and state.
- * DuckDB initializes eagerly in the background when DuckDBProvider mounts,
- * so components don't need to trigger initialization.
+ * The server connection initializes eagerly when DuckDBProvider mounts.
  *
  * @returns DuckDB instance with { db, connection, isLoading, isInitialized, error }
  *

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -104,14 +104,8 @@ interface VisualizationSetupProps {
 /**
  * VisualizationSetup - Wires up the visualization system.
  *
- * Engine selection is surface-scoped (no `isElectron` branches here):
- * - Web tier / WASM path: DuckDBProvider initializes the WASM engine; this
- *   component wraps children with VisualizationProvider once it's ready.
- * - Desktop tier / native path: the host ProviderWrapper mounts a
- *   ChartEngineProvider with a pre-built Mosaic Connector. When that connector
- *   is present, this component wires the connector into VisualizationProvider.
- *   DuckDB-WASM still initializes on the desktop path because useInsightView
- *   depends on it to load DataFrames before uploading them to the native engine.
+ * Both hosts inject the same server-native Mosaic connector. The retained WASM
+ * implementation is not an active fallback or selectable mode in v0.3.
  *
  * ## Error surfaces
  *
@@ -121,10 +115,6 @@ interface VisualizationSetupProps {
  *   It's a persistent condition — charts stay broken until reload — so a fading
  *   toast is the wrong surface. This component still passes children through so
  *   non-chart content (nav, routes) stays usable.
- * - Native connector healthy but WASM failed: WASM error shown as an inline
- *   ErrorState inside the native provider (chart queries still route to native;
- *   data-viewer paths that need WASM see the banner).
- * - WASM-only path failure: standard ErrorState with retry.
  * - Mid-session render throw (engine dies while rendering): caught by
  *   VisualizationBoundary → toast WITH a Reload action (a momentary event, so a
  *   toast is right), never crashes the renderer.
@@ -140,30 +130,19 @@ interface VisualizationSetupProps {
  *
  * ## Provider Hierarchy
  *
- * ### Web (WASM):
- * ```
- * DuckDBProvider (handles lazy loading via requestIdleCallback)
- *     └── VisualizationSetup
- *           └── VisualizationProvider (wasmConnector → Mosaic coordinator)
- *                 └── RendererRegistration (registers vgplot)
- *                 └── children
- * ```
- *
- * ### Desktop (native engine):
+ * ### Web and desktop:
  * ```
  * ChartEngineProvider (native Mosaic connector — supplied by desktop host)
- *     └── DuckDBProvider (still runs for table/pagination — data-viewer paths)
+ *     └── DuckDBProvider (server query adapter for table/pagination)
  *         └── VisualizationSetup
  *               └── VisualizationProvider (native connector → Mosaic coordinator)
  *                     └── RendererRegistration (registers vgplot)
- *                     └── [WASM error banner if DuckDB-WASM failed]
  *                     └── children
  * ```
  */
 export function VisualizationSetup({ children }: VisualizationSetupProps) {
   const { connector } = useChartEngine();
-  const { db, connection, isInitialized, isLoading, error, initDuckDB } =
-    useDuckDBContext();
+  const { isLoading, error, initDuckDB } = useDuckDBContext();
   const { showError } = useToastStore();
 
   const handleRetry = useCallback(() => {
@@ -191,12 +170,7 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
 
   // ── Native engine path (desktop host supplied a connector) ──────────────
   if (connector) {
-    // Chart queries route to the native engine via the connector.
-    // DuckDB-WASM still runs for data-viewer paths (useInsightView needs
-    // connection to load DataFrames before uploading them to the native engine).
-    // If WASM fails, surface it as a banner inside the native provider so chart
-    // content still renders while the user sees what's degraded.
-    const wasmErrorBanner =
+    const serverErrorBanner =
       error && !isLoading ? (
         <ErrorState
           title="Failed to initialize data engine"
@@ -207,7 +181,7 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
       ) : null;
 
     // VisualizationBoundary wraps the provider's setup components (renderer
-    // registration, WASM banner) but NOT {children}. Children include the full
+    // registration and server error banner) but NOT {children}. Children include the full
     // Shell — navigation, the <Toaster>, route outlets — all of which must stay
     // alive if the visualization setup crashes. Children are still inside
     // VisualizationProvider (needed for useVisualization() context) but sit
@@ -228,21 +202,15 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
       <VisualizationProvider connector={connector}>
         <VisualizationBoundary fallback={null} onError={handleBoundaryError}>
           <RendererRegistration />
-          {wasmErrorBanner}
+          {serverErrorBanner}
         </VisualizationBoundary>
         {children}
       </VisualizationProvider>
     );
   }
 
-  // ── WASM path (web tier default) OR native bootstrap failure ─────────────
-  // When the Electron IPC call fails or returns missing server info, `main.tsx`
-  // sets engineError with connector=null. The whole-engine-down condition is
-  // surfaced as a persistent inline affordance in VisualizationDisplay (where
-  // the chart would render), not here — so this path just falls through to the
-  // WASM path so non-chart content still renders.
-  //
-  // Show error state if DuckDB WASM initialization failed
+  // No connector means the supported server data plane is unavailable. Keep
+  // navigation usable, but never activate the retained WASM engine implicitly.
   if (error) {
     return (
       <>
@@ -257,15 +225,5 @@ export function VisualizationSetup({ children }: VisualizationSetupProps) {
     );
   }
 
-  // Pass through children during loading - components handle their own loading states
-  if (isLoading || !isInitialized || !db || !connection) {
-    return <>{children}</>;
-  }
-
-  return (
-    <VisualizationProvider db={db} connection={connection}>
-      <RendererRegistration />
-      {children}
-    </VisualizationProvider>
-  );
+  return <>{children}</>;
 }

--- a/packages/app/src/components/providers/VisualizationSetup.tsx
+++ b/packages/app/src/components/providers/VisualizationSetup.tsx
@@ -132,7 +132,7 @@ interface VisualizationSetupProps {
  *
  * ### Web and desktop:
  * ```
- * ChartEngineProvider (native Mosaic connector — supplied by desktop host)
+ * ChartEngineProvider (native Mosaic connector — supplied by the web or desktop host)
  *     └── DuckDBProvider (server query adapter for table/pagination)
  *         └── VisualizationSetup
  *               └── VisualizationProvider (native connector → Mosaic coordinator)

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -183,6 +183,7 @@ function VisualizationDisplayContent({
     error: insightViewError,
   } = useInsightView(insightForView, {
     effectiveParams,
+    dataTables,
   });
 
   // Use insight pagination for table data (queries DuckDB directly).

--- a/packages/app/src/components/visualizations/VisualizationDisplay.tsx
+++ b/packages/app/src/components/visualizations/VisualizationDisplay.tsx
@@ -1,5 +1,4 @@
 import { useChartEngine } from "@/components/providers/ChartEngineProvider";
-import { useDuckDBContext } from "@/components/providers/DuckDBProvider";
 import { useInsightPagination } from "@/hooks/useInsightPagination";
 import { useInsightView } from "@/hooks/useInsightView";
 import { api } from "@/wystack/api";
@@ -16,56 +15,13 @@ import type {
 } from "@dashframe/types";
 import { parseEncoding } from "@dashframe/types";
 import { VirtualTable, type VirtualTableColumnConfig } from "@dashframe/ui";
-import {
-  Chart,
-  VisualizationProvider,
-  useVisualization,
-} from "@dashframe/visualization";
+import { Chart, useVisualization } from "@dashframe/visualization";
 import { useQuery } from "@wystack/client";
 import { ErrorState, Spinner, Surface, Toggle } from "@wystack/ui-react";
 import { ChartIcon, LayersIcon, TableIcon } from "@wystack/ui-react/icons";
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { EngineUnavailableState } from "./EngineUnavailableState";
 import { VisualizationErrorBoundary } from "./VisualizationErrorBoundary";
-
-/**
- * Wraps `children` in a WASM-backed VisualizationProvider when `nativeCapable`
- * is false (insight has non-indexeddb DataFrames that could not be uploaded to
- * the native engine). The inner WASM provider shadows the outer native-connector
- * provider, so Mosaic queries for this insight route to DuckDB-WASM instead of
- * hard-failing on the native engine with a missing-table error.
- *
- * When `nativeCapable` is true (or on the WASM-only web path), this is a
- * transparent pass-through — no extra provider is mounted.
- */
-function WasmFallbackWrapper({
-  nativeCapable,
-  children,
-}: {
-  nativeCapable: boolean;
-  children: ReactNode;
-}) {
-  const { db, connection } = useDuckDBContext();
-
-  // Only wrap when native is incapable AND we have a live WASM connection.
-  // If WASM is also unavailable (e.g. still loading), render children as-is —
-  // the caller's loading state guard will handle that path.
-  if (!nativeCapable && db && connection) {
-    return (
-      <VisualizationProvider db={db} connection={connection}>
-        {children}
-      </VisualizationProvider>
-    );
-  }
-  return <>{children}</>;
-}
 
 // Minimum visible rows needed to enable "Show Both" mode
 const MIN_VISIBLE_ROWS_FOR_BOTH = 5;
@@ -213,8 +169,6 @@ function VisualizationDisplayContent({
   );
 
   // Use insight view hook to get the proper table name (handles joins).
-  // `nativeCapable` is false when any DataFrame uses non-indexeddb storage —
-  // Chart queries must route to WASM in that case (WasmFallbackWrapper below).
   // `error` surfaces a post-bootstrap failure (e.g. native upload failed because
   // the loopback server stopped or returned 500). Without consuming it here the
   // view never becomes ready and the component would spin forever.
@@ -227,7 +181,6 @@ function VisualizationDisplayContent({
     viewName: insightViewName,
     isReady: isInsightViewReady,
     error: insightViewError,
-    nativeCapable,
   } = useInsightView(insightForView, {
     effectiveParams,
   });
@@ -609,14 +562,12 @@ function VisualizationDisplayContent({
 
       {activeTab === "chart" && tableName && (
         <div className="mt-3 min-h-0 flex-1 overflow-hidden px-4 pb-8">
-          <WasmFallbackWrapper nativeCapable={nativeCapable}>
-            <Chart
-              tableName={tableName}
-              visualizationType={activeViz.visualizationType}
-              encoding={resolvedEncoding}
-              className="h-full w-full"
-            />
-          </WasmFallbackWrapper>
+          <Chart
+            tableName={tableName}
+            visualizationType={activeViz.visualizationType}
+            encoding={resolvedEncoding}
+            className="h-full w-full"
+          />
         </div>
       )}
 
@@ -641,14 +592,12 @@ function VisualizationDisplayContent({
         <div className="mt-3 flex min-h-0 flex-1 flex-col overflow-hidden">
           {/* Chart takes 60% of space */}
           <div className="h-[60%] min-h-[200px] overflow-hidden px-4 pb-4">
-            <WasmFallbackWrapper nativeCapable={nativeCapable}>
-              <Chart
-                tableName={tableName}
-                visualizationType={activeViz.visualizationType}
-                encoding={resolvedEncoding}
-                className="h-full w-full"
-              />
-            </WasmFallbackWrapper>
+            <Chart
+              tableName={tableName}
+              visualizationType={activeViz.visualizationType}
+              encoding={resolvedEncoding}
+              className="h-full w-full"
+            />
           </div>
           {/* Table capped at 40% of space */}
           <div className="flex h-[40%] max-h-[40%] min-h-0 flex-col overflow-hidden px-4">

--- a/packages/app/src/components/visualizations/VisualizationPreview.tsx
+++ b/packages/app/src/components/visualizations/VisualizationPreview.tsx
@@ -87,7 +87,7 @@ function VisualizationPreviewContent({
 
   // Create/get the DuckDB view using the same hook as insight pages
   // This ensures views are created on-demand and properly cached
-  const { viewName, isReady, error } = useInsightView(insight);
+  const { viewName, isReady, error } = useInsightView(insight, { dataTables });
 
   // Resolve instance-qualified fields for repeat-join insights so that
   // field:<uuid>_j1 encodings resolve to their SQL alias correctly.

--- a/packages/app/src/hooks/useInsightView.test.tsx
+++ b/packages/app/src/hooks/useInsightView.test.tsx
@@ -547,6 +547,79 @@ describe("useInsightView", () => {
       expect(mockQuery).toHaveBeenCalledTimes(2);
     });
 
+    it("never lets a blocked old frame revision replace the newer GA4 view", async () => {
+      const insight = createMockInsight({
+        id: "insight-ga4-race",
+        baseTableId: "table-ga4-race",
+      });
+      const oldTable = createMockDataTable({
+        id: "table-ga4-race",
+        dataFrameId: "df-ga4-old",
+        lastFetchedAt: 1,
+      });
+      const newTable = createMockDataTable({
+        id: "table-ga4-race",
+        dataFrameId: "df-ga4-new",
+        lastFetchedAt: 2,
+      });
+      let releaseOld!: () => void;
+      const oldBlocked = new Promise<void>((resolve) => {
+        releaseOld = resolve;
+      });
+      let currentRows: Array<{ revision: string }> = [];
+
+      mockGetDataTable
+        .mockResolvedValueOnce(oldTable)
+        .mockResolvedValue(newTable);
+      mockGetDataFrame.mockImplementation((id) =>
+        Promise.resolve(createMockDataFrame(id, "file")),
+      );
+      mockEnsureTableLoaded.mockImplementation((frame: DataFrame) =>
+        frame.id === "df-ga4-old" ? oldBlocked : Promise.resolve(undefined),
+      );
+      mockBuildInsightSQL.mockImplementation((table: DataTable) =>
+        table.dataFrameId === "df-ga4-old"
+          ? "SELECT 'old' AS revision"
+          : "SELECT 'new' AS revision",
+      );
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.startsWith("CREATE OR REPLACE VIEW")) {
+          currentRows = [
+            { revision: sql.includes("SELECT 'new'") ? "new" : "old" },
+          ];
+        }
+        return { toArray: () => currentRows };
+      });
+
+      const { result, rerender } = renderHook(
+        ({ dataTables }) => useInsightView(insight, { dataTables }),
+        { initialProps: { dataTables: [oldTable] } },
+      );
+      await waitFor(() =>
+        expect(mockEnsureTableLoaded).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "df-ga4-old" }),
+          mockConnection,
+        ),
+      );
+
+      rerender({ dataTables: [newTable] });
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+      releaseOld();
+      await waitFor(() =>
+        expect(mockEnsureTableLoaded).toHaveBeenCalledTimes(2),
+      );
+
+      const createCalls = mockQuery.mock.calls.filter(([sql]) =>
+        String(sql).startsWith("CREATE OR REPLACE VIEW"),
+      );
+      expect(createCalls).toHaveLength(1);
+      expect(createCalls[0]?.[0]).toContain("SELECT 'new' AS revision");
+      const final = await mockConnection.query(
+        'SELECT * FROM "insight_view_insight_ga4_race"',
+      );
+      expect(final.toArray()).toEqual([{ revision: "new" }]);
+    });
+
     it("should clear error when config-key switches to an already-cached config", async () => {
       // Regression: config A fails (error set) → switch to config B which is
       // already in createdViewsCache → effect returns early on the cache hit

--- a/packages/app/src/hooks/useInsightView.test.tsx
+++ b/packages/app/src/hooks/useInsightView.test.tsx
@@ -11,7 +11,7 @@
  * - Configuration changes (insight ID changes, join changes)
  * - DuckDB connection requirements
  * - View name format and uniqueness
- * - Per-insight native fallback (non-indexeddb storage → nativeCapable: false)
+ * - Server-native frame loading and explicit ingestion failures
  */
 import type { DataFrame, DataTable, Insight } from "@dashframe/types";
 import { act, renderHook, waitFor } from "@testing-library/react";
@@ -19,7 +19,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearInsightViewCache,
   getCachedViewName,
-  isNativeCapableDataFrame,
   useInsightView,
 } from "./useInsightView";
 
@@ -50,39 +49,14 @@ vi.mock("@/lib/data-access/data-tables", () => ({
   getDataTable: mockGetDataTable,
 }));
 
-const { mockBuildInsightSQL, mockEnsureTableLoaded, mockLoadArrowData } =
-  vi.hoisted(() => ({
-    mockBuildInsightSQL: vi.fn(),
-    mockEnsureTableLoaded: vi.fn(),
-    mockLoadArrowData: vi.fn(),
-  }));
+const { mockBuildInsightSQL, mockEnsureTableLoaded } = vi.hoisted(() => ({
+  mockBuildInsightSQL: vi.fn(),
+  mockEnsureTableLoaded: vi.fn(),
+}));
 
 vi.mock("@dashframe/engine-browser", () => ({
   buildInsightSQL: mockBuildInsightSQL,
   ensureTableLoaded: mockEnsureTableLoaded,
-  loadArrowData: (...args: unknown[]) => mockLoadArrowData(...args),
-}));
-
-const { mockUploadArrowTable, mockConnectorQuery, mockUseChartEngine } =
-  vi.hoisted(() => {
-    const upload = vi.fn();
-    const connectorQuery = vi.fn();
-    // Default: WASM-only path (no native connector) — tests that need the
-    // native path override this via mockUseChartEngine.mockReturnValue(...)
-    const useChartEngine = vi.fn().mockReturnValue({
-      connector: null,
-      engineError: null,
-      uploadArrowTable: null,
-    });
-    return {
-      mockUploadArrowTable: upload,
-      mockConnectorQuery: connectorQuery,
-      mockUseChartEngine: useChartEngine,
-    };
-  });
-
-vi.mock("@/components/providers/ChartEngineProvider", () => ({
-  useChartEngine: () => mockUseChartEngine(),
 }));
 
 /**
@@ -137,10 +111,12 @@ function createMockDataTable(options: {
  */
 function createMockDataFrame(
   id: string,
-  storageType: "indexeddb" | "s3" | "r2" = "indexeddb",
+  storageType: "indexeddb" | "file" | "s3" | "r2" = "indexeddb",
 ): DataFrame {
   let storage: DataFrame["storage"];
-  if (storageType === "s3") {
+  if (storageType === "file") {
+    storage = { type: "file", key: id };
+  } else if (storageType === "s3") {
     storage = { type: "s3", bucket: "my-bucket", key: `data/${id}.arrow` };
   } else if (storageType === "r2") {
     storage = { type: "r2", accountId: "acct-123", key: `data/${id}.arrow` };
@@ -206,12 +182,6 @@ describe("getCachedViewName", () => {
   beforeEach(() => {
     clearInsightViewCache();
     vi.clearAllMocks();
-    // Re-apply WASM default after clearAllMocks wipes mockReturnValue
-    mockUseChartEngine.mockReturnValue({
-      connector: null,
-      engineError: null,
-      uploadArrowTable: null,
-    });
   });
 
   it("should return null for non-existent insight", () => {
@@ -329,15 +299,6 @@ describe("useInsightView", () => {
       isInitialized: true,
       db: {},
       error: null,
-    });
-
-    // Restore default: WASM-only path (no native connector).
-    // vi.clearAllMocks() wipes mockReturnValue; re-apply the default so any
-    // test that doesn't explicitly set the native path gets WASM behaviour.
-    mockUseChartEngine.mockReturnValue({
-      connector: null,
-      engineError: null,
-      uploadArrowTable: null,
     });
 
     // Clear console.error mock
@@ -1370,31 +1331,10 @@ describe("useInsightView", () => {
 });
 
 // ============================================================================
-// isNativeCapableDataFrame
+// Native-only active data plane (nativeCapable compatibility signal)
 // ============================================================================
 
-describe("isNativeCapableDataFrame", () => {
-  it("returns true for indexeddb-backed DataFrames", () => {
-    const df = createMockDataFrame("df-local", "indexeddb");
-    expect(isNativeCapableDataFrame(df)).toBe(true);
-  });
-
-  it("returns false for s3-backed DataFrames", () => {
-    const df = createMockDataFrame("df-s3", "s3");
-    expect(isNativeCapableDataFrame(df)).toBe(false);
-  });
-
-  it("returns false for r2-backed DataFrames", () => {
-    const df = createMockDataFrame("df-r2", "r2");
-    expect(isNativeCapableDataFrame(df)).toBe(false);
-  });
-});
-
-// ============================================================================
-// Per-insight native-path fallback (nativeCapable signal)
-// ============================================================================
-
-describe("useInsightView — per-insight native fallback", () => {
+describe("useInsightView — native-only active plane", () => {
   beforeEach(() => {
     clearInsightViewCache();
     vi.clearAllMocks();
@@ -1409,57 +1349,16 @@ describe("useInsightView — per-insight native fallback", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  it("nativeCapable is true on the WASM-only path (no uploadArrowTable)", async () => {
-    // WASM path: no connector, no uploadArrowTable
-    mockUseChartEngine.mockReturnValue({
-      connector: null,
-      engineError: null,
-      uploadArrowTable: null,
-    });
-
-    const insight = createMockInsight({ id: "iv-wasm", baseTableId: "t-wasm" });
-    const baseTable = createMockDataTable({
-      id: "t-wasm",
-      dataFrameId: "df-wasm",
-    });
-    const baseDataFrame = createMockDataFrame("df-wasm", "indexeddb");
-
-    mockGetDataTable.mockResolvedValue(baseTable);
-    mockGetDataFrame.mockResolvedValue(baseDataFrame);
-    mockEnsureTableLoaded.mockResolvedValue(undefined);
-    mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
-    mockQuery.mockResolvedValue(undefined);
-
-    const { result } = renderHook(() => useInsightView(insight));
-
-    await waitFor(() => {
-      expect(result.current.isReady).toBe(true);
-    });
-
-    expect(result.current.nativeCapable).toBe(true);
-    expect(result.current.error).toBeNull();
-  });
-
-  it("nativeCapable is true when indexeddb DataFrame is uploaded successfully", async () => {
-    const connector = { query: mockConnectorQuery };
-    mockUseChartEngine.mockReturnValue({
-      connector,
-      engineError: null,
-      uploadArrowTable: mockUploadArrowTable,
-    });
-    mockConnectorQuery.mockResolvedValue(undefined);
-    mockUploadArrowTable.mockResolvedValue(undefined);
-    mockLoadArrowData.mockResolvedValue(new Uint8Array([1, 2, 3]));
-
+  it("creates a native view through the configured server connection", async () => {
     const insight = createMockInsight({
-      id: "iv-native",
-      baseTableId: "t-native",
+      id: "iv-server",
+      baseTableId: "t-server",
     });
     const baseTable = createMockDataTable({
-      id: "t-native",
-      dataFrameId: "df-native",
+      id: "t-server",
+      dataFrameId: "df-server",
     });
-    const baseDataFrame = createMockDataFrame("df-native", "indexeddb");
+    const baseDataFrame = createMockDataFrame("df-server", "indexeddb");
 
     mockGetDataTable.mockResolvedValue(baseTable);
     mockGetDataFrame.mockResolvedValue(baseDataFrame);
@@ -1475,62 +1374,37 @@ describe("useInsightView — per-insight native fallback", () => {
 
     expect(result.current.nativeCapable).toBe(true);
     expect(result.current.error).toBeNull();
-    expect(mockUploadArrowTable).toHaveBeenCalledWith(
-      "df_df_native",
-      expect.any(Uint8Array),
+    expect(mockEnsureTableLoaded).toHaveBeenCalledWith(
+      baseDataFrame,
+      mockConnection,
     );
-    // View should be created in the native engine too
-    expect(mockConnectorQuery).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "exec" }),
-    );
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 
-  it("nativeCapable is false for s3-backed DataFrame — view created in WASM, not thrown", async () => {
-    // Contract: non-indexeddb storage must NOT throw. The insight renders via
-    // WASM; the caller sees nativeCapable=false and routes the Chart to WASM.
-    const connector = { query: mockConnectorQuery };
-    mockUseChartEngine.mockReturnValue({
-      connector,
-      engineError: null,
-      uploadArrowTable: mockUploadArrowTable,
-    });
-
+  it("fails explicitly for storage with no server ingestion path", async () => {
     const insight = createMockInsight({ id: "iv-s3", baseTableId: "t-s3" });
     const baseTable = createMockDataTable({ id: "t-s3", dataFrameId: "df-s3" });
     const baseDataFrame = createMockDataFrame("df-s3", "s3"); // non-indexeddb
 
     mockGetDataTable.mockResolvedValue(baseTable);
     mockGetDataFrame.mockResolvedValue(baseDataFrame);
-    mockEnsureTableLoaded.mockResolvedValue(undefined);
+    mockEnsureTableLoaded.mockRejectedValue(
+      new Error("S3 storage not yet implemented"),
+    );
     mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
     mockQuery.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useInsightView(insight));
 
-    // Should become ready (not hard-fail) via the WASM view
     await waitFor(() => {
-      expect(result.current.isReady).toBe(true);
+      expect(result.current.error).toBe("S3 storage not yet implemented");
     });
 
-    expect(result.current.nativeCapable).toBe(false);
-    expect(result.current.error).toBeNull();
-    // Upload must NOT be attempted for remote storage
-    expect(mockUploadArrowTable).not.toHaveBeenCalled();
-    // The native-engine view creation must be skipped (no native connector.query)
-    expect(mockConnectorQuery).not.toHaveBeenCalled();
+    expect(result.current.isReady).toBe(false);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
-  it("nativeCapable is false when Arrow buffer is missing from local storage — no hard-fail", async () => {
-    // Contract: missing Arrow buffer (evicted from IndexedDB) must not throw.
-    const connector = { query: mockConnectorQuery };
-    mockUseChartEngine.mockReturnValue({
-      connector,
-      engineError: null,
-      uploadArrowTable: mockUploadArrowTable,
-    });
-    // loadArrowData returns null (buffer missing)
-    mockLoadArrowData.mockResolvedValue(null);
-
+  it("fails explicitly when retained local bytes are missing", async () => {
     const insight = createMockInsight({
       id: "iv-missing-buf",
       baseTableId: "t-mb",
@@ -1540,39 +1414,29 @@ describe("useInsightView — per-insight native fallback", () => {
 
     mockGetDataTable.mockResolvedValue(baseTable);
     mockGetDataFrame.mockResolvedValue(baseDataFrame);
-    mockEnsureTableLoaded.mockResolvedValue(undefined);
+    mockEnsureTableLoaded.mockRejectedValue(
+      new Error("DataFrame df-mb not found in storage"),
+    );
     mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
     mockQuery.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useInsightView(insight));
 
     await waitFor(() => {
-      expect(result.current.isReady).toBe(true);
+      expect(result.current.error).toBe("DataFrame df-mb not found in storage");
     });
 
-    expect(result.current.nativeCapable).toBe(false);
-    expect(result.current.error).toBeNull();
-    expect(mockUploadArrowTable).not.toHaveBeenCalled();
-    expect(mockConnectorQuery).not.toHaveBeenCalled();
+    expect(result.current.isReady).toBe(false);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
-  it("restores nativeCapable=false from cache on remount (does not reset to true)", async () => {
-    // Regression: the fallback decision must travel with the cached view. A
-    // remount that hits createdViewsCache used to reset nativeCapable to its
-    // initial `true`, which would route a WASM-only view to the native engine.
-    const connector = { query: mockConnectorQuery };
-    mockUseChartEngine.mockReturnValue({
-      connector,
-      engineError: null,
-      uploadArrowTable: mockUploadArrowTable,
-    });
-
+  it("uses a file-backed frame without reading or uploading browser bytes", async () => {
     const insight = createMockInsight({
-      id: "iv-cache-fallback",
+      id: "iv-server-frame",
       baseTableId: "t-cf",
     });
     const baseTable = createMockDataTable({ id: "t-cf", dataFrameId: "df-cf" });
-    const baseDataFrame = createMockDataFrame("df-cf", "s3"); // non-indexeddb
+    const baseDataFrame = createMockDataFrame("df-cf", "file");
 
     mockGetDataTable.mockResolvedValue(baseTable);
     mockGetDataFrame.mockResolvedValue(baseDataFrame);
@@ -1580,39 +1444,23 @@ describe("useInsightView — per-insight native fallback", () => {
     mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
     mockQuery.mockResolvedValue(undefined);
 
-    // First mount: creates the WASM-only view, caches nativeCapable=false.
-    const { result: first, unmount } = renderHook(() =>
-      useInsightView(insight),
-    );
+    const { result: first } = renderHook(() => useInsightView(insight));
     await waitFor(() => {
       expect(first.current.isReady).toBe(true);
     });
-    expect(first.current.nativeCapable).toBe(false);
-    unmount();
-
-    // Second mount: short-circuits on the cache. nativeCapable MUST stay false.
-    const { result: second } = renderHook(() => useInsightView(insight));
-    await waitFor(() => {
-      expect(second.current.isReady).toBe(true);
-    });
-    expect(second.current.nativeCapable).toBe(false);
-    // No second native-view creation attempt on the cache-hit path.
-    expect(mockConnectorQuery).not.toHaveBeenCalled();
+    expect(first.current.nativeCapable).toBe(true);
+    expect(mockEnsureTableLoaded).toHaveBeenCalledWith(
+      baseDataFrame,
+      mockConnection,
+    );
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 
-  it("surfaces error (and stays not-ready) when the native upload fails at runtime", async () => {
-    // Regression: a runtime upload failure (loopback down, 500) must become a
+  it("surfaces error (and stays not-ready) when server ingestion fails at runtime", async () => {
+    // Regression: a runtime registration failure (loopback down, 500) must become a
     // consumable error, not an indefinite loading state. The view never becomes
     // ready; VisualizationDisplay reads `error` to show an error state.
-    const connector = { query: mockConnectorQuery };
-    mockUseChartEngine.mockReturnValue({
-      connector,
-      engineError: null,
-      uploadArrowTable: mockUploadArrowTable,
-    });
-    mockLoadArrowData.mockResolvedValue(new Uint8Array([1, 2, 3]));
-    // Upload rejects — the native engine is unreachable / returned 500.
-    mockUploadArrowTable.mockRejectedValue(
+    mockEnsureTableLoaded.mockRejectedValue(
       new Error("Native engine timed out — the local server did not respond."),
     );
 
@@ -1625,7 +1473,6 @@ describe("useInsightView — per-insight native fallback", () => {
 
     mockGetDataTable.mockResolvedValue(baseTable);
     mockGetDataFrame.mockResolvedValue(baseDataFrame);
-    mockEnsureTableLoaded.mockResolvedValue(undefined);
     mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
     mockQuery.mockResolvedValue(undefined);
 

--- a/packages/app/src/hooks/useInsightView.test.tsx
+++ b/packages/app/src/hooks/useInsightView.test.tsx
@@ -89,6 +89,7 @@ function createMockDataTable(options: {
   id?: string;
   name?: string;
   dataFrameId?: string | undefined;
+  lastFetchedAt?: number;
 }): DataTable {
   return {
     id: (options.id ?? "table-abc") as DataTable["id"],
@@ -101,6 +102,7 @@ function createMockDataTable(options: {
       : "df-123") as DataTable["dataFrameId"],
     fields: [],
     metrics: [],
+    lastFetchedAt: options.lastFetchedAt,
     createdAt: Date.parse("2024-01-01T00:00:00.000Z"),
   };
 }
@@ -503,6 +505,46 @@ describe("useInsightView", () => {
       });
 
       expect(result.current.isReady).toBe(true);
+    });
+
+    it("recreates a cached view when its source frame is refreshed", async () => {
+      const insight = createMockInsight({
+        id: "insight-refresh",
+        baseTableId: "table-refresh",
+      });
+      const firstTable = createMockDataTable({
+        id: "table-refresh",
+        dataFrameId: "df-first",
+        lastFetchedAt: 1,
+      });
+      const secondTable = createMockDataTable({
+        id: "table-refresh",
+        dataFrameId: "df-second",
+        lastFetchedAt: 2,
+      });
+      mockGetDataTable.mockResolvedValue(firstTable);
+      mockGetDataFrame.mockImplementation((id) =>
+        Promise.resolve(createMockDataFrame(id)),
+      );
+      mockEnsureTableLoaded.mockResolvedValue(undefined);
+      mockBuildInsightSQL.mockReturnValue("SELECT * FROM test");
+      mockQuery.mockResolvedValue(undefined);
+
+      const { result, rerender } = renderHook(
+        ({ dataTables }) => useInsightView(insight, { dataTables }),
+        { initialProps: { dataTables: [firstTable] } },
+      );
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+      expect(mockEnsureTableLoaded).toHaveBeenCalledTimes(1);
+
+      mockGetDataTable.mockResolvedValue(secondTable);
+      rerender({ dataTables: [secondTable] });
+
+      await waitFor(() =>
+        expect(mockEnsureTableLoaded).toHaveBeenCalledTimes(2),
+      );
+      expect(mockGetDataFrame).toHaveBeenLastCalledWith("df-second");
+      expect(mockQuery).toHaveBeenCalledTimes(2);
     });
 
     it("should clear error when config-key switches to an already-cached config", async () => {

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -1,4 +1,3 @@
-import { useChartEngine } from "@/components/providers/ChartEngineProvider";
 import { useDuckDB } from "@/components/providers/DuckDBProvider";
 import { getDataFrame } from "@/lib/data-access/data-frames";
 import { getDataTable } from "@/lib/data-access/data-tables";
@@ -7,13 +6,8 @@ import {
   buildInsightAvailableFields,
   fieldIdToColumnAlias,
 } from "@dashframe/engine";
-import {
-  buildInsightSQL,
-  ensureTableLoaded,
-  loadArrowData,
-} from "@dashframe/engine-browser";
+import { buildInsightSQL, ensureTableLoaded } from "@dashframe/engine-browser";
 import type {
-  DataFrame,
   DataTable,
   Insight,
   InsightFilter,
@@ -23,27 +17,9 @@ import type {
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
- * Check whether a DataFrame can be served to the native chart engine.
- *
- * The native engine receives data via `uploadArrowTable`, which reads the
- * local IndexedDB Arrow buffer. Remote-backed storage (s3/r2) has no local
- * buffer, so the upload path is not available for those DataFrames.
- *
- * @returns `true` when the DataFrame can be uploaded to the native engine.
- */
-export function isNativeCapableDataFrame(dataFrame: DataFrame): boolean {
-  return dataFrame.storage.type === "indexeddb";
-}
-
-/**
- * What a created view needs to be re-rendered correctly after a remount/HMR.
- *
- * `nativeCapable` MUST travel with the view name: on the desktop path the view
- * may have been created in DuckDB-WASM only (a DataFrame could not be uploaded
- * to the native engine). If a remount restored only the view name and let
- * `nativeCapable` reset to its initial `true`, VisualizationDisplay would skip
- * the WASM fallback and route the chart to the native engine for a view that
- * was intentionally never created there → missing-table error.
+ * What a created server view needs after a remount/HMR. `nativeCapable` remains
+ * in the return contract for compatibility but successful v0.3 views are always
+ * native; unsupported storage fails explicitly before caching.
  */
 interface CachedView {
   viewName: string;
@@ -225,7 +201,6 @@ export function useInsightView(
 ) {
   const { effectiveParams } = options;
   const { connection, isInitialized, isLoading: isDuckDBLoading } = useDuckDB();
-  const { connector, uploadArrowTable } = useChartEngine();
 
   // Stable key for the effective params so the cache differentiates cells that
   // share the same insight but have distinct overrides.  Keyed on FILTERS ONLY:
@@ -304,28 +279,12 @@ export function useInsightView(
     cachedViewName ? configKey : null,
   );
   const [error, setError] = useState<string | null>(null);
-  /**
-   * Whether all DataFrames for this insight can be served to the native engine.
-   *
-   * `true`  — all DataFrames use indexeddb storage and were uploaded successfully;
-   *            chart queries will run against the native DuckDB engine.
-   * `false` — at least one DataFrame uses remote storage (s3/r2) or had a missing
-   *            local Arrow buffer; the view exists in DuckDB-WASM only.
-   *            VisualizationDisplay wraps the Chart in a WASM VisualizationProvider
-   *            so queries route to WASM instead of hard-failing on the native engine.
-   *
-   * Only meaningful on the desktop path (when `uploadArrowTable` is set).
-   * Always `true` on the WASM-only path.
-   *
-   * Seeded from the module cache so a remount/HMR that short-circuits view
-   * creation (cache hit) restores the original fallback decision instead of
-   * resetting to `true` and routing a WASM-only view to the native engine.
-   */
+  /** Compatibility flag: every successfully created v0.3 view is native. */
   const [nativeCapable, setNativeCapable] = useState<boolean>(
     cachedView?.nativeCapable ?? true,
   );
 
-  // A cache hit for the CURRENT config restores the cached fallback decision.
+  // A cache hit for the current config restores its compatibility metadata.
   // (Initial state only captures the FIRST configKey; this keeps nativeCapable
   // correct when configKey changes to one already in the cache.)
   const nativeCapableForCurrentKey =
@@ -414,7 +373,7 @@ export function useInsightView(
           const cached = createdViewsCache.get(configKey)!;
           setResolvedViewName(cached.viewName);
           setResolvedConfigKey(configKey);
-          // Restore the cached fallback decision — never assume native-capable.
+          // Restore the cached compatibility metadata.
           setNativeCapable(cached.nativeCapable);
           return cached;
         }
@@ -462,43 +421,16 @@ export function useInsightView(
         // Wait for all join table resolutions
         await Promise.all(joinLoadPromises);
 
-        // Load ALL DataFrames into DuckDB-WASM in parallel.
-        // On desktop, also upload each Arrow IPC buffer to the native engine
-        // so chart queries running via the loopback connector can reference
-        // the same table names (df_<id>). The table name formula mirrors
-        // engine-browser's makeTableName: `df_${dataFrameId.replace(/-/g, "_")}`.
-        //
-        // Per-insight fallback: if any DataFrame cannot be uploaded to the native
-        // engine (remote storage, missing local buffer), we record `allNativeCapable
-        // = false` rather than throwing. The view is still created in DuckDB-WASM so
-        // the WASM path can render it. VisualizationDisplay reads `nativeCapable` and
-        // wraps the Chart in a WASM VisualizationProvider when false, so chart
-        // queries route to WASM instead of hard-failing on the native engine.
-        let allNativeCapable = true;
+        // Load every frame into the active native server connection. File-backed
+        // frames register by handle inside the server; IndexedDB frames use the
+        // connection's explicit Arrow upload. Unsupported storage fails; no
+        // fallback exists in the active v0.3 plane.
+        const allNativeCapable = true;
 
         await Promise.all(
           dataFramesToLoad.map(async ({ dataFrame }) => {
             if (!dataFrame) return;
             await ensureTableLoaded(dataFrame, connection);
-            // Desktop native path: upload the DataFrame's Arrow buffer so the
-            // native engine has the same df_* table the WASM engine has.
-            if (uploadArrowTable) {
-              if (!isNativeCapableDataFrame(dataFrame)) {
-                // Remote storage (s3/r2) — no local buffer to upload.
-                // Fall back to WASM for this insight rather than hard-failing.
-                allNativeCapable = false;
-                return;
-              }
-              const arrowBytes = await loadArrowData(dataFrame.storage.key);
-              if (!arrowBytes) {
-                // Local Arrow buffer is missing (e.g. data was evicted from
-                // IndexedDB). Fall back to WASM rather than hard-failing.
-                allNativeCapable = false;
-                return;
-              }
-              const tableName = `df_${dataFrame.id.replace(/-/g, "_")}`;
-              await uploadArrowTable(tableName, arrowBytes);
-            }
           }),
         );
 
@@ -560,18 +492,8 @@ export function useInsightView(
         const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${viewSql}`;
         await connection.query(createViewSql);
 
-        // Desktop: chart queries run against the native engine, so the view
-        // must also exist there — but only when all DataFrames were successfully
-        // uploaded (nativeCapable path). When any DataFrame fell back to WASM,
-        // skip the native view creation; VisualizationDisplay will route the
-        // Chart's queries to the WASM engine instead.
-        if (connector && allNativeCapable) {
-          await connector.query({ type: "exec", sql: createViewSql });
-        }
-
         // Store in module-level cache (survives Strict Mode and HMR). The
-        // fallback decision travels with the view name so a later remount that
-        // hits this cache restores the correct engine routing.
+        // Engine metadata travels with the view name across remounts.
         const created: CachedView = {
           viewName: newViewName,
           nativeCapable: allNativeCapable,
@@ -617,8 +539,7 @@ export function useInsightView(
     // - Do NOT include `insight` (object reference changes every render)
     // - Do NOT include `isReady` (would create feedback loop when we setIsReady)
     // - `joinsKey` is a serialized representation of `insight.joins`, so we don't need `insight.joins` directly
-    // - `connector`/`uploadArrowTable` are stable (set once at bootstrap)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveFiltersKey track insight.joins/overrides changes; connector/uploadArrowTable are stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- joinsKey/effectiveFiltersKey track insight.joins/overrides changes
   }, [
     connection,
     isInitialized,
@@ -628,8 +549,6 @@ export function useInsightView(
     joinsKey,
     configKey,
     effectiveFiltersKey, // re-run when the cell's filter override changes
-    connector,
-    uploadArrowTable,
   ]);
 
   return {
@@ -639,14 +558,7 @@ export function useInsightView(
     isReady,
     /** Error message if view creation failed, or null when the current config is clean. */
     error: errorForCurrentKey,
-    /**
-     * Whether all DataFrames for this insight were successfully uploaded to
-     * the native engine. `false` means at least one DataFrame uses remote
-     * storage (s3/r2) or had a missing local Arrow buffer; the view exists in
-     * DuckDB-WASM only and the Chart must route queries there instead.
-     *
-     * Only meaningful on the desktop path. Always `true` on the WASM path.
-     */
+    /** Compatibility flag; successful active-plane views are always native. */
     nativeCapable: nativeCapableForCurrentKey,
   };
 }

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -193,13 +193,19 @@ export interface UseInsightViewOptions {
    * the pre-override behaviour.
    */
   effectiveParams?: EffectiveParams;
+  /**
+   * Live table metadata used to invalidate a cached view when its snapshot
+   * replaces one of its source frames. All UI consumers already subscribe to
+   * this table list for rendering, so no additional query is required here.
+   */
+  dataTables?: readonly DataTable[];
 }
 
 export function useInsightView(
   insight: Insight | null | undefined,
   options: UseInsightViewOptions = {},
 ) {
-  const { effectiveParams } = options;
+  const { effectiveParams, dataTables } = options;
   const { connection, isInitialized, isLoading: isDuckDBLoading } = useDuckDB();
 
   // Stable key for the effective params so the cache differentiates cells that
@@ -230,11 +236,22 @@ export function useInsightView(
       )
     : null;
 
+  const frameRevision = dataTables
+    ? [baseTableId, ...(insight?.joins ?? []).map((join) => join.rightTableId)]
+        .map((tableId) => {
+          const table = dataTables.find(
+            (candidate) => candidate.id === tableId,
+          );
+          return `${tableId ?? ""}:${table?.dataFrameId ?? ""}:${table?.lastFetchedAt ?? ""}`;
+        })
+        .join("|")
+    : "";
+
   // Compute config key for cache lookup.
   // Keyed on the effective FILTERS only (the only override dimension that changes
   // the model-mode view); cells differing only in sort/limit reuse one view.
   const configKey = insightId
-    ? `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}`
+    ? `${insightId}:${joinsKey}:${effectiveFiltersKey ?? ""}:${frameRevision}`
     : null;
 
   // Track the most recently rendered configKey so in-flight createView calls
@@ -422,7 +439,7 @@ export function useInsightView(
         await Promise.all(joinLoadPromises);
 
         // Load every frame into the active native server connection. File-backed
-        // frames register by handle inside the server; IndexedDB frames use the
+        // server snapshots register by DataFrame ID; IndexedDB frames use the
         // connection's explicit Arrow upload. Unsupported storage fails; no
         // fallback exists in the active v0.3 plane.
         const allNativeCapable = true;
@@ -498,6 +515,11 @@ export function useInsightView(
           viewName: newViewName,
           nativeCapable: allNativeCapable,
         };
+        for (const key of createdViewsCache.keys()) {
+          if (key !== configKey && key.startsWith(`${insightId}:`)) {
+            createdViewsCache.delete(key);
+          }
+        }
         createdViewsCache.set(configKey, created);
 
         // Guard: if the component has moved on to a different configKey while
@@ -549,6 +571,7 @@ export function useInsightView(
     joinsKey,
     configKey,
     effectiveFiltersKey, // re-run when the cell's filter override changes
+    frameRevision,
   ]);
 
   return {

--- a/packages/app/src/hooks/useInsightView.ts
+++ b/packages/app/src/hooks/useInsightView.ts
@@ -385,9 +385,12 @@ export function useInsightView(
     // eslint-disable-next-line sonarjs/cognitive-complexity -- defensive stale-state guards (currentConfigKeyRef checks) after every await legitimately raise complexity; extracting further would obscure the guard pattern
     const createView = async (): Promise<CachedView | null> => {
       try {
+        const superseded = () => currentConfigKeyRef.current !== configKey;
+        if (superseded()) return null;
         // Double-check cache in case another effect already created it
         if (createdViewsCache.has(configKey)) {
           const cached = createdViewsCache.get(configKey)!;
+          if (superseded()) return null;
           setResolvedViewName(cached.viewName);
           setResolvedConfigKey(configKey);
           // Restore the cached compatibility metadata.
@@ -397,6 +400,7 @@ export function useInsightView(
 
         // Get base table
         const baseTable = await getDataTable(baseTableId);
+        if (superseded()) return null;
         if (!baseTable || !baseTable.dataFrameId) {
           if (currentConfigKeyRef.current === configKey) {
             setError("Base table not found");
@@ -407,6 +411,7 @@ export function useInsightView(
 
         // Ensure base DataFrame is loaded
         const baseDataFrame = await getDataFrame(baseTable.dataFrameId);
+        if (superseded()) return null;
         if (!baseDataFrame) {
           if (currentConfigKeyRef.current === configKey) {
             setError("Base DataFrame not found");
@@ -437,6 +442,7 @@ export function useInsightView(
 
         // Wait for all join table resolutions
         await Promise.all(joinLoadPromises);
+        if (superseded()) return null;
 
         // Load every frame into the active native server connection. File-backed
         // server snapshots register by DataFrame ID; IndexedDB frames use the
@@ -450,6 +456,10 @@ export function useInsightView(
             await ensureTableLoaded(dataFrame, connection);
           }),
         );
+        // This is the side-effect boundary. A superseded run must not replace
+        // the shared insight view or mutate cache state after a newer frame
+        // revision has won.
+        if (superseded()) return null;
 
         // Build SQL for the model (all columns, no aggregation).
         // Metric filters are stripped (they require HAVING, incompatible with
@@ -508,6 +518,7 @@ export function useInsightView(
           : sql;
         const createViewSql = `CREATE OR REPLACE VIEW "${newViewName}" AS ${viewSql}`;
         await connection.query(createViewSql);
+        if (superseded()) return null;
 
         // Store in module-level cache (survives Strict Mode and HMR). The
         // Engine metadata travels with the view name across remounts.
@@ -526,12 +537,10 @@ export function useInsightView(
         // this async path was in-flight, discard these results (but still
         // resolve with the created view so subscribed followers get it). The
         // newer config's createView will (or already did) set the correct state.
-        if (currentConfigKeyRef.current === configKey) {
-          setResolvedViewName(newViewName);
-          setResolvedConfigKey(configKey);
-          setNativeCapable(allNativeCapable);
-          setError(null);
-        }
+        setResolvedViewName(newViewName);
+        setResolvedConfigKey(configKey);
+        setNativeCapable(allNativeCapable);
+        setError(null);
         return created;
       } catch (err) {
         console.error("[useInsightView] Failed to create view:", err);

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -19,3 +19,13 @@ export {
   type WyStackRuntime,
   type WyStackRuntimeConfig,
 } from "./wystack/runtime";
+
+export {
+  createServerConnector,
+  type ServerMosaicConnector,
+} from "./lib/server-connector";
+export {
+  configureServerDataPlane,
+  getServerDataPlane,
+  type ServerDuckDBConnection,
+} from "./lib/server-data-plane";

--- a/packages/app/src/lib/data-access/data-frames.test.ts
+++ b/packages/app/src/lib/data-access/data-frames.test.ts
@@ -1,7 +1,7 @@
 import { setWyStackClient } from "@/wystack/client";
 import type { DataFrame, UUID } from "@dashframe/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { replaceDataFrame } from "./data-frames";
+import { getDataFrame, replaceDataFrame } from "./data-frames";
 
 const { mockDeleteArrowData, mockMutate, mockQuery } = vi.hoisted(() => ({
   mockDeleteArrowData: vi.fn(),
@@ -11,6 +11,7 @@ const { mockDeleteArrowData, mockMutate, mockQuery } = vi.hoisted(() => ({
 
 vi.mock("@dashframe/engine-browser", () => ({
   DataFrame: class {},
+  QueryBuilder: class {},
   deleteArrowData: mockDeleteArrowData,
 }));
 vi.mock("@/wystack/api", () => ({
@@ -58,6 +59,24 @@ describe("replaceDataFrame", () => {
         columnCount: 1,
         analysis: null,
       }),
+    });
+  });
+
+  it("constructs a server reference instead of BrowserDataFrame for file storage", async () => {
+    mockQuery.mockResolvedValue({
+      id: DATA_FRAME_ID,
+      storage: { type: "file", key: DATA_FRAME_ID },
+      fieldIds: [],
+      createdAt: 123,
+      name: "Remote frame",
+    });
+
+    const frame = await getDataFrame(DATA_FRAME_ID);
+
+    expect(frame?.getStorageType()).toBe("Server File");
+    expect(frame?.toJSON().storage).toEqual({
+      type: "file",
+      key: DATA_FRAME_ID,
     });
   });
 });

--- a/packages/app/src/lib/data-access/data-frames.ts
+++ b/packages/app/src/lib/data-access/data-frames.ts
@@ -1,3 +1,4 @@
+import type { DuckDBConnection } from "@dashframe/engine-browser";
 import {
   DataFrame as BrowserDataFrame,
   deleteArrowData,
@@ -9,7 +10,6 @@ import type {
   DataFrameJSON,
   UUID,
 } from "@dashframe/types";
-import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 
 import { api } from "../../wystack/api";
 import { getWyStackClient } from "../../wystack/client";
@@ -41,7 +41,7 @@ class ServerDataFrame implements DataFrame {
     this.createdAt = entry.createdAt;
   }
 
-  load(connection: AsyncDuckDBConnection): Promise<QueryBuilder> {
+  load(connection: DuckDBConnection): Promise<QueryBuilder> {
     return Promise.resolve(new QueryBuilder(this, connection));
   }
 

--- a/packages/app/src/lib/data-access/data-frames.ts
+++ b/packages/app/src/lib/data-access/data-frames.ts
@@ -1,6 +1,7 @@
 import {
   DataFrame as BrowserDataFrame,
   deleteArrowData,
+  QueryBuilder,
 } from "@dashframe/engine-browser";
 import type {
   DataFrame,
@@ -8,6 +9,7 @@ import type {
   DataFrameJSON,
   UUID,
 } from "@dashframe/types";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 
 import { api } from "../../wystack/api";
 import { getWyStackClient } from "../../wystack/client";
@@ -22,6 +24,41 @@ export type DataFrameEntry = DataFrameJSON & {
   analysis?: DataFrameAnalysis | null;
   lastRefreshedAt?: number;
 };
+
+/** Metadata-only reference for frames owned by the native server data plane. */
+class ServerDataFrame implements DataFrame {
+  readonly id: UUID;
+  readonly storage: DataFrameJSON["storage"];
+  readonly fieldIds: UUID[];
+  readonly primaryKey?: string | string[];
+  readonly createdAt: number;
+
+  constructor(entry: DataFrameEntry) {
+    this.id = entry.id;
+    this.storage = entry.storage;
+    this.fieldIds = entry.fieldIds;
+    this.primaryKey = entry.primaryKey;
+    this.createdAt = entry.createdAt;
+  }
+
+  load(connection: AsyncDuckDBConnection): Promise<QueryBuilder> {
+    return Promise.resolve(new QueryBuilder(this, connection));
+  }
+
+  toJSON(): DataFrameJSON {
+    return {
+      id: this.id,
+      storage: this.storage,
+      fieldIds: this.fieldIds,
+      primaryKey: this.primaryKey,
+      createdAt: this.createdAt,
+    };
+  }
+
+  getStorageType(): string {
+    return "Server File";
+  }
+}
 
 async function deleteArrowDataBestEffort(key: string): Promise<void> {
   try {
@@ -107,9 +144,14 @@ export async function clearAllData(): Promise<void> {
 
 export async function getDataFrame(
   id: UUID,
-): Promise<InstanceType<typeof BrowserDataFrame> | undefined> {
+): Promise<
+  InstanceType<typeof BrowserDataFrame> | ServerDataFrame | undefined
+> {
   const entity = await getDataFrameEntry(id);
-  return entity ? BrowserDataFrame.fromJSON(entity) : undefined;
+  if (!entity) return undefined;
+  return entity.storage.type === "file"
+    ? new ServerDataFrame(entity)
+    : BrowserDataFrame.fromJSON(entity);
 }
 
 export async function getDataFrameEntry(

--- a/packages/app/src/lib/local-csv-handler.ts
+++ b/packages/app/src/lib/local-csv-handler.ts
@@ -215,7 +215,10 @@ export async function handleLocalCSVUpload(
     }
 
     // Ensure the DataTable points to the updated DataFrame
-    await updateDataTable(dataTableId, { dataFrameId });
+    await updateDataTable(dataTableId, {
+      dataFrameId,
+      lastFetchedAt: Date.now(),
+    });
   } else {
     // 3b. Create DataTable via the CreateDataTable command — PRIMITIVE path.
     // CreateDataTable does NOT auto-inject metrics, so we pass the default
@@ -242,7 +245,10 @@ export async function handleLocalCSVUpload(
     dataFrameId = dataFrame.id;
 
     // 5. Link DataFrame to DataTable
-    await updateDataTable(dataTableId, { dataFrameId });
+    await updateDataTable(dataTableId, {
+      dataFrameId,
+      lastFetchedAt: Date.now(),
+    });
   }
 
   // Note: Column analysis is run lazily in InsightView when first needed
@@ -322,7 +328,10 @@ export async function handleFileConnectorResult(
       dataFrameId = dataFrame.id;
     }
 
-    await updateDataTable(dataTableId, { dataFrameId });
+    await updateDataTable(dataTableId, {
+      dataFrameId,
+      lastFetchedAt: Date.now(),
+    });
   } else {
     // Create DataTable via the CreateDataTable command — PRIMITIVE path.
     // CreateDataTable does NOT auto-inject metrics, so we pass the default
@@ -349,7 +358,10 @@ export async function handleFileConnectorResult(
     dataFrameId = dataFrame.id;
 
     // Link DataFrame to DataTable
-    await updateDataTable(dataTableId, { dataFrameId });
+    await updateDataTable(dataTableId, {
+      dataFrameId,
+      lastFetchedAt: Date.now(),
+    });
   }
 
   // Note: Column analysis is run lazily in InsightView when first needed

--- a/packages/app/src/lib/server-connector.test.ts
+++ b/packages/app/src/lib/server-connector.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createServerConnector } from "./server-connector";
+
+describe("server connector timeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the timeout active while consuming an Arrow response body", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init: RequestInit) =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () =>
+            new Promise<ArrayBuffer>((_resolve, reject) => {
+              init.signal?.addEventListener("abort", () => {
+                reject(new DOMException("aborted", "AbortError"));
+              });
+            }),
+        }),
+      ),
+    );
+    const connector = createServerConnector({
+      serverUrl: "http://127.0.0.1:4000",
+    });
+
+    const query = expect(
+      connector.query({ type: "arrow", sql: "SELECT 1" }),
+    ).rejects.toThrow("Server connector timed out");
+    await vi.advanceTimersByTimeAsync(11_000);
+    await query;
+  });
+});

--- a/packages/app/src/lib/server-connector.test.ts
+++ b/packages/app/src/lib/server-connector.test.ts
@@ -34,4 +34,28 @@ describe("server connector timeout", () => {
     await vi.advanceTimersByTimeAsync(11_000);
     await query;
   });
+
+  it("registers frames with JSON and auth but no request body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const connector = createServerConnector({
+      serverUrl: "http://127.0.0.1:4000",
+      token: "secret",
+    });
+
+    await connector.registerServerFrame("frame-id", "df_report");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:4000/data/frames/frame-id/tables/df_report",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer secret",
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).not.toHaveProperty("body");
+  });
 });

--- a/packages/app/src/lib/server-connector.ts
+++ b/packages/app/src/lib/server-connector.ts
@@ -4,11 +4,21 @@ import type { MosaicConnector } from "../components/providers/ChartEngineProvide
 
 const TIMEOUT_MS = 10_000;
 
-async function request(url: string, init: RequestInit): Promise<Response> {
+async function request<T>(
+  url: string,
+  init: RequestInit,
+  consume: (response: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    return await consume(response);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("Server connector timed out");
+    }
+    throw error;
   } finally {
     clearTimeout(timer);
   }
@@ -30,23 +40,28 @@ export function createServerConnector(options: {
 
   async function query(q: { type?: string; sql: string }): Promise<unknown> {
     const type = q.type ?? "arrow";
-    const response = await request(`${options.serverUrl}/data/arrow`, {
-      method: "POST",
-      headers: headers("application/json"),
-      body: JSON.stringify({ type, sql: q.sql }),
-    });
-    if (!response.ok) {
-      throw new Error(
-        `Server query failed (${response.status}): ${await response.text()}`,
-      );
-    }
-    if (type === "exec") return undefined;
-    if (type === "json") {
-      return (await response.json()) as Record<string, unknown>[];
-    }
-    return tableFromIPC(new Uint8Array(await response.arrayBuffer()), {
-      useDate: true,
-    });
+    return request(
+      `${options.serverUrl}/data/arrow`,
+      {
+        method: "POST",
+        headers: headers("application/json"),
+        body: JSON.stringify({ type, sql: q.sql }),
+      },
+      async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Server query failed (${response.status}): ${await response.text()}`,
+          );
+        }
+        if (type === "exec") return undefined;
+        if (type === "json") {
+          return (await response.json()) as Record<string, unknown>[];
+        }
+        return tableFromIPC(new Uint8Array(await response.arrayBuffer()), {
+          useDate: true,
+        });
+      },
+    );
   }
 
   async function registerServerFrame(
@@ -54,15 +69,20 @@ export function createServerConnector(options: {
     tableName: string,
   ): Promise<void> {
     const endpoint = `${options.serverUrl}/data/frames/${encodeURIComponent(frameId)}/tables/${encodeURIComponent(tableName)}`;
-    const response = await request(endpoint, {
-      method: "POST",
-      headers: headers("application/json"),
-    });
-    if (!response.ok) {
-      throw new Error(
-        `Server frame registration failed (${response.status}): ${await response.text()}`,
-      );
-    }
+    await request(
+      endpoint,
+      {
+        method: "POST",
+        headers: headers("application/json"),
+      },
+      async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Server frame registration failed (${response.status}): ${await response.text()}`,
+          );
+        }
+      },
+    );
   }
 
   return { query, registerServerFrame } as ServerMosaicConnector;

--- a/packages/app/src/lib/server-connector.ts
+++ b/packages/app/src/lib/server-connector.ts
@@ -1,0 +1,69 @@
+import { tableFromIPC } from "@uwdata/flechette";
+
+import type { MosaicConnector } from "../components/providers/ChartEngineProvider";
+
+const TIMEOUT_MS = 10_000;
+
+async function request(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface ServerMosaicConnector extends MosaicConnector {
+  registerServerFrame(frameId: string, tableName: string): Promise<void>;
+}
+
+/** Native server connector shared by web and Electron. */
+export function createServerConnector(options: {
+  serverUrl: string;
+  token?: string;
+}): ServerMosaicConnector {
+  const headers = (contentType: string): Record<string, string> => ({
+    "Content-Type": contentType,
+    ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
+  });
+
+  async function query(q: { type?: string; sql: string }): Promise<unknown> {
+    const type = q.type ?? "arrow";
+    const response = await request(`${options.serverUrl}/data/arrow`, {
+      method: "POST",
+      headers: headers("application/json"),
+      body: JSON.stringify({ type, sql: q.sql }),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Server query failed (${response.status}): ${await response.text()}`,
+      );
+    }
+    if (type === "exec") return undefined;
+    if (type === "json") {
+      return (await response.json()) as Record<string, unknown>[];
+    }
+    return tableFromIPC(new Uint8Array(await response.arrayBuffer()), {
+      useDate: true,
+    });
+  }
+
+  async function registerServerFrame(
+    frameId: string,
+    tableName: string,
+  ): Promise<void> {
+    const endpoint = `${options.serverUrl}/data/frames/${encodeURIComponent(frameId)}/tables/${encodeURIComponent(tableName)}`;
+    const response = await request(endpoint, {
+      method: "POST",
+      headers: headers("application/json"),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Server frame registration failed (${response.status}): ${await response.text()}`,
+      );
+    }
+  }
+
+  return { query, registerServerFrame } as ServerMosaicConnector;
+}

--- a/packages/app/src/lib/server-data-plane.test.ts
+++ b/packages/app/src/lib/server-data-plane.test.ts
@@ -1,3 +1,5 @@
+import type { DataFrame } from "@dashframe/engine";
+import { ensureTableLoaded } from "@dashframe/engine-browser";
 import { tableFromArrays, tableToIPC } from "apache-arrow";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -60,6 +62,79 @@ describe("server data plane", () => {
     expect(registerServerFrame).toHaveBeenCalledWith("frame-id", "df_report");
   });
 
+  it("uses the real table loader without assuming a WASM prepare method", async () => {
+    const empty = tableToIPC(tableFromArrays({ exists: [] }), "stream");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => empty.buffer,
+      }),
+    );
+    const registerServerFrame = vi.fn().mockResolvedValue(undefined);
+    const connection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: connector(registerServerFrame),
+    });
+    const frame = {
+      id: "11111111-1111-4111-8111-111111111111",
+      storage: {
+        type: "file",
+        key: "22222222-2222-4222-8222-222222222222",
+      },
+      fieldIds: [],
+      createdAt: 0,
+      toJSON() {
+        return this;
+      },
+    } as DataFrame;
+
+    await expect(ensureTableLoaded(frame, connection)).resolves.toBe(
+      "df_11111111_1111_4111_8111_111111111111",
+    );
+    expect(registerServerFrame).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      "df_11111111_1111_4111_8111_111111111111",
+    );
+  });
+
+  it("reloads an existing server table when its storage generation is unknown", async () => {
+    // useInsightView mocks ensureTableLoaded, so exercise the real loader here
+    // against the actual configured server connection contract.
+    const existing = tableToIPC(tableFromArrays({ exists: [1] }), "stream");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => existing.buffer,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const registerServerFrame = vi.fn().mockResolvedValue(undefined);
+    const connection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: connector(registerServerFrame),
+    });
+    const frame = {
+      id: "33333333-3333-4333-8333-333333333333",
+      storage: {
+        type: "file",
+        key: "44444444-4444-4444-8444-444444444444",
+      },
+      fieldIds: [],
+      createdAt: 0,
+      toJSON() {
+        return this;
+      },
+    } as DataFrame;
+
+    await expect(ensureTableLoaded(frame, connection)).resolves.toBe(
+      "df_33333333_3333_4333_8333_333333333333",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(registerServerFrame).toHaveBeenCalledWith(
+      "44444444-4444-4444-8444-444444444444",
+      "df_33333333_3333_4333_8333_333333333333",
+    );
+  });
+
   it("fails a stalled server query instead of hanging the consumer", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(
@@ -71,6 +146,34 @@ describe("server data plane", () => {
               reject(new DOMException("aborted", "AbortError"));
             });
           }),
+      ),
+    );
+    const connection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: connector(),
+    });
+
+    const query = expect(connection.query("SELECT 1")).rejects.toThrow(
+      "Server data plane timed out",
+    );
+    await vi.advanceTimersByTimeAsync(11_000);
+    await query;
+  });
+
+  it("keeps the timeout active while consuming a stalled response body", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init: RequestInit) =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () =>
+            new Promise<ArrayBuffer>((_resolve, reject) => {
+              init.signal?.addEventListener("abort", () => {
+                reject(new DOMException("aborted", "AbortError"));
+              });
+            }),
+        }),
       ),
     );
     const connection = configureServerDataPlane({

--- a/packages/app/src/lib/server-data-plane.test.ts
+++ b/packages/app/src/lib/server-data-plane.test.ts
@@ -1,0 +1,87 @@
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ServerMosaicConnector } from "./server-connector";
+import { configureServerDataPlane } from "./server-data-plane";
+
+function connector(
+  registerServerFrame = vi.fn().mockResolvedValue(undefined),
+): ServerMosaicConnector {
+  return {
+    query: vi.fn(),
+    registerServerFrame,
+  } as unknown as ServerMosaicConnector;
+}
+
+describe("server data plane", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("queries Arrow through the server and decodes the result", async () => {
+    const bytes = tableToIPC(tableFromArrays({ value: [1, 2] }), "stream");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => bytes.buffer,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const connection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      token: "secret",
+      connector: connector(),
+    });
+
+    const result = await connection.query("SELECT value FROM df_report");
+
+    expect(result.numRows).toBe(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:4000/data/arrow",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+        }),
+        body: JSON.stringify({ sql: "SELECT value FROM df_report" }),
+      }),
+    );
+  });
+
+  it("delegates file registration by handle without loading bytes", async () => {
+    const registerServerFrame = vi.fn().mockResolvedValue(undefined);
+    const connection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: connector(registerServerFrame),
+    });
+
+    await connection.registerServerFrame("frame-id", "df_report");
+
+    expect(registerServerFrame).toHaveBeenCalledWith("frame-id", "df_report");
+  });
+
+  it("fails a stalled server query instead of hanging the consumer", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => {
+              reject(new DOMException("aborted", "AbortError"));
+            });
+          }),
+      ),
+    );
+    const connection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: connector(),
+    });
+
+    const query = expect(connection.query("SELECT 1")).rejects.toThrow(
+      "Server data plane timed out",
+    );
+    await vi.advanceTimersByTimeAsync(11_000);
+    await query;
+  });
+});

--- a/packages/app/src/lib/server-data-plane.test.ts
+++ b/packages/app/src/lib/server-data-plane.test.ts
@@ -1,5 +1,8 @@
 import type { DataFrame } from "@dashframe/engine";
-import { ensureTableLoaded } from "@dashframe/engine-browser";
+import {
+  clearAllTableCaches,
+  ensureTableLoaded,
+} from "@dashframe/engine-browser";
 import { tableFromArrays, tableToIPC } from "apache-arrow";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -17,9 +20,70 @@ function connector(
 
 describe("server data plane", () => {
   afterEach(() => {
+    clearAllTableCaches();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("replaces and reopens a GA4 frame with the fresh queryable bytes", async () => {
+    const dataFrameId = "55555555-5555-4555-8555-555555555555";
+    const oldFrameId = "66666666-6666-4666-8666-666666666666";
+    const newFrameId = "77777777-7777-4777-8777-777777777777";
+    const tableName = "df_55555555_5555_4555_8555_555555555555";
+    let registeredFrameId: string | undefined;
+    const arrow = (values: string[]) =>
+      tableToIPC(tableFromArrays({ revision: values }), "stream");
+    const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+      const sql = JSON.parse(String(init.body)).sql as string;
+      if (sql.includes("information_schema.tables")) {
+        const bytes = arrow(registeredFrameId ? ["exists"] : []);
+        return { ok: true, arrayBuffer: async () => bytes.buffer };
+      }
+      if (sql.startsWith("DROP TABLE")) {
+        registeredFrameId = undefined;
+        const bytes = arrow([]);
+        return { ok: true, arrayBuffer: async () => bytes.buffer };
+      }
+      const bytes = arrow([registeredFrameId === newFrameId ? "new" : "old"]);
+      return { ok: true, arrayBuffer: async () => bytes.buffer };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const registerServerFrame = vi.fn(async (frameId: string) => {
+      registeredFrameId = frameId;
+    });
+    const serverConnector = connector(registerServerFrame);
+    const frame = (key: string, createdAt: number) =>
+      ({
+        id: dataFrameId,
+        storage: { type: "file", key },
+        fieldIds: [],
+        createdAt,
+      }) as DataFrame;
+
+    const firstConnection = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: serverConnector,
+    });
+    await ensureTableLoaded(frame(oldFrameId, 1), firstConnection);
+    await ensureTableLoaded(frame(newFrameId, 2), firstConnection);
+    expect(
+      (await firstConnection.query(`SELECT * FROM ${tableName}`)).toArray(),
+    ).toEqual([expect.objectContaining({ revision: "new" })]);
+
+    await firstConnection.close();
+    const reopened = configureServerDataPlane({
+      serverUrl: "http://127.0.0.1:4000",
+      connector: serverConnector,
+    });
+    await ensureTableLoaded(frame(newFrameId, 2), reopened);
+    expect(
+      (await reopened.query(`SELECT * FROM ${tableName}`)).toArray(),
+    ).toEqual([expect.objectContaining({ revision: "new" })]);
+    expect(registerServerFrame.mock.calls).toEqual([
+      [oldFrameId, tableName],
+      [newFrameId, tableName],
+    ]);
   });
 
   it("queries Arrow through the server and decodes the result", async () => {

--- a/packages/app/src/lib/server-data-plane.ts
+++ b/packages/app/src/lib/server-data-plane.ts
@@ -1,0 +1,81 @@
+import { tableFromIPC } from "apache-arrow";
+
+import type { ServerMosaicConnector } from "./server-connector";
+
+const TIMEOUT_MS = 10_000;
+
+async function request(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("Server data plane timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface ServerDuckDBConnection {
+  query(sql: string): Promise<ReturnType<typeof tableFromIPC>>;
+  insertArrowFromIPCStream(
+    arrow: Uint8Array,
+    options: { name: string },
+  ): Promise<void>;
+  registerServerFrame(frameId: string, tableName: string): Promise<void>;
+  close(): Promise<void>;
+}
+
+let activeConnection: ServerDuckDBConnection | null = null;
+
+export function configureServerDataPlane(options: {
+  serverUrl: string;
+  token?: string;
+  connector: ServerMosaicConnector;
+}): ServerDuckDBConnection {
+  const authHeaders = (contentType: string) => ({
+    "Content-Type": contentType,
+    ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
+  });
+  activeConnection = {
+    async query(sql) {
+      const response = await request(`${options.serverUrl}/data/arrow`, {
+        method: "POST",
+        headers: authHeaders("application/json"),
+        body: JSON.stringify({ sql }),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Server query failed (${response.status}): ${await response.text()}`,
+        );
+      }
+      return tableFromIPC(new Uint8Array(await response.arrayBuffer()));
+    },
+    async insertArrowFromIPCStream(arrow, { name }) {
+      const response = await request(
+        `${options.serverUrl}/data/tables/${encodeURIComponent(name)}`,
+        {
+          method: "POST",
+          headers: authHeaders("application/vnd.apache.arrow.stream"),
+          body: arrow,
+        },
+      );
+      if (!response.ok) {
+        throw new Error(
+          `Server table upload failed (${response.status}): ${await response.text()}`,
+        );
+      }
+    },
+    registerServerFrame: (frameId, tableName) =>
+      options.connector.registerServerFrame(frameId, tableName),
+    async close() {},
+  };
+  return activeConnection;
+}
+
+export function getServerDataPlane(): ServerDuckDBConnection | null {
+  return activeConnection;
+}

--- a/packages/app/src/lib/server-data-plane.ts
+++ b/packages/app/src/lib/server-data-plane.ts
@@ -1,14 +1,20 @@
+import type { ServerDuckDBConnectionLike } from "@dashframe/engine-browser";
 import { tableFromIPC } from "apache-arrow";
 
 import type { ServerMosaicConnector } from "./server-connector";
 
 const TIMEOUT_MS = 10_000;
 
-async function request(url: string, init: RequestInit): Promise<Response> {
+async function request<T>(
+  url: string,
+  init: RequestInit,
+  consume: (response: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    return await consume(response);
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       throw new Error("Server data plane timed out");
@@ -19,8 +25,8 @@ async function request(url: string, init: RequestInit): Promise<Response> {
   }
 }
 
-export interface ServerDuckDBConnection {
-  query(sql: string): Promise<ReturnType<typeof tableFromIPC>>;
+export interface ServerDuckDBConnection extends ServerDuckDBConnectionLike {
+  query(sql: string): Promise<Awaited<ReturnType<typeof tableFromIPC>>>;
   insertArrowFromIPCStream(
     arrow: Uint8Array,
     options: { name: string },
@@ -42,32 +48,39 @@ export function configureServerDataPlane(options: {
   });
   activeConnection = {
     async query(sql) {
-      const response = await request(`${options.serverUrl}/data/arrow`, {
-        method: "POST",
-        headers: authHeaders("application/json"),
-        body: JSON.stringify({ sql }),
-      });
-      if (!response.ok) {
-        throw new Error(
-          `Server query failed (${response.status}): ${await response.text()}`,
-        );
-      }
-      return tableFromIPC(new Uint8Array(await response.arrayBuffer()));
+      return request(
+        `${options.serverUrl}/data/arrow`,
+        {
+          method: "POST",
+          headers: authHeaders("application/json"),
+          body: JSON.stringify({ sql }),
+        },
+        async (response) => {
+          if (!response.ok) {
+            throw new Error(
+              `Server query failed (${response.status}): ${await response.text()}`,
+            );
+          }
+          return tableFromIPC(new Uint8Array(await response.arrayBuffer()));
+        },
+      );
     },
     async insertArrowFromIPCStream(arrow, { name }) {
-      const response = await request(
+      await request(
         `${options.serverUrl}/data/tables/${encodeURIComponent(name)}`,
         {
           method: "POST",
           headers: authHeaders("application/vnd.apache.arrow.stream"),
           body: arrow,
         },
+        async (response) => {
+          if (!response.ok) {
+            throw new Error(
+              `Server table upload failed (${response.status}): ${await response.text()}`,
+            );
+          }
+        },
       );
-      if (!response.ok) {
-        throw new Error(
-          `Server table upload failed (${response.status}): ${await response.text()}`,
-        );
-      }
     },
     registerServerFrame: (frameId, tableName) =>
       options.connector.registerServerFrame(frameId, tableName),

--- a/packages/engine-browser/src/__tests__/query-builder.execution.test.ts
+++ b/packages/engine-browser/src/__tests__/query-builder.execution.test.ts
@@ -498,10 +498,12 @@ describe("QueryBuilder - Execution Methods", () => {
       } as unknown as AsyncDuckDBConnection;
       const first = {
         ...mockDataFrame,
+        createdAt: 1,
         storage: { type: "file" as const, key: "first-frame" },
       };
       const refreshed = {
         ...mockDataFrame,
+        createdAt: 2,
         storage: { type: "file" as const, key: "refreshed-frame" },
       };
 
@@ -517,25 +519,36 @@ describe("QueryBuilder - Execution Methods", () => {
       );
     });
 
-    it("reloads a refreshed generation that arrives during an older load", async () => {
+    it("leaves newer queryable bytes when they arrive during an older load", async () => {
       let releaseFirst!: () => void;
       const firstBlocked = new Promise<void>((resolve) => {
         releaseFirst = resolve;
       });
+      let queryableRevision: string | undefined;
       const registerServerFrame = vi
         .fn()
-        .mockImplementationOnce(() => firstBlocked)
-        .mockResolvedValueOnce(undefined);
+        .mockImplementationOnce(async () => {
+          await firstBlocked;
+          queryableRevision = "old";
+        })
+        .mockImplementationOnce(async () => {
+          queryableRevision = "new";
+        });
       const connection = {
-        query: vi.fn().mockResolvedValue({ toArray: () => [] }),
+        query: vi.fn().mockImplementation(async (sql: string) => ({
+          toArray: () =>
+            sql.startsWith("SELECT *") ? [{ revision: queryableRevision }] : [],
+        })),
         registerServerFrame,
       } as unknown as AsyncDuckDBConnection;
       const first = {
         ...mockDataFrame,
+        createdAt: 1,
         storage: { type: "file" as const, key: "first-frame" },
       };
       const refreshed = {
         ...mockDataFrame,
+        createdAt: 2,
         storage: { type: "file" as const, key: "refreshed-frame" },
       };
 
@@ -551,6 +564,53 @@ describe("QueryBuilder - Execution Methods", () => {
         ["first-frame", "df_test_df_id"],
         ["refreshed-frame", "df_test_df_id"],
       ]);
+      const final = await connection.query('SELECT * FROM "df_test_df_id"');
+      expect(final.toArray()).toEqual([{ revision: "new" }]);
+    });
+
+    it("never lets an older generation queued behind a newer load replace it", async () => {
+      let releaseNew!: () => void;
+      const newBlocked = new Promise<void>((resolve) => {
+        releaseNew = resolve;
+      });
+      let queryableRevision: string | undefined;
+      const registerServerFrame = vi.fn().mockImplementation(async () => {
+        await newBlocked;
+        queryableRevision = "new";
+      });
+      const connection = {
+        query: vi.fn().mockImplementation(async (sql: string) => ({
+          toArray: () =>
+            sql.startsWith("SELECT *") ? [{ revision: queryableRevision }] : [],
+        })),
+        registerServerFrame,
+      } as unknown as AsyncDuckDBConnection;
+      const refreshed = {
+        ...mockDataFrame,
+        createdAt: 2,
+        storage: { type: "file" as const, key: "refreshed-frame" },
+      };
+      const stale = {
+        ...mockDataFrame,
+        createdAt: 1,
+        storage: { type: "file" as const, key: "first-frame" },
+      };
+
+      const refreshedLoad = new QueryBuilder(refreshed, connection).sql();
+      await vi.waitFor(() =>
+        expect(registerServerFrame).toHaveBeenCalledOnce(),
+      );
+      const staleLoad = new QueryBuilder(stale, connection).sql();
+      releaseNew();
+      await Promise.all([refreshedLoad, staleLoad]);
+
+      expect(registerServerFrame).toHaveBeenCalledTimes(1);
+      expect(registerServerFrame).toHaveBeenCalledWith(
+        "refreshed-frame",
+        "df_test_df_id",
+      );
+      const final = await connection.query('SELECT * FROM "df_test_df_id"');
+      expect(final.toArray()).toEqual([{ revision: "new" }]);
     });
   });
 });

--- a/packages/engine-browser/src/__tests__/query-builder.execution.test.ts
+++ b/packages/engine-browser/src/__tests__/query-builder.execution.test.ts
@@ -11,7 +11,7 @@
 import type { DataFrame } from "@dashframe/engine";
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { QueryBuilder } from "../query-builder";
+import { clearAllTableCaches, QueryBuilder } from "../query-builder";
 import {
   createMockConnectionForRun,
   createMockConnectionWithResults,
@@ -36,6 +36,7 @@ describe("QueryBuilder - Execution Methods", () => {
   let mockDataFrame: DataFrame;
 
   beforeEach(() => {
+    clearAllTableCaches();
     mockDataFrame = createMockDataFrame();
     vi.clearAllMocks();
   });
@@ -455,27 +456,20 @@ describe("QueryBuilder - Execution Methods", () => {
     });
   });
 
-  describe("table existence check - parameterized query", () => {
-    it("should use prepare() with parameterized SQL and pass table name to stmt.query()", async () => {
-      // Create mock prepared statement with tracking
-      const mockStmtQuery = vi.fn().mockResolvedValue({
+  describe("table existence check - shared query contract", () => {
+    it("uses query() and reloads an existing table with an unknown generation", async () => {
+      const mockQuery = vi.fn().mockResolvedValue({
         toArray: () => [{ exists: 1 }],
       });
-      const mockStmtClose = vi.fn().mockResolvedValue(undefined);
-      const mockStmt = {
-        query: mockStmtQuery,
-        close: mockStmtClose,
-      };
-
-      // Create mock connection with prepare tracking
-      const mockPrepare = vi.fn().mockResolvedValue(mockStmt);
+      const registerServerFrame = vi.fn().mockResolvedValue(undefined);
       const mockConn = {
-        prepare: mockPrepare,
-        query: vi.fn().mockResolvedValue({
-          toArray: () => [],
-        }),
-        insertArrowFromIPCStream: vi.fn().mockResolvedValue(undefined),
+        query: mockQuery,
+        registerServerFrame,
       } as unknown as AsyncDuckDBConnection;
+      mockDataFrame = {
+        ...mockDataFrame,
+        storage: { type: "file", key: "server-frame" },
+      };
 
       // Create QueryBuilder WITHOUT tableName to trigger ensureLoaded()
       const qb = new QueryBuilder(mockDataFrame, mockConn);
@@ -483,16 +477,80 @@ describe("QueryBuilder - Execution Methods", () => {
       // Trigger table loading by calling sql()
       await qb.sql();
 
-      // Verify prepare() was called with parameterized SQL containing ? placeholder
-      expect(mockPrepare).toHaveBeenCalledWith(
-        "SELECT 1 FROM information_schema.tables WHERE table_name = ? LIMIT 1",
+      expect(mockQuery).toHaveBeenCalledWith(
+        "SELECT 1 FROM information_schema.tables WHERE table_name = 'df_test_df_id' LIMIT 1",
       );
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(registerServerFrame).toHaveBeenCalledWith(
+        "server-frame",
+        "df_test_df_id",
+      );
+    });
 
-      // Verify stmt.query() was called with the table name
-      expect(mockStmtQuery).toHaveBeenCalledWith("df_test_df_id");
+    it("reloads a same-id frame when its storage generation changes", async () => {
+      const query = vi
+        .fn()
+        .mockResolvedValue({ toArray: () => [{ exists: 1 }] });
+      const registerServerFrame = vi.fn().mockResolvedValue(undefined);
+      const connection = {
+        query,
+        registerServerFrame,
+      } as unknown as AsyncDuckDBConnection;
+      const first = {
+        ...mockDataFrame,
+        storage: { type: "file" as const, key: "first-frame" },
+      };
+      const refreshed = {
+        ...mockDataFrame,
+        storage: { type: "file" as const, key: "refreshed-frame" },
+      };
 
-      // Verify stmt.close() was called
-      expect(mockStmtClose).toHaveBeenCalled();
+      await new QueryBuilder(first, connection).sql();
+      await new QueryBuilder(refreshed, connection).sql();
+
+      expect(query).toHaveBeenCalledWith(
+        'DROP TABLE IF EXISTS "df_test_df_id"',
+      );
+      expect(registerServerFrame).toHaveBeenCalledWith(
+        "refreshed-frame",
+        "df_test_df_id",
+      );
+    });
+
+    it("reloads a refreshed generation that arrives during an older load", async () => {
+      let releaseFirst!: () => void;
+      const firstBlocked = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const registerServerFrame = vi
+        .fn()
+        .mockImplementationOnce(() => firstBlocked)
+        .mockResolvedValueOnce(undefined);
+      const connection = {
+        query: vi.fn().mockResolvedValue({ toArray: () => [] }),
+        registerServerFrame,
+      } as unknown as AsyncDuckDBConnection;
+      const first = {
+        ...mockDataFrame,
+        storage: { type: "file" as const, key: "first-frame" },
+      };
+      const refreshed = {
+        ...mockDataFrame,
+        storage: { type: "file" as const, key: "refreshed-frame" },
+      };
+
+      const firstLoad = new QueryBuilder(first, connection).sql();
+      await vi.waitFor(() =>
+        expect(registerServerFrame).toHaveBeenCalledOnce(),
+      );
+      const refreshedLoad = new QueryBuilder(refreshed, connection).sql();
+      releaseFirst();
+      await Promise.all([firstLoad, refreshedLoad]);
+
+      expect(registerServerFrame.mock.calls).toEqual([
+        ["first-frame", "df_test_df_id"],
+        ["refreshed-frame", "df_test_df_id"],
+      ]);
     });
   });
 });

--- a/packages/engine-browser/src/analyze.ts
+++ b/packages/engine-browser/src/analyze.ts
@@ -13,8 +13,8 @@ import type {
   UnknownAnalysis,
 } from "@dashframe/types";
 import { CARDINALITY_THRESHOLDS } from "@dashframe/types";
-import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { debugLog } from "./debug";
+import type { DuckDBConnection } from "./query-builder";
 
 // Re-export types and utilities from @dashframe/types for backward compatibility
 export {
@@ -331,7 +331,7 @@ function analyzeString(
  * @returns Array of column analysis results
  */
 export async function analyzeDataFrame(
-  conn: AsyncDuckDBConnection,
+  conn: DuckDBConnection,
   tableName: string,
   columns: DataFrameColumn[],
   fields?: Record<string, Field>,
@@ -953,7 +953,7 @@ export function suggestJoinColumns(
  * @returns Column analysis for all columns in the view
  */
 export async function analyzeView(
-  conn: AsyncDuckDBConnection,
+  conn: DuckDBConnection,
   viewName: string,
 ): Promise<ColumnAnalysis[]> {
   try {

--- a/packages/engine-browser/src/dataframe.ts
+++ b/packages/engine-browser/src/dataframe.ts
@@ -105,6 +105,8 @@ export class BrowserDataFrame implements DataFrame {
     switch (this.storage.type) {
       case "indexeddb":
         return "Browser Storage";
+      case "file":
+        return "Server File";
       case "s3":
         return "AWS S3";
       case "r2":

--- a/packages/engine-browser/src/dataframe.ts
+++ b/packages/engine-browser/src/dataframe.ts
@@ -5,7 +5,7 @@ import type {
   DataFrameStorageLocation,
   UUID,
 } from "@dashframe/engine";
-import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import type { DuckDBConnection } from "./query-builder";
 import { generateArrowKey, persistArrowData } from "./storage";
 
 /**
@@ -33,7 +33,7 @@ export class BrowserDataFrame implements DataFrame {
    * Entry point to query operations - loads data and returns QueryBuilder.
    * Import QueryBuilder dynamically to avoid circular dependency.
    */
-  async load(conn: AsyncDuckDBConnection) {
+  async load(conn: DuckDBConnection) {
     const { QueryBuilder } = await import("./query-builder");
     return new QueryBuilder(this, conn);
   }

--- a/packages/engine-browser/src/index.ts
+++ b/packages/engine-browser/src/index.ts
@@ -53,6 +53,8 @@ export {
   clearAllTableCaches,
   ensureTableLoaded,
   invalidateTableCache,
+  type DuckDBConnection,
+  type ServerDuckDBConnectionLike,
 } from "./query-builder";
 
 // ============================================================================

--- a/packages/engine-browser/src/query-builder.ts
+++ b/packages/engine-browser/src/query-builder.ts
@@ -35,18 +35,45 @@ export type DuckDBConnection =
  */
 const tableLoadingMutex = new Map<
   string,
-  { signature: string; promise: Promise<string> }
+  { generation: TableGeneration; promise: Promise<string> }
 >();
 
+interface TableGeneration {
+  revision: number;
+  signature: string;
+}
+
+function tableGeneration(dataFrame: DataFrame): TableGeneration {
+  return {
+    revision: Number.isFinite(dataFrame.createdAt) ? dataFrame.createdAt : 0,
+    signature: JSON.stringify(dataFrame.storage),
+  };
+}
+
+function compareGeneration(
+  candidate: TableGeneration,
+  current: TableGeneration,
+): "same" | "newer" | "older" | "conflict" {
+  if (candidate.revision > current.revision) return "newer";
+  if (candidate.revision < current.revision) return "older";
+  return candidate.signature === current.signature ? "same" : "conflict";
+}
+
 async function awaitExistingLoad(
-  existing: { signature: string; promise: Promise<string> },
-  signature: string,
+  existing: { generation: TableGeneration; promise: Promise<string> },
+  generation: TableGeneration,
   dataFrame: DataFrame,
   conn: DuckDBConnection,
 ): Promise<string> {
-  if (existing.signature === signature) return existing.promise;
-  // A refreshed generation arrived while the old bytes were loading. Let the
-  // old operation settle, then re-check/reload against the new signature.
+  const order = compareGeneration(generation, existing.generation);
+  if (order === "same" || order === "older") return existing.promise;
+  if (order === "conflict") {
+    throw new Error(
+      `Conflicting DataFrame generations share revision ${generation.revision}`,
+    );
+  }
+  // A strictly newer generation arrived while old bytes were loading. Let the
+  // old operation settle, then reload against the new generation.
   await existing.promise.catch(() => undefined);
   return ensureTableLoaded(dataFrame, conn);
 }
@@ -66,11 +93,41 @@ const formatValue = (value: unknown): string => {
   return `'${String(value).replace(/'/g, "''")}'`;
 };
 
-const loadedStorageSignatures = new Map<string, string>();
+const loadedTableGenerations = new Map<string, TableGeneration>();
+
+function requiresTableLoad(
+  tableName: string,
+  generation: TableGeneration,
+  tableExists: boolean,
+): boolean {
+  const loadedGeneration = loadedTableGenerations.get(tableName);
+  const order = loadedGeneration
+    ? compareGeneration(generation, loadedGeneration)
+    : "newer";
+  if (tableExists && order === "same") {
+    loadedTableGenerations.set(tableName, generation);
+    return false;
+  }
+  if (loadedGeneration && order === "older") {
+    if (!tableExists) {
+      throw new Error(
+        `Refusing stale DataFrame generation ${generation.revision}; ` +
+          `generation ${loadedGeneration.revision} was already loaded`,
+      );
+    }
+    return false;
+  }
+  if (order === "conflict") {
+    throw new Error(
+      `Conflicting DataFrame generations share revision ${generation.revision}`,
+    );
+  }
+  return true;
+}
 
 /** Invalidate the known storage generation for a specific DataFrame. */
 export function invalidateTableCache(dataFrameId: string): void {
-  loadedStorageSignatures.delete(makeTableName(dataFrameId));
+  loadedTableGenerations.delete(makeTableName(dataFrameId));
 }
 
 /**
@@ -80,7 +137,7 @@ export function invalidateTableCache(dataFrameId: string): void {
  * storage-generation marker used to detect same-id frame replacement.
  */
 export function clearAllTableCaches(): void {
-  loadedStorageSignatures.clear();
+  loadedTableGenerations.clear();
 }
 
 // ============================================================================
@@ -233,12 +290,12 @@ export async function ensureTableLoaded(
   conn: DuckDBConnection,
 ): Promise<string> {
   const tableName = makeTableName(dataFrame.id);
-  const storageSignature = JSON.stringify(dataFrame.storage);
+  const generation = tableGeneration(dataFrame);
 
   // Check if there's an ongoing load for this table (mutex prevents concurrent loads)
   const existingLoad = tableLoadingMutex.get(tableName);
   if (existingLoad) {
-    return awaitExistingLoad(existingLoad, storageSignature, dataFrame, conn);
+    return awaitExistingLoad(existingLoad, generation, dataFrame, conn);
   }
 
   // Create mutex promise for this load
@@ -249,7 +306,7 @@ export async function ensureTableLoaded(
     rejectLoad = reject;
   });
   tableLoadingMutex.set(tableName, {
-    signature: storageSignature,
+    generation,
     promise: loadPromise,
   });
 
@@ -267,10 +324,7 @@ export async function ensureTableLoaded(
       tableExists = false;
     }
 
-    const loadedSignature = loadedStorageSignatures.get(tableName);
-    if (tableExists && loadedSignature === storageSignature) {
-      // Table already exists in DuckDB - return immediately
-      loadedStorageSignatures.set(tableName, storageSignature);
+    if (!requiresTableLoad(tableName, generation, tableExists)) {
       resolveLoad(tableName);
       return tableName;
     }
@@ -314,7 +368,7 @@ export async function ensureTableLoaded(
       }
     }
 
-    loadedStorageSignatures.set(tableName, storageSignature);
+    loadedTableGenerations.set(tableName, generation);
     resolveLoad(tableName);
     return tableName;
   } catch (err) {

--- a/packages/engine-browser/src/query-builder.ts
+++ b/packages/engine-browser/src/query-builder.ts
@@ -5,6 +5,21 @@ import { debugLog } from "./debug";
 import { joinTypeToSQL } from "./join-sql";
 import { loadArrowData } from "./storage";
 
+/** Shared subset used by both DuckDB-WASM and the native server adapter. */
+export interface ServerDuckDBConnectionLike {
+  query(sql: string): Promise<{ toArray(): unknown[] }>;
+  insertArrowFromIPCStream(
+    arrow: Uint8Array,
+    options: { name: string; create?: boolean },
+  ): Promise<void>;
+  registerServerFrame(frameId: string, tableName: string): Promise<void>;
+  close(): Promise<void>;
+}
+
+export type DuckDBConnection =
+  | AsyncDuckDBConnection
+  | ServerDuckDBConnectionLike;
+
 // ============================================================================
 // Global Table Loading Mutex
 // ============================================================================
@@ -18,7 +33,23 @@ import { loadArrowData } from "./storage";
  *
  * Solution: A global promise-based mutex that serializes table creation per DataFrame.
  */
-const tableLoadingMutex = new Map<string, Promise<string>>();
+const tableLoadingMutex = new Map<
+  string,
+  { signature: string; promise: Promise<string> }
+>();
+
+async function awaitExistingLoad(
+  existing: { signature: string; promise: Promise<string> },
+  signature: string,
+  dataFrame: DataFrame,
+  conn: DuckDBConnection,
+): Promise<string> {
+  if (existing.signature === signature) return existing.promise;
+  // A refreshed generation arrived while the old bytes were loading. Let the
+  // old operation settle, then re-check/reload against the new signature.
+  await existing.promise.catch(() => undefined);
+  return ensureTableLoaded(dataFrame, conn);
+}
 
 const makeTableName = (dataFrameId: string): string =>
   `df_${dataFrameId.replace(/-/g, "_")}`;
@@ -35,24 +66,21 @@ const formatValue = (value: unknown): string => {
   return `'${String(value).replace(/'/g, "''")}'`;
 };
 
-/**
- * Invalidate the loaded table cache for a specific DataFrame.
- *
- * @deprecated No-op. Table existence is now checked directly via SQL.
- * The mutex pattern handles concurrent loads without needing a separate cache.
- */
-export function invalidateTableCache(_dataFrameId: string): void {
-  // No-op: table existence is verified via information_schema query
+const loadedStorageSignatures = new Map<string, string>();
+
+/** Invalidate the known storage generation for a specific DataFrame. */
+export function invalidateTableCache(dataFrameId: string): void {
+  loadedStorageSignatures.delete(makeTableName(dataFrameId));
 }
 
 /**
  * Clear all loaded table caches.
  *
- * @deprecated No-op. Table existence is now checked directly via SQL.
- * The mutex pattern handles concurrent loads without needing a separate cache.
+ * Table existence is still checked directly via SQL; this only clears the
+ * storage-generation marker used to detect same-id frame replacement.
  */
 export function clearAllTableCaches(): void {
-  // No-op: table existence is verified via information_schema query
+  loadedStorageSignatures.clear();
 }
 
 // ============================================================================
@@ -202,14 +230,15 @@ const buildOrderClause = (sorts: SortOrderLocal[]): string | undefined => {
 
 export async function ensureTableLoaded(
   dataFrame: DataFrame,
-  conn: AsyncDuckDBConnection,
+  conn: DuckDBConnection,
 ): Promise<string> {
   const tableName = makeTableName(dataFrame.id);
+  const storageSignature = JSON.stringify(dataFrame.storage);
 
   // Check if there's an ongoing load for this table (mutex prevents concurrent loads)
   const existingLoad = tableLoadingMutex.get(tableName);
   if (existingLoad) {
-    return existingLoad;
+    return awaitExistingLoad(existingLoad, storageSignature, dataFrame, conn);
   }
 
   // Create mutex promise for this load
@@ -219,26 +248,29 @@ export async function ensureTableLoaded(
     resolveLoad = resolve;
     rejectLoad = reject;
   });
-  tableLoadingMutex.set(tableName, loadPromise);
+  tableLoadingMutex.set(tableName, {
+    signature: storageSignature,
+    promise: loadPromise,
+  });
 
   try {
     // Always check if table exists in DuckDB (even if cache says it's loaded)
     // This handles cases where DuckDB was reset or table was dropped externally
     let tableExists = false;
     try {
-      const stmt = await conn.prepare(
-        `SELECT 1 FROM information_schema.tables WHERE table_name = ? LIMIT 1`,
+      const checkResult = await conn.query(
+        `SELECT 1 FROM information_schema.tables WHERE table_name = ${formatValue(tableName)} LIMIT 1`,
       );
-      const checkResult = await stmt.query(tableName);
       tableExists = checkResult.toArray().length > 0;
-      await stmt.close();
     } catch {
       // If check fails (e.g., DuckDB not ready), assume table doesn't exist
       tableExists = false;
     }
 
-    if (tableExists) {
+    const loadedSignature = loadedStorageSignatures.get(tableName);
+    if (tableExists && loadedSignature === storageSignature) {
       // Table already exists in DuckDB - return immediately
+      loadedStorageSignatures.set(tableName, storageSignature);
       resolveLoad(tableName);
       return tableName;
     }
@@ -266,11 +298,7 @@ export async function ensureTableLoaded(
           "registerServerFrame" in conn &&
           typeof conn.registerServerFrame === "function"
         ) {
-          await (
-            conn as AsyncDuckDBConnection & {
-              registerServerFrame(id: string, name: string): Promise<void>;
-            }
-          ).registerServerFrame(dataFrame.storage.key, tableName);
+          await conn.registerServerFrame(dataFrame.storage.key, tableName);
           break;
         }
         throw new Error("Server file frames require the server data plane");
@@ -286,13 +314,16 @@ export async function ensureTableLoaded(
       }
     }
 
+    loadedStorageSignatures.set(tableName, storageSignature);
     resolveLoad(tableName);
     return tableName;
   } catch (err) {
     rejectLoad(err instanceof Error ? err : new Error(String(err)));
     throw err;
   } finally {
-    tableLoadingMutex.delete(tableName);
+    if (tableLoadingMutex.get(tableName)?.promise === loadPromise) {
+      tableLoadingMutex.delete(tableName);
+    }
   }
 }
 
@@ -308,13 +339,13 @@ export async function ensureTableLoaded(
  */
 export class QueryBuilder {
   private readonly dataFrame: DataFrame;
-  private readonly conn: AsyncDuckDBConnection;
+  private readonly conn: DuckDBConnection;
   private readonly operations: Operation[];
   private tableName?: string;
 
   constructor(
     dataFrame: DataFrame,
-    conn: AsyncDuckDBConnection,
+    conn: DuckDBConnection,
     operations: Operation[] = [],
     tableName?: string,
   ) {
@@ -510,7 +541,7 @@ export class QueryBuilder {
    * ```
    */
   static async batchQuery<T extends Record<string, unknown>>(
-    conn: AsyncDuckDBConnection,
+    conn: DuckDBConnection,
     queries: string[],
   ): Promise<T[][]> {
     if (queries.length === 0) return [];

--- a/packages/engine-browser/src/query-builder.ts
+++ b/packages/engine-browser/src/query-builder.ts
@@ -261,6 +261,19 @@ export async function ensureTableLoaded(
         });
         break;
       }
+      case "file":
+        if (
+          "registerServerFrame" in conn &&
+          typeof conn.registerServerFrame === "function"
+        ) {
+          await (
+            conn as AsyncDuckDBConnection & {
+              registerServerFrame(id: string, name: string): Promise<void>;
+            }
+          ).registerServerFrame(dataFrame.storage.key, tableName);
+          break;
+        }
+        throw new Error("Server file frames require the server data plane");
       case "s3":
         throw new Error("S3 storage not yet implemented");
       case "r2":

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -13,6 +13,10 @@
     "./arrow-data-path": {
       "bun": "./src/arrow-data-path.ts",
       "default": "./src/arrow-data-path.ts"
+    },
+    "./file-dataframe-storage": {
+      "bun": "./src/file-dataframe-storage.ts",
+      "default": "./src/file-dataframe-storage.ts"
     }
   },
   "scripts": {

--- a/packages/engine-server/src/arrow-data-path.test.ts
+++ b/packages/engine-server/src/arrow-data-path.test.ts
@@ -194,6 +194,7 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
    */
   function fakeRegistrar(): ArrowQueryRunner & {
     registerArrowTable(name: string, arrow: Uint8Array): Promise<void>;
+    unregisterTable(name: string): Promise<void>;
     registrations: Array<{ name: string; bytes: Uint8Array }>;
   } {
     const registrations: Array<{ name: string; bytes: Uint8Array }> = [];
@@ -202,6 +203,10 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
       queryArrow: async () => new Uint8Array(),
       async registerArrowTable(name: string, arrow: Uint8Array) {
         registrations.push({ name, bytes: arrow });
+      },
+      async unregisterTable(name: string) {
+        const index = registrations.findIndex((entry) => entry.name === name);
+        if (index >= 0) registrations.splice(index, 1);
       },
       registrations,
     } as ReturnType<typeof fakeRegistrar>;
@@ -323,6 +328,49 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
 
     expect(response.status).toBe(415);
     expect(loads).toBe(0);
+    expect(engine.registrations).toEqual([]);
+  });
+
+  it("does not register bytes whose ownership disappears while load is paused", async () => {
+    const engine = fakeRegistrar();
+    const id = "11111111-1111-4111-8111-111111111111";
+    let available = true;
+    let releaseLoad!: () => void;
+    let signalRead!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      signalRead = resolve;
+    });
+    const loadReleased = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+    const app = createArrowDataPath({
+      engine,
+      isFrameAvailable: async () => available,
+      dataFrameStorage: {
+        save: async () => {},
+        load: async () => {
+          signalRead();
+          await loadReleased;
+          return new Uint8Array([1, 2, 3]);
+        },
+        delete: async () => {},
+        exists: async () => available,
+        list: async () => (available ? [id] : []),
+        getUsage: async () => ({ count: available ? 1 : 0 }),
+      },
+    });
+
+    const request = app.request(`/frames/${id}/tables/df_delayed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    await readStarted;
+    available = false;
+    await engine.unregisterTable("df_delayed");
+    releaseLoad();
+
+    const response = await request;
+    expect(response.status).toBe(404);
     expect(engine.registrations).toEqual([]);
   });
 });

--- a/packages/engine-server/src/arrow-data-path.test.ts
+++ b/packages/engine-server/src/arrow-data-path.test.ts
@@ -287,12 +287,43 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
 
     const response = await app.request(`/frames/${id}/tables/df_server`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TOKEN}` },
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-Type": "application/json",
+      },
     });
 
     expect(response.status).toBe(200);
     expect(engine.registrations).toEqual([{ name: "df_server", bytes }]);
     expect(await response.json()).toEqual({ ok: true, id, name: "df_server" });
+  });
+
+  it("rejects a browser-simple frame registration before loading bytes", async () => {
+    const engine = fakeRegistrar();
+    const id = "11111111-1111-4111-8111-111111111111";
+    let loads = 0;
+    const app = createArrowDataPath({
+      engine,
+      dataFrameStorage: {
+        save: async () => {},
+        load: async () => {
+          loads += 1;
+          return new Uint8Array([1]);
+        },
+        delete: async () => {},
+        exists: async () => true,
+        list: async () => [id],
+        getUsage: async () => ({ count: 1 }),
+      },
+    });
+
+    const response = await app.request(`/frames/${id}/tables/df_server`, {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(415);
+    expect(loads).toBe(0);
+    expect(engine.registrations).toEqual([]);
   });
 });
 

--- a/packages/engine-server/src/arrow-data-path.test.ts
+++ b/packages/engine-server/src/arrow-data-path.test.ts
@@ -267,6 +267,33 @@ describe("Arrow data path — /tables/:name content-type enforcement", () => {
       expect(engine.registrations[0]?.name).toBe("df_ok");
     }
   });
+
+  it("registers a durable server frame without returning its bytes", async () => {
+    const engine = fakeRegistrar();
+    const id = "11111111-1111-4111-8111-111111111111";
+    const bytes = new Uint8Array([1, 2, 3]);
+    const app = createArrowDataPath({
+      engine,
+      authToken: TOKEN,
+      dataFrameStorage: {
+        save: async () => {},
+        load: async (requested) => (requested === id ? bytes : null),
+        delete: async () => {},
+        exists: async () => true,
+        list: async () => [id],
+        getUsage: async () => ({ count: 1 }),
+      },
+    });
+
+    const response = await app.request(`/frames/${id}/tables/df_server`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(response.status).toBe(200);
+    expect(engine.registrations).toEqual([{ name: "df_server", bytes }]);
+    expect(await response.json()).toEqual({ ok: true, id, name: "df_server" });
+  });
 });
 
 describe("Arrow data path — vault-backed auth (fail-closed)", () => {

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -26,12 +26,16 @@
  *   Only available when the engine implements `registerArrowTable` (i.e. the
  *   native engine is wired into this process — not the WASM-backup path).
  */
+import type { DataFrameStorage } from "@dashframe/engine";
+import type { UUID } from "@dashframe/types";
 import type { SecretRef, SecretVault } from "@wystack/secret-vault";
 import { tableFromIPC } from "apache-arrow";
 import { Hono } from "hono";
 import { createHash, timingSafeEqual } from "node:crypto";
 
 export const ARROW_STREAM_CONTENT_TYPE = "application/vnd.apache.arrow.stream";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** What the data path needs from an engine: compiled SQL → Arrow IPC bytes. */
 export interface ArrowQueryRunner {
@@ -50,6 +54,8 @@ export interface ArrowTableRegistrar {
 export interface ArrowDataPathOptions {
   /** The engine that executes compiled SQL and returns Arrow IPC. */
   engine: ArrowQueryRunner & Partial<ArrowTableRegistrar>;
+  /** Project-owned frames that may be registered without crossing the client. */
+  dataFrameStorage?: DataFrameStorage;
   /**
    * Per-launch loopback bearer token (plaintext). When set, every request must
    * carry `Authorization: Bearer <token>`. When unset, the path is open
@@ -320,6 +326,42 @@ export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
     }
 
     return c.json({ ok: true, name });
+  });
+
+  // Register a durable project frame directly in native DuckDB. The browser
+  // sends only opaque identifiers; Arrow bytes never make a client roundtrip.
+  app.post("/frames/:id/tables/:name", async (c) => {
+    if (!(await checkAuth(c.req.header("authorization"), options))) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    if (!options.dataFrameStorage) {
+      return c.json({ error: "Server DataFrame storage is unavailable" }, 503);
+    }
+    if (typeof options.engine.registerArrowTable !== "function") {
+      return c.json(
+        { error: "Engine does not support table registration" },
+        501,
+      );
+    }
+    const id = c.req.param("id");
+    const name = c.req.param("name");
+    if (!UUID_PATTERN.test(id)) {
+      return c.json({ error: "Invalid frame id" }, 400);
+    }
+    if (!name || !/^[a-zA-Z_]\w*$/.test(name)) {
+      return c.json(
+        { error: "Table name must be a valid SQL identifier" },
+        400,
+      );
+    }
+    const arrow = await options.dataFrameStorage.load(id as UUID);
+    if (!arrow) return c.json({ error: "Frame not found" }, 404);
+    try {
+      await options.engine.registerArrowTable(name, arrow);
+    } catch {
+      return c.json({ error: "Failed to register frame" }, 500);
+    }
+    return c.json({ ok: true, id, name });
   });
 
   return app;

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -56,6 +56,8 @@ export interface ArrowDataPathOptions {
   engine: ArrowQueryRunner & Partial<ArrowTableRegistrar>;
   /** Project-owned frames that may be registered without crossing the client. */
   dataFrameStorage?: DataFrameStorage;
+  /** Confirms a durable frame is still canonically owned before registration. */
+  isFrameAvailable?: (id: UUID) => Promise<boolean>;
   /**
    * Per-launch loopback bearer token (plaintext). When set, every request must
    * carry `Authorization: Bearer <token>`. When unset, the path is open
@@ -78,6 +80,27 @@ export interface ArrowDataPathOptions {
    * `authRef` is set.
    */
   vault?: SecretVault;
+}
+
+async function unregisterIfPresent(
+  engine: ArrowQueryRunner & Partial<ArrowTableRegistrar>,
+  name: string,
+): Promise<boolean> {
+  try {
+    await engine.unregisterTable?.(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function frameIsUnavailable(
+  options: ArrowDataPathOptions,
+  id: UUID,
+): Promise<boolean> {
+  return options.isFrameAvailable
+    ? !(await options.isFrameAvailable(id))
+    : false;
 }
 
 /** Native shape: `{ sql, params? }` */
@@ -360,10 +383,32 @@ export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
     }
     const arrow = await options.dataFrameStorage.load(id as UUID);
     if (!arrow) return c.json({ error: "Frame not found" }, 404);
+    if (await frameIsUnavailable(options, id as UUID)) {
+      // Also retries cleanup from an earlier request whose post-registration
+      // ownership check lost the race but whose native DROP failed.
+      if (!(await unregisterIfPresent(options.engine, name))) {
+        return c.json(
+          { error: "Frame is unavailable and registration cleanup failed" },
+          500,
+        );
+      }
+      return c.json({ error: "Frame is no longer available" }, 404);
+    }
     try {
       await options.engine.registerArrowTable(name, arrow);
     } catch {
       return c.json({ error: "Failed to register frame" }, 500);
+    }
+    // Ownership can disappear while native registration is in flight. Undo
+    // that late registration before acknowledging it.
+    if (await frameIsUnavailable(options, id as UUID)) {
+      if (!(await unregisterIfPresent(options.engine, name))) {
+        return c.json(
+          { error: "Frame was deleted and registration cleanup failed" },
+          500,
+        );
+      }
+      return c.json({ error: "Frame is no longer available" }, 409);
     }
     return c.json({ ok: true, id, name });
   });
@@ -401,6 +446,18 @@ function arrowIpcToJsonRows(arrow: Uint8Array): Record<string, unknown>[] {
     rows.push(row);
   }
   return rows;
+}
+
+/** Decode and summarize IPC without exposing row values. Throws on bad IPC. */
+export function inspectArrowIpc(arrow: Uint8Array): {
+  fieldNames: string[];
+  rowCount: number;
+} {
+  const table = tableFromIPC(arrow);
+  return {
+    fieldNames: table.schema.fields.map((field) => field.name),
+    rowCount: table.numRows,
+  };
 }
 
 function tokenOk(authHeader: string | undefined, expected: string): boolean {

--- a/packages/engine-server/src/arrow-data-path.ts
+++ b/packages/engine-server/src/arrow-data-path.ts
@@ -21,10 +21,9 @@
  *
  * `POST /tables/:name`
  *   Accepts a raw Arrow IPC stream body (`application/vnd.apache.arrow.stream`)
- *   and registers it as a named in-memory table in the engine. The renderer
- *   uploads each DataFrame's Arrow buffer before issuing chart-compute queries.
- *   Only available when the engine implements `registerArrowTable` (i.e. the
- *   native engine is wired into this process — not the WASM-backup path).
+ *   and registers it as a named in-memory table in the engine. Retained explicit
+ *   backup paths may upload Arrow here; project-owned file frames instead use
+ *   `POST /frames/:id/tables/:name` so bytes never cross the client.
  */
 import type { DataFrameStorage } from "@dashframe/engine";
 import type { UUID } from "@dashframe/types";
@@ -45,10 +44,11 @@ export interface ArrowQueryRunner {
 /**
  * Optional extension: the engine can accept Arrow IPC buffers as named tables
  * so chart-compute (and other clients) can register the same frame data the
- * server engine will query — without materializing through the WASM backup path.
+ * server engine will query — without routing bytes through the WASM backup path.
  */
 export interface ArrowTableRegistrar {
   registerArrowTable(name: string, arrow: Uint8Array): Promise<void>;
+  unregisterTable?(name: string): Promise<void>;
 }
 
 export interface ArrowDataPathOptions {
@@ -333,6 +333,10 @@ export function createArrowDataPath(options: ArrowDataPathOptions): Hono {
   app.post("/frames/:id/tables/:name", async (c) => {
     if (!(await checkAuth(c.req.header("authorization"), options))) {
       return c.json({ error: "Unauthorized" }, 401);
+    }
+    const contentType = c.req.header("content-type")?.split(";", 1)[0]?.trim();
+    if (contentType?.toLowerCase() !== "application/json") {
+      return c.json({ error: "Content-Type must be application/json" }, 415);
     }
     if (!options.dataFrameStorage) {
       return c.json({ error: "Server DataFrame storage is unavailable" }, 503);

--- a/packages/engine-server/src/file-dataframe-storage.test.ts
+++ b/packages/engine-server/src/file-dataframe-storage.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { FileDataFrameStorage } from "./file-dataframe-storage";
 
@@ -9,6 +9,7 @@ describe("FileDataFrameStorage", () => {
   const roots: string[] = [];
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(
       roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
     );
@@ -111,5 +112,150 @@ describe("FileDataFrameStorage", () => {
 
     expect(await storage.load(referenced)).toEqual(new Uint8Array([1]));
     expect(await storage.exists(removed)).toBe(false);
+  });
+
+  it("preserves a replacement save when committing a staged generation", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([1]));
+    const token = await storage.stageDelete(id);
+
+    await storage.save(id, new Uint8Array([2]));
+    await storage.commitDelete(token!);
+
+    expect(await storage.load(id)).toEqual(new Uint8Array([2]));
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(false);
+  });
+
+  it("reports a rollback collision and retains its recovery token", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([1]));
+    const token = await storage.stageDelete(id);
+
+    await storage.save(id, new Uint8Array([2]));
+    await expect(storage.rollbackDelete(token!)).rejects.toThrow(
+      "contains a newer generation",
+    );
+
+    expect(await storage.load(id)).toEqual(new Uint8Array([2]));
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(true);
+  });
+
+  it("resolves a replacement collision on restart without overwriting newer bytes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const directory = path.join(root, "frames");
+    const id = "11111111-1111-4111-8111-111111111111";
+    const storage = new FileDataFrameStorage(directory);
+    await storage.save(id, new Uint8Array([1]));
+    await storage.stageDelete(id);
+    await storage.save(id, new Uint8Array([2]));
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await new FileDataFrameStorage(directory).recoverStagedDeletes([id]);
+
+    expect(await storage.load(id)).toEqual(new Uint8Array([2]));
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(false);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("discarding the older staged generation"),
+    );
+  });
+
+  it("restores referenced bytes when the active link was unlinked", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const directory = path.join(root, "frames");
+    const trash = path.join(directory, ".trash");
+    const synced: string[] = [];
+    const storage = new FileDataFrameStorage(directory, async (entry) => {
+      synced.push(entry);
+    });
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([9, 8]));
+    await storage.stageDelete(id);
+    await rm(path.join(directory, `${id}.arrow`));
+    synced.length = 0;
+
+    await storage.recoverStagedDeletes([id]);
+
+    expect(await storage.load(id)).toEqual(new Uint8Array([9, 8]));
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(false);
+    expect(synced).toEqual([directory, trash]);
+  });
+
+  it("finalizes an unreferenced staged generation without deleting a replacement", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([1]));
+    await storage.stageDelete(id);
+    await storage.save(id, new Uint8Array([3]));
+
+    await storage.recoverStagedDeletes([]);
+
+    expect(await storage.load(id)).toEqual(new Uint8Array([3]));
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(false);
+  });
+
+  it("validates the complete delete token before touching active bytes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([7]));
+
+    await expect(storage.commitDelete(`${id}.malformed`)).rejects.toThrow(
+      "Invalid delete token",
+    );
+
+    expect(await storage.load(id)).toEqual(new Uint8Array([7]));
+  });
+
+  it("reports whether valid staged DataFrame deletes are pending", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const directory = path.join(root, "frames");
+    const storage = new FileDataFrameStorage(directory);
+    const id = "11111111-1111-4111-8111-111111111111";
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(false);
+    await storage.save(id, new Uint8Array([1]));
+    const token = await storage.stageDelete(id);
+
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(true);
+
+    await storage.rollbackDelete(token!);
+    expect(await storage.hasPendingDataFrameDeletes()).toBe(false);
+  });
+
+  it("removes only save temp files matching the exact startup recovery format", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const directory = path.join(root, "frames");
+    const storage = new FileDataFrameStorage(directory);
+    const id = "11111111-1111-4111-8111-111111111111";
+    const nonce = "22222222-2222-4222-8222-222222222222";
+    await storage.save(id, new Uint8Array([1]));
+    const stale = `.${id}.1234.${nonce}.tmp`;
+    const unrelated = [
+      ".notes",
+      `.${id}.not-a-pid.${nonce}.tmp`,
+      `.${id}.1234.not-a-uuid.tmp`,
+    ];
+    await writeFile(path.join(directory, stale), "stale");
+    await Promise.all(
+      unrelated.map((entry) => writeFile(path.join(directory, entry), "keep")),
+    );
+
+    await storage.recoverStagedDeletes([id]);
+
+    const entries = await readdir(directory);
+    expect(entries).not.toContain(stale);
+    expect(entries).toEqual(expect.arrayContaining(unrelated));
   });
 });

--- a/packages/engine-server/src/file-dataframe-storage.test.ts
+++ b/packages/engine-server/src/file-dataframe-storage.test.ts
@@ -48,13 +48,52 @@ describe("FileDataFrameStorage", () => {
     await storage.save(id, new Uint8Array([7]));
 
     const rollbackToken = await storage.stageDelete(id);
-    expect(await storage.exists(id)).toBe(false);
+    expect(await storage.exists(id)).toBe(true);
     await storage.rollbackDelete(rollbackToken!);
     expect(await storage.load(id)).toEqual(new Uint8Array([7]));
 
     const commitToken = await storage.stageDelete(id);
     await storage.commitDelete(commitToken!);
     expect(await storage.exists(id)).toBe(false);
+  });
+
+  it("syncs delete lifecycle directory entries before advancing metadata", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const directory = path.join(root, "frames");
+    const trash = path.join(directory, ".trash");
+    const synced: string[] = [];
+    const storage = new FileDataFrameStorage(directory, async (entry) => {
+      synced.push(entry);
+    });
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([7]));
+    synced.length = 0;
+
+    const rollbackToken = await storage.stageDelete(id);
+    expect(synced).toEqual([directory, trash, trash]);
+    synced.length = 0;
+    await storage.rollbackDelete(rollbackToken!);
+    expect(synced).toEqual([trash]);
+
+    const commitToken = await storage.stageDelete(id);
+    synced.length = 0;
+    await storage.commitDelete(commitToken!);
+    expect(synced).toEqual([directory, trash]);
+  });
+
+  it("keeps the active frame readable while a staged delete rolls back", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([1]));
+
+    const token = await storage.stageDelete(id);
+    expect(token).not.toBeNull();
+    expect(await storage.load(id)).toEqual(new Uint8Array([1]));
+    await storage.rollbackDelete(token!);
+    expect(await storage.load(id)).toEqual(new Uint8Array([1]));
   });
 
   it("recovers interrupted staged deletes from committed ownership", async () => {

--- a/packages/engine-server/src/file-dataframe-storage.test.ts
+++ b/packages/engine-server/src/file-dataframe-storage.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FileDataFrameStorage } from "./file-dataframe-storage";
+
+describe("FileDataFrameStorage", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it("survives recreation against the same project directory", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const directory = path.join(root, "frames");
+    const id = "11111111-1111-4111-8111-111111111111";
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    await new FileDataFrameStorage(directory).save(id, bytes);
+    const restarted = new FileDataFrameStorage(directory);
+
+    expect(await restarted.load(id)).toEqual(bytes);
+    expect(await restarted.exists(id)).toBe(true);
+    expect(await restarted.list()).toEqual([id]);
+    expect(await restarted.getUsage()).toEqual({ count: 1, totalBytes: 4 });
+  });
+
+  it("rejects ids that could escape the storage directory", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+
+    await expect(storage.save("../escape", new Uint8Array())).rejects.toThrow(
+      "Invalid DataFrame id",
+    );
+  });
+
+  it("rolls back and commits staged deletes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const id = "11111111-1111-4111-8111-111111111111";
+    await storage.save(id, new Uint8Array([7]));
+
+    const rollbackToken = await storage.stageDelete(id);
+    expect(await storage.exists(id)).toBe(false);
+    await storage.rollbackDelete(rollbackToken!);
+    expect(await storage.load(id)).toEqual(new Uint8Array([7]));
+
+    const commitToken = await storage.stageDelete(id);
+    await storage.commitDelete(commitToken!);
+    expect(await storage.exists(id)).toBe(false);
+  });
+
+  it("recovers interrupted staged deletes from committed ownership", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "dashframe-frames-"));
+    roots.push(root);
+    const storage = new FileDataFrameStorage(path.join(root, "frames"));
+    const referenced = "11111111-1111-4111-8111-111111111111";
+    const removed = "22222222-2222-4222-8222-222222222222";
+    await storage.save(referenced, new Uint8Array([1]));
+    await storage.save(removed, new Uint8Array([2]));
+    await storage.stageDelete(referenced);
+    await storage.stageDelete(removed);
+
+    await storage.recoverStagedDeletes([referenced]);
+
+    expect(await storage.load(referenced)).toEqual(new Uint8Array([1]));
+    expect(await storage.exists(removed)).toBe(false);
+  });
+});

--- a/packages/engine-server/src/file-dataframe-storage.ts
+++ b/packages/engine-server/src/file-dataframe-storage.ts
@@ -1,0 +1,178 @@
+import type { DataFrameStorage } from "@dashframe/engine";
+import type { UUID } from "@dashframe/types";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const FRAME_EXTENSION = ".arrow";
+const TRASH_DIRECTORY = ".trash";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Durable Arrow IPC storage rooted inside one DashFrame project. */
+export class FileDataFrameStorage implements DataFrameStorage {
+  constructor(readonly directory: string) {}
+
+  private framePath(id: UUID): string {
+    if (!UUID_PATTERN.test(id)) {
+      throw new Error(`Invalid DataFrame id: ${id}`);
+    }
+    return path.join(this.directory, `${id}${FRAME_EXTENSION}`);
+  }
+
+  async save(id: UUID, data: Uint8Array): Promise<void> {
+    const target = this.framePath(id);
+    await fs.mkdir(this.directory, { recursive: true });
+    const temporary = path.join(
+      this.directory,
+      `.${id}.${process.pid}.${randomUUID()}.tmp`,
+    );
+    try {
+      await fs.writeFile(temporary, data, { mode: 0o600 });
+      await fs.rename(temporary, target);
+    } finally {
+      await fs.rm(temporary, { force: true }).catch(() => undefined);
+    }
+  }
+
+  async load(id: UUID): Promise<Uint8Array | null> {
+    try {
+      return new Uint8Array(await fs.readFile(this.framePath(id)));
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async delete(id: UUID): Promise<void> {
+    await fs.rm(this.framePath(id), { force: true });
+  }
+
+  async stageDelete(id: UUID): Promise<string | null> {
+    const target = this.framePath(id);
+    const token = `${id}.${randomUUID()}`;
+    const trashDirectory = path.join(this.directory, TRASH_DIRECTORY);
+    await fs.mkdir(trashDirectory, { recursive: true });
+    try {
+      await fs.rename(target, path.join(trashDirectory, token));
+      return token;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async commitDelete(token: string): Promise<void> {
+    await fs.rm(this.trashPath(token), { force: true });
+  }
+
+  async rollbackDelete(token: string): Promise<void> {
+    const [id] = token.split(".");
+    if (!id || !UUID_PATTERN.test(id)) throw new Error("Invalid delete token");
+    try {
+      await fs.rename(this.trashPath(token), this.framePath(id as UUID));
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async recoverStagedDeletes(referencedIds: readonly UUID[]): Promise<void> {
+    const referenced = new Set(referencedIds);
+    const trashDirectory = path.join(this.directory, TRASH_DIRECTORY);
+    let tokens: string[];
+    try {
+      tokens = await fs.readdir(trashDirectory);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return;
+      }
+      throw error;
+    }
+    for (const token of tokens) {
+      const [id] = token.split(".");
+      if (!id || !UUID_PATTERN.test(id)) continue;
+      if (referenced.has(id as UUID)) {
+        await this.rollbackDelete(token);
+      } else {
+        await this.commitDelete(token);
+      }
+    }
+  }
+
+  private trashPath(token: string): string {
+    if (!/^[0-9a-f-]{36}\.[0-9a-f-]{36}$/i.test(token)) {
+      throw new Error("Invalid delete token");
+    }
+    return path.join(this.directory, TRASH_DIRECTORY, token);
+  }
+
+  async exists(id: UUID): Promise<boolean> {
+    try {
+      await fs.access(this.framePath(id));
+      return true;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async list(): Promise<UUID[]> {
+    let entries: string[];
+    try {
+      entries = await fs.readdir(this.directory);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return [];
+      }
+      throw error;
+    }
+    return entries
+      .filter((entry) => entry.endsWith(FRAME_EXTENSION))
+      .map((entry) => entry.slice(0, -FRAME_EXTENSION.length))
+      .filter((id): id is UUID => UUID_PATTERN.test(id));
+  }
+
+  async getUsage(): Promise<{ count: number; totalBytes: number }> {
+    const ids = await this.list();
+    const sizes = await Promise.all(
+      ids.map(async (id) => (await fs.stat(this.framePath(id))).size),
+    );
+    return {
+      count: ids.length,
+      totalBytes: sizes.reduce((total, size) => total + size, 0),
+    };
+  }
+}

--- a/packages/engine-server/src/file-dataframe-storage.ts
+++ b/packages/engine-server/src/file-dataframe-storage.ts
@@ -6,8 +6,17 @@ import path from "node:path";
 
 const FRAME_EXTENSION = ".arrow";
 const TRASH_DIRECTORY = ".trash";
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_FRAGMENT =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+const UUID_PATTERN = new RegExp(`^${UUID_FRAGMENT}$`, "i");
+const DELETE_TOKEN_PATTERN = new RegExp(
+  `^(${UUID_FRAGMENT})\\.(${UUID_FRAGMENT})$`,
+  "i",
+);
+const SAVE_TEMP_PATTERN = new RegExp(
+  `^\\.${UUID_FRAGMENT}\\.\\d+\\.${UUID_FRAGMENT}\\.tmp$`,
+  "i",
+);
 
 async function syncDirectory(directory: string): Promise<void> {
   const handle = await fs.open(directory, "r");
@@ -39,6 +48,44 @@ async function ensureDirectory(
   await fs.mkdir(directory, { recursive: true });
   await sync(path.dirname(directory));
   await sync(directory);
+}
+
+function isEnoent(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+async function statIfExists(
+  file: string,
+): Promise<Awaited<ReturnType<typeof fs.stat>> | null> {
+  try {
+    return await fs.stat(file);
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
+  }
+}
+
+function isSameGeneration(
+  left: Awaited<ReturnType<typeof fs.stat>>,
+  right: Awaited<ReturnType<typeof fs.stat>>,
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+class StagedDeleteCollisionError extends Error {
+  constructor(
+    readonly id: UUID,
+    readonly token: string,
+  ) {
+    super(
+      `Cannot roll back staged DataFrame delete ${token}: active frame ${id} contains a newer generation`,
+    );
+    this.name = "StagedDeleteCollisionError";
+  }
 }
 
 /** Durable Arrow IPC storage rooted inside one DashFrame project. */
@@ -123,11 +170,18 @@ export class FileDataFrameStorage implements DataFrameStorage {
   }
 
   async commitDelete(token: string): Promise<void> {
-    const [id] = token.split(".");
-    if (!id || !UUID_PATTERN.test(id)) throw new Error("Invalid delete token");
-    await fs.rm(this.framePath(id as UUID), { force: true });
-    await syncDirectoryIfExists(this.directory, this.sync);
-    await fs.rm(this.trashPath(token), { force: true });
+    const { id, trash } = this.parseDeleteToken(token);
+    const staged = await statIfExists(trash);
+    if (!staged) return;
+
+    const active = this.framePath(id);
+    const activeStat = await statIfExists(active);
+    if (activeStat && isSameGeneration(staged, activeStat)) {
+      await fs.unlink(active);
+      await this.sync(this.directory);
+    }
+
+    await fs.rm(trash, { force: true });
     await syncDirectoryIfExists(
       path.join(this.directory, TRASH_DIRECTORY),
       this.sync,
@@ -135,7 +189,37 @@ export class FileDataFrameStorage implements DataFrameStorage {
   }
 
   async rollbackDelete(token: string): Promise<void> {
-    await fs.rm(this.trashPath(token), { force: true });
+    const { id, trash } = this.parseDeleteToken(token);
+    const staged = await statIfExists(trash);
+    if (!staged) return;
+
+    const active = this.framePath(id);
+    const activeStat = await statIfExists(active);
+    if (activeStat && !isSameGeneration(staged, activeStat)) {
+      throw new StagedDeleteCollisionError(id, token);
+    }
+    if (!activeStat) {
+      try {
+        await fs.link(trash, active);
+        await this.sync(this.directory);
+      } catch (error) {
+        if (
+          !(
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "EEXIST"
+          )
+        ) {
+          throw error;
+        }
+        const racedActive = await fs.stat(active);
+        if (!isSameGeneration(staged, racedActive)) {
+          throw new StagedDeleteCollisionError(id, token);
+        }
+      }
+    }
+
+    await fs.rm(trash, { force: true });
     await syncDirectoryIfExists(
       path.join(this.directory, TRASH_DIRECTORY),
       this.sync,
@@ -143,6 +227,7 @@ export class FileDataFrameStorage implements DataFrameStorage {
   }
 
   async recoverStagedDeletes(referencedIds: readonly UUID[]): Promise<void> {
+    await this.removeStaleSaveTemps();
     const referenced = new Set(referencedIds);
     const trashDirectory = path.join(this.directory, TRASH_DIRECTORY);
     let tokens: string[];
@@ -159,41 +244,72 @@ export class FileDataFrameStorage implements DataFrameStorage {
       throw error;
     }
     for (const token of tokens) {
-      const [id] = token.split(".");
-      if (!id || !UUID_PATTERN.test(id)) continue;
-      if (referenced.has(id as UUID)) {
-        await this.recoverReferencedToken(id as UUID, token);
-      } else {
-        await this.commitDelete(token);
-      }
+      await this.recoverDeleteToken(token, referenced);
     }
   }
 
-  private async recoverReferencedToken(id: UUID, token: string): Promise<void> {
+  private async recoverDeleteToken(
+    token: string,
+    referenced: ReadonlySet<UUID>,
+  ): Promise<void> {
+    const match = DELETE_TOKEN_PATTERN.exec(token);
+    if (!match) return;
+    const id = match[1] as UUID;
+    if (!referenced.has(id)) {
+      await this.commitDelete(token);
+      return;
+    }
     try {
       await this.rollbackDelete(token);
     } catch (error) {
-      // A later save owns the active path. Keep the staged bytes intact for
-      // explicit recovery instead of replacing the newer committed frame.
-      if (
-        error instanceof Error &&
-        error.message.includes("an active frame already exists")
-      ) {
-        console.error(
-          `[dashframe] staged frame ${id} collides with an active frame; leaving staged bytes for recovery`,
-          error,
-        );
-        return;
-      }
+      if (!(error instanceof StagedDeleteCollisionError)) throw error;
+      // The active path is a later save and therefore the committed bytes for
+      // this ID. Finalize only the older staged generation; commitDelete
+      // compares inode generations and cannot unlink the replacement.
+      console.error(
+        `[dashframe] ${error.message}; discarding the older staged generation during recovery`,
+      );
+      await this.commitDelete(token);
+    }
+  }
+
+  async hasPendingDataFrameDeletes(): Promise<boolean> {
+    try {
+      const tokens = await fs.readdir(
+        path.join(this.directory, TRASH_DIRECTORY),
+      );
+      return tokens.some((token) => DELETE_TOKEN_PATTERN.test(token));
+    } catch (error) {
+      if (isEnoent(error)) return false;
       throw error;
     }
   }
 
-  private trashPath(token: string): string {
-    if (!/^[0-9a-f-]{36}\.[0-9a-f-]{36}$/i.test(token)) {
-      throw new Error("Invalid delete token");
+  private parseDeleteToken(token: string): { id: UUID; trash: string } {
+    const match = DELETE_TOKEN_PATTERN.exec(token);
+    if (!match) throw new Error("Invalid delete token");
+    return {
+      id: match[1] as UUID,
+      trash: path.join(this.directory, TRASH_DIRECTORY, token),
+    };
+  }
+
+  private async removeStaleSaveTemps(): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fs.readdir(this.directory);
+    } catch (error) {
+      if (isEnoent(error)) return;
+      throw error;
     }
-    return path.join(this.directory, TRASH_DIRECTORY, token);
+    const stale = entries.filter((entry) => SAVE_TEMP_PATTERN.test(entry));
+    if (stale.length === 0) return;
+    await Promise.all(
+      stale.map((entry) =>
+        fs.rm(path.join(this.directory, entry), { force: true }),
+      ),
+    );
+    await this.sync(this.directory);
   }
 
   async exists(id: UUID): Promise<boolean> {

--- a/packages/engine-server/src/file-dataframe-storage.ts
+++ b/packages/engine-server/src/file-dataframe-storage.ts
@@ -9,9 +9,44 @@ const TRASH_DIRECTORY = ".trash";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+async function syncDirectory(directory: string): Promise<void> {
+  const handle = await fs.open(directory, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function syncDirectoryIfExists(
+  directory: string,
+  sync: (directory: string) => Promise<void>,
+): Promise<void> {
+  try {
+    await sync(directory);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function ensureDirectory(
+  directory: string,
+  sync: (directory: string) => Promise<void>,
+): Promise<void> {
+  await fs.mkdir(directory, { recursive: true });
+  await sync(path.dirname(directory));
+  await sync(directory);
+}
+
 /** Durable Arrow IPC storage rooted inside one DashFrame project. */
 export class FileDataFrameStorage implements DataFrameStorage {
-  constructor(readonly directory: string) {}
+  constructor(
+    readonly directory: string,
+    private readonly sync = syncDirectory,
+  ) {}
 
   private framePath(id: UUID): string {
     if (!UUID_PATTERN.test(id)) {
@@ -22,14 +57,23 @@ export class FileDataFrameStorage implements DataFrameStorage {
 
   async save(id: UUID, data: Uint8Array): Promise<void> {
     const target = this.framePath(id);
-    await fs.mkdir(this.directory, { recursive: true });
+    await ensureDirectory(this.directory, this.sync);
     const temporary = path.join(
       this.directory,
       `.${id}.${process.pid}.${randomUUID()}.tmp`,
     );
     try {
-      await fs.writeFile(temporary, data, { mode: 0o600 });
+      const handle = await fs.open(temporary, "wx", 0o600);
+      try {
+        await handle.writeFile(data);
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
       await fs.rename(temporary, target);
+      // The file sync makes its bytes durable; the directory sync makes the
+      // atomic rename durable before metadata is allowed to reference it.
+      await this.sync(this.directory);
     } finally {
       await fs.rm(temporary, { force: true }).catch(() => undefined);
     }
@@ -52,15 +96,19 @@ export class FileDataFrameStorage implements DataFrameStorage {
 
   async delete(id: UUID): Promise<void> {
     await fs.rm(this.framePath(id), { force: true });
+    await syncDirectoryIfExists(this.directory, this.sync);
   }
 
   async stageDelete(id: UUID): Promise<string | null> {
     const target = this.framePath(id);
     const token = `${id}.${randomUUID()}`;
     const trashDirectory = path.join(this.directory, TRASH_DIRECTORY);
-    await fs.mkdir(trashDirectory, { recursive: true });
+    await ensureDirectory(trashDirectory, this.sync);
     try {
-      await fs.rename(target, path.join(trashDirectory, token));
+      // Preserve the active name while metadata still references it. The hard
+      // link is the recovery copy; final deletion happens only after commit.
+      await fs.link(target, path.join(trashDirectory, token));
+      await this.sync(trashDirectory);
       return token;
     } catch (error) {
       if (
@@ -75,24 +123,23 @@ export class FileDataFrameStorage implements DataFrameStorage {
   }
 
   async commitDelete(token: string): Promise<void> {
+    const [id] = token.split(".");
+    if (!id || !UUID_PATTERN.test(id)) throw new Error("Invalid delete token");
+    await fs.rm(this.framePath(id as UUID), { force: true });
+    await syncDirectoryIfExists(this.directory, this.sync);
     await fs.rm(this.trashPath(token), { force: true });
+    await syncDirectoryIfExists(
+      path.join(this.directory, TRASH_DIRECTORY),
+      this.sync,
+    );
   }
 
   async rollbackDelete(token: string): Promise<void> {
-    const [id] = token.split(".");
-    if (!id || !UUID_PATTERN.test(id)) throw new Error("Invalid delete token");
-    try {
-      await fs.rename(this.trashPath(token), this.framePath(id as UUID));
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        "code" in error &&
-        error.code === "ENOENT"
-      ) {
-        return;
-      }
-      throw error;
-    }
+    await fs.rm(this.trashPath(token), { force: true });
+    await syncDirectoryIfExists(
+      path.join(this.directory, TRASH_DIRECTORY),
+      this.sync,
+    );
   }
 
   async recoverStagedDeletes(referencedIds: readonly UUID[]): Promise<void> {
@@ -115,10 +162,30 @@ export class FileDataFrameStorage implements DataFrameStorage {
       const [id] = token.split(".");
       if (!id || !UUID_PATTERN.test(id)) continue;
       if (referenced.has(id as UUID)) {
-        await this.rollbackDelete(token);
+        await this.recoverReferencedToken(id as UUID, token);
       } else {
         await this.commitDelete(token);
       }
+    }
+  }
+
+  private async recoverReferencedToken(id: UUID, token: string): Promise<void> {
+    try {
+      await this.rollbackDelete(token);
+    } catch (error) {
+      // A later save owns the active path. Keep the staged bytes intact for
+      // explicit recovery instead of replacing the newer committed frame.
+      if (
+        error instanceof Error &&
+        error.message.includes("an active frame already exists")
+      ) {
+        console.error(
+          `[dashframe] staged frame ${id} collides with an active frame; leaving staged bytes for recovery`,
+          error,
+        );
+        return;
+      }
+      throw error;
     }
   }
 

--- a/packages/engine-server/src/index.ts
+++ b/packages/engine-server/src/index.ts
@@ -2,13 +2,14 @@
  * @dashframe/engine-server — the server-authoritative native execution path.
  *
  * Primary data plane for DashFrame: native DuckDB in the server process, shared
- * by desktop and (once wired) web. WASM is a backup mode, not a peer primary.
+ * by desktop and web. The retained WASM implementation has no active product
+ * mode.
  *
  * Five-stage pipeline (compile → place → execute → cache → transport):
  *
  *   - Stage 1 Compile   — `hashCompiledQuery` (content-addressing boundary)
- *   - Stage 2 Place     — `selectEngineBinding` (policy seam; web still defaults
- *                         to wasm until serve + web data path land)
+ *   - Stage 2 Place     — `selectEngineBinding` (policy seam; active web and
+ *                         desktop hosts both select the native server)
  *   - Stage 3 Execute   — `NativeDuckDBEngine` (native DuckDB QueryEngine)
  *   - Stage 4 Cache     — `ParquetCache` + `CacheWriteGate` seam (sensitivity gate, see #67)
  *   - Stage 5 Transport — `createArrowDataPath` (dedicated Arrow IPC HTTP path)
@@ -54,3 +55,5 @@ export {
   type ArrowQueryRunner,
   type ArrowTableRegistrar,
 } from "./arrow-data-path";
+
+export { FileDataFrameStorage } from "./file-dataframe-storage";

--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -15,7 +15,7 @@ import {
 } from "apache-arrow";
 import fs from "node:fs/promises";
 import os from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { NativeDuckDBEngine } from "./native-engine";
 
@@ -25,6 +25,7 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
   let engine: NativeDuckDBEngine | null = null;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await engine?.dispose();
     engine = null;
   });
@@ -238,6 +239,36 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
       expect(engine.hasTable("df_tracked")).toBe(false);
       await expect(
         engine.query('SELECT * FROM "df_tracked"'),
+      ).rejects.toThrow();
+    });
+
+    it("keeps a registration retryable when native DROP fails transiently", async () => {
+      engine = new NativeDuckDBEngine();
+      await engine.registerArrowTable("df_retry_drop", producerBuffer());
+      const connection = (
+        engine as unknown as {
+          connection: { run(sql: string): Promise<unknown> };
+        }
+      ).connection;
+      vi.spyOn(connection, "run").mockRejectedValueOnce(
+        new Error("transient native DROP failure"),
+      );
+
+      await expect(engine.unregisterTable("df_retry_drop")).rejects.toThrow(
+        "transient native DROP failure",
+      );
+      expect(engine.hasTable("df_retry_drop")).toBe(true);
+      expect(
+        Number(
+          (await engine.query('SELECT COUNT(*) AS n FROM "df_retry_drop"'))
+            .rows[0]?.n,
+        ),
+      ).toBe(3);
+
+      await engine.unregisterTable("df_retry_drop");
+      expect(engine.hasTable("df_retry_drop")).toBe(false);
+      await expect(
+        engine.query('SELECT * FROM "df_retry_drop"'),
       ).rejects.toThrow();
     });
 

--- a/packages/engine-server/src/native-engine.test.ts
+++ b/packages/engine-server/src/native-engine.test.ts
@@ -241,6 +241,19 @@ describe("NativeDuckDBEngine — real native DuckDB (Stage 3)", () => {
       ).rejects.toThrow();
     });
 
+    it("serializes unregister behind an in-flight registration", async () => {
+      engine = new NativeDuckDBEngine();
+      await engine.initialize();
+      const registering = engine.registerArrowTable(
+        "df_race",
+        producerBuffer(),
+      );
+      const unregistering = engine.unregisterTable("df_race");
+      await Promise.all([registering, unregistering]);
+      expect(engine.hasTable("df_race")).toBe(false);
+      await expect(engine.query('SELECT * FROM "df_race"')).rejects.toThrow();
+    });
+
     it("atomic ingest — a failed append leaves the prior table intact (no partial replace)", async () => {
       // Contract: if registerArrowTable throws mid-append (e.g. type mismatch),
       // the previously registered table must be unchanged and still queryable.

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -331,13 +331,22 @@ export class NativeDuckDBEngine implements QueryEngine {
   }
 
   async unregisterTable(name: string): Promise<void> {
-    if (!this._registeredTables.has(name)) return;
+    await this.initialize();
+    const gate = this._registrationLock;
+    let unlock!: () => void;
+    this._registrationLock = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    await gate;
     try {
+      if (!this._registeredTables.has(name)) return;
       await this.conn().run(`DROP TABLE IF EXISTS ${quoteIdent(name)}`);
     } catch {
       // Best-effort; table may already be gone.
+    } finally {
+      this._registeredTables.delete(name);
+      unlock();
     }
-    this._registeredTables.delete(name);
   }
 
   hasTable(name: string): boolean {

--- a/packages/engine-server/src/native-engine.ts
+++ b/packages/engine-server/src/native-engine.ts
@@ -341,10 +341,11 @@ export class NativeDuckDBEngine implements QueryEngine {
     try {
       if (!this._registeredTables.has(name)) return;
       await this.conn().run(`DROP TABLE IF EXISTS ${quoteIdent(name)}`);
-    } catch {
-      // Best-effort; table may already be gone.
-    } finally {
+      // Forget the registration only after DuckDB confirms the DROP. A
+      // transient native failure must leave the entry discoverable so cleanup
+      // can retry instead of leaking a table the registry claims is gone.
       this._registeredTables.delete(name);
+    } finally {
       unlock();
     }
   }

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -12,13 +12,13 @@ bun add @dashframe/engine
 
 The engine package defines runtime-agnostic interfaces:
 
-| Interface          | Real implementation today                                                     |
-| ------------------ | ----------------------------------------------------------------------------- |
-| `QueryEngine`      | `NativeDuckDBEngine` (`@dashframe/engine-server`)                             |
-| `DataFrameStorage` | Project files (`@dashframe/engine-server`); retained IndexedDB implementation |
-| `DataFrame`        | `BrowserDataFrame` (`@dashframe/engine-browser`)                              |
+| Interface          | Real implementation today                                             |
+| ------------------ | --------------------------------------------------------------------- |
+| `QueryEngine`      | `NativeDuckDBEngine` (`@dashframe/engine-server`)                     |
+| `DataFrameStorage` | Project files for server snapshots; retained IndexedDB implementation |
+| `DataFrame`        | Server query results; retained `BrowserDataFrame` implementation      |
 
-The active path is **server-side native DuckDB** (`NativeDuckDBEngine`) for both desktop and web. DuckDB-WASM helpers in `@dashframe/engine-browser` remain in the codebase, but no product mode currently activates them.
+Remote imports and refreshes use **server-side native DuckDB** (`NativeDuckDBEngine`) and durable project-file snapshots for both desktop and web. Local-file import still uses the legacy browser/IndexedDB path until the required server-ingestion follow-up lands. There is no selectable WASM mode or fallback.
 
 This package has no shared `QueryPlanner` / push-down API. Connectors may still run remote queries themselves (e.g. Postgres table-reference fetches push LIMIT/OFFSET server-side); that is connector-local, not a cross-engine planner.
 
@@ -65,7 +65,15 @@ interface DataFrameStorage {
   save(id: UUID, data: Uint8Array): Promise<void>;
   load(id: UUID): Promise<Uint8Array | null>;
   delete(id: UUID): Promise<void>;
+  // These three optional methods are an all-or-nothing reversible-delete group.
+  stageDelete?(id: UUID): Promise<string | null>;
+  commitDelete?(token: string): Promise<void>;
+  rollbackDelete?(token: string): Promise<void>;
+  // Independently optional startup recovery for interrupted staged deletes.
+  recoverStagedDeletes?(referencedIds: readonly UUID[]): Promise<void>;
   exists(id: UUID): Promise<boolean>;
+  list(): Promise<UUID[]>;
+  getUsage(): Promise<{ count: number; totalBytes?: number }>;
 }
 ```
 
@@ -128,4 +136,4 @@ import type {
 ## Implementations
 
 - **`@dashframe/engine-server`** — primary: native DuckDB pipeline (`NativeDuckDBEngine`, Arrow data path, placement policy)
-- **`@dashframe/engine-browser`** — retained DuckDB-WASM, IndexedDB, and BrowserDataFrame implementation; no active product mode
+- **`@dashframe/engine-browser`** — retained DuckDB-WASM, IndexedDB, and BrowserDataFrame implementation; local-file import still depends on it pending server ingestion

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -12,13 +12,13 @@ bun add @dashframe/engine
 
 The engine package defines runtime-agnostic interfaces:
 
-| Interface          | Real implementation today                         |
-| ------------------ | ------------------------------------------------- |
-| `QueryEngine`      | `NativeDuckDBEngine` (`@dashframe/engine-server`) |
-| `DataFrameStorage` | IndexedDB (`@dashframe/engine-browser`)           |
-| `DataFrame`        | `BrowserDataFrame` (`@dashframe/engine-browser`)  |
+| Interface          | Real implementation today                                                     |
+| ------------------ | ----------------------------------------------------------------------------- |
+| `QueryEngine`      | `NativeDuckDBEngine` (`@dashframe/engine-server`)                             |
+| `DataFrameStorage` | Project files (`@dashframe/engine-server`); retained IndexedDB implementation |
+| `DataFrame`        | `BrowserDataFrame` (`@dashframe/engine-browser`)                              |
 
-Primary path is **server-side native DuckDB** (`NativeDuckDBEngine`). Desktop already uses it; web is meant to share the same server process once headless `serve` wires the engine. DuckDB-WASM helpers in `@dashframe/engine-browser` are a **backup** path and do not implement `QueryEngine`.
+The active path is **server-side native DuckDB** (`NativeDuckDBEngine`) for both desktop and web. DuckDB-WASM helpers in `@dashframe/engine-browser` remain in the codebase, but no product mode currently activates them.
 
 This package has no shared `QueryPlanner` / push-down API. Connectors may still run remote queries themselves (e.g. Postgres table-reference fetches push LIMIT/OFFSET server-side); that is connector-local, not a cross-engine planner.
 
@@ -128,4 +128,4 @@ import type {
 ## Implementations
 
 - **`@dashframe/engine-server`** — primary: native DuckDB pipeline (`NativeDuckDBEngine`, Arrow data path, placement policy)
-- **`@dashframe/engine-browser`** — backup / transitional web helpers (DuckDB-WASM, IndexedDB, BrowserDataFrame)
+- **`@dashframe/engine-browser`** — retained DuckDB-WASM, IndexedDB, and BrowserDataFrame implementation; no active product mode

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -69,8 +69,11 @@ interface DataFrameStorage {
   stageDelete?(id: UUID): Promise<string | null>;
   commitDelete?(token: string): Promise<void>;
   rollbackDelete?(token: string): Promise<void>;
-  // Independently optional startup recovery for interrupted staged deletes.
+  // Independently optional startup recovery for staged deletes and save temps.
   recoverStagedDeletes?(referencedIds: readonly UUID[]): Promise<void>;
+  // Independently optional probe used to decide whether recovery needs a
+  // retained-snapshot durability flush before resolving delete tokens.
+  hasPendingDataFrameDeletes?(): Promise<boolean>;
   exists(id: UUID): Promise<boolean>;
   list(): Promise<UUID[]>;
   getUsage(): Promise<{ count: number; totalBytes?: number }>;

--- a/packages/engine/src/interfaces/storage.ts
+++ b/packages/engine/src/interfaces/storage.ts
@@ -33,11 +33,13 @@ export interface DataFrameStorage {
    * Optional reversible delete used when binary storage and artifact metadata
    * must cross one failure boundary. Implementations move bytes out of the
    * active namespace, then either commit or roll back after the DB transaction.
+   * `stageDelete`, `commitDelete`, and `rollbackDelete` form one optional group:
+   * implementations must provide all three or omit all three.
    */
   stageDelete?(id: UUID): Promise<string | null>;
   commitDelete?(token: string): Promise<void>;
   rollbackDelete?(token: string): Promise<void>;
-  /** Reconcile interrupted staged deletes against committed metadata. */
+  /** Independently optional recovery for interrupted staged deletes. */
   recoverStagedDeletes?(referencedIds: readonly UUID[]): Promise<void>;
 
   /**

--- a/packages/engine/src/interfaces/storage.ts
+++ b/packages/engine/src/interfaces/storage.ts
@@ -39,8 +39,14 @@ export interface DataFrameStorage {
   stageDelete?(id: UUID): Promise<string | null>;
   commitDelete?(token: string): Promise<void>;
   rollbackDelete?(token: string): Promise<void>;
-  /** Independently optional recovery for interrupted staged deletes. */
+  /**
+   * Independently optional startup recovery for interrupted staged deletes
+   * and implementation-owned save temporaries. Referenced staged generations
+   * are restored; unreferenced generations are finalized.
+   */
   recoverStagedDeletes?(referencedIds: readonly UUID[]): Promise<void>;
+  /** Whether durable delete tokens remain and recovery needs a durability gate. */
+  hasPendingDataFrameDeletes?(): Promise<boolean>;
 
   /**
    * Check if a DataFrame exists in storage.

--- a/packages/engine/src/interfaces/storage.ts
+++ b/packages/engine/src/interfaces/storage.ts
@@ -30,6 +30,17 @@ export interface DataFrameStorage {
   delete(id: UUID): Promise<void>;
 
   /**
+   * Optional reversible delete used when binary storage and artifact metadata
+   * must cross one failure boundary. Implementations move bytes out of the
+   * active namespace, then either commit or roll back after the DB transaction.
+   */
+  stageDelete?(id: UUID): Promise<string | null>;
+  commitDelete?(token: string): Promise<void>;
+  rollbackDelete?(token: string): Promise<void>;
+  /** Reconcile interrupted staged deletes against committed metadata. */
+  recoverStagedDeletes?(referencedIds: readonly UUID[]): Promise<void>;
+
+  /**
    * Check if a DataFrame exists in storage.
    * @param id - Unique identifier for the data
    */

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -53,7 +53,6 @@ import {
   hasCorruptWalSegment,
   restoreNewestSnapshot,
   SnapshotScheduler,
-  writeSnapshot,
   type FailedRestoreAttempt,
   type SnapshotMeta,
 } from "./snapshots";
@@ -256,15 +255,9 @@ export async function openProject(
   );
 
   const close = async (): Promise<CloseResult> => {
-    // Cancel the pending debounced timer, then await any snapshot already in
-    // flight before writing (and closing). Without the flush, a debounced/max-
-    // wait dump still running here would overlap the final dump on the same
-    // client — or worse, still be using the client when `close()` tears it down.
-    scheduler.cancel();
-    await scheduler.flush();
     let snapshotError: Error | null = null;
     try {
-      await writeSnapshot(db.$client, dir);
+      await scheduler.close();
     } catch (err) {
       snapshotError = err instanceof Error ? err : new Error(String(err));
     }

--- a/packages/server-core/src/project.ts
+++ b/packages/server-core/src/project.ts
@@ -145,6 +145,8 @@ export interface ProjectHandle {
    * leave an inert orphan rather than risk a dangling live reference.
    */
   flushSnapshot(): Promise<void>;
+  /** Replace every retained recovery snapshot with the current project state. */
+  flushSnapshotRetentionWindow(): Promise<void>;
   /** Flush pending writes, write a final snapshot, and close the underlying PGlite connection. */
   close(): Promise<CloseResult>;
 }
@@ -279,6 +281,7 @@ export async function openProject(
     recovery,
     touchSnapshot: () => scheduler.touch(),
     flushSnapshot: () => scheduler.flushNow(),
+    flushSnapshotRetentionWindow: () => scheduler.flushRetentionWindow(),
     close,
   };
 }

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -117,8 +117,8 @@ export const dataTables = pgTable(
   (t) => [index("data_tables_data_source_id_idx").on(t.dataSourceId)],
 );
 
-// data_frames — browser DataFrame metadata only. Arrow bytes remain in the
-// renderer's IndexedDB storage via @dashframe/engine-browser.
+// data_frames — DataFrame metadata only. Arrow bytes live in the location
+// named by `storage` (project-local file storage or retained browser IndexedDB).
 export const dataFrames = pgTable(
   "data_frames",
   {

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -26,7 +26,7 @@ import {
   openProject,
   type ProjectHandle,
 } from "./project";
-import { projectMeta } from "./schema";
+import { dataFrames, projectMeta } from "./schema";
 import {
   hasCorruptWalSegment,
   listSnapshots,
@@ -146,6 +146,42 @@ describe("writeSnapshot + listSnapshots", () => {
     } finally {
       await pg.close();
     }
+  });
+});
+
+describe("retained snapshot resource safety", () => {
+  test("flushSnapshotRetentionWindow removes deleted frame metadata from every retained fallback", async () => {
+    const projectDir = tempDir();
+    const project = await openProject({ dir: projectDir });
+    const frameId = "11111111-1111-4111-8111-111111111111";
+    await project.db.insert(dataFrames).values({
+      id: frameId,
+      storage: { type: "file", key: frameId },
+      fieldIds: [],
+      name: "old snapshot frame",
+    });
+    await project.flushSnapshot();
+    await project.db.delete(dataFrames);
+
+    await project.flushSnapshotRetentionWindow();
+
+    const retained = await listSnapshots(projectDir);
+    expect(retained).toHaveLength(SNAPSHOT_KEEP_N);
+    for (const [index, snapshot] of retained.entries()) {
+      const restoredDir = join(projectDir, `retained-${index}`);
+      const restored = new PGlite(restoredDir, {
+        loadDataDir: new Blob([readFileSync(snapshot.absPath)]),
+      });
+      await restored.waitReady;
+      expect(
+        await restored.query("SELECT id FROM data_frames WHERE id = $1", [
+          frameId,
+        ]),
+      ).toMatchObject({ rows: [] });
+      await restored.close();
+    }
+    await project.close();
+    rmSync(projectDir, { recursive: true, force: true });
   });
 });
 

--- a/packages/server-core/src/snapshots.test.ts
+++ b/packages/server-core/src/snapshots.test.ts
@@ -125,6 +125,54 @@ describe("writeSnapshot + listSnapshots", () => {
     }
   });
 
+  test("uses a timestamp newer than future-dated retained snapshots", async () => {
+    const projectDir = join(root, "future-retained");
+    const dbPath = join(projectDir, "artifacts.db");
+    mkdirSync(projectDir, { recursive: true });
+    const pg = await openFreshPGlite(dbPath);
+    try {
+      const futureMs = Date.parse("2099-01-01T00:00:00.000Z");
+      for (let index = 0; index < SNAPSHOT_KEEP_N; index += 1) {
+        await writeSnapshot(pg, projectDir, () => futureMs + index);
+      }
+
+      const written = await writeSnapshot(pg, projectDir, () =>
+        Date.parse("2024-01-01T00:00:00.000Z"),
+      );
+      const retained = await listSnapshots(projectDir);
+
+      expect(existsSync(written)).toBe(true);
+      expect(retained.at(-1)?.absPath).toBe(written);
+      expect(Date.parse(retained.at(-1)!.timestamp)).toBe(
+        futureMs + SNAPSHOT_KEEP_N,
+      );
+    } finally {
+      await pg.close();
+    }
+  });
+
+  test("syncs the project directory before first snapshot contents", async () => {
+    const projectDir = join(root, "directory-sync-order");
+    mkdirSync(projectDir, { recursive: true });
+    const events: string[] = [];
+    const client = {
+      dumpDataDir: async () => {
+        events.push("dump");
+        return new Blob([Buffer.from("snapshot")]);
+      },
+    } as unknown as PGlite;
+
+    await writeSnapshot(client, projectDir, Date.now, async (directory) => {
+      events.push(`sync:${basename(directory)}`);
+    });
+
+    expect(events).toEqual([
+      "sync:directory-sync-order",
+      "dump",
+      "sync:snapshots",
+    ]);
+  });
+
   test("listSnapshots returns empty array when no snapshots dir exists", async () => {
     const snaps = await listSnapshots(join(root, "nonexistent"));
     expect(snaps).toEqual([]);
@@ -169,6 +217,50 @@ describe("retained snapshot resource safety", () => {
     expect(retained).toHaveLength(SNAPSHOT_KEEP_N);
     for (const [index, snapshot] of retained.entries()) {
       const restoredDir = join(projectDir, `retained-${index}`);
+      const restored = new PGlite(restoredDir, {
+        loadDataDir: new Blob([readFileSync(snapshot.absPath)]),
+      });
+      await restored.waitReady;
+      expect(
+        await restored.query("SELECT id FROM data_frames WHERE id = $1", [
+          frameId,
+        ]),
+      ).toMatchObject({ rows: [] });
+      await restored.close();
+    }
+    await project.close();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("replaces future-dated retained snapshots with current state after a backward clock", async () => {
+    const projectDir = tempDir();
+    const project = await openProject({ dir: projectDir });
+    const frameId = "11111111-1111-4111-8111-111111111111";
+    await project.db.insert(dataFrames).values({
+      id: frameId,
+      storage: { type: "file", key: frameId },
+      fieldIds: [],
+      name: "future snapshot frame",
+    });
+    const futureMs = Date.parse("2099-01-01T00:00:00.000Z");
+    for (let index = 0; index < SNAPSHOT_KEEP_N; index += 1) {
+      await writeSnapshot(
+        project.db.$client,
+        projectDir,
+        () => futureMs + index,
+      );
+    }
+    await project.db.delete(dataFrames);
+
+    await project.flushSnapshotRetentionWindow();
+
+    const retained = await listSnapshots(projectDir);
+    expect(retained).toHaveLength(SNAPSHOT_KEEP_N);
+    expect(
+      retained.every(({ timestamp }) => Date.parse(timestamp) > futureMs),
+    ).toBe(true);
+    for (const [index, snapshot] of retained.entries()) {
+      const restoredDir = join(projectDir, `future-retained-${index}`);
       const restored = new PGlite(restoredDir, {
         loadDataDir: new Blob([readFileSync(snapshot.absPath)]),
       });
@@ -362,6 +454,39 @@ describe("SnapshotScheduler", () => {
     expect(maxActive).toBe(1);
 
     sched.cancel();
+  });
+
+  test("queues the entire retention window before the final close snapshot", async () => {
+    const projectDir = join(root, "retention-before-close");
+    mkdirSync(projectDir, { recursive: true });
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let signalFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirst = resolve;
+    });
+    let calls = 0;
+    const client = {
+      dumpDataDir: async () => {
+        calls += 1;
+        if (calls === 1) {
+          signalFirst();
+          await firstBlocked;
+        }
+        return new Blob([Buffer.from(`snapshot-${calls}`)]);
+      },
+    } as unknown as PGlite;
+    const sched = new SnapshotScheduler(client, projectDir);
+
+    const retention = sched.flushRetentionWindow();
+    await firstStarted;
+    const closing = sched.close();
+    releaseFirst();
+    await Promise.all([retention, closing]);
+
+    expect(calls).toBe(SNAPSHOT_KEEP_N + 1);
   });
 });
 
@@ -911,6 +1036,66 @@ describe("ProjectHandle.close() — surfaces snapshot failure (site 1)", () => {
     // Use the raw PGlite client's query() method rather than drizzle's execute()
     // so the call returns a genuine promise (drizzle's execute returns a lazy builder).
     await expect(handle.db.$client.query("SELECT 1")).rejects.toThrow();
+  });
+
+  test("serializes a blocked dump with final close and seals later snapshot work", async () => {
+    const dir = join(root, "close-serialization");
+    const handle = await openProject({ dir, snapshotDebounceMs: 100_000 });
+    openHandles.splice(0);
+    const client = handle.db.$client;
+    const originalDump = client.dumpDataDir.bind(client);
+    const originalClose = client.close.bind(client);
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let signalFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirst = resolve;
+    });
+    let calls = 0;
+    let active = 0;
+    let maxActive = 0;
+    let clientClosed = false;
+    let startsAfterClientClose = 0;
+
+    client.dumpDataDir = async (...args) => {
+      calls += 1;
+      if (clientClosed) startsAfterClientClose += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      if (calls === 1) {
+        signalFirst();
+        await firstBlocked;
+      }
+      try {
+        return await originalDump(...args);
+      } finally {
+        active -= 1;
+      }
+    };
+    client.close = async () => {
+      clientClosed = true;
+      return originalClose();
+    };
+
+    const firstFlush = handle.flushSnapshot();
+    await firstStarted;
+    const closing = handle.close();
+    handle.touchSnapshot();
+    await expect(handle.flushSnapshot()).rejects.toThrow(
+      "Snapshot scheduler is closing",
+    );
+    await expect(handle.flushSnapshotRetentionWindow()).rejects.toThrow(
+      "Snapshot scheduler is closing",
+    );
+    releaseFirst();
+
+    await firstFlush;
+    expect((await closing).snapshotError).toBeNull();
+    expect(calls).toBe(2);
+    expect(maxActive).toBe(1);
+    expect(startsAfterClientClose).toBe(0);
   });
 });
 

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -132,11 +132,19 @@ export async function writeSnapshot(
   projectDir: string,
   /** Injected for testing — returns the timestamp to embed in the filename. */
   nowMs: () => number = Date.now,
+  /** Injected for testing — durably syncs a directory entry sequence. */
+  sync: (directory: string) => Promise<void> = syncDirectory,
 ): Promise<string> {
   const snapshotsDir = resolveSnapshotsDir(projectDir);
   await fs.mkdir(snapshotsDir, { recursive: true });
+  await sync(projectDir);
 
-  let snapshotMs = nowMs();
+  const retained = await listSnapshots(projectDir);
+  const newestRetainedMs = retained
+    .map(({ timestamp }) => Date.parse(timestamp))
+    .filter(Number.isFinite)
+    .at(-1);
+  let snapshotMs = Math.max(nowMs(), (newestRetainedMs ?? -1) + 1);
   let filename: string;
   let destPath: string;
   while (true) {
@@ -166,7 +174,7 @@ export async function writeSnapshot(
       await file.close();
     }
     await fs.rename(tempPath, destPath);
-    await syncDirectory(snapshotsDir);
+    await sync(snapshotsDir);
   } catch (err) {
     // Clean up temp file on any error so it doesn't accumulate.
     await fs.unlink(tempPath).catch(() => {});
@@ -414,7 +422,9 @@ export class SnapshotScheduler {
    * tail so they run strictly one-at-a-time; `flush()` lets `close()` await the
    * in-flight write before its own.
    */
-  private inFlight: Promise<unknown> = Promise.resolve();
+  private inFlight: Promise<void> = Promise.resolve();
+  private closing = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(
     private readonly pgliteClient: PGlite,
@@ -432,6 +442,7 @@ export class SnapshotScheduler {
 
   /** Notify the scheduler that a write just happened. */
   touch(): void {
+    if (this.closing) return;
     const now = this.nowMs();
     if (this.firstPendingAt === null) this.firstPendingAt = now;
 
@@ -449,6 +460,7 @@ export class SnapshotScheduler {
 
   /** Write a snapshot now and reset the pending-burst tracking. */
   private fireNow(): void {
+    if (this.closing) return;
     if (this.timer !== null) {
       clearTimeout(this.timer);
       this.timer = null;
@@ -457,13 +469,13 @@ export class SnapshotScheduler {
     // Chain onto the in-flight tail so writes never overlap on the shared
     // client. A failed write is logged and swallowed so it doesn't poison the
     // chain for the next snapshot.
-    this.inFlight = this.inFlight
-      .catch(() => {})
-      .then(() =>
-        writeSnapshot(this.pgliteClient, this.projectDir).catch((err) => {
-          console.error("[dashframe] debounced snapshot failed:", err);
-        }),
-      );
+    this.enqueue(async () => {
+      try {
+        await writeSnapshot(this.pgliteClient, this.projectDir);
+      } catch (err) {
+        console.error("[dashframe] debounced snapshot failed:", err);
+      }
+    });
   }
 
   /**
@@ -485,9 +497,8 @@ export class SnapshotScheduler {
    * ref must not be released from the vault until the snapshot that drops that
    * ref from the config is known to be durable.
    *
-   * Serialisation: the write is chained onto `inFlight` exactly as `fireNow()`
-   * does, so it cannot overlap a concurrently running debounced write or the
-   * final snapshot from `ProjectHandle.close()`.
+   * Serialisation: the complete operation is chained onto `inFlight`, so it
+   * cannot overlap a debounced, retention-window, or final close snapshot.
    *
    * Error propagation: unlike `fireNow()`, which swallows errors to keep the
    * chain healthy for the next debounced snapshot, this method surfaces write
@@ -496,6 +507,7 @@ export class SnapshotScheduler {
    * reference.
    */
   async flushNow(): Promise<void> {
+    this.assertOpen();
     // Cancel any pending debounce timer — we are writing immediately.
     if (this.timer !== null) {
       clearTimeout(this.timer);
@@ -503,21 +515,12 @@ export class SnapshotScheduler {
     }
     this.firstPendingAt = null;
 
-    // Chain onto the in-flight tail (prevents overlap) and capture a promise
-    // that both (a) updates inFlight to suppress "nothing pending" and (b)
-    // propagates the error to this caller. The chain has TWO branches:
-    //   - inFlight (error-swallowed): keeps the chain healthy for future
-    //     debounced calls if this flush is later followed by more touch() calls.
-    //   - write (error-propagated): returned to the caller so the pre-release
-    //     gate learns whether durability was achieved.
-    const write = this.inFlight
-      .catch(() => {}) // don't let a prior failure block this write
-      .then(() => writeSnapshot(this.pgliteClient, this.projectDir));
-    // Register the error-swallowed tail so future debounced writes still chain
-    // correctly even if `write` throws.
-    this.inFlight = write.catch(() => {});
-    // Await with error propagation — callers must handle rejection.
-    await write;
+    // Enqueue before awaiting so close cannot insert its final snapshot between
+    // this request and its write. The returned branch propagates errors while
+    // the scheduler tail remains healthy for later work.
+    await this.enqueue(async () => {
+      await writeSnapshot(this.pgliteClient, this.projectDir);
+    });
   }
 
   /**
@@ -526,9 +529,24 @@ export class SnapshotScheduler {
    * after this resolves: no retained fallback can restore a reference to them.
    */
   async flushRetentionWindow(): Promise<void> {
-    for (let index = 0; index < SNAPSHOT_KEEP_N; index += 1) {
-      await this.flushNow();
-    }
+    this.assertOpen();
+    this.cancel();
+    await this.enqueue(async () => {
+      for (let index = 0; index < SNAPSHOT_KEEP_N; index += 1) {
+        await writeSnapshot(this.pgliteClient, this.projectDir);
+      }
+    });
+  }
+
+  /** Queue the final snapshot and reject all later snapshot work. */
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closing = true;
+    this.cancel();
+    this.closePromise = this.enqueue(async () => {
+      await writeSnapshot(this.pgliteClient, this.projectDir);
+    });
+    return this.closePromise;
   }
 
   /** Cancel any pending debounced snapshot (call before close). */
@@ -538,5 +556,17 @@ export class SnapshotScheduler {
       this.timer = null;
     }
     this.firstPendingAt = null;
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const result = this.inFlight.catch(() => {}).then(operation);
+    this.inFlight = result.catch(() => {});
+    return result;
+  }
+
+  private assertOpen(): void {
+    if (this.closing) {
+      throw new Error("Snapshot scheduler is closing");
+    }
   }
 }

--- a/packages/server-core/src/snapshots.ts
+++ b/packages/server-core/src/snapshots.ts
@@ -136,9 +136,21 @@ export async function writeSnapshot(
   const snapshotsDir = resolveSnapshotsDir(projectDir);
   await fs.mkdir(snapshotsDir, { recursive: true });
 
-  const timestamp = new Date(nowMs()).toISOString().replace(/[:.]/g, "-");
-  const filename = `${SNAPSHOT_PREFIX}${timestamp}${SNAPSHOT_EXT}`;
-  const destPath = path.join(snapshotsDir, filename);
+  let snapshotMs = nowMs();
+  let filename: string;
+  let destPath: string;
+  while (true) {
+    const timestamp = new Date(snapshotMs).toISOString().replace(/[:.]/g, "-");
+    filename = `${SNAPSHOT_PREFIX}${timestamp}${SNAPSHOT_EXT}`;
+    destPath = path.join(snapshotsDir, filename);
+    try {
+      await fs.access(destPath);
+      snapshotMs += 1;
+    } catch (error) {
+      if (isEnoent(error)) break;
+      throw error;
+    }
+  }
   const tempPath = path.join(snapshotsDir, `.tmp-${filename}`);
 
   const blob = await pgliteClient.dumpDataDir("gzip");
@@ -146,8 +158,15 @@ export async function writeSnapshot(
 
   // Write to a temp file first; rename to final path atomically.
   try {
-    await fs.writeFile(tempPath, buffer);
+    const file = await fs.open(tempPath, "w");
+    try {
+      await file.writeFile(buffer);
+      await file.sync();
+    } finally {
+      await file.close();
+    }
     await fs.rename(tempPath, destPath);
+    await syncDirectory(snapshotsDir);
   } catch (err) {
     // Clean up temp file on any error so it doesn't accumulate.
     await fs.unlink(tempPath).catch(() => {});
@@ -230,6 +249,7 @@ async function pruneSnapshots(snapshotsDir: string): Promise<void> {
       `[dashframe] pruneSnapshots: ${failures.length} of ${toDelete.length} deletion(s) failed`,
     );
   }
+  if (toDelete.length > 0) await syncDirectory(snapshotsDir);
 }
 
 /**
@@ -345,6 +365,15 @@ function isEnoent(err: unknown): boolean {
     "code" in err &&
     (err as NodeJS.ErrnoException).code === "ENOENT"
   );
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  const handle = await fs.open(directory, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
 }
 
 /**
@@ -489,6 +518,17 @@ export class SnapshotScheduler {
     this.inFlight = write.catch(() => {});
     // Await with error propagation — callers must handle rejection.
     await write;
+  }
+
+  /**
+   * Replace the complete retained recovery window with snapshots of the current
+   * state. Physical resources removed from that state are safe to delete only
+   * after this resolves: no retained fallback can restore a reference to them.
+   */
+  async flushRetentionWindow(): Promise<void> {
+    for (let index = 0; index < SNAPSHOT_KEEP_N; index += 1) {
+      await this.flushNow();
+    }
   }
 
   /** Cancel any pending debounced snapshot (call before close). */

--- a/packages/types/src/dataframe.ts
+++ b/packages/types/src/dataframe.ts
@@ -11,6 +11,7 @@ import type { UUID } from "./uuid";
  */
 export type DataFrameStorageLocation =
   | { type: "indexeddb"; key: string }
+  | { type: "file"; key: string }
   | { type: "s3"; bucket: string; key: string }
   | { type: "r2"; accountId: string; key: string };
 

--- a/packages/visualization/src/components/Chart.tsx
+++ b/packages/visualization/src/components/Chart.tsx
@@ -202,9 +202,8 @@ export function Chart({
 
   // Renderer bound to the enclosing VisualizationProvider's engine. Preferred
   // over the global registry so this Chart routes to ITS provider's connector.
-  // This is what makes the per-insight WASM fallback work: a nested WASM
-  // provider supplies a WASM-bound renderer here that shadows the globally
-  // registered native renderer, so the fallback chart queries WASM, not native.
+  // Provider shadowing remains a general capability, but v0.3 hosts inject the
+  // shared native-server connector and do not mount a WASM fallback provider.
   const {
     renderer: contextRenderer,
     isReady: providerReady,


### PR DESCRIPTION
## Summary
- persist imported and refreshed DataFrames as durable project-owned server snapshots with restart recovery
- return the DataFrame ID as the snapshot identity; row bytes remain server-side
- route web and desktop preview, Insight, and visualization reads through the shared server Arrow query plane
- make replacement, delete, clear, draft lifecycle, and DeleteNode cleanup failure-safe with reference-counted shared DataFrame cleanup

## Scope
- TASK-753 + the server-query consumer slice of TASK-755
- connector-specific import/refresh routes remain; TASK-754 connector-neutral ingestion orchestration is excluded
- no selectable WASM mode, fallback, or bridge is introduced; dormant browser engine code remains
- this PR does **not** claim the server-first 0.3 data path is complete while local-file import still uses the legacy browser/IndexedDB path

## Required stack / dependency
1. **This PR (#326):** durable server snapshots, DataFrame-ID linkage, cleanup, and web + desktop server query consumers
2. **Required child:** migrate local-file Import to server ingestion and project-file snapshots; remove the active IndexedDB import path
3. **Glossary child:** codify Import / Refresh / Ingestion / Snapshot / DataFrame / Insight terminology after every active import path is server-first

## Verification (exact HEAD 167da602)
- `TURBO_CONCURRENCY=1 bun run check` — PASS, 85/85 tasks; all four repository checks PASS
- `bun run format:check` — PASS
- affected server connector/ownership tests — PASS, 201/201
- real storage + native DuckDB restart QA — PASS (`persisted: true`, query sum 6 before and after reconstruction)
- live shared web/desktop server data-plane query against loopback Arrow endpoint — PASS (1 row, value 9)
- final local code review — running
- fresh independent second review — running

## Privacy and data movement
Connector inspection returns schema for review. Import or Refresh persists a snapshot only after approved fields pass the server privacy gate. Connector row bytes do not roundtrip through browser base64 or IndexedDB.
