### PR TITLE
[codex] Add stateless MCP draft continuity

### DIFF
--- a/apps/server/src/app-context.ts
+++ b/apps/server/src/app-context.ts
@@ -1,6 +1,6 @@
 import type { DataFrameStorage } from "@dashframe/engine";
 import type { ApiAccessCredentials, ArtifactDb } from "@dashframe/server-core";
-import type { Principal } from "@wystack/identity";
+import { isPrincipal, type Principal } from "@wystack/identity";
 import type { SecretVault } from "@wystack/secret-vault";
 import type { FunctionContext, WyStackApp } from "@wystack/server";
 
@@ -44,3 +44,11 @@ export interface AppContext {
 }
 
 export type DashframeFunctionContext = FunctionContext<AppContext>;
+
+/** Stable, non-secret identity used to bind durable resources to a principal. */
+export function principalKey(principal: unknown): string | null {
+  if (!isPrincipal(principal)) return null;
+  return principal.kind === "service"
+    ? `service:${principal.credentialId}`
+    : `user:${principal.userId}`;
+}

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -81,7 +81,7 @@ import {
 } from "./draft-controller";
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { functions } from "./functions";
-import { createMcpRoute } from "./mcp/route";
+import { createMcpRoute, type McpMode } from "./mcp/route";
 import {
   expectedPermissionIds,
   LOCAL_USER_ID,
@@ -157,6 +157,14 @@ export interface DashframeServerOptions {
   hostname?: string;
   /** Bind port. Default `0` — the OS assigns an ephemeral port. */
   port?: number;
+  /** Explicit MCP transport mode. Defaults to stateful. */
+  mcpMode?: McpMode;
+  /** Stateful MCP session bound; primarily configurable for deterministic tests. */
+  mcpMaxStatefulSessions?: number;
+  /** Idle stateful MCP session lifetime. */
+  mcpStatefulSessionTtlMs?: number;
+  /** Injectable stateful-session clock for deterministic lifecycle tests. */
+  mcpSessionNow?: () => number;
   /**
    * Allowed CORS origin(s) for the renderer. Defaults to local Vite/preview
    * origins (`localhost` / `127.0.0.1`) for dev and smoke verification.
@@ -1235,7 +1243,17 @@ export async function createDashframeServer(
     }),
   );
 
-  honoApp.all("/mcp", createMcpRoute({ app, resolveContext }));
+  honoApp.all(
+    "/mcp",
+    createMcpRoute({
+      app,
+      resolveContext,
+      mode: opts.mcpMode,
+      maxStatefulSessions: opts.mcpMaxStatefulSessions,
+      statefulSessionTtlMs: opts.mcpStatefulSessionTtlMs,
+      now: opts.mcpSessionNow,
+    }),
+  );
 
   // OAuth callback + resume are intentionally outside createRoutes: neither
   // browser request carries a bearer token. The callback reaches project writes

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -81,7 +81,7 @@ import {
 } from "./draft-controller";
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { functions } from "./functions";
-import { createMcpRoute, type McpMode } from "./mcp/route";
+import { createMcpRoute } from "./mcp/route";
 import {
   expectedPermissionIds,
   LOCAL_USER_ID,
@@ -157,8 +157,6 @@ export interface DashframeServerOptions {
   hostname?: string;
   /** Bind port. Default `0` — the OS assigns an ephemeral port. */
   port?: number;
-  /** MCP transport mode. Defaults to stateful for backward compatibility. */
-  mcpMode?: McpMode;
   /**
    * Allowed CORS origin(s) for the renderer. Defaults to local Vite/preview
    * origins (`localhost` / `127.0.0.1`) for dev and smoke verification.
@@ -1171,8 +1169,8 @@ export async function createDashframeServer(
     app: honoApp,
   });
   // The MCP transport needs headers and methods the rest of the surface does
-  // not. Stateful mode uses all of them; stateless mode still allows client
-  // probes through CORS so the route can answer unsupported methods with 405
+  // not. Allow client probes through CORS so the route can answer unsupported
+  // methods with 405
   // instead of an opaque browser network error. Scoped to /mcp rather than
   // widening the general policy, and registered first so a preflight for /mcp
   // is answered here and never reaches the policy below.
@@ -1237,10 +1235,7 @@ export async function createDashframeServer(
     }),
   );
 
-  honoApp.all(
-    "/mcp",
-    createMcpRoute({ app, resolveContext, mode: opts.mcpMode }),
-  );
+  honoApp.all("/mcp", createMcpRoute({ app, resolveContext }));
 
   // OAuth callback + resume are intentionally outside createRoutes: neither
   // browser request carries a bearer token. The callback reaches project writes

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1168,12 +1168,16 @@ export async function createDashframeServer(
   const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({
     app: honoApp,
   });
-  // The MCP transport needs headers and a method the rest of the surface does
-  // not: a session id it both sends and reads back, a resumption id, the
-  // negotiated protocol version, and DELETE to end a session. Scoped to /mcp
-  // rather than widening the general policy, and registered first so a
-  // preflight for /mcp is answered here and never reaches the policy below —
-  // one Access-Control-Allow-Origin on the response, not two.
+  // The MCP transport needs headers and methods the rest of the surface does
+  // not. /mcp is stateless — it mints no session id and serves only POST — but
+  // an MCP client still probes GET and DELETE and sends the session,
+  // resumption and protocol-version headers on its own initiative. They stay
+  // allowed here so the browser lets those requests through to the route,
+  // which answers the two it does not serve with 405; blocking them at CORS
+  // would surface as an opaque network error instead. Scoped to /mcp rather
+  // than widening the general policy, and registered first so a preflight for
+  // /mcp is answered here and never reaches the policy below — one
+  // Access-Control-Allow-Origin on the response, not two.
   honoApp.use(
     "/mcp",
     cors({

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -81,7 +81,7 @@ import {
 } from "./draft-controller";
 import { assertPublishLogHasNoLateBound } from "./draft-late-bound";
 import { functions } from "./functions";
-import { createMcpRoute } from "./mcp/route";
+import { createMcpRoute, type McpMode } from "./mcp/route";
 import {
   expectedPermissionIds,
   LOCAL_USER_ID,
@@ -157,6 +157,8 @@ export interface DashframeServerOptions {
   hostname?: string;
   /** Bind port. Default `0` — the OS assigns an ephemeral port. */
   port?: number;
+  /** MCP transport mode. Defaults to stateful for backward compatibility. */
+  mcpMode?: McpMode;
   /**
    * Allowed CORS origin(s) for the renderer. Defaults to local Vite/preview
    * origins (`localhost` / `127.0.0.1`) for dev and smoke verification.
@@ -1169,15 +1171,11 @@ export async function createDashframeServer(
     app: honoApp,
   });
   // The MCP transport needs headers and methods the rest of the surface does
-  // not. /mcp is stateless — it mints no session id and serves only POST — but
-  // an MCP client still probes GET and DELETE and sends the session,
-  // resumption and protocol-version headers on its own initiative. They stay
-  // allowed here so the browser lets those requests through to the route,
-  // which answers the two it does not serve with 405; blocking them at CORS
-  // would surface as an opaque network error instead. Scoped to /mcp rather
-  // than widening the general policy, and registered first so a preflight for
-  // /mcp is answered here and never reaches the policy below — one
-  // Access-Control-Allow-Origin on the response, not two.
+  // not. Stateful mode uses all of them; stateless mode still allows client
+  // probes through CORS so the route can answer unsupported methods with 405
+  // instead of an opaque browser network error. Scoped to /mcp rather than
+  // widening the general policy, and registered first so a preflight for /mcp
+  // is answered here and never reaches the policy below.
   honoApp.use(
     "/mcp",
     cors({
@@ -1239,7 +1237,10 @@ export async function createDashframeServer(
     }),
   );
 
-  honoApp.all("/mcp", createMcpRoute({ app, resolveContext }));
+  honoApp.all(
+    "/mcp",
+    createMcpRoute({ app, resolveContext, mode: opts.mcpMode }),
+  );
 
   // OAuth callback + resume are intentionally outside createRoutes: neither
   // browser request carries a bearer token. The callback reaches project writes

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1170,8 +1170,8 @@ export async function createDashframeServer(
   });
   // The MCP transport needs headers and methods the rest of the surface does
   // not. Allow client probes through CORS so the route can answer unsupported
-  // methods with 405
-  // instead of an opaque browser network error. Scoped to /mcp rather than
+  // methods with 405 instead of an opaque browser network error. Scoped to
+  // /mcp rather than
   // widening the general policy, and registered first so a preflight for /mcp
   // is answered here and never reaches the policy below.
   honoApp.use(

--- a/apps/server/src/assistant-host.ts
+++ b/apps/server/src/assistant-host.ts
@@ -6,6 +6,7 @@ import type {
 import type { Principal } from "@wystack/identity";
 import type { WyStackApp } from "@wystack/server";
 
+import { principalKey } from "./app-context";
 import { createAssistantReadHost } from "./assistant-read-host";
 import type { DraftController } from "./draft-controller";
 import {
@@ -41,7 +42,11 @@ export function createDashframeAssistantHost(
   options: DashframeAssistantHostOptions,
 ): AssistantHost {
   return {
-    open: () => options.draftController.openDraft(),
+    open: () =>
+      options.draftController.openDraft(
+        undefined,
+        principalKey(options.principal) ?? undefined,
+      ),
     append: async (draftId, batch, context) => {
       // Route through the operated draft mutation RPC. Besides authorization and
       // command validation, this is the seam that relays a rejected batch's

--- a/apps/server/src/draft-access.ts
+++ b/apps/server/src/draft-access.ts
@@ -1,0 +1,19 @@
+import type { Principal } from "@wystack/identity";
+
+import { principalKey } from "./app-context";
+import type { DraftController } from "./draft-controller";
+
+export const DRAFT_UNAVAILABLE = "draft is unavailable";
+
+/** Users own review; services may access only their exact durable owner row. */
+export async function assertDraftAccess(
+  controller: DraftController,
+  principal: Principal | undefined,
+  draftId: string,
+): Promise<void> {
+  if (principal?.kind === "user") return;
+  const key = principalKey(principal);
+  if (key === null || !(await controller.draftOwnedBy(draftId, key))) {
+    throw new Error(DRAFT_UNAVAILABLE);
+  }
+}

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -412,8 +412,8 @@ export interface DraftController {
     batch: DraftCommand[],
     context?: Record<string, unknown>,
   ): Promise<CommandResult[]>;
-  /** List every open draft from durable metadata, newest activity first. */
-  listDrafts(): Promise<DraftListEntry[]>;
+  /** List open drafts, optionally restricted to one exact durable owner. */
+  listDrafts(ownerPrincipalKey?: string): Promise<DraftListEntry[]>;
   /**
    * True when `draft_metadata` still holds this handle. That table is the
    * registry of record: `openDraft` inserts the row and both lifecycle exits
@@ -1110,10 +1110,11 @@ export function createDraftController(
       return rows.length > 0;
     },
 
-    async listDrafts(): Promise<DraftListEntry[]> {
+    async listDrafts(ownerPrincipalKey?: string): Promise<DraftListEntry[]> {
       const rows = normalizeRows(
         await db.execute(
-          sql.raw(`
+          sql`
+            ${sql.raw(`
             WITH draft_summary AS (
               SELECT
                 draft_id,
@@ -1150,8 +1151,16 @@ export function createDraftController(
             FROM draft_metadata AS metadata
             LEFT JOIN draft_summary AS summary
               ON summary.draft_id = metadata.draft_id
-            ORDER BY COALESCE(summary.updated_at, metadata.created_at) DESC
-          `),
+          `)}
+            ${
+              ownerPrincipalKey === undefined
+                ? sql``
+                : sql`WHERE metadata.owner_principal_key = ${ownerPrincipalKey}`
+            }
+            ${sql.raw(
+              "ORDER BY COALESCE(summary.updated_at, metadata.created_at) DESC",
+            )}
+          `,
         ),
       );
       return rows.map((row) => ({

--- a/apps/server/src/draft-controller.ts
+++ b/apps/server/src/draft-controller.ts
@@ -79,7 +79,7 @@ import {
   type DraftCommand,
   type WyStackApp,
 } from "@wystack/server";
-import { eq, getTableName, sql } from "drizzle-orm";
+import { and, eq, getTableName, sql } from "drizzle-orm";
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import {
@@ -387,7 +387,7 @@ export interface DraftController {
    * future conflict-detection pass (out of scope for this mechanism slice); it
    * is opaque and not inspected here.
    */
-  openDraft(baseVersion?: unknown): Promise<string>;
+  openDraft(baseVersion?: unknown, ownerPrincipalKey?: string): Promise<string>;
   /**
    * Apply a batch INSIDE the draft. Routes each command's writes through the
    * `withDraft(draftId)` write-path into `<table>__draft` (durable), then
@@ -424,6 +424,8 @@ export interface DraftController {
    * that `listDrafts` can never surface and no lifecycle path can ever sweep.
    */
   draftExists(draftId: string): Promise<boolean>;
+  /** One non-oracular lookup for a durably owned, still-open handle. */
+  draftOwnedBy(draftId: string, ownerPrincipalKey: string): Promise<boolean>;
   /** Atomically replace a reviewed log after guarded remove/bind operations. */
   reviseDraft(
     draftId: string,
@@ -1065,7 +1067,10 @@ export function createDraftController(
   }
 
   return {
-    async openDraft(baseVersion?: unknown): Promise<string> {
+    async openDraft(
+      baseVersion?: unknown,
+      ownerPrincipalKey?: string,
+    ): Promise<string> {
       // DashFrame owns the handle. `withDraft` accepts any id, so a UUID is the
       // durable draftId across the shadow tables and the command log.
       const draftId = crypto.randomUUID();
@@ -1073,11 +1078,28 @@ export function createDraftController(
       // base for both timestamp- and delete-based conflict detection.
       await db.insert(draftMetadata).values({
         draftId,
+        ...(ownerPrincipalKey === undefined ? {} : { ownerPrincipalKey }),
         baseVersion: normalizeBaseVersion(baseVersion),
         logRevision: 0,
         baseInventory: await snapshotCanonicalInventory(),
       });
       return draftId;
+    },
+
+    async draftOwnedBy(
+      draftId: string,
+      ownerPrincipalKey: string,
+    ): Promise<boolean> {
+      const rows = await db
+        .select({ draftId: draftMetadata.draftId })
+        .from(draftMetadata)
+        .where(
+          and(
+            eq(draftMetadata.draftId, draftId),
+            eq(draftMetadata.ownerPrincipalKey, ownerPrincipalKey),
+          ),
+        );
+      return rows.length > 0;
     },
 
     async draftExists(draftId: string): Promise<boolean> {

--- a/apps/server/src/functions/commit-batch.test.ts
+++ b/apps/server/src/functions/commit-batch.test.ts
@@ -277,12 +277,18 @@ describe("commitBatch and draft-only API credentials", () => {
   it("allows service draft append, denies its publish/discard, and lets a user finish", async () => {
     const seedApp = await buildDashframeApp({ db: project!.db });
     const controller = createDraftController(seedApp, project!.db);
+    const serviceCredentialId =
+      await accessCredentials.authenticate(serviceToken);
+    expect(serviceCredentialId).not.toBeNull();
     const servicePrincipal = {
       kind: "service" as const,
-      credentialId: "seed-service",
+      credentialId: serviceCredentialId!,
     };
 
-    const publishDraftId = await controller.openDraft();
+    const publishDraftId = await controller.openDraft(
+      undefined,
+      `service:${servicePrincipal.credentialId}`,
+    );
     const publishedSourceId = crypto.randomUUID();
     await controller.appendToDraft(
       publishDraftId,
@@ -337,7 +343,10 @@ describe("commitBatch and draft-only API credentials", () => {
       ),
     ).toBe(true);
 
-    const discardDraftId = await controller.openDraft();
+    const discardDraftId = await controller.openDraft(
+      undefined,
+      `service:${servicePrincipal.credentialId}`,
+    );
     await controller.appendToDraft(discardDraftId, [], {
       principal: servicePrincipal,
     });

--- a/apps/server/src/functions/draft-batch.test.ts
+++ b/apps/server/src/functions/draft-batch.test.ts
@@ -19,9 +19,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  buildDashframeApp,
   createDashframeServer,
   createDraftController,
   type DashframeServer,
+  type DraftController,
 } from "../app";
 import { computeLogSignature } from "../draft-log-signature";
 import { cmd } from "./commands";
@@ -438,5 +440,138 @@ describe("draftBatch and reviseDraft", () => {
     const seqs = rows.map((r) => r.seq).sort((a, b) => a - b);
     // seed + 5 + 5 = 11 dense 0..10
     expect(seqs).toEqual(Array.from({ length: 11 }, (_, i) => i));
+  });
+
+  it("cleans an empty generated draft before a queued append can commit", async () => {
+    const app = await buildDashframeApp({ db: project!.db });
+    const baseController = createDraftController(app, project!.db);
+    const principal = {
+      kind: "service" as const,
+      credentialId: "queued-service",
+    };
+    const context = {
+      wyStackApp: app,
+      artifactDb: project!.db,
+      principal,
+    };
+
+    let resolveOpened!: (draftId: string) => void;
+    const opened = new Promise<string>((resolve) => {
+      resolveOpened = resolve;
+    });
+    let resolveFirstAppend!: () => void;
+    const firstAppend = new Promise<void>((resolve) => {
+      resolveFirstAppend = resolve;
+    });
+    let releaseFirstAppend!: () => void;
+    const firstAppendRelease = new Promise<void>((resolve) => {
+      releaseFirstAppend = resolve;
+    });
+    let resolveSecondValidated!: () => void;
+    const secondValidated = new Promise<void>((resolve) => {
+      resolveSecondValidated = resolve;
+    });
+    let resolveSecondStarted!: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      resolveSecondStarted = resolve;
+    });
+    let resolveSecondCommitted!: () => void;
+    const secondCommitted = new Promise<void>((resolve) => {
+      resolveSecondCommitted = resolve;
+    });
+
+    let ownershipChecks = 0;
+    let appendCalls = 0;
+    let cleanupWaiting = false;
+    let cleanupFinished = false;
+    const controller: DraftController = {
+      ...baseController,
+      async openDraft(baseVersion, ownerPrincipalKey) {
+        const draftId = await baseController.openDraft(
+          baseVersion,
+          ownerPrincipalKey,
+        );
+        resolveOpened(draftId);
+        return draftId;
+      },
+      async draftOwnedBy(draftId, ownerPrincipalKey) {
+        ownershipChecks += 1;
+        if (ownershipChecks === 2) resolveSecondValidated();
+        if (cleanupWaiting && !cleanupFinished) return true;
+        return baseController.draftOwnedBy(draftId, ownerPrincipalKey);
+      },
+      async appendToDraft(draftId, batch, appendContext) {
+        appendCalls += 1;
+        if (appendCalls === 1) {
+          resolveFirstAppend();
+          await firstAppendRelease;
+          throw new Error("first batch failed before any write");
+        }
+        resolveSecondStarted();
+        const result = await baseController.appendToDraft(
+          draftId,
+          batch,
+          appendContext,
+        );
+        resolveSecondCommitted();
+        return result;
+      },
+      async discardDraft(draftId, options) {
+        cleanupWaiting = true;
+        await Promise.race([
+          secondStarted,
+          new Promise<void>((resolve) => setTimeout(resolve, 100)),
+        ]);
+        if (appendCalls > 1) await secondCommitted;
+        await baseController.discardDraft(draftId, options);
+        cleanupFinished = true;
+      },
+    };
+    const callContext = { ...context, draftController: controller };
+    const command = cmd("CreateDataSource", {
+      id: crypto.randomUUID(),
+      type: "csv",
+      name: "queued append",
+    });
+
+    const firstResult = app
+      .call("draftBatch", { commands: [command] }, callContext)
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    await firstAppend;
+    const draftId = await opened;
+
+    const queuedResult = app
+      .call(
+        "draftBatch",
+        {
+          draftId,
+          commands: [
+            cmd("CreateDataSource", {
+              id: crypto.randomUUID(),
+              type: "csv",
+              name: "must not be swept",
+            }),
+          ],
+        },
+        callContext,
+      )
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    await secondValidated;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseFirstAppend();
+
+    expect(await firstResult).toEqual(
+      new Error("first batch failed before any write"),
+    );
+    expect(await queuedResult).toEqual(new Error("draft is unavailable"));
+    expect(appendCalls).toBe(1);
+    expect(await baseController.draftExists(draftId)).toBe(false);
+    expect(await baseController.getDraftLog(draftId)).toEqual([]);
   });
 });

--- a/apps/server/src/functions/draft-batch.ts
+++ b/apps/server/src/functions/draft-batch.ts
@@ -65,6 +65,37 @@ function requireDraftController(
   return controller;
 }
 
+async function rethrowFailedBatch(
+  controller: DraftController,
+  targetDraftId: string,
+  openedHere: boolean,
+  error: unknown,
+): Promise<never> {
+  const recoveredWrites = recoveredDraftWriteTables(error);
+  // A rejected batch can still have an earlier, atomically logged prefix.
+  // Add the log table to the controller's shadow-table metadata so the host
+  // can invalidate and schedule persistence before rethrowing the same error.
+  if (recoveredWrites.length > 0) {
+    addRecoveredDraftWriteTables(error, [DRAFT_COMMAND_LOG_TABLE]);
+    // Only a newly opened, already-owned handle is attached. This lets the
+    // caller retain a durable successful prefix without exposing any
+    // caller-supplied or foreign handle.
+    if (openedHere && error instanceof Error) {
+      (error as DraftBatchError).draftId = targetDraftId;
+    }
+  } else if (openedHere) {
+    // A first-command failure has no durable work to recover. Remove only
+    // the handle opened by this call; caller-carried handles are untouched.
+    // Cleanup must not replace the command's original error.
+    try {
+      await controller.discardDraft(targetDraftId);
+    } catch {
+      // Preserve the original command failure for the caller.
+    }
+  }
+  throw error;
+}
+
 const draftBatch = wy.procedure
   .input({ commands: jsonb, draftId: text.optional() })
   .authorize(permissions.commands.draft)
@@ -86,47 +117,45 @@ const draftBatch = wy.procedure
     }
     const targetDraftId =
       draftId ?? (await controller.openDraft(undefined, ownerKey));
+    const openedHere = draftId === undefined;
     const context: Record<string, unknown> = {};
     if (ctx.principal !== undefined) context.principal = ctx.principal;
     if (ctx.vault !== undefined) context.vault = ctx.vault;
-    let results: CommandResult[];
-    try {
-      results = await serializeAppend(targetDraftId, async () => {
-        // The handle may close while this append waits behind another writer.
-        if (!(await controller.draftOwnedBy(targetDraftId, ownerKey))) {
-          throw new Error(DRAFT_UNAVAILABLE);
-        }
+    const results: CommandResult[] = await serializeAppend(
+      targetDraftId,
+      async () => {
         try {
-          return await controller.appendToDraft(
-            targetDraftId,
-            commands as Command[],
-            context,
-          );
-        } catch (error) {
-          if (
-            error instanceof DraftLogStaleError &&
-            !(await controller.draftOwnedBy(targetDraftId, ownerKey))
-          ) {
+          // The handle may close while this append waits behind another writer.
+          if (!(await controller.draftOwnedBy(targetDraftId, ownerKey))) {
             throw new Error(DRAFT_UNAVAILABLE);
           }
-          throw error;
+          try {
+            return await controller.appendToDraft(
+              targetDraftId,
+              commands as Command[],
+              context,
+            );
+          } catch (error) {
+            if (
+              error instanceof DraftLogStaleError &&
+              !(await controller.draftOwnedBy(targetDraftId, ownerKey))
+            ) {
+              throw new Error(DRAFT_UNAVAILABLE);
+            }
+            throw error;
+          }
+        } catch (error) {
+          // Cleanup stays inside the serialized callback so a queued append
+          // cannot commit between this failure and removal of an empty handle.
+          return rethrowFailedBatch(
+            controller,
+            targetDraftId,
+            openedHere,
+            error,
+          );
         }
-      });
-    } catch (err) {
-      // A rejected batch can still have an earlier, atomically logged prefix.
-      // Add the log table to the controller's shadow-table metadata so the host
-      // can invalidate and schedule persistence before rethrowing the same error.
-      if (recoveredDraftWriteTables(err).length > 0) {
-        addRecoveredDraftWriteTables(err, [DRAFT_COMMAND_LOG_TABLE]);
-        // Only a newly opened, already-owned handle is attached. This lets the
-        // caller retain a durable successful prefix without exposing any
-        // caller-supplied or foreign handle.
-        if (draftId === undefined && err instanceof Error) {
-          (err as DraftBatchError).draftId = targetDraftId;
-        }
-      }
-      throw err;
-    }
+      },
+    );
 
     return {
       draftId: targetDraftId,

--- a/apps/server/src/functions/draft-batch.ts
+++ b/apps/server/src/functions/draft-batch.ts
@@ -1,10 +1,12 @@
 import { jsonb, text } from "@wystack/db";
 import type { Command, CommandResult } from "@wystack/server";
 
-import type { DashframeFunctionContext } from "../app-context";
+import { principalKey, type DashframeFunctionContext } from "../app-context";
+import { DRAFT_UNAVAILABLE } from "../draft-access";
 import {
   addRecoveredDraftWriteTables,
   DRAFT_COMMAND_LOG_TABLE,
+  DraftLogStaleError,
   recoveredDraftWriteTables,
   type DraftController,
 } from "../draft-controller";
@@ -13,6 +15,16 @@ import { wy } from "../wystack";
 import { assertKnownCommandPaths } from "./commands";
 
 const appendTails = new Map<string, Promise<void>>();
+
+export interface DraftBatchError extends Error {
+  draftId?: string;
+}
+
+export function draftIdFromBatchError(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const draftId = (error as DraftBatchError).draftId;
+  return typeof draftId === "string" ? draftId : undefined;
+}
 
 /**
  * This RPC owns an in-process promise chain per durable draft handle so its
@@ -63,28 +75,55 @@ const draftBatch = wy.procedure
     assertKnownCommandPaths(commands as Command[], "draftBatch");
 
     const controller = requireDraftController(ctx);
-    // A caller-supplied handle must already be registered. The command log and
-    // the shadow tables accept any id, so appending under an unknown draftId
-    // would return 200 and write rows that `listDrafts` never surfaces and no
-    // publish or discard can ever sweep — invisible, permanent orphans.
-    if (draftId !== undefined && !(await controller.draftExists(draftId))) {
-      throw new Error(`draftBatch: no open draft ${draftId}`);
+    const ownerKey = principalKey(ctx.principal);
+    if (ownerKey === null) throw new Error(DRAFT_UNAVAILABLE);
+    // One predicate and one response for unknown, closed, and foreign handles.
+    if (
+      draftId !== undefined &&
+      !(await controller.draftOwnedBy(draftId, ownerKey))
+    ) {
+      throw new Error(DRAFT_UNAVAILABLE);
     }
-    const targetDraftId = draftId ?? (await controller.openDraft());
+    const targetDraftId =
+      draftId ?? (await controller.openDraft(undefined, ownerKey));
     const context: Record<string, unknown> = {};
     if (ctx.principal !== undefined) context.principal = ctx.principal;
     if (ctx.vault !== undefined) context.vault = ctx.vault;
     let results: CommandResult[];
     try {
-      results = await serializeAppend(targetDraftId, () =>
-        controller.appendToDraft(targetDraftId, commands as Command[], context),
-      );
+      results = await serializeAppend(targetDraftId, async () => {
+        // The handle may close while this append waits behind another writer.
+        if (!(await controller.draftOwnedBy(targetDraftId, ownerKey))) {
+          throw new Error(DRAFT_UNAVAILABLE);
+        }
+        try {
+          return await controller.appendToDraft(
+            targetDraftId,
+            commands as Command[],
+            context,
+          );
+        } catch (error) {
+          if (
+            error instanceof DraftLogStaleError &&
+            !(await controller.draftOwnedBy(targetDraftId, ownerKey))
+          ) {
+            throw new Error(DRAFT_UNAVAILABLE);
+          }
+          throw error;
+        }
+      });
     } catch (err) {
       // A rejected batch can still have an earlier, atomically logged prefix.
       // Add the log table to the controller's shadow-table metadata so the host
       // can invalidate and schedule persistence before rethrowing the same error.
       if (recoveredDraftWriteTables(err).length > 0) {
         addRecoveredDraftWriteTables(err, [DRAFT_COMMAND_LOG_TABLE]);
+        // Only a newly opened, already-owned handle is attached. This lets the
+        // caller retain a durable successful prefix without exposing any
+        // caller-supplied or foreign handle.
+        if (draftId === undefined && err instanceof Error) {
+          (err as DraftBatchError).draftId = targetDraftId;
+        }
       }
       throw err;
     }

--- a/apps/server/src/functions/draft-lifecycle.ts
+++ b/apps/server/src/functions/draft-lifecycle.ts
@@ -32,6 +32,7 @@ import {
   collectSupersededRefs,
   releaseRefsAtTransition,
 } from "../credential-release";
+import { assertDraftAccess } from "../draft-access";
 import {
   DRAFT_COMMAND_LOG_TABLE,
   DRAFT_METADATA_TABLE,
@@ -426,6 +427,7 @@ const getDraftLog = wy.procedure
       );
     }
 
+    await assertDraftAccess(draftController, ctx.principal, draftId);
     return draftController.getDraftLog(draftId);
   });
 

--- a/apps/server/src/functions/draft-review.test.ts
+++ b/apps/server/src/functions/draft-review.test.ts
@@ -271,7 +271,10 @@ describe("draft review RPC workflow", () => {
   });
 
   it("serializes concurrent appends to one draft into a dense log", async () => {
-    const draftId = await controller.openDraft();
+    const draftId = await controller.openDraft(
+      undefined,
+      `service:${service.credentialId}`,
+    );
     await Promise.all([
       call(
         "draftBatch",
@@ -309,5 +312,56 @@ describe("draft review RPC workflow", () => {
       .from(draftCommandLog)
       .orderBy(draftCommandLog.seq);
     expect(rows).toEqual([{ seq: 0 }, { seq: 1 }]);
+  });
+
+  it("normalizes a queued append whose owned draft closes before execution", async () => {
+    const ownerKey = `service:${service.credentialId}`;
+    const draftId = await controller.openDraft(undefined, ownerKey);
+    const original = controller;
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered!: () => void;
+    const firstEntered = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    controller = {
+      ...original,
+      appendToDraft: async (...args) => {
+        entered();
+        await blocked;
+        return original.appendToDraft(...args);
+      },
+    };
+
+    const append = () =>
+      call(
+        "draftBatch",
+        {
+          draftId,
+          commands: [
+            cmd("CreateDashboard", {
+              id: crypto.randomUUID(),
+              name: "Queued close race",
+            }),
+          ],
+        },
+        service,
+      );
+    const first = append();
+    await firstEntered;
+    const queued = append();
+    const firstRejected = expect(first).rejects.toThrow(
+      /^draft is unavailable$/,
+    );
+    const queuedRejected = expect(queued).rejects.toThrow(
+      /^draft is unavailable$/,
+    );
+    await original.discardDraft(draftId);
+    release();
+
+    await firstRejected;
+    await queuedRejected;
   });
 });

--- a/apps/server/src/functions/drafts.test.ts
+++ b/apps/server/src/functions/drafts.test.ts
@@ -337,7 +337,7 @@ describe("draft publish functions", () => {
           principal: { kind: "user", userId: LOCAL_USER_ID },
         },
       ),
-    ).rejects.toThrow(/no open draft/);
+    ).rejects.toThrow(/^draft is unavailable$/);
 
     // Nothing was written: an accepted append here would be permanently
     // invisible to listDrafts and unreachable by publish or discard.

--- a/apps/server/src/functions/drafts.ts
+++ b/apps/server/src/functions/drafts.ts
@@ -7,6 +7,8 @@ import type { PreviewDiff } from "@dashframe/types";
 import { text } from "@wystack/db";
 import type { Command, WyStackApp } from "@wystack/server";
 
+import { principalKey } from "../app-context";
+import { assertDraftAccess } from "../draft-access";
 import { createDraftController } from "../draft-controller";
 import { findLateBound, type LateBoundOperandRef } from "../draft-late-bound";
 import { computeLogSignature } from "../draft-log-signature";
@@ -109,6 +111,7 @@ const draftPublishReview = wy.procedure
   .query(async (ctx, { draftId }): Promise<DraftPublishReview> => {
     const { app, db } = requireServerContext(ctx);
     const controller = createDraftController(app, db);
+    await assertDraftAccess(controller, ctx.principal, draftId);
     const draftExists = await controller.draftExists(draftId);
     const commands = await controller.getDraftLog(draftId);
     const lateBound = findLateBound(commands);
@@ -148,7 +151,17 @@ const listDrafts = wy.procedure
     const controller =
       asDraftFunctionContext(ctx).draftController ??
       createDraftController(app, db);
-    return controller.listDrafts();
+    const drafts = await controller.listDrafts();
+    if (ctx.principal?.kind === "user") return drafts;
+    const key = principalKey(ctx.principal);
+    if (key === null) return [];
+    const owned = await Promise.all(
+      drafts.map(async (draft) => ({
+        draft,
+        allowed: await controller.draftOwnedBy(draft.draftId, key),
+      })),
+    );
+    return owned.filter(({ allowed }) => allowed).map(({ draft }) => draft);
   });
 
 export const draftFunctions = {

--- a/apps/server/src/functions/drafts.ts
+++ b/apps/server/src/functions/drafts.ts
@@ -151,17 +151,10 @@ const listDrafts = wy.procedure
     const controller =
       asDraftFunctionContext(ctx).draftController ??
       createDraftController(app, db);
-    const drafts = await controller.listDrafts();
-    if (ctx.principal?.kind === "user") return drafts;
+    if (ctx.principal?.kind === "user") return controller.listDrafts();
     const key = principalKey(ctx.principal);
     if (key === null) return [];
-    const owned = await Promise.all(
-      drafts.map(async (draft) => ({
-        draft,
-        allowed: await controller.draftOwnedBy(draft.draftId, key),
-      })),
-    );
-    return owned.filter(({ allowed }) => allowed).map(({ draft }) => draft);
+    return controller.listDrafts(key);
   });
 
 export const draftFunctions = {

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -166,18 +166,6 @@ describe("dashframe serve CLI", () => {
       });
     });
 
-    it("should parse both MCP transport modes and reject unknown modes", () => {
-      expect(parseArgs(["--mcp-mode", "stateful"])).toEqual({
-        mcpMode: "stateful",
-      });
-      expect(parseArgs(["--mcp-mode", "stateless"])).toEqual({
-        mcpMode: "stateless",
-      });
-      expect(() => parseArgs(["--mcp-mode", "hybrid"])).toThrow(
-        /expected "stateful" or "stateless"/,
-      );
-    });
-
     it("should parse the host-local data directory independently", () => {
       expect(
         parseArgs([
@@ -227,7 +215,6 @@ describe("dashframe serve CLI", () => {
       expect(helpText).toContain("--bind <addr>");
       expect(helpText).toContain("--token <token>");
       expect(helpText).toContain("--data-dir <dir>");
-      expect(helpText).toContain("--mcp-mode <mode>");
       expect(helpText).toContain("canonical padded base64");
       expect(helpText).toContain("Security boundary:");
       expect(helpText).toContain("non-loopback bind");

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -180,6 +180,18 @@ describe("dashframe serve CLI", () => {
       });
     });
 
+    it("should parse both MCP transport modes and reject unknown modes", () => {
+      expect(parseArgs(["--mcp-mode", "stateful"])).toEqual({
+        mcpMode: "stateful",
+      });
+      expect(parseArgs(["--mcp-mode", "stateless"])).toEqual({
+        mcpMode: "stateless",
+      });
+      expect(() => parseArgs(["--mcp-mode", "hybrid"])).toThrow(
+        /expected "stateful" or "stateless"/,
+      );
+    });
+
     it("should reject an unbracketed IPv6 bind with a bracket hint", () => {
       // eslint-disable-next-line sonarjs/no-hardcoded-ip -- the malformed literal is the input under test
       expect(() => parseArgs(["--bind", "::1:4000"])).toThrow(
@@ -215,6 +227,7 @@ describe("dashframe serve CLI", () => {
       expect(helpText).toContain("--bind <addr>");
       expect(helpText).toContain("--token <token>");
       expect(helpText).toContain("--data-dir <dir>");
+      expect(helpText).toContain("--mcp-mode <mode>");
       expect(helpText).toContain("canonical padded base64");
       expect(helpText).toContain("Security boundary:");
       expect(helpText).toContain("non-loopback bind");

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -166,6 +166,18 @@ describe("dashframe serve CLI", () => {
       });
     });
 
+    it("should parse both MCP transport modes and reject unknown modes", () => {
+      expect(parseArgs(["--mcp-mode", "stateful"])).toEqual({
+        mcpMode: "stateful",
+      });
+      expect(parseArgs(["--mcp-mode", "stateless"])).toEqual({
+        mcpMode: "stateless",
+      });
+      expect(() => parseArgs(["--mcp-mode", "hybrid"])).toThrow(
+        /expected "stateful" or "stateless"/,
+      );
+    });
+
     it("should parse the host-local data directory independently", () => {
       expect(
         parseArgs([
@@ -215,6 +227,7 @@ describe("dashframe serve CLI", () => {
       expect(helpText).toContain("--bind <addr>");
       expect(helpText).toContain("--token <token>");
       expect(helpText).toContain("--data-dir <dir>");
+      expect(helpText).toContain("--mcp-mode <mode>");
       expect(helpText).toContain("canonical padded base64");
       expect(helpText).toContain("Security boundary:");
       expect(helpText).toContain("non-loopback bind");

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from "./app";
 import { isLoopbackHost } from "./bind-host";
 import { readOptionalGoogleOAuthConfig } from "./connector-setup/oauth-provider";
+import type { McpMode } from "./mcp/route";
 import {
   ENCRYPTED_FILE_BACKEND_NAME,
   EncryptedFileSecretBackend,
@@ -39,6 +40,7 @@ import {
 export interface CliOptions {
   hostname?: string;
   port?: number;
+  mcpMode?: McpMode;
   project?: string;
   dataDir?: string;
   name?: string;
@@ -64,6 +66,7 @@ Options:
   --token <token>         Require Bearer token auth for HTTP and WebSocket clients
   --host <host>           Bind host alias (default: 127.0.0.1)
   --port <port>           Bind port alias (default: 0, OS-assigned)
+  --mcp-mode <mode>       MCP transport: stateful (default) or stateless
   --name <name>           Project display name when initializing
   --cors-origin <origin>  Allowed browser origin; repeat or comma-separate for multiple
   --insecure              Allow a non-loopback bind without --token (opt out of the auth requirement)
@@ -108,6 +111,13 @@ function readValue(args: string[], index: number, flag: string): string {
     throw new Error(`${flag} requires a value`);
   }
   return value;
+}
+
+function parseMcpMode(raw: string): McpMode {
+  if (raw === "stateful" || raw === "stateless") return raw;
+  throw new Error(
+    `Invalid --mcp-mode "${raw}": expected "stateful" or "stateless"`,
+  );
 }
 
 export function parsePort(raw: string): number {
@@ -214,6 +224,9 @@ function parseArgAt(opts: CliOptions, args: string[], index: number): number {
       return index + 1;
     case "--port":
       opts.port = parsePort(readValue(args, index, arg));
+      return index + 1;
+    case "--mcp-mode":
+      opts.mcpMode = parseMcpMode(readValue(args, index, arg));
       return index + 1;
     case "--project":
       opts.project = readValue(args, index, arg);
@@ -454,6 +467,7 @@ export function createStandaloneServerOptions(
     ),
     hostname: opts.hostname,
     port: opts.port,
+    mcpMode: opts.mcpMode,
     corsOrigin: opts.corsOrigin,
     authToken: opts.token,
     arrowEngine,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -30,7 +30,6 @@ import {
 } from "./app";
 import { isLoopbackHost } from "./bind-host";
 import { readOptionalGoogleOAuthConfig } from "./connector-setup/oauth-provider";
-import type { McpMode } from "./mcp/route";
 import {
   ENCRYPTED_FILE_BACKEND_NAME,
   EncryptedFileSecretBackend,
@@ -40,7 +39,6 @@ import {
 export interface CliOptions {
   hostname?: string;
   port?: number;
-  mcpMode?: McpMode;
   project?: string;
   dataDir?: string;
   name?: string;
@@ -66,7 +64,6 @@ Options:
   --token <token>         Require Bearer token auth for HTTP and WebSocket clients
   --host <host>           Bind host alias (default: 127.0.0.1)
   --port <port>           Bind port alias (default: 0, OS-assigned)
-  --mcp-mode <mode>       MCP transport: stateful (default) or stateless
   --name <name>           Project display name when initializing
   --cors-origin <origin>  Allowed browser origin; repeat or comma-separate for multiple
   --insecure              Allow a non-loopback bind without --token (opt out of the auth requirement)
@@ -111,13 +108,6 @@ function readValue(args: string[], index: number, flag: string): string {
     throw new Error(`${flag} requires a value`);
   }
   return value;
-}
-
-function parseMcpMode(raw: string): McpMode {
-  if (raw === "stateful" || raw === "stateless") return raw;
-  throw new Error(
-    `Invalid --mcp-mode "${raw}": expected "stateful" or "stateless"`,
-  );
 }
 
 export function parsePort(raw: string): number {
@@ -224,9 +214,6 @@ function parseArgAt(opts: CliOptions, args: string[], index: number): number {
       return index + 1;
     case "--port":
       opts.port = parsePort(readValue(args, index, arg));
-      return index + 1;
-    case "--mcp-mode":
-      opts.mcpMode = parseMcpMode(readValue(args, index, arg));
       return index + 1;
     case "--project":
       opts.project = readValue(args, index, arg);
@@ -467,7 +454,6 @@ export function createStandaloneServerOptions(
     ),
     hostname: opts.hostname,
     port: opts.port,
-    mcpMode: opts.mcpMode,
     corsOrigin: opts.corsOrigin,
     authToken: opts.token,
     arrowEngine,

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -238,7 +238,9 @@ describe("MCP route", () => {
     );
 
     await expect(tool!.execute({})).rejects.toThrow(/^draft is unavailable$/);
-    expect(readDraftIds).toEqual([originalDraftId]);
+    expect(readDraftIds.length).toBeGreaterThan(0);
+    expect(new Set(readDraftIds)).toEqual(new Set([originalDraftId]));
+    expect(checks).toBe(2);
   });
 
   it("mints the credential as a user before the MCP service-principal round trip", async () => {
@@ -450,7 +452,7 @@ describe("MCP route", () => {
     }
   });
 
-  it("opens a fresh draft when a person has already discarded the supplied draft", async () => {
+  it("keeps a discarded caller-carried draft id unavailable", async () => {
     const { client, transport } = await connect();
     try {
       const write = async (name: string, draftId?: string) =>
@@ -888,6 +890,51 @@ describe("MCP route", () => {
     });
     expect(malformed.status).toBe(400);
     expect(await malformed.json()).toMatchObject({ error: { code: -32700 } });
+  });
+
+  it("rejects authenticated JSON-RPC arrays with HTTP 400", async () => {
+    const response = await fetch(`${server!.url}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        ...bearer(serviceToken),
+      },
+      body: JSON.stringify([{ jsonrpc: "2.0", id: 1, method: "tools/list" }]),
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { code: -32600 } });
+  });
+
+  it("removes a server-opened empty draft after the first command fails", async () => {
+    const { client, transport } = await connect();
+    try {
+      const missingId = crypto.randomUUID();
+      const result = await client.callTool({
+        name: "draft_batch",
+        arguments: {
+          commands: [
+            {
+              type: "SetChartType",
+              args: { id: missingId, visualizationType: "bar" },
+            },
+          ],
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain(
+        `Visualization ${missingId} not found`,
+      );
+      expect(result.structuredContent).toBeUndefined();
+      expect(
+        await project!.db.select().from(schema.draftMetadata),
+      ).toHaveLength(0);
+      expect(
+        await project!.db.select().from(schema.draftCommandLog),
+      ).toHaveLength(0);
+    } finally {
+      await transport.close();
+    }
   });
 
   /** Stateful mode keeps one credential-bound session and remembered draft. */

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -24,7 +24,6 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createDashframeServer, type DashframeServer } from "../app";
-import type { McpMode } from "./route";
 import { createMcpTools } from "./tools";
 
 const USER_TOKEN = "mcp-test-user-token";
@@ -85,7 +84,7 @@ describe("MCP route", () => {
   let server: DashframeServer | null = null;
   let serviceToken: string;
 
-  async function start(mode: McpMode): Promise<void> {
+  async function start(): Promise<void> {
     server?.stop();
     await project?.close();
     server = null;
@@ -99,7 +98,6 @@ describe("MCP route", () => {
       accessCredentials,
       vault,
       authToken: USER_TOKEN,
-      mcpMode: mode,
     });
 
     const issued = await fetch(`${server.url}/api/issueAccessCredential`, {
@@ -115,7 +113,7 @@ describe("MCP route", () => {
   }
 
   beforeEach(async () => {
-    await start("stateless");
+    await start();
   });
 
   afterEach(async () => {
@@ -159,11 +157,10 @@ describe("MCP route", () => {
         return { result: [] };
       },
     } as unknown as Parameters<typeof createMcpTools>[0];
-    const tool = createMcpTools(
-      fakeApp,
-      { principal: { kind: "service", credentialId: "test" }, draftId },
-      "stateless",
-    ).find((candidate) => candidate.name === "find_nodes");
+    const tool = createMcpTools(fakeApp, {
+      principal: { kind: "service", credentialId: "test" },
+      draftId,
+    }).find((candidate) => candidate.name === "find_nodes");
 
     await expect(tool!.execute({})).rejects.toThrow(/is no longer open/i);
   });
@@ -247,7 +244,8 @@ describe("MCP route", () => {
         {
           name: "read_graph",
           // Preserve the assistant boundary's Convert-then-Check contract in
-          // stateless mode; models commonly emit numeric arguments as strings.
+          // Preserve the assistant boundary's coercion contract; models commonly
+          // emit numeric arguments as strings.
           args: { from: { kind: "dataSource", id: missingId }, depth: "0" },
           structured: { reached: [] },
           text: "Reached 0 node(s) within 0 hop(s).",
@@ -693,111 +691,6 @@ describe("MCP route", () => {
     });
     expect(malformed.status).toBe(400);
     expect(await malformed.json()).toMatchObject({ error: { code: -32700 } });
-  });
-
-  it("preserves stateful sessions and their server-carried draft continuity", async () => {
-    await start("stateful");
-    const { client, transport } = await connect();
-    try {
-      expect(transport.sessionId).toEqual(expect.any(String));
-      const listed = await client.listTools();
-      const readSchema = listed.tools.find((tool) => tool.name === "find_nodes")
-        ?.inputSchema as { properties?: Record<string, unknown> };
-      const writeSchema = listed.tools.find(
-        (tool) => tool.name === "draft_batch",
-      )?.inputSchema as { properties?: Record<string, unknown> };
-      expect(readSchema.properties).not.toHaveProperty("draftId");
-      expect(writeSchema.properties).not.toHaveProperty("draftId");
-
-      const write = async (id: string, name: string) =>
-        client.callTool({
-          name: "draft_batch",
-          arguments: {
-            commands: [{ type: "CreateDashboard", args: { id, name } }],
-          },
-        });
-      const first = await write(crypto.randomUUID(), "Stateful first");
-      const second = await write(crypto.randomUUID(), "Stateful second");
-      const firstId = (first.structuredContent as { draftId: string }).draftId;
-      expect(second.structuredContent).toMatchObject({ draftId: firstId });
-
-      const foreign = await fetch(`${server!.url}/api/draftBatch`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
-        body: JSON.stringify({
-          commands: [
-            {
-              path: "createDashboardCmd",
-              args: {
-                id: crypto.randomUUID(),
-                name: "Foreign stateful draft",
-              },
-            },
-          ],
-        }),
-      });
-      expect(foreign.status).toBe(200);
-      const foreignId = (
-        (await foreign.json()) as { data: { draftId: string } }
-      ).data.draftId;
-      expect(foreignId).not.toBe(firstId);
-
-      const hiddenOverride = await client.callTool({
-        name: "draft_batch",
-        arguments: {
-          draftId: foreignId,
-          commands: [
-            {
-              type: "CreateDashboard",
-              args: {
-                id: crypto.randomUUID(),
-                name: "Stateful hidden override",
-              },
-            },
-          ],
-        },
-      });
-      expect(hiddenOverride.structuredContent).toMatchObject({
-        draftId: firstId,
-      });
-
-      const read = await client.callTool({
-        name: "find_nodes",
-        arguments: { name: "Stateful" },
-      });
-      const names = (
-        read.structuredContent as { hits: Array<{ name: string }> }
-      ).hits
-        .map((hit) => hit.name)
-        .sort();
-      expect(names).toEqual([
-        "Stateful first",
-        "Stateful hidden override",
-        "Stateful second",
-      ]);
-
-      const issued = await fetch(`${server!.url}/api/issueAccessCredential`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
-        body: JSON.stringify({ name: "Other MCP integration" }),
-      });
-      const otherToken = (
-        (await issued.json()) as { data: { accessCredential: string } }
-      ).data.accessCredential;
-      const stolen = await fetch(`${server!.url}/mcp`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json, text/event-stream",
-          "Mcp-Session-Id": transport.sessionId!,
-          ...bearer(otherToken),
-        },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/list" }),
-      });
-      expect(stolen.status).toBe(403);
-    } finally {
-      await transport.close();
-    }
   });
 
   /**

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -243,7 +243,6 @@ describe("MCP route", () => {
         },
         {
           name: "read_graph",
-          // Preserve the assistant boundary's Convert-then-Check contract in
           // Preserve the assistant boundary's coercion contract; models commonly
           // emit numeric arguments as strings.
           args: { from: { kind: "dataSource", id: missingId }, depth: "0" },

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -24,12 +24,27 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createDashframeServer, type DashframeServer } from "../app";
+import type { McpMode } from "./route";
 import { createMcpTools } from "./tools";
 
 const USER_TOKEN = "mcp-test-user-token";
 
 function bearer(token: string): { Authorization: string } {
   return { Authorization: `Bearer ${token}` };
+}
+
+function writeDashboard(client: Client, name: string) {
+  return client.callTool({
+    name: "draft_batch",
+    arguments: {
+      commands: [
+        {
+          type: "CreateDashboard",
+          args: { id: crypto.randomUUID(), name },
+        },
+      ],
+    },
+  });
 }
 
 /**
@@ -83,8 +98,16 @@ describe("MCP route", () => {
   let project: ProjectHandle | null = null;
   let server: DashframeServer | null = null;
   let serviceToken: string;
+  let accessCredentials: ApiAccessCredentials;
 
-  async function start(): Promise<void> {
+  async function start(
+    mode: McpMode,
+    sessionOptions: {
+      mcpMaxStatefulSessions?: number;
+      mcpStatefulSessionTtlMs?: number;
+      mcpSessionNow?: () => number;
+    } = {},
+  ): Promise<void> {
     server?.stop();
     await project?.close();
     server = null;
@@ -92,12 +115,16 @@ describe("MCP route", () => {
     if (root !== "") rmSync(root, { recursive: true, force: true });
     root = mkdtempSync(join(tmpdir(), "dashframe-mcp-"));
     project = await openProject({ dir: join(root, "project") });
-    const { vault, accessCredentials } = makeVault(join(root, "credentials"));
+    const vaultBundle = makeVault(join(root, "credentials"));
+    const { vault } = vaultBundle;
+    accessCredentials = vaultBundle.accessCredentials;
     server = await createDashframeServer({
       db: project.db,
       accessCredentials,
       vault,
       authToken: USER_TOKEN,
+      mcpMode: mode,
+      ...sessionOptions,
     });
 
     const issued = await fetch(`${server.url}/api/issueAccessCredential`, {
@@ -113,7 +140,7 @@ describe("MCP route", () => {
   }
 
   beforeEach(async () => {
-    await start();
+    await start("stateless");
   });
 
   afterEach(async () => {
@@ -125,16 +152,21 @@ describe("MCP route", () => {
     root = "";
   });
 
-  async function connect(): Promise<{
+  async function connect(token = serviceToken): Promise<{
     client: Client;
     transport: StreamableHTTPClientTransport;
   }> {
     const client = new Client({ name: "dashframe-mcp-test", version: "1.0.0" });
     const transport = new StreamableHTTPClientTransport(
       new URL(`${server!.url}/mcp`),
-      { requestInit: { headers: bearer(serviceToken) } },
+      { requestInit: { headers: bearer(token) } },
     );
-    await client.connect(transport);
+    try {
+      await client.connect(transport);
+    } catch (error) {
+      await transport.close().catch(() => undefined);
+      throw error;
+    }
     return { client, transport };
   }
 
@@ -157,12 +189,56 @@ describe("MCP route", () => {
         return { result: [] };
       },
     } as unknown as Parameters<typeof createMcpTools>[0];
-    const tool = createMcpTools(fakeApp, {
-      principal: { kind: "service", credentialId: "test" },
-      draftId,
-    }).find((candidate) => candidate.name === "find_nodes");
+    const tool = createMcpTools(
+      fakeApp,
+      { principal: { kind: "service", credentialId: "test" }, draftId },
+      "stateless",
+    ).find((candidate) => candidate.name === "find_nodes");
 
-    await expect(tool!.execute({})).rejects.toThrow(/is no longer open/i);
+    await expect(tool!.execute({})).rejects.toThrow(/draft is unavailable/i);
+  });
+
+  it("validates and reads one snapshotted stateful draft handle", async () => {
+    const originalDraftId = crypto.randomUUID();
+    const replacementDraftId = crypto.randomUUID();
+    const requestContext = {
+      principal: { kind: "service" as const, credentialId: "test" },
+      draftId: originalDraftId,
+    };
+    let checks = 0;
+    const readDraftIds: unknown[] = [];
+    const fakeApp = {
+      createTracked() {
+        return {};
+      },
+      async runHandler(
+        _path: string,
+        _args: unknown,
+        _tracked: unknown,
+        context: Record<string, unknown>,
+      ) {
+        readDraftIds.push(context.draftId);
+        requestContext.draftId = replacementDraftId;
+        return [];
+      },
+      async call(path: string) {
+        if (path === "listDrafts") {
+          return {
+            result:
+              checks++ === 0
+                ? [{ draftId: originalDraftId }]
+                : [{ draftId: replacementDraftId }],
+          };
+        }
+        return { result: [] };
+      },
+    } as unknown as Parameters<typeof createMcpTools>[0];
+    const tool = createMcpTools(fakeApp, requestContext, "stateful").find(
+      (candidate) => candidate.name === "find_nodes",
+    );
+
+    await expect(tool!.execute({})).rejects.toThrow(/^draft is unavailable$/);
+    expect(readDraftIds).toEqual([originalDraftId]);
   });
 
   it("mints the credential as a user before the MCP service-principal round trip", async () => {
@@ -414,17 +490,30 @@ describe("MCP route", () => {
         client,
         "find_nodes",
         { name: "Before the discard", draftId: firstId },
-        /is no longer open/i,
+        /draft is unavailable/i,
       );
 
-      const second = await write("After the discard", firstId);
-      expect(second.isError).not.toBe(true);
-      const secondId = (second.structuredContent as { draftId: string })
-        .draftId;
-      expect(secondId).not.toBe(firstId);
+      await expectToolError(
+        client,
+        "draft_batch",
+        {
+          draftId: firstId,
+          commands: [
+            {
+              type: "CreateDataSource",
+              args: {
+                id: crypto.randomUUID(),
+                type: "csv",
+                name: "After the discard",
+              },
+            },
+          ],
+        },
+        /draft is unavailable/i,
+      );
       expect(
         await project!.db.select().from(schema.draftCommandLog),
-      ).toHaveLength(1);
+      ).toHaveLength(0);
     } finally {
       await transport.close();
     }
@@ -509,6 +598,115 @@ describe("MCP route", () => {
       ).toHaveLength(0);
     } finally {
       await transport.close();
+    }
+  });
+
+  it("isolates stateless drafts by credential without leaking handle existence", async () => {
+    const owner = await connect();
+    let other: Awaited<ReturnType<typeof connect>> | undefined;
+    try {
+      const sourceId = crypto.randomUUID();
+      const opened = await owner.client.callTool({
+        name: "draft_batch",
+        arguments: {
+          commands: [
+            {
+              type: "CreateDataSource",
+              args: { id: sourceId, type: "csv", name: "Owner only" },
+            },
+          ],
+        },
+      });
+      const draftId = (opened.structuredContent as { draftId: string }).draftId;
+
+      const issued = await fetch(`${server!.url}/api/issueAccessCredential`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
+        body: JSON.stringify({ name: "Other MCP integration" }),
+      });
+      expect(issued.status).toBe(200);
+      const otherToken = (
+        (await issued.json()) as { data: { accessCredential: string } }
+      ).data.accessCredential;
+      expect(otherToken).not.toBe(serviceToken);
+      const ownerCredentialId =
+        await accessCredentials.authenticate(serviceToken);
+      const otherCredentialId =
+        await accessCredentials.authenticate(otherToken);
+      expect(otherCredentialId).not.toBe(ownerCredentialId);
+      expect(
+        (
+          await project!.db
+            .select({ owner: schema.draftMetadata.ownerPrincipalKey })
+            .from(schema.draftMetadata)
+        )[0]?.owner,
+      ).toBe(`service:${ownerCredentialId}`);
+      const legacyDraftId = crypto.randomUUID();
+      await project!.db.insert(schema.draftMetadata).values({
+        draftId: legacyDraftId,
+        baseVersion: new Date(),
+        logRevision: 0,
+      });
+      other = await connect(otherToken);
+
+      await expectToolError(
+        other.client,
+        "draft_batch",
+        {
+          draftId,
+          commands: [
+            {
+              type: "CreateDashboard",
+              args: { id: crypto.randomUUID(), name: "Must not land" },
+            },
+          ],
+        },
+        /^draft is unavailable$/i,
+      );
+      await expectToolError(
+        other.client,
+        "find_nodes",
+        { name: "Owner only", draftId },
+        /^draft is unavailable$/i,
+      );
+
+      const listUrl = new URL(`${server!.url}/api/listDrafts`);
+      listUrl.searchParams.set("args", JSON.stringify({}));
+      const otherList = await fetch(listUrl, { headers: bearer(otherToken) });
+      expect((await otherList.json()) as unknown).toMatchObject({ data: [] });
+
+      const humanList = await fetch(listUrl, { headers: bearer(USER_TOKEN) });
+      const humanDraftIds = (
+        (await humanList.json()) as { data: Array<{ draftId: string }> }
+      ).data.map(({ draftId: id }) => id);
+      expect(humanDraftIds).toEqual(
+        expect.arrayContaining([draftId, legacyDraftId]),
+      );
+
+      for (const path of ["getDraftLog", "draftPublishReview"]) {
+        const url = new URL(`${server!.url}/api/${path}`);
+        url.searchParams.set("args", JSON.stringify({ draftId }));
+        const denied = await fetch(url, { headers: bearer(otherToken) });
+        const body = await denied.text();
+        expect(body).toMatch(/draft is unavailable/i);
+        expect(body).not.toContain(draftId);
+        expect(body).not.toContain(sourceId);
+      }
+
+      const ownerRead = await owner.client.callTool({
+        name: "find_nodes",
+        arguments: { name: "Owner only", draftId },
+      });
+      expect(ownerRead.isError).not.toBe(true);
+
+      const humanReview = new URL(`${server!.url}/api/draftPublishReview`);
+      humanReview.searchParams.set("args", JSON.stringify({ draftId }));
+      expect(
+        await fetch(humanReview, { headers: bearer(USER_TOKEN) }),
+      ).toHaveProperty("status", 200);
+    } finally {
+      await other?.transport.close();
+      await owner.transport.close();
     }
   });
 
@@ -692,14 +890,218 @@ describe("MCP route", () => {
     expect(await malformed.json()).toMatchObject({ error: { code: -32700 } });
   });
 
-  /**
-   * A stateless endpoint keeps nothing for a GET stream to carry or a DELETE to
-   * terminate. Serving GET is worse than refusing it: the transport hands back
-   * an SSE stream that the per-request `server.close()` tears down at once, and
-   * a connected client reopens it roughly once a second forever, rebuilding a
-   * Server and the whole tool list each time. 405 is the answer the client
-   * reads as "no server-initiated stream here", so it stops asking.
-   */
+  /** Stateful mode keeps one credential-bound session and remembered draft. */
+  it("preserves configured stateful sessions and server-carried continuity", async () => {
+    await start("stateful");
+    const { client, transport } = await connect();
+    try {
+      expect(transport.sessionId).toEqual(expect.any(String));
+      const listed = await client.listTools();
+      expect(
+        listed.tools.find((tool) => tool.name === "find_nodes")?.inputSchema,
+      ).not.toMatchObject({ properties: { draftId: expect.anything() } });
+
+      const first = await writeDashboard(client, "Stateful first");
+      const second = await writeDashboard(client, "Stateful second");
+      const draftId = (first.structuredContent as { draftId: string }).draftId;
+      expect(second.structuredContent).toMatchObject({ draftId });
+
+      const read = await client.callTool({
+        name: "find_nodes",
+        arguments: { name: "Stateful" },
+      });
+      expect(read.isError).not.toBe(true);
+      expect(
+        (read.structuredContent as { hits: Array<{ name: string }> }).hits.map(
+          ({ name }) => name,
+        ),
+      ).toEqual(expect.arrayContaining(["Stateful first", "Stateful second"]));
+
+      const discarded = await fetch(`${server!.url}/api/discardDraft`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
+        body: JSON.stringify({ draftId }),
+      });
+      expect(discarded.status).toBe(200);
+      await expectToolError(
+        client,
+        "find_nodes",
+        { name: "Stateful" },
+        /^draft is unavailable$/i,
+      );
+      const afterClose = await writeDashboard(client, "Stateful replacement");
+      expect(afterClose.isError).not.toBe(true);
+      expect(afterClose.structuredContent).not.toMatchObject({ draftId });
+    } finally {
+      await transport.close();
+    }
+  });
+
+  it("serializes concurrent first stateful writes onto one draft", async () => {
+    await start("stateful");
+    const { client, transport } = await connect();
+    try {
+      const [first, second] = await Promise.all([
+        writeDashboard(client, "Concurrent first"),
+        writeDashboard(client, "Concurrent second"),
+      ]);
+      const firstId = (first.structuredContent as { draftId: string }).draftId;
+      expect(second.structuredContent).toMatchObject({ draftId: firstId });
+      expect(
+        await project!.db.select().from(schema.draftMetadata),
+      ).toHaveLength(1);
+      expect(
+        await project!.db.select().from(schema.draftCommandLog),
+      ).toHaveLength(2);
+    } finally {
+      await transport.close();
+    }
+  });
+
+  for (const mode of ["stateless", "stateful"] as const) {
+    it(`retains a recoverable owned handle after a ${mode} partial-prefix failure`, async () => {
+      await start(mode);
+      const { client, transport } = await connect();
+      try {
+        const result = await client.callTool({
+          name: "draft_batch",
+          arguments: {
+            commands: [
+              {
+                type: "CreateDashboard",
+                args: {
+                  id: crypto.randomUUID(),
+                  name: `${mode} retained prefix`,
+                },
+              },
+              {
+                type: "SetChartType",
+                args: { id: crypto.randomUUID(), visualizationType: "bar" },
+              },
+            ],
+          },
+        });
+        expect(result.isError).toBe(true);
+        const draftId = (result.structuredContent as { draftId: string })
+          .draftId;
+        expect(draftId).toEqual(expect.any(String));
+        expect(resultText(result)).toMatch(/not found/i);
+
+        const continued = await client.callTool({
+          name: "draft_batch",
+          arguments: {
+            ...(mode === "stateless" ? { draftId } : {}),
+            commands: [
+              {
+                type: "CreateDashboard",
+                args: { id: crypto.randomUUID(), name: `${mode} continued` },
+              },
+            ],
+          },
+        });
+        expect(continued.isError).not.toBe(true);
+        expect(continued.structuredContent).toMatchObject({ draftId });
+      } finally {
+        await transport.close();
+      }
+    });
+  }
+
+  it("evicts stateful sessions at capacity and after idle expiry", async () => {
+    await start("stateful", { mcpMaxStatefulSessions: 1 });
+    const first = await connect();
+    const firstSessionId = first.transport.sessionId!;
+    const second = await connect();
+    const evicted = await fetch(`${server!.url}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": firstSessionId,
+        ...bearer(serviceToken),
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 9, method: "tools/list" }),
+    });
+    expect(evicted.status).toBe(404);
+    await second.transport.close();
+
+    let currentTime = 0;
+    await start("stateful", {
+      mcpStatefulSessionTtlMs: 10,
+      mcpSessionNow: () => currentTime,
+    });
+    const expiring = await connect();
+    const expiringId = expiring.transport.sessionId!;
+    currentTime = 11;
+    const expired = await fetch(`${server!.url}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": expiringId,
+        ...bearer(serviceToken),
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 10, method: "tools/list" }),
+    });
+    expect(expired.status).toBe(404);
+  });
+
+  it("keeps concurrent stateful initialization within capacity one", async () => {
+    await start("stateful", { mcpMaxStatefulSessions: 1 });
+    const attempts = await Promise.allSettled([connect(), connect()]);
+    const connected = attempts.flatMap((attempt) =>
+      attempt.status === "fulfilled" ? [attempt.value] : [],
+    );
+    expect(connected.length).toBeGreaterThanOrEqual(1);
+
+    const statuses = await Promise.all(
+      connected.map(({ transport }) =>
+        fetch(`${server!.url}/mcp`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+            "Mcp-Session-Id": transport.sessionId!,
+            ...bearer(serviceToken),
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: crypto.randomUUID(),
+            method: "tools/list",
+          }),
+        }).then((response) => response.status),
+      ),
+    );
+    expect(statuses.filter((status) => status === 200)).toHaveLength(1);
+    await Promise.allSettled(
+      connected.map(({ transport }) => transport.close()),
+    );
+  });
+
+  it("does not let another credential evict an active stateful session", async () => {
+    await start("stateful", { mcpMaxStatefulSessions: 1 });
+    const owner = await connect();
+    try {
+      const issued = await fetch(`${server!.url}/api/issueAccessCredential`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
+        body: JSON.stringify({ name: "Capacity challenger" }),
+      });
+      expect(issued.status).toBe(200);
+      const challengerToken = (
+        (await issued.json()) as { data: { accessCredential: string } }
+      ).data.accessCredential;
+
+      await expect(connect(challengerToken)).rejects.toThrow();
+      await expect(owner.client.listTools()).resolves.toMatchObject({
+        tools: expect.any(Array),
+      });
+    } finally {
+      await owner.transport.close();
+    }
+  });
+
+  /** Stateless mode has no GET stream or DELETE lifecycle, so both return 405. */
   it("refuses GET and DELETE with 405 so a connected client stops reopening them", async () => {
     for (const method of ["GET", "DELETE"]) {
       const response = await fetch(`${server!.url}/mcp`, {

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -375,6 +375,13 @@ describe("MCP route", () => {
       });
       expect(discarded.status).toBe(200);
 
+      await expectToolError(
+        client,
+        "find_nodes",
+        { name: "Before the discard", draftId: firstId },
+        /is no longer open/i,
+      );
+
       const second = await write("After the discard", firstId);
       expect(second.isError).not.toBe(true);
       const secondId = (second.structuredContent as { draftId: string })
@@ -676,6 +683,46 @@ describe("MCP route", () => {
       const firstId = (first.structuredContent as { draftId: string }).draftId;
       expect(second.structuredContent).toMatchObject({ draftId: firstId });
 
+      const foreign = await fetch(`${server!.url}/api/draftBatch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
+        body: JSON.stringify({
+          commands: [
+            {
+              path: "createDashboardCmd",
+              args: {
+                id: crypto.randomUUID(),
+                name: "Foreign stateful draft",
+              },
+            },
+          ],
+        }),
+      });
+      expect(foreign.status).toBe(200);
+      const foreignId = (
+        (await foreign.json()) as { data: { draftId: string } }
+      ).data.draftId;
+      expect(foreignId).not.toBe(firstId);
+
+      const hiddenOverride = await client.callTool({
+        name: "draft_batch",
+        arguments: {
+          draftId: foreignId,
+          commands: [
+            {
+              type: "CreateDashboard",
+              args: {
+                id: crypto.randomUUID(),
+                name: "Stateful hidden override",
+              },
+            },
+          ],
+        },
+      });
+      expect(hiddenOverride.structuredContent).toMatchObject({
+        draftId: firstId,
+      });
+
       const read = await client.callTool({
         name: "find_nodes",
         arguments: { name: "Stateful" },
@@ -685,7 +732,11 @@ describe("MCP route", () => {
       ).hits
         .map((hit) => hit.name)
         .sort();
-      expect(names).toEqual(["Stateful first", "Stateful second"]);
+      expect(names).toEqual([
+        "Stateful first",
+        "Stateful hidden override",
+        "Stateful second",
+      ]);
 
       const issued = await fetch(`${server!.url}/api/issueAccessCredential`, {
         method: "POST",

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -655,6 +655,14 @@ describe("MCP route", () => {
     const { client, transport } = await connect();
     try {
       expect(transport.sessionId).toEqual(expect.any(String));
+      const listed = await client.listTools();
+      const readSchema = listed.tools.find((tool) => tool.name === "find_nodes")
+        ?.inputSchema as { properties?: Record<string, unknown> };
+      const writeSchema = listed.tools.find(
+        (tool) => tool.name === "draft_batch",
+      )?.inputSchema as { properties?: Record<string, unknown> };
+      expect(readSchema.properties).not.toHaveProperty("draftId");
+      expect(writeSchema.properties).not.toHaveProperty("draftId");
 
       const write = async (id: string, name: string) =>
         client.callTool({

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -246,7 +246,9 @@ describe("MCP route", () => {
         },
         {
           name: "read_graph",
-          args: { from: { kind: "dataSource", id: missingId }, depth: 0 },
+          // Preserve the assistant boundary's Convert-then-Check contract in
+          // stateless mode; models commonly emit numeric arguments as strings.
+          args: { from: { kind: "dataSource", id: missingId }, depth: "0" },
           structured: { reached: [] },
           text: "Reached 0 node(s) within 0 hop(s).",
         },

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -25,6 +25,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createDashframeServer, type DashframeServer } from "../app";
 import type { McpMode } from "./route";
+import { createMcpTools } from "./tools";
 
 const USER_TOKEN = "mcp-test-user-token";
 
@@ -138,6 +139,34 @@ describe("MCP route", () => {
     await client.connect(transport);
     return { client, transport };
   }
+
+  it("refuses a draft read when the draft closes during the read", async () => {
+    const draftId = crypto.randomUUID();
+    let draftChecks = 0;
+    const fakeApp = {
+      createTracked() {
+        return {};
+      },
+      async runHandler() {
+        return [];
+      },
+      async call(path: string) {
+        if (path === "listDrafts") {
+          return {
+            result: draftChecks++ === 0 ? [{ draftId }] : [],
+          };
+        }
+        return { result: [] };
+      },
+    } as unknown as Parameters<typeof createMcpTools>[0];
+    const tool = createMcpTools(
+      fakeApp,
+      { principal: { kind: "service", credentialId: "test" }, draftId },
+      "stateless",
+    ).find((candidate) => candidate.name === "find_nodes");
+
+    await expect(tool!.execute({})).rejects.toThrow(/is no longer open/i);
+  });
 
   it("mints the credential as a user before the MCP service-principal round trip", async () => {
     const response = await fetch(
@@ -366,6 +395,13 @@ describe("MCP route", () => {
       const first = await write("Before the discard");
       expect(first.isError).not.toBe(true);
       const firstId = (first.structuredContent as { draftId: string }).draftId;
+
+      await expectToolError(
+        client,
+        "find_nodes",
+        { name: "Before the discard", draftId: {} },
+        /validation failed/i,
+      );
 
       // Out of band, as a person: the draft the agent is carrying goes away.
       const discarded = await fetch(`${server!.url}/api/discardDraft`, {

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createDashframeServer, type DashframeServer } from "../app";
+import type { McpMode } from "./route";
 
 const USER_TOKEN = "mcp-test-user-token";
 
@@ -78,12 +79,17 @@ async function expectToolError(
 }
 
 describe("MCP route", () => {
-  let root: string;
-  let project: ProjectHandle | null;
-  let server: DashframeServer | null;
+  let root = "";
+  let project: ProjectHandle | null = null;
+  let server: DashframeServer | null = null;
   let serviceToken: string;
 
-  beforeEach(async () => {
+  async function start(mode: McpMode): Promise<void> {
+    server?.stop();
+    await project?.close();
+    server = null;
+    project = null;
+    if (root !== "") rmSync(root, { recursive: true, force: true });
     root = mkdtempSync(join(tmpdir(), "dashframe-mcp-"));
     project = await openProject({ dir: join(root, "project") });
     const { vault, accessCredentials } = makeVault(join(root, "credentials"));
@@ -92,6 +98,7 @@ describe("MCP route", () => {
       accessCredentials,
       vault,
       authToken: USER_TOKEN,
+      mcpMode: mode,
     });
 
     const issued = await fetch(`${server.url}/api/issueAccessCredential`, {
@@ -104,12 +111,19 @@ describe("MCP route", () => {
       data: { accessCredential: string };
     };
     serviceToken = payload.data.accessCredential;
+  }
+
+  beforeEach(async () => {
+    await start("stateless");
   });
 
   afterEach(async () => {
     server?.stop();
     await project?.close();
     rmSync(root, { recursive: true, force: true });
+    server = null;
+    project = null;
+    root = "";
   });
 
   async function connect(): Promise<{
@@ -634,6 +648,59 @@ describe("MCP route", () => {
     });
     expect(malformed.status).toBe(400);
     expect(await malformed.json()).toMatchObject({ error: { code: -32700 } });
+  });
+
+  it("preserves stateful sessions and their server-carried draft continuity", async () => {
+    await start("stateful");
+    const { client, transport } = await connect();
+    try {
+      expect(transport.sessionId).toEqual(expect.any(String));
+
+      const write = async (id: string, name: string) =>
+        client.callTool({
+          name: "draft_batch",
+          arguments: {
+            commands: [{ type: "CreateDashboard", args: { id, name } }],
+          },
+        });
+      const first = await write(crypto.randomUUID(), "Stateful first");
+      const second = await write(crypto.randomUUID(), "Stateful second");
+      const firstId = (first.structuredContent as { draftId: string }).draftId;
+      expect(second.structuredContent).toMatchObject({ draftId: firstId });
+
+      const read = await client.callTool({
+        name: "find_nodes",
+        arguments: { name: "Stateful" },
+      });
+      const names = (
+        read.structuredContent as { hits: Array<{ name: string }> }
+      ).hits
+        .map((hit) => hit.name)
+        .sort();
+      expect(names).toEqual(["Stateful first", "Stateful second"]);
+
+      const issued = await fetch(`${server!.url}/api/issueAccessCredential`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
+        body: JSON.stringify({ name: "Other MCP integration" }),
+      });
+      const otherToken = (
+        (await issued.json()) as { data: { accessCredential: string } }
+      ).data.accessCredential;
+      const stolen = await fetch(`${server!.url}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "Mcp-Session-Id": transport.sessionId!,
+          ...bearer(otherToken),
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/list" }),
+      });
+      expect(stolen.status).toBe(403);
+    } finally {
+      await transport.close();
+    }
   });
 
   /**

--- a/apps/server/src/mcp/route.test.ts
+++ b/apps/server/src/mcp/route.test.ts
@@ -138,7 +138,7 @@ describe("MCP route", () => {
     });
   });
 
-  it("lists the existing read tools, reads through the service session, and drafts without changing canonical", async () => {
+  it("lists the existing read tools, reads through the service principal, and drafts without changing canonical", async () => {
     const { client, transport } = await connect();
     try {
       const listed = await client.listTools();
@@ -154,9 +154,15 @@ describe("MCP route", () => {
       for (const tool of listed.tools) {
         const roundTripped = JSON.parse(JSON.stringify(tool.inputSchema)) as {
           type?: string;
+          properties?: Record<string, { description?: string }>;
         };
         expect(roundTripped.type).toBe("object");
         expect(Object.getOwnPropertySymbols(roundTripped)).toHaveLength(0);
+        if (tool.name !== "draft_batch") {
+          expect(roundTripped.properties?.draftId?.description).toBe(
+            "Draft id from draft_batch. Pass it to read through that draft's overlay; omit to read canonical state.",
+          );
+        }
       }
 
       // The write tool's description is the only thing an agent reads before
@@ -173,6 +179,9 @@ describe("MCP route", () => {
       ]) {
         expect(writeTool?.description).toContain(denied);
       }
+      expect(writeTool?.description).toContain(
+        "Carry the returned draftId forward",
+      );
 
       // Every read tool, against an empty graph. `isError` alone would pass on
       // a tool that returned nothing at all, so each one asserts the shape it
@@ -261,7 +270,7 @@ describe("MCP route", () => {
 
       const draftScopedRead = await client.callTool({
         name: "find_nodes",
-        arguments: { name: "Drafted source" },
+        arguments: { name: "Drafted source", draftId: firstDraft.draftId },
       });
       expect(draftScopedRead.structuredContent).toMatchObject({
         hits: [
@@ -273,6 +282,12 @@ describe("MCP route", () => {
       // A client that shows the model only the text content still has to be
       // able to get from a name to an id.
       expect(resultText(draftScopedRead)).toContain(sourceId);
+
+      const canonicalRead = await client.callTool({
+        name: "find_nodes",
+        arguments: { name: "Drafted source" },
+      });
+      expect(canonicalRead.structuredContent).toMatchObject({ hits: [] });
 
       const listedDrafts = await fetch(
         `${server!.url}/api/listDrafts?args=%7B%7D`,
@@ -293,6 +308,7 @@ describe("MCP route", () => {
       const second = await client.callTool({
         name: "draft_batch",
         arguments: {
+          draftId: firstDraft.draftId,
           commands: [
             {
               type: "CreateDashboard",
@@ -316,13 +332,14 @@ describe("MCP route", () => {
     }
   });
 
-  it("opens a fresh draft when a person has already discarded the session's", async () => {
+  it("opens a fresh draft when a person has already discarded the supplied draft", async () => {
     const { client, transport } = await connect();
     try {
-      const write = async (name: string) =>
+      const write = async (name: string, draftId?: string) =>
         client.callTool({
           name: "draft_batch",
           arguments: {
+            ...(draftId === undefined ? {} : { draftId }),
             commands: [
               {
                 type: "CreateDataSource",
@@ -336,7 +353,7 @@ describe("MCP route", () => {
       expect(first.isError).not.toBe(true);
       const firstId = (first.structuredContent as { draftId: string }).draftId;
 
-      // Out of band, as a person: the draft the session is holding goes away.
+      // Out of band, as a person: the draft the agent is carrying goes away.
       const discarded = await fetch(`${server!.url}/api/discardDraft`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
@@ -344,9 +361,7 @@ describe("MCP route", () => {
       });
       expect(discarded.status).toBe(200);
 
-      // The agent cannot supply a draft id, so if the stale handle survived
-      // here every remaining write on this connection would fail.
-      const second = await write("After the discard");
+      const second = await write("After the discard", firstId);
       expect(second.isError).not.toBe(true);
       const secondId = (second.structuredContent as { draftId: string })
         .draftId;
@@ -484,42 +499,6 @@ describe("MCP route", () => {
     }
   });
 
-  it("refuses to hand one credential's session to another", async () => {
-    const { client, transport } = await connect();
-    try {
-      const sessionId = transport.sessionId;
-      expect(typeof sessionId === "string").toBe(true);
-
-      const issued = await fetch(`${server!.url}/api/issueAccessCredential`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...bearer(USER_TOKEN) },
-        body: JSON.stringify({ name: "Second integration credential" }),
-      });
-      expect(issued.status).toBe(200);
-      const otherToken = (
-        (await issued.json()) as { data: { accessCredential: string } }
-      ).data.accessCredential;
-
-      const stolen = await fetch(`${server!.url}/mcp`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json, text/event-stream",
-          "mcp-session-id": sessionId!,
-          ...bearer(otherToken),
-        },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
-      });
-      expect(stolen.status).toBe(403);
-
-      // The original credential still owns its session.
-      const listed = await client.listTools();
-      expect(listed.tools.length).toBeGreaterThan(0);
-    } finally {
-      await transport.close();
-    }
-  });
-
   it("answers an MCP preflight with exactly one allow-origin and the session headers", async () => {
     const preflight = await fetch(`${server!.url}/mcp`, {
       method: "OPTIONS",
@@ -597,35 +576,52 @@ describe("MCP route", () => {
     }
   });
 
-  it("only mints a session for an initialize request", async () => {
-    // Without this guard every sessionless POST built a fresh server and
-    // transport, so an authenticated caller could exhaust memory by looping
-    // any other method.
-    const notInitialize = await fetch(`${server!.url}/mcp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        ...bearer(serviceToken),
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
-    });
-    expect(notInitialize.status).toBe(400);
-    expect(await notInitialize.json()).toMatchObject({
-      error: { code: -32000 },
-    });
+  it("handles bare tool calls statelessly and carries draft ids between requests", async () => {
+    const call = async (id: number, draftId?: string) =>
+      fetch(`${server!.url}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          ...bearer(serviceToken),
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          method: "tools/call",
+          params: {
+            name: "draft_batch",
+            arguments: {
+              ...(draftId === undefined ? {} : { draftId }),
+              commands: [
+                {
+                  type: "CreateDashboard",
+                  args: { id: crypto.randomUUID(), name: `Stateless ${id}` },
+                },
+              ],
+            },
+          },
+        }),
+      });
 
-    const unknownSession = await fetch(`${server!.url}/mcp`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        "mcp-session-id": crypto.randomUUID(),
-        ...bearer(serviceToken),
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    const first = await call(1);
+    expect(first.status).toBe(200);
+    expect(first.headers.get("mcp-session-id")).toBeNull();
+    const firstBody = (await first.json()) as {
+      result: { structuredContent: { draftId: string } };
+    };
+    const draftId = firstBody.result.structuredContent.draftId;
+    expect(draftId).toEqual(expect.any(String));
+
+    const second = await call(2, draftId);
+    expect(second.status).toBe(200);
+    expect(second.headers.get("mcp-session-id")).toBeNull();
+    expect((await second.json()) as unknown).toMatchObject({
+      result: { structuredContent: { draftId } },
     });
-    expect(unknownSession.status).toBe(404);
+    expect(
+      await project!.db.select().from(schema.draftCommandLog),
+    ).toHaveLength(2);
 
     const malformed = await fetch(`${server!.url}/mcp`, {
       method: "POST",
@@ -638,6 +634,34 @@ describe("MCP route", () => {
     });
     expect(malformed.status).toBe(400);
     expect(await malformed.json()).toMatchObject({ error: { code: -32700 } });
+  });
+
+  /**
+   * A stateless endpoint keeps nothing for a GET stream to carry or a DELETE to
+   * terminate. Serving GET is worse than refusing it: the transport hands back
+   * an SSE stream that the per-request `server.close()` tears down at once, and
+   * a connected client reopens it roughly once a second forever, rebuilding a
+   * Server and the whole tool list each time. 405 is the answer the client
+   * reads as "no server-initiated stream here", so it stops asking.
+   */
+  it("refuses GET and DELETE with 405 so a connected client stops reopening them", async () => {
+    for (const method of ["GET", "DELETE"]) {
+      const response = await fetch(`${server!.url}/mcp`, {
+        method,
+        headers: { Accept: "text/event-stream", ...bearer(serviceToken) },
+      });
+      expect(response.status).toBe(405);
+      expect(response.headers.get("allow")).toBe("POST");
+      await response.body?.cancel();
+    }
+
+    // Unauthenticated callers learn nothing about which methods are served.
+    const anonymous = await fetch(`${server!.url}/mcp`, {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(anonymous.status).toBe(401);
+    await anonymous.body?.cancel();
   });
 
   it("answers missing and invalid credentials with HTTP 401 and opens no draft", async () => {

--- a/apps/server/src/mcp/route.ts
+++ b/apps/server/src/mcp/route.ts
@@ -2,6 +2,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
   CallToolRequestSchema,
+  isInitializeRequest,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { WyStackApp } from "@wystack/server";
@@ -14,9 +15,19 @@ export interface McpRequestContext {
   draftId?: string;
 }
 
+export type McpMode = "stateful" | "stateless";
+
 interface McpRouteOptions {
   app: WyStackApp;
+  mode?: McpMode;
   resolveContext(request: Request): Promise<Record<string, unknown>>;
+}
+
+interface ActiveMcpSession {
+  context: McpRequestContext;
+  principalKey: string;
+  transport: WebStandardStreamableHTTPServerTransport;
+  server: Server;
 }
 
 /**
@@ -31,6 +42,14 @@ function isIdentifiedPrincipal(context: Record<string, unknown>): boolean {
   if (record.kind === "service") return typeof record.credentialId === "string";
   if (record.kind === "user") return typeof record.userId === "string";
   return false;
+}
+
+function principalKey(context: Record<string, unknown>): string | null {
+  if (!isIdentifiedPrincipal(context)) return null;
+  const principal = context.principal as Record<string, unknown>;
+  return principal.kind === "service"
+    ? `service:${principal.credentialId as string}`
+    : `user:${principal.userId as string}`;
 }
 
 /**
@@ -157,6 +176,9 @@ function createServer(tools: McpTool[]): Server {
 
 /** In-process Streamable HTTP route; all auth remains in the server resolver. */
 export function createMcpRoute(opts: McpRouteOptions) {
+  const mode = opts.mode ?? "stateful";
+  const sessions = new Map<string, ActiveMcpSession>();
+
   return async (c: Context): Promise<Response> => {
     let context: Record<string, unknown>;
     try {
@@ -165,10 +187,22 @@ export function createMcpRoute(opts: McpRouteOptions) {
       // Never echo the Authorization header or any credential material.
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
-    if (!isIdentifiedPrincipal(context)) {
+    const key = principalKey(context);
+    if (key === null) {
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
 
+    if (mode === "stateful") {
+      return handleStateful(c, context.principal, key);
+    }
+
+    return handleStateless(c, context.principal);
+  };
+
+  async function handleStateless(
+    c: Context,
+    principal: unknown,
+  ): Promise<Response> {
     // Checked after auth, so an unauthenticated caller learns nothing about
     // which methods this route serves.
     if (c.req.method !== "POST") {
@@ -197,10 +231,14 @@ export function createMcpRoute(opts: McpRouteOptions) {
       enableJsonResponse: true,
     });
     const server = createServer(
-      createMcpTools(opts.app, {
-        principal: context.principal,
-        draftId: requestDraftId(parsedBody),
-      }),
+      createMcpTools(
+        opts.app,
+        {
+          principal,
+          draftId: requestDraftId(parsedBody),
+        },
+        "stateless",
+      ),
     );
     try {
       await server.connect(transport);
@@ -208,5 +246,81 @@ export function createMcpRoute(opts: McpRouteOptions) {
     } finally {
       await server.close();
     }
-  };
+  }
+
+  async function handleStateful(
+    c: Context,
+    principal: unknown,
+    key: string,
+  ): Promise<Response> {
+    const requestedSessionId = c.req.header("mcp-session-id");
+    const existing =
+      requestedSessionId === undefined
+        ? undefined
+        : sessions.get(requestedSessionId);
+    if (existing !== undefined && existing.principalKey !== key) {
+      return jsonRpcError(
+        403,
+        -32003,
+        "MCP session is not available to this credential.",
+      );
+    }
+
+    let parsedBody: unknown;
+    if (c.req.method === "POST") {
+      try {
+        parsedBody = await c.req.raw.json();
+      } catch {
+        return jsonRpcError(400, -32700, "Parse error: invalid JSON body.");
+      }
+    }
+
+    let active: ActiveMcpSession;
+    if (existing !== undefined) {
+      active = existing;
+    } else if (requestedSessionId !== undefined) {
+      return jsonRpcError(
+        404,
+        -32001,
+        "Unknown MCP session. Re-initialize the connection.",
+      );
+    } else if (c.req.method === "POST" && isInitializeRequest(parsedBody)) {
+      active = await openSession(principal, key);
+    } else {
+      return jsonRpcError(
+        400,
+        -32000,
+        "Expected an initialize request or an mcp-session-id header.",
+      );
+    }
+
+    return active.transport.handleRequest(c.req.raw, { parsedBody });
+  }
+
+  async function openSession(
+    principal: unknown,
+    key: string,
+  ): Promise<ActiveMcpSession> {
+    const context: McpRequestContext = { principal };
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      enableJsonResponse: true,
+      onsessioninitialized: (sessionId) => {
+        sessions.set(sessionId, {
+          context,
+          principalKey: key,
+          transport,
+          server,
+        });
+      },
+      onsessionclosed: async (sessionId) => {
+        const closed = sessions.get(sessionId);
+        sessions.delete(sessionId);
+        await closed?.server.close();
+      },
+    });
+    const server = createServer(createMcpTools(opts.app, context, "stateful"));
+    await server.connect(transport);
+    return { context, principalKey: key, transport, server };
+  }
 }

--- a/apps/server/src/mcp/route.ts
+++ b/apps/server/src/mcp/route.ts
@@ -2,7 +2,6 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
   CallToolRequestSchema,
-  isInitializeRequest,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { WyStackApp } from "@wystack/server";
@@ -10,10 +9,9 @@ import type { Context } from "hono";
 
 import { createMcpTools, type McpTool } from "./tools";
 
-export interface McpSession {
-  draftId?: string;
+export interface McpRequestContext {
   principal: unknown;
-  principalKey: string;
+  draftId?: string;
 }
 
 interface McpRouteOptions {
@@ -21,23 +19,28 @@ interface McpRouteOptions {
   resolveContext(request: Request): Promise<Record<string, unknown>>;
 }
 
-interface ActiveMcpSession {
-  session: McpSession;
-  transport: WebStandardStreamableHTTPServerTransport;
-  server: Server;
+/**
+ * Whether the resolver produced a principal this route will act as. A resolver
+ * that succeeds without identifying anyone is not an authenticated caller, so
+ * the shape is checked here rather than trusted downstream.
+ */
+function isIdentifiedPrincipal(context: Record<string, unknown>): boolean {
+  const principal = context.principal;
+  if (typeof principal !== "object" || principal === null) return false;
+  const record = principal as Record<string, unknown>;
+  if (record.kind === "service") return typeof record.credentialId === "string";
+  if (record.kind === "user") return typeof record.userId === "string";
+  return false;
 }
 
-function principalKey(context: Record<string, unknown>): string | null {
-  const principal = context.principal;
-  if (typeof principal !== "object" || principal === null) return null;
-  const record = principal as Record<string, unknown>;
-  if (record.kind === "service" && typeof record.credentialId === "string") {
-    return `service:${record.credentialId}`;
-  }
-  if (record.kind === "user" && typeof record.userId === "string") {
-    return `user:${record.userId}`;
-  }
-  return null;
+function requestDraftId(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const params = (body as Record<string, unknown>).params;
+  if (typeof params !== "object" || params === null) return undefined;
+  const args = (params as Record<string, unknown>).arguments;
+  if (typeof args !== "object" || args === null) return undefined;
+  const draftId = (args as Record<string, unknown>).draftId;
+  return typeof draftId === "string" ? draftId : undefined;
 }
 
 /**
@@ -54,6 +57,32 @@ function jsonRpcError(
   return new Response(
     JSON.stringify({ jsonrpc: "2.0", id: null, error: { code, message } }),
     { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+/**
+ * GET (a standalone server-to-client SSE stream) and DELETE (session
+ * termination) both only mean something when the server keeps sessions. This
+ * one does not, so they are refused before a transport is built.
+ *
+ * 405 is the answer the spec reserves for exactly this, and the client acts on
+ * it: it reads 405 on GET as "no server-initiated stream here" and stops
+ * asking. Serving GET instead hands back an SSE stream that the per-request
+ * `server.close()` tears down within milliseconds, and a connected client
+ * reopens it about once a second for as long as it stays connected — a fresh
+ * Server, tool list and transport built and discarded on every pass.
+ */
+function methodNotAllowed(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32000, message: "Method not allowed." },
+    }),
+    {
+      status: 405,
+      headers: { Allow: "POST", "Content-Type": "application/json" },
+    },
   );
 }
 
@@ -107,8 +136,6 @@ function createServer(tools: McpTool[]): Server {
 
 /** In-process Streamable HTTP route; all auth remains in the server resolver. */
 export function createMcpRoute(opts: McpRouteOptions) {
-  const sessions = new Map<string, ActiveMcpSession>();
-
   return async (c: Context): Promise<Response> => {
     let context: Record<string, unknown>;
     try {
@@ -117,80 +144,40 @@ export function createMcpRoute(opts: McpRouteOptions) {
       // Never echo the Authorization header or any credential material.
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
-    const key = principalKey(context);
-    if (key === null) {
+    if (!isIdentifiedPrincipal(context)) {
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
 
-    const requestedSessionId = c.req.header("mcp-session-id");
-    const existing =
-      requestedSessionId === undefined
-        ? undefined
-        : sessions.get(requestedSessionId);
-    if (existing !== undefined && existing.session.principalKey !== key) {
-      return jsonRpcError(
-        403,
-        -32003,
-        "MCP session is not available to this credential.",
-      );
+    // Checked after auth, so an unauthenticated caller learns nothing about
+    // which methods this route serves.
+    if (c.req.method !== "POST") {
+      return methodNotAllowed();
     }
 
     // The body is read only after the caller has been authenticated, and is
     // then handed to the transport so the stream is consumed exactly once.
     let parsedBody: unknown;
-    if (c.req.method === "POST") {
-      try {
-        parsedBody = await c.req.raw.json();
-      } catch {
-        return jsonRpcError(400, -32700, "Parse error: invalid JSON body.");
-      }
+    try {
+      parsedBody = await c.req.raw.json();
+    } catch {
+      return jsonRpcError(400, -32700, "Parse error: invalid JSON body.");
     }
 
-    let active: ActiveMcpSession;
-    if (existing !== undefined) {
-      active = existing;
-    } else if (requestedSessionId !== undefined) {
-      return jsonRpcError(
-        404,
-        -32001,
-        "Unknown MCP session. Re-initialize the connection.",
-      );
-    } else if (c.req.method === "POST" && isInitializeRequest(parsedBody)) {
-      // Only an initialize request may mint a session. Without this guard every
-      // sessionless POST built a fresh Server and transport that nothing ever
-      // reclaimed, so an authenticated caller could exhaust memory by looping
-      // any other method at /mcp.
-      active = await openSession(context.principal, key);
-    } else {
-      return jsonRpcError(
-        400,
-        -32000,
-        "Expected an initialize request or an mcp-session-id header.",
-      );
-    }
-
-    return active.transport.handleRequest(c.req.raw, { parsedBody });
-  };
-
-  async function openSession(
-    principal: unknown,
-    key: string,
-  ): Promise<ActiveMcpSession> {
-    const session: McpSession = { principal, principalKey: key };
     const transport = new WebStandardStreamableHTTPServerTransport({
-      sessionIdGenerator: () => crypto.randomUUID(),
+      sessionIdGenerator: undefined,
       enableJsonResponse: true,
-      onsessioninitialized: (sessionId) => {
-        sessions.set(sessionId, { session, transport, server });
-      },
-      onsessionclosed: async (sessionId) => {
-        const closed = sessions.get(sessionId);
-        sessions.delete(sessionId);
-        await closed?.server.close();
-      },
     });
-    const server = createServer(createMcpTools(opts.app, session));
-    await server.connect(transport);
-    return { session, transport, server };
-  }
+    const server = createServer(
+      createMcpTools(opts.app, {
+        principal: context.principal,
+        draftId: requestDraftId(parsedBody),
+      }),
+    );
+    try {
+      await server.connect(transport);
+      return await transport.handleRequest(c.req.raw, { parsedBody });
+    } finally {
+      await server.close();
+    }
+  };
 }

--- a/apps/server/src/mcp/route.ts
+++ b/apps/server/src/mcp/route.ts
@@ -33,6 +33,14 @@ function isIdentifiedPrincipal(context: Record<string, unknown>): boolean {
   return false;
 }
 
+/**
+ * The draft id an agent supplies alongside a tool call's arguments. Read tools
+ * advertise it, and it scopes their overlay for this request only.
+ *
+ * Deliberately single-message: a JSON-RPC array has no `params` of its own, so
+ * a batch would silently read canonical state while carrying a draft id. Batch
+ * bodies are refused outright by `isJsonRpcBatch` rather than answered wrongly.
+ */
 function requestDraftId(body: unknown): string | undefined {
   if (typeof body !== "object" || body === null) return undefined;
   const params = (body as Record<string, unknown>).params;
@@ -41,6 +49,17 @@ function requestDraftId(body: unknown): string | undefined {
   if (typeof args !== "object" || args === null) return undefined;
   const draftId = (args as Record<string, unknown>).draftId;
   return typeof draftId === "string" ? draftId : undefined;
+}
+
+/**
+ * JSON-RPC batching left the MCP spec in 2025-06-18 and no current client emits
+ * it, but the transport would still accept an array and answer it. That is the
+ * one shape where a draft id rides in a place `requestDraftId` cannot see, so a
+ * batched read would quietly return canonical state instead of the overlay the
+ * caller asked for. A wrong answer is worse than a refusal.
+ */
+function isJsonRpcBatch(body: unknown): boolean {
+  return Array.isArray(body);
 }
 
 /**
@@ -106,7 +125,9 @@ function createServer(tools: McpTool[]): Server {
     tools: tools.map((tool) => ({
       name: tool.name,
       description: tool.description,
-      // TypeBox is JSON Schema. Deliberately pass the original schema through.
+      // TypeBox is JSON Schema, so each tool's advertised schema is passed
+      // through as-is. For a read tool that schema is its parameters plus the
+      // optional draftId this surface adds — see toMcpTool in tools.ts.
       inputSchema: tool.inputSchema,
     })),
   }));
@@ -161,6 +182,14 @@ export function createMcpRoute(opts: McpRouteOptions) {
       parsedBody = await c.req.raw.json();
     } catch {
       return jsonRpcError(400, -32700, "Parse error: invalid JSON body.");
+    }
+    if (isJsonRpcBatch(parsedBody)) {
+      return jsonRpcError(
+        400,
+        -32600,
+        "Batched JSON-RPC requests are not supported. Send one request per " +
+          "call so a draft id applies to the call that carries it.",
+      );
     }
 
     const transport = new WebStandardStreamableHTTPServerTransport({

--- a/apps/server/src/mcp/route.ts
+++ b/apps/server/src/mcp/route.ts
@@ -2,7 +2,6 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
   CallToolRequestSchema,
-  isInitializeRequest,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { WyStackApp } from "@wystack/server";
@@ -15,19 +14,9 @@ export interface McpRequestContext {
   draftId?: string;
 }
 
-export type McpMode = "stateful" | "stateless";
-
 interface McpRouteOptions {
   app: WyStackApp;
-  mode?: McpMode;
   resolveContext(request: Request): Promise<Record<string, unknown>>;
-}
-
-interface ActiveMcpSession {
-  context: McpRequestContext;
-  principalKey: string;
-  transport: WebStandardStreamableHTTPServerTransport;
-  server: Server;
 }
 
 /**
@@ -42,14 +31,6 @@ function isIdentifiedPrincipal(context: Record<string, unknown>): boolean {
   if (record.kind === "service") return typeof record.credentialId === "string";
   if (record.kind === "user") return typeof record.userId === "string";
   return false;
-}
-
-function principalKey(context: Record<string, unknown>): string | null {
-  if (!isIdentifiedPrincipal(context)) return null;
-  const principal = context.principal as Record<string, unknown>;
-  return principal.kind === "service"
-    ? `service:${principal.credentialId as string}`
-    : `user:${principal.userId as string}`;
 }
 
 /**
@@ -176,9 +157,6 @@ function createServer(tools: McpTool[]): Server {
 
 /** In-process Streamable HTTP route; all auth remains in the server resolver. */
 export function createMcpRoute(opts: McpRouteOptions) {
-  const mode = opts.mode ?? "stateful";
-  const sessions = new Map<string, ActiveMcpSession>();
-
   return async (c: Context): Promise<Response> => {
     let context: Record<string, unknown>;
     try {
@@ -187,22 +165,10 @@ export function createMcpRoute(opts: McpRouteOptions) {
       // Never echo the Authorization header or any credential material.
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
-    const key = principalKey(context);
-    if (key === null) {
+    if (!isIdentifiedPrincipal(context)) {
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
 
-    if (mode === "stateful") {
-      return handleStateful(c, context.principal, key);
-    }
-
-    return handleStateless(c, context.principal);
-  };
-
-  async function handleStateless(
-    c: Context,
-    principal: unknown,
-  ): Promise<Response> {
     // Checked after auth, so an unauthenticated caller learns nothing about
     // which methods this route serves.
     if (c.req.method !== "POST") {
@@ -231,14 +197,10 @@ export function createMcpRoute(opts: McpRouteOptions) {
       enableJsonResponse: true,
     });
     const server = createServer(
-      createMcpTools(
-        opts.app,
-        {
-          principal,
-          draftId: requestDraftId(parsedBody),
-        },
-        "stateless",
-      ),
+      createMcpTools(opts.app, {
+        principal: context.principal,
+        draftId: requestDraftId(parsedBody),
+      }),
     );
     try {
       await server.connect(transport);
@@ -246,81 +208,5 @@ export function createMcpRoute(opts: McpRouteOptions) {
     } finally {
       await server.close();
     }
-  }
-
-  async function handleStateful(
-    c: Context,
-    principal: unknown,
-    key: string,
-  ): Promise<Response> {
-    const requestedSessionId = c.req.header("mcp-session-id");
-    const existing =
-      requestedSessionId === undefined
-        ? undefined
-        : sessions.get(requestedSessionId);
-    if (existing !== undefined && existing.principalKey !== key) {
-      return jsonRpcError(
-        403,
-        -32003,
-        "MCP session is not available to this credential.",
-      );
-    }
-
-    let parsedBody: unknown;
-    if (c.req.method === "POST") {
-      try {
-        parsedBody = await c.req.raw.json();
-      } catch {
-        return jsonRpcError(400, -32700, "Parse error: invalid JSON body.");
-      }
-    }
-
-    let active: ActiveMcpSession;
-    if (existing !== undefined) {
-      active = existing;
-    } else if (requestedSessionId !== undefined) {
-      return jsonRpcError(
-        404,
-        -32001,
-        "Unknown MCP session. Re-initialize the connection.",
-      );
-    } else if (c.req.method === "POST" && isInitializeRequest(parsedBody)) {
-      active = await openSession(principal, key);
-    } else {
-      return jsonRpcError(
-        400,
-        -32000,
-        "Expected an initialize request or an mcp-session-id header.",
-      );
-    }
-
-    return active.transport.handleRequest(c.req.raw, { parsedBody });
-  }
-
-  async function openSession(
-    principal: unknown,
-    key: string,
-  ): Promise<ActiveMcpSession> {
-    const context: McpRequestContext = { principal };
-    const transport = new WebStandardStreamableHTTPServerTransport({
-      sessionIdGenerator: () => crypto.randomUUID(),
-      enableJsonResponse: true,
-      onsessioninitialized: (sessionId) => {
-        sessions.set(sessionId, {
-          context,
-          principalKey: key,
-          transport,
-          server,
-        });
-      },
-      onsessionclosed: async (sessionId) => {
-        const closed = sessions.get(sessionId);
-        sessions.delete(sessionId);
-        await closed?.server.close();
-      },
-    });
-    const server = createServer(createMcpTools(opts.app, context, "stateful"));
-    await server.connect(transport);
-    return { context, principalKey: key, transport, server };
-  }
+  };
 }

--- a/apps/server/src/mcp/route.ts
+++ b/apps/server/src/mcp/route.ts
@@ -2,11 +2,13 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
   CallToolRequestSchema,
+  isInitializeRequest,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { WyStackApp } from "@wystack/server";
 import type { Context } from "hono";
 
+import { draftIdFromBatchError } from "../functions/draft-batch";
 import { createMcpTools, type McpTool } from "./tools";
 
 export interface McpRequestContext {
@@ -14,9 +16,23 @@ export interface McpRequestContext {
   draftId?: string;
 }
 
+export type McpMode = "stateful" | "stateless";
+
 interface McpRouteOptions {
   app: WyStackApp;
+  mode?: McpMode;
+  maxStatefulSessions?: number;
+  statefulSessionTtlMs?: number;
+  now?: () => number;
   resolveContext(request: Request): Promise<Record<string, unknown>>;
+}
+
+interface ActiveMcpSession {
+  context: McpRequestContext;
+  principalKey: string;
+  transport: WebStandardStreamableHTTPServerTransport;
+  server: Server;
+  lastSeenAt: number;
 }
 
 /**
@@ -31,6 +47,14 @@ function isIdentifiedPrincipal(context: Record<string, unknown>): boolean {
   if (record.kind === "service") return typeof record.credentialId === "string";
   if (record.kind === "user") return typeof record.userId === "string";
   return false;
+}
+
+function contextPrincipalKey(context: Record<string, unknown>): string | null {
+  if (!isIdentifiedPrincipal(context)) return null;
+  const principal = context.principal as Record<string, unknown>;
+  return principal.kind === "service"
+    ? `service:${principal.credentialId as string}`
+    : `user:${principal.userId as string}`;
 }
 
 /**
@@ -69,7 +93,7 @@ function isJsonRpcBatch(body: unknown): boolean {
  * the two reads only the status line.
  */
 function jsonRpcError(
-  status: 400 | 401 | 403 | 404 | 500,
+  status: 400 | 401 | 403 | 404 | 500 | 503,
   code: number,
   message: string,
 ): Response {
@@ -81,13 +105,13 @@ function jsonRpcError(
 
 /**
  * GET (a standalone server-to-client SSE stream) and DELETE (session
- * termination) both only mean something when the server keeps sessions. This
- * one does not, so they are refused before a transport is built.
+ * termination) both only mean something when the server keeps sessions.
+ * Stateless mode does not, so it refuses them before a transport is built.
  *
  * 405 is the answer the spec reserves for exactly this, and the client acts on
  * it: it reads 405 on GET as "no server-initiated stream here" and stops
- * asking. Serving GET instead hands back an SSE stream that the per-request
- * `server.close()` tears down within milliseconds, and a connected client
+ * asking. Serving GET in stateless mode instead hands back an SSE stream that
+ * the per-request `server.close()` tears down within milliseconds, and a client
  * reopens it about once a second for as long as it stays connected — a fresh
  * Server, tool list and transport built and discarded on every pass.
  */
@@ -109,11 +133,19 @@ function methodNotAllowed(): Response {
  * Tool-level failure. The message names the offending field or command, never
  * a value — see the credential-ref gate in tools.ts.
  */
-function toolFailure(message: string): {
+function toolFailure(
+  message: string,
+  draftId?: string,
+): {
   content: Array<{ type: "text"; text: string }>;
   isError: true;
+  structuredContent?: { draftId: string };
 } {
-  return { content: [{ type: "text", text: message }], isError: true };
+  return {
+    content: [{ type: "text", text: message }],
+    isError: true,
+    ...(draftId === undefined ? {} : { structuredContent: { draftId } }),
+  };
 }
 
 function createServer(tools: McpTool[]): Server {
@@ -149,6 +181,7 @@ function createServer(tools: McpTool[]): Server {
       // isError content reaches it as "that did not work, here is why".
       return toolFailure(
         error instanceof Error ? error.message : String(error),
+        draftIdFromBatchError(error),
       );
     }
   });
@@ -157,6 +190,22 @@ function createServer(tools: McpTool[]): Server {
 
 /** In-process Streamable HTTP route; all auth remains in the server resolver. */
 export function createMcpRoute(opts: McpRouteOptions) {
+  const mode = opts.mode ?? "stateful";
+  const maxStatefulSessions = opts.maxStatefulSessions ?? 128;
+  const statefulSessionTtlMs = opts.statefulSessionTtlMs ?? 30 * 60_000;
+  const now = opts.now ?? Date.now;
+  const sessions = new Map<string, ActiveMcpSession>();
+  let admissionTail: Promise<void> = Promise.resolve();
+
+  async function serializeAdmission<T>(run: () => Promise<T>): Promise<T> {
+    const current = admissionTail.catch(() => {}).then(run);
+    admissionTail = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    return current;
+  }
+
   return async (c: Context): Promise<Response> => {
     let context: Record<string, unknown>;
     try {
@@ -165,10 +214,22 @@ export function createMcpRoute(opts: McpRouteOptions) {
       // Never echo the Authorization header or any credential material.
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
-    if (!isIdentifiedPrincipal(context)) {
+    const key = contextPrincipalKey(context);
+    if (key === null) {
       return jsonRpcError(401, -32001, "Unauthorized MCP request.");
     }
 
+    if (mode === "stateful") await sweepExpiredSessions();
+
+    return mode === "stateful"
+      ? handleStateful(c, context.principal, key)
+      : handleStateless(c, context.principal);
+  };
+
+  async function handleStateless(
+    c: Context,
+    principal: unknown,
+  ): Promise<Response> {
     // Checked after auth, so an unauthenticated caller learns nothing about
     // which methods this route serves.
     if (c.req.method !== "POST") {
@@ -197,10 +258,14 @@ export function createMcpRoute(opts: McpRouteOptions) {
       enableJsonResponse: true,
     });
     const server = createServer(
-      createMcpTools(opts.app, {
-        principal: context.principal,
-        draftId: requestDraftId(parsedBody),
-      }),
+      createMcpTools(
+        opts.app,
+        {
+          principal,
+          draftId: requestDraftId(parsedBody),
+        },
+        "stateless",
+      ),
     );
     try {
       await server.connect(transport);
@@ -208,5 +273,117 @@ export function createMcpRoute(opts: McpRouteOptions) {
     } finally {
       await server.close();
     }
-  };
+  }
+
+  async function handleStateful(
+    c: Context,
+    principal: unknown,
+    key: string,
+  ): Promise<Response> {
+    const requestedSessionId = c.req.header("mcp-session-id");
+    const existing = requestedSessionId
+      ? sessions.get(requestedSessionId)
+      : undefined;
+    if (existing !== undefined && existing.principalKey !== key) {
+      return jsonRpcError(
+        403,
+        -32003,
+        "MCP session is not available to this credential.",
+      );
+    }
+    if (existing !== undefined) existing.lastSeenAt = now();
+
+    let parsedBody: unknown;
+    if (c.req.method === "POST") {
+      try {
+        parsedBody = await c.req.raw.json();
+      } catch {
+        return jsonRpcError(400, -32700, "Parse error: invalid JSON body.");
+      }
+    }
+
+    let active: ActiveMcpSession;
+    if (existing !== undefined) {
+      active = existing;
+    } else if (requestedSessionId !== undefined) {
+      return jsonRpcError(
+        404,
+        -32001,
+        "Unknown MCP session. Re-initialize the connection.",
+      );
+    } else if (c.req.method === "POST" && isInitializeRequest(parsedBody)) {
+      return serializeAdmission(async () => {
+        if (sessions.size >= maxStatefulSessions) {
+          const eligible = [...sessions.entries()]
+            .filter(([, session]) => session.principalKey === key)
+            .sort(([, a], [, b]) => a.lastSeenAt - b.lastSeenAt)[0];
+          if (eligible === undefined) {
+            return jsonRpcError(
+              503,
+              -32000,
+              "MCP session capacity is unavailable.",
+            );
+          }
+          await closeSession(eligible[0]);
+        }
+        const opened = await openSession(principal, key);
+        // Keep admission reserved through handleRequest: the transport inserts
+        // into `sessions` only from onsessioninitialized during this call.
+        return opened.transport.handleRequest(c.req.raw, { parsedBody });
+      });
+    } else {
+      return jsonRpcError(
+        400,
+        -32000,
+        "Expected an initialize request or an mcp-session-id header.",
+      );
+    }
+    return active.transport.handleRequest(c.req.raw, { parsedBody });
+  }
+
+  async function openSession(
+    principal: unknown,
+    key: string,
+  ): Promise<ActiveMcpSession> {
+    const context: McpRequestContext = { principal };
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      enableJsonResponse: true,
+      onsessioninitialized: (sessionId) => {
+        sessions.set(sessionId, {
+          context,
+          principalKey: key,
+          transport,
+          server,
+          lastSeenAt: now(),
+        });
+      },
+      onsessionclosed: async (sessionId) => {
+        const closed = sessions.get(sessionId);
+        sessions.delete(sessionId);
+        await closed?.server.close();
+      },
+    });
+    const server = createServer(createMcpTools(opts.app, context, "stateful"));
+    await server.connect(transport);
+    return { context, principalKey: key, transport, server, lastSeenAt: now() };
+  }
+
+  async function closeSession(sessionId: string): Promise<void> {
+    const active = sessions.get(sessionId);
+    if (active === undefined) return;
+    sessions.delete(sessionId);
+    try {
+      await active.transport.close();
+    } finally {
+      await active.server.close();
+    }
+  }
+
+  async function sweepExpiredSessions(): Promise<void> {
+    const cutoff = now() - statefulSessionTtlMs;
+    for (const [sessionId, active] of sessions) {
+      if (active.lastSeenAt <= cutoff) await closeSession(sessionId);
+    }
+  }
 }

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -21,7 +21,7 @@ import type { WyStackApp } from "@wystack/server";
 
 import { createAssistantReadHost } from "../assistant-read-host";
 import { assertKnownCommandPaths } from "../functions/commands";
-import type { McpMode, McpRequestContext } from "./route";
+import type { McpRequestContext } from "./route";
 
 type AssistantTool = {
   name: string;
@@ -64,22 +64,13 @@ function draftSafeCommandList(): string {
  * An MCP client sees tool descriptions and nothing else before it calls, so a
  * guide behind a second round trip is a guide the agent will not read.
  */
-function draftBatchDescription(mode: McpMode): string {
-  const continuity =
-    mode === "stateless"
-      ? [
-          "draft, never commit. Carry the returned draftId forward: pass it on later",
-          "draft_batch calls to append, and on read tools to see the draft overlay.",
-        ]
-      : [
-          "draft, never commit. The server carries the returned draftId for this",
-          "session, so later writes and reads continue against the same overlay.",
-        ];
+function draftBatchDescription(): string {
   return [
     "Append a batch of draft-safe DashFrame commands to a DashFrame draft.",
     "Nothing here reaches canonical state: the draft opens on the first",
     "successful call, and only a person can publish it. API credentials can",
-    ...continuity,
+    "draft, never commit. Carry the returned draftId forward: pass it on later",
+    "draft_batch calls to append, and on read tools to see the draft overlay.",
     "",
     "Each entry is { type, args } where `type` is a command NAME from the guide",
     "below (not a registry path).",
@@ -176,10 +167,9 @@ function isMissingDraftError(error: unknown): boolean {
 function createDelegatingReader(
   app: WyStackApp,
   context: McpRequestContext,
-  mode: McpMode,
 ): GraphReader {
   const assertDraftOpen = async (): Promise<void> => {
-    if (mode !== "stateless" || context.draftId === undefined) return;
+    if (context.draftId === undefined) return;
     const listed = await app.call(
       "listDrafts",
       {},
@@ -273,41 +263,35 @@ function refLine(details: unknown): string | null {
     : `Ids: ${rendered}`;
 }
 
-function toMcpTool(
-  tool: AssistantTool,
-  isReadTool: boolean,
-  mode: McpMode,
-): McpTool {
-  const inputSchema =
-    isReadTool && mode === "stateless"
-      ? {
-          ...tool.parameters,
-          properties: {
-            ...(tool.parameters as { properties: Record<string, TSchema> })
-              .properties,
-            draftId: Type.Optional(
-              Type.String({
-                description:
-                  "Draft id from draft_batch. Pass it to read through that " +
-                  "draft's overlay; omit to read canonical state.",
-              }),
-            ),
-          },
-        }
-      : tool.parameters;
+function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
+  const inputSchema = isReadTool
+    ? {
+        ...tool.parameters,
+        properties: {
+          ...(tool.parameters as { properties: Record<string, TSchema> })
+            .properties,
+          draftId: Type.Optional(
+            Type.String({
+              description:
+                "Draft id from draft_batch. Pass it to read through that " +
+                "draft's overlay; omit to read canonical state.",
+            }),
+          ),
+        },
+      }
+    : tool.parameters;
   return {
     name: tool.name,
     description: tool.description,
     inputSchema,
     async execute(args) {
-      const isStatelessReadArgs =
+      const isReadArgs =
         isReadTool &&
-        mode === "stateless" &&
         typeof args === "object" &&
         args !== null &&
         !Array.isArray(args);
       if (
-        isStatelessReadArgs &&
+        isReadArgs &&
         Object.hasOwn(args, "draftId") &&
         typeof (args as Record<string, unknown>).draftId !== "string"
       ) {
@@ -315,7 +299,7 @@ function toMcpTool(
           "Tool argument validation failed: /draftId must be string",
         );
       }
-      const toolArgs = isStatelessReadArgs
+      const toolArgs = isReadArgs
         ? (() => {
             const rest = { ...(args as Record<string, unknown>) };
             delete rest.draftId;
@@ -345,30 +329,24 @@ function toMcpTool(
 export function createMcpTools(
   app: WyStackApp,
   context: McpRequestContext,
-  mode: McpMode,
 ): McpTool[] {
   const readTools = Object.values(
-    createReadTools(createDelegatingReader(app, context, mode)),
+    createReadTools(createDelegatingReader(app, context)),
   ) as AssistantTool[];
 
   const writeTool = defineToolHandler({
     name: DRAFT_BATCH_TOOL_NAME,
-    description: draftBatchDescription(mode),
+    description: draftBatchDescription(),
     label: "Draft batch",
     executionMode: "sequential",
     parameters: Type.Object({
-      ...(mode === "stateless"
-        ? {
-            draftId: Type.Optional(
-              Type.String({
-                description:
-                  "Draft id returned by an earlier draft_batch call. Omit " +
-                  "to open a new draft; a missing or stale id also opens a " +
-                  "new draft.",
-              }),
-            ),
-          }
-        : {}),
+      draftId: Type.Optional(
+        Type.String({
+          description:
+            "Draft id returned by an earlier draft_batch call. Omit " +
+            "to open a new draft; a missing or stale id also opens a new draft.",
+        }),
+      ),
       commands: Type.Array(
         Type.Object({
           type: Type.String({
@@ -404,12 +382,7 @@ export function createMcpTools(
         return response.result as { draftId: string; results: unknown[] };
       };
 
-      const suppliedDraftId =
-        mode === "stateless"
-          ? (params as { draftId?: string }).draftId
-          : undefined;
-      const draftId =
-        suppliedDraftId ?? (mode === "stateful" ? context.draftId : undefined);
+      const draftId = (params as { draftId?: string }).draftId;
       let result: { draftId: string; results: unknown[] };
       try {
         result = await append(draftId);
@@ -419,7 +392,6 @@ export function createMcpTools(
         }
         result = await append(undefined);
       }
-      if (mode === "stateful") context.draftId = result.draftId;
       return {
         content: [
           {
@@ -437,7 +409,7 @@ export function createMcpTools(
   });
 
   return [
-    ...readTools.map((tool) => toMcpTool(tool, true, mode)),
-    toMcpTool(writeTool as AssistantTool, false, mode),
+    ...readTools.map((tool) => toMcpTool(tool, true)),
+    toMcpTool(writeTool as AssistantTool, false),
   ];
 }

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -176,10 +176,25 @@ function isMissingDraftError(error: unknown): boolean {
 function createDelegatingReader(
   app: WyStackApp,
   context: McpRequestContext,
+  mode: McpMode,
 ): GraphReader {
   return new Proxy({} as GraphReader, {
     get(_target, property: keyof GraphReader) {
-      return (...args: unknown[]) => {
+      return async (...args: unknown[]) => {
+        if (mode === "stateless" && context.draftId !== undefined) {
+          const listed = await app.call(
+            "listDrafts",
+            {},
+            { principal: context.principal },
+          );
+          const drafts = listed.result as Array<{ draftId: string }>;
+          if (!drafts.some((draft) => draft.draftId === context.draftId)) {
+            throw new Error(
+              `Draft ${context.draftId} is no longer open. Use the latest ` +
+                "draftId returned by draft_batch, or omit it to read canonical state.",
+            );
+          }
+        }
         const reader = createAssistantReadHost({
           app,
           ...(context.draftId === undefined
@@ -315,7 +330,7 @@ export function createMcpTools(
   mode: McpMode,
 ): McpTool[] {
   const readTools = Object.values(
-    createReadTools(createDelegatingReader(app, context)),
+    createReadTools(createDelegatingReader(app, context, mode)),
   ) as AssistantTool[];
 
   const writeTool = defineToolHandler({
@@ -371,7 +386,10 @@ export function createMcpTools(
         return response.result as { draftId: string; results: unknown[] };
       };
 
-      const suppliedDraftId = (params as { draftId?: string }).draftId;
+      const suppliedDraftId =
+        mode === "stateless"
+          ? (params as { draftId?: string }).draftId
+          : undefined;
       const draftId =
         suppliedDraftId ?? (mode === "stateful" ? context.draftId : undefined);
       let result: { draftId: string; results: unknown[] };

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -324,13 +324,18 @@ export function createMcpTools(
     label: "Draft batch",
     executionMode: "sequential",
     parameters: Type.Object({
-      draftId: Type.Optional(
-        Type.String({
-          description:
-            "Draft id returned by an earlier draft_batch call. Omit to open " +
-            "a new draft; a missing or stale id also opens a new draft.",
-        }),
-      ),
+      ...(mode === "stateless"
+        ? {
+            draftId: Type.Optional(
+              Type.String({
+                description:
+                  "Draft id returned by an earlier draft_batch call. Omit " +
+                  "to open a new draft; a missing or stale id also opens a " +
+                  "new draft.",
+              }),
+            ),
+          }
+        : {}),
       commands: Type.Array(
         Type.Object({
           type: Type.String({
@@ -366,7 +371,7 @@ export function createMcpTools(
         return response.result as { draftId: string; results: unknown[] };
       };
 
-      const suppliedDraftId = params.draftId as string | undefined;
+      const suppliedDraftId = (params as { draftId?: string }).draftId;
       const draftId =
         suppliedDraftId ?? (mode === "stateful" ? context.draftId : undefined);
       let result: { draftId: string; results: unknown[] };

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -178,23 +178,26 @@ function createDelegatingReader(
   context: McpRequestContext,
   mode: McpMode,
 ): GraphReader {
+  const assertDraftOpen = async (): Promise<void> => {
+    if (mode !== "stateless" || context.draftId === undefined) return;
+    const listed = await app.call(
+      "listDrafts",
+      {},
+      { principal: context.principal },
+    );
+    const drafts = listed.result as Array<{ draftId: string }>;
+    if (!drafts.some((draft) => draft.draftId === context.draftId)) {
+      throw new Error(
+        `Draft ${context.draftId} is no longer open. Use the latest ` +
+          "draftId returned by draft_batch, or omit it to read canonical state.",
+      );
+    }
+  };
+
   return new Proxy({} as GraphReader, {
     get(_target, property: keyof GraphReader) {
       return async (...args: unknown[]) => {
-        if (mode === "stateless" && context.draftId !== undefined) {
-          const listed = await app.call(
-            "listDrafts",
-            {},
-            { principal: context.principal },
-          );
-          const drafts = listed.result as Array<{ draftId: string }>;
-          if (!drafts.some((draft) => draft.draftId === context.draftId)) {
-            throw new Error(
-              `Draft ${context.draftId} is no longer open. Use the latest ` +
-                "draftId returned by draft_batch, or omit it to read canonical state.",
-            );
-          }
-        }
+        await assertDraftOpen();
         const reader = createAssistantReadHost({
           app,
           ...(context.draftId === undefined
@@ -202,7 +205,12 @@ function createDelegatingReader(
             : { draftId: context.draftId }),
         });
         const method = reader[property] as (...values: unknown[]) => unknown;
-        return method.apply(reader, args);
+        const result = await method.apply(reader, args);
+        // A person can publish or discard between the first check and the
+        // overlay read. Refuse that result instead of returning canonical data
+        // from a draft handle whose shadow disappeared mid-request.
+        await assertDraftOpen();
+        return result;
       };
     },
   });
@@ -292,18 +300,25 @@ function toMcpTool(
     description: tool.description,
     inputSchema,
     async execute(args) {
+      // Validate the schema advertised to MCP clients before removing the
+      // transport-only draftId. Otherwise a malformed present value silently
+      // becomes an absent value and scopes the read to canonical state.
+      const checkedInput = validateToolArgs(inputSchema as TSchema, args);
+      if (!checkedInput.ok) throw new Error(checkedInput.error.message);
       const toolArgs =
         isReadTool &&
         mode === "stateless" &&
-        typeof args === "object" &&
-        args !== null &&
-        !Array.isArray(args)
+        typeof checkedInput.value === "object" &&
+        checkedInput.value !== null &&
+        !Array.isArray(checkedInput.value)
           ? (() => {
-              const rest = { ...(args as Record<string, unknown>) };
+              const rest = {
+                ...(checkedInput.value as Record<string, unknown>),
+              };
               delete rest.draftId;
               return rest;
             })()
-          : args;
+          : checkedInput.value;
       const checked = validateToolArgs(tool.parameters, toolArgs);
       if (!checked.ok) throw new Error(checked.error.message);
       const result = await tool.execute(

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -21,7 +21,7 @@ import type { WyStackApp } from "@wystack/server";
 
 import { createAssistantReadHost } from "../assistant-read-host";
 import { assertKnownCommandPaths } from "../functions/commands";
-import type { McpRequestContext } from "./route";
+import type { McpMode, McpRequestContext } from "./route";
 
 type AssistantTool = {
   name: string;
@@ -64,13 +64,22 @@ function draftSafeCommandList(): string {
  * An MCP client sees tool descriptions and nothing else before it calls, so a
  * guide behind a second round trip is a guide the agent will not read.
  */
-function draftBatchDescription(): string {
+function draftBatchDescription(mode: McpMode): string {
+  const continuity =
+    mode === "stateless"
+      ? [
+          "draft, never commit. Carry the returned draftId forward: pass it on later",
+          "draft_batch calls to append, and on read tools to see the draft overlay.",
+        ]
+      : [
+          "draft, never commit. The server carries the returned draftId for this",
+          "session, so later writes and reads continue against the same overlay.",
+        ];
   return [
     "Append a batch of draft-safe DashFrame commands to a DashFrame draft.",
     "Nothing here reaches canonical state: the draft opens on the first",
     "successful call, and only a person can publish it. API credentials can",
-    "draft, never commit. Carry the returned draftId forward: pass it on later",
-    "draft_batch calls to append, and on read tools to see the draft overlay.",
+    ...continuity,
     "",
     "Each entry is { type, args } where `type` is a command NAME from the guide",
     "below (not a registry path).",
@@ -241,23 +250,28 @@ function refLine(details: unknown): string | null {
     : `Ids: ${rendered}`;
 }
 
-function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
-  const inputSchema = isReadTool
-    ? {
-        ...tool.parameters,
-        properties: {
-          ...(tool.parameters as { properties: Record<string, TSchema> })
-            .properties,
-          draftId: Type.Optional(
-            Type.String({
-              description:
-                "Draft id from draft_batch. Pass it to read through that " +
-                "draft's overlay; omit to read canonical state.",
-            }),
-          ),
-        },
-      }
-    : tool.parameters;
+function toMcpTool(
+  tool: AssistantTool,
+  isReadTool: boolean,
+  mode: McpMode,
+): McpTool {
+  const inputSchema =
+    isReadTool && mode === "stateless"
+      ? {
+          ...tool.parameters,
+          properties: {
+            ...(tool.parameters as { properties: Record<string, TSchema> })
+              .properties,
+            draftId: Type.Optional(
+              Type.String({
+                description:
+                  "Draft id from draft_batch. Pass it to read through that " +
+                  "draft's overlay; omit to read canonical state.",
+              }),
+            ),
+          },
+        }
+      : tool.parameters;
   return {
     name: tool.name,
     description: tool.description,
@@ -265,6 +279,7 @@ function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
     async execute(args) {
       const toolArgs =
         isReadTool &&
+        mode === "stateless" &&
         typeof args === "object" &&
         args !== null &&
         !Array.isArray(args)
@@ -297,6 +312,7 @@ function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
 export function createMcpTools(
   app: WyStackApp,
   context: McpRequestContext,
+  mode: McpMode,
 ): McpTool[] {
   const readTools = Object.values(
     createReadTools(createDelegatingReader(app, context)),
@@ -304,7 +320,7 @@ export function createMcpTools(
 
   const writeTool = defineToolHandler({
     name: DRAFT_BATCH_TOOL_NAME,
-    description: draftBatchDescription(),
+    description: draftBatchDescription(mode),
     label: "Draft batch",
     executionMode: "sequential",
     parameters: Type.Object({
@@ -350,7 +366,9 @@ export function createMcpTools(
         return response.result as { draftId: string; results: unknown[] };
       };
 
-      const draftId = params.draftId as string | undefined;
+      const suppliedDraftId = params.draftId as string | undefined;
+      const draftId =
+        suppliedDraftId ?? (mode === "stateful" ? context.draftId : undefined);
       let result: { draftId: string; results: unknown[] };
       try {
         result = await append(draftId);
@@ -360,6 +378,7 @@ export function createMcpTools(
         }
         result = await append(undefined);
       }
+      if (mode === "stateful") context.draftId = result.draftId;
       return {
         content: [
           {
@@ -377,7 +396,7 @@ export function createMcpTools(
   });
 
   return [
-    ...readTools.map((tool) => toMcpTool(tool, true)),
-    toMcpTool(writeTool as AssistantTool, false),
+    ...readTools.map((tool) => toMcpTool(tool, true, mode)),
+    toMcpTool(writeTool as AssistantTool, false, mode),
   ];
 }

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -21,7 +21,7 @@ import type { WyStackApp } from "@wystack/server";
 
 import { createAssistantReadHost } from "../assistant-read-host";
 import { assertKnownCommandPaths } from "../functions/commands";
-import type { McpSession } from "./route";
+import type { McpRequestContext } from "./route";
 
 type AssistantTool = {
   name: string;
@@ -66,13 +66,14 @@ function draftSafeCommandList(): string {
  */
 function draftBatchDescription(): string {
   return [
-    "Append a batch of draft-safe DashFrame commands to this session's draft.",
+    "Append a batch of draft-safe DashFrame commands to a DashFrame draft.",
     "Nothing here reaches canonical state: the draft opens on the first",
-    "successful call, is reused for the rest of the session, and only a person",
-    "can publish it. API credentials can draft, never commit.",
+    "successful call, and only a person can publish it. API credentials can",
+    "draft, never commit. Carry the returned draftId forward: pass it on later",
+    "draft_batch calls to append, and on read tools to see the draft overlay.",
     "",
     "Each entry is { type, args } where `type` is a command NAME from the guide",
-    "below (not a registry path). Do not pass a draft id — this tool holds it.",
+    "below (not a registry path).",
     `Allowed here: ${draftSafeCommandList()}.`,
     "",
     "Refused at this boundary — do not retry these, they will never succeed:",
@@ -85,9 +86,6 @@ function draftBatchDescription(): string {
     "  Publishing is a person's decision.",
     "- A secret reference (secret:<uuid>) in a credential field. Send the",
     "  plaintext value; the server stores it and hands back the reference.",
-    "",
-    "Reads before the first write see canonical state; reads afterwards see the",
-    "draft overlay, so you can read back what you just wrote.",
     "",
     renderCommandGuide(),
   ].join("\n");
@@ -163,21 +161,21 @@ function isMissingDraftError(error: unknown): boolean {
 }
 
 /**
- * The reader is deliberately a forwarder: the draft id belongs to the MCP
- * session and is looked up when each read executes, not when tools are listed.
+ * The reader is deliberately a forwarder: the request's draft id is applied
+ * when each read executes, not when tools are listed.
  */
 function createDelegatingReader(
   app: WyStackApp,
-  session: McpSession,
+  context: McpRequestContext,
 ): GraphReader {
   return new Proxy({} as GraphReader, {
     get(_target, property: keyof GraphReader) {
       return (...args: unknown[]) => {
         const reader = createAssistantReadHost({
           app,
-          ...(session.draftId === undefined
+          ...(context.draftId === undefined
             ? {}
-            : { draftId: session.draftId }),
+            : { draftId: context.draftId }),
         });
         const method = reader[property] as (...values: unknown[]) => unknown;
         return method.apply(reader, args);
@@ -243,19 +241,46 @@ function refLine(details: unknown): string | null {
     : `Ids: ${rendered}`;
 }
 
-function toMcpTool(tool: AssistantTool, surfaceRefs: boolean): McpTool {
+function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
+  const inputSchema = isReadTool
+    ? {
+        ...tool.parameters,
+        properties: {
+          ...(tool.parameters as { properties: Record<string, TSchema> })
+            .properties,
+          draftId: Type.Optional(
+            Type.String({
+              description:
+                "Draft id from draft_batch. Pass it to read through that " +
+                "draft's overlay; omit to read canonical state.",
+            }),
+          ),
+        },
+      }
+    : tool.parameters;
   return {
     name: tool.name,
     description: tool.description,
-    inputSchema: tool.parameters,
+    inputSchema,
     async execute(args) {
-      const checked = validateToolArgs(tool.parameters, args);
+      const toolArgs =
+        isReadTool &&
+        typeof args === "object" &&
+        args !== null &&
+        !Array.isArray(args)
+          ? (() => {
+              const rest = { ...(args as Record<string, unknown>) };
+              delete rest.draftId;
+              return rest;
+            })()
+          : args;
+      const checked = validateToolArgs(tool.parameters, toolArgs);
       if (!checked.ok) throw new Error(checked.error.message);
       const result = await tool.execute(
         crypto.randomUUID(),
         checked.value as never,
       );
-      const ids = surfaceRefs ? refLine(result.details) : null;
+      const ids = isReadTool ? refLine(result.details) : null;
       return {
         content:
           ids === null
@@ -271,10 +296,10 @@ function toMcpTool(tool: AssistantTool, surfaceRefs: boolean): McpTool {
 
 export function createMcpTools(
   app: WyStackApp,
-  session: McpSession,
+  context: McpRequestContext,
 ): McpTool[] {
   const readTools = Object.values(
-    createReadTools(createDelegatingReader(app, session)),
+    createReadTools(createDelegatingReader(app, context)),
   ) as AssistantTool[];
 
   const writeTool = defineToolHandler({
@@ -283,6 +308,13 @@ export function createMcpTools(
     label: "Draft batch",
     executionMode: "sequential",
     parameters: Type.Object({
+      draftId: Type.Optional(
+        Type.String({
+          description:
+            "Draft id returned by an earlier draft_batch call. Omit to open " +
+            "a new draft; a missing or stale id also opens a new draft.",
+        }),
+      ),
       commands: Type.Array(
         Type.Object({
           type: Type.String({
@@ -313,34 +345,26 @@ export function createMcpTools(
         const response = await app.call(
           "draftBatch",
           { commands, ...(draftId === undefined ? {} : { draftId }) },
-          { principal: session.principal },
+          { principal: context.principal },
         );
         return response.result as { draftId: string; results: unknown[] };
       };
 
-      // The session's draft is not the session's to keep: a person can publish
-      // or discard it at any moment, and `deleteDraftMetadata` then makes the
-      // remembered id unknown to `draftBatch` forever. The agent cannot rescue
-      // itself — this tool holds the id and never accepts one — so a stale
-      // handle would brick every remaining write on the connection. Forget it
-      // and open a fresh draft instead. Retried once, and only for this error:
-      // any other failure is the caller's to see.
+      const draftId = params.draftId as string | undefined;
       let result: { draftId: string; results: unknown[] };
       try {
-        result = await append(session.draftId);
+        result = await append(draftId);
       } catch (error) {
-        if (session.draftId === undefined || !isMissingDraftError(error)) {
+        if (draftId === undefined || !isMissingDraftError(error)) {
           throw error;
         }
-        session.draftId = undefined;
         result = await append(undefined);
       }
-      session.draftId = result.draftId;
       return {
         content: [
           {
             type: "text" as const,
-            text: `Appended ${commands.length} command(s) to the session draft.`,
+            text: `Appended ${commands.length} command(s) to draft ${result.draftId}.`,
           },
         ],
         details: {

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -300,25 +300,28 @@ function toMcpTool(
     description: tool.description,
     inputSchema,
     async execute(args) {
-      // Validate the schema advertised to MCP clients before removing the
-      // transport-only draftId. Otherwise a malformed present value silently
-      // becomes an absent value and scopes the read to canonical state.
-      const checkedInput = validateToolArgs(inputSchema as TSchema, args);
-      if (!checkedInput.ok) throw new Error(checkedInput.error.message);
-      const toolArgs =
+      const isStatelessReadArgs =
         isReadTool &&
         mode === "stateless" &&
-        typeof checkedInput.value === "object" &&
-        checkedInput.value !== null &&
-        !Array.isArray(checkedInput.value)
-          ? (() => {
-              const rest = {
-                ...(checkedInput.value as Record<string, unknown>),
-              };
-              delete rest.draftId;
-              return rest;
-            })()
-          : checkedInput.value;
+        typeof args === "object" &&
+        args !== null &&
+        !Array.isArray(args);
+      if (
+        isStatelessReadArgs &&
+        Object.hasOwn(args, "draftId") &&
+        typeof (args as Record<string, unknown>).draftId !== "string"
+      ) {
+        throw new Error(
+          "Tool argument validation failed: /draftId must be string",
+        );
+      }
+      const toolArgs = isStatelessReadArgs
+        ? (() => {
+            const rest = { ...(args as Record<string, unknown>) };
+            delete rest.draftId;
+            return rest;
+          })()
+        : args;
       const checked = validateToolArgs(tool.parameters, toolArgs);
       if (!checked.ok) throw new Error(checked.error.message);
       const result = await tool.execute(

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -20,8 +20,10 @@ import { isSecretRef } from "@wystack/secret-vault";
 import type { WyStackApp } from "@wystack/server";
 
 import { createAssistantReadHost } from "../assistant-read-host";
+import { DRAFT_UNAVAILABLE } from "../draft-access";
 import { assertKnownCommandPaths } from "../functions/commands";
-import type { McpRequestContext } from "./route";
+import { draftIdFromBatchError } from "../functions/draft-batch";
+import type { McpMode, McpRequestContext } from "./route";
 
 type AssistantTool = {
   name: string;
@@ -64,13 +66,24 @@ function draftSafeCommandList(): string {
  * An MCP client sees tool descriptions and nothing else before it calls, so a
  * guide behind a second round trip is a guide the agent will not read.
  */
-function draftBatchDescription(): string {
+function draftBatchDescription(mode: McpMode): string {
+  const continuity =
+    mode === "stateless"
+      ? [
+          "draft, never commit. Carry the returned draftId forward: pass it on later",
+          "draft_batch calls to append, and on read tools to see the draft overlay.",
+        ]
+      : [
+          "draft, never commit. The server carries the returned draftId for this",
+          "session, so later writes and reads continue against the same overlay.",
+        ];
   return [
     "Append a batch of draft-safe DashFrame commands to a DashFrame draft.",
-    "Nothing here reaches canonical state: the draft opens on the first",
-    "successful call, and only a person can publish it. API credentials can",
-    "draft, never commit. Carry the returned draftId forward: pass it on later",
-    "draft_batch calls to append, and on read tools to see the draft overlay.",
+    "Nothing here reaches canonical state: the draft opens before commands run,",
+    "and only a person can publish it. If a later command fails after an earlier",
+    "prefix committed, the error retains the owned draftId so that work can",
+    "continue. API credentials can",
+    ...continuity,
     "",
     "Each entry is { type, args } where `type` is a command NAME from the guide",
     "below (not a registry path).",
@@ -148,58 +161,47 @@ function lowerCommands(commands: readonly DraftBatchCommandInput[]): Command[] {
 }
 
 /**
- * `draftBatch` rejects a handle it cannot find with exactly this phrasing
- * (`draftBatch: no open draft <id>`), and nothing else on that path produces
- * it. Matching the text is the narrowest available signal — the RPC layer
- * carries no error codes — so it is kept deliberately specific rather than
- * matching anything draft-shaped.
- */
-function isMissingDraftError(error: unknown): boolean {
-  if (error instanceof Error) return error.message.includes("no open draft");
-  if (typeof error === "string") return error.includes("no open draft");
-  return false;
-}
-
-/**
- * The reader is deliberately a forwarder: the request's draft id is applied
- * when each read executes, not when tools are listed.
+ * The reader is deliberately a forwarder: each read snapshots the current
+ * handle, whether caller-supplied in stateless mode or retained by a stateful
+ * session, rather than binding a handle when tools are listed.
  */
 function createDelegatingReader(
   app: WyStackApp,
   context: McpRequestContext,
 ): GraphReader {
-  const assertDraftOpen = async (): Promise<void> => {
-    if (context.draftId === undefined) return;
+  const assertDraftOpen = async (
+    draftId: string | undefined,
+  ): Promise<void> => {
+    if (draftId === undefined) return;
     const listed = await app.call(
       "listDrafts",
       {},
       { principal: context.principal },
     );
     const drafts = listed.result as Array<{ draftId: string }>;
-    if (!drafts.some((draft) => draft.draftId === context.draftId)) {
-      throw new Error(
-        `Draft ${context.draftId} is no longer open. Use the latest ` +
-          "draftId returned by draft_batch, or omit it to read canonical state.",
-      );
+    if (!drafts.some((draft) => draft.draftId === draftId)) {
+      throw new Error(DRAFT_UNAVAILABLE);
     }
   };
 
   return new Proxy({} as GraphReader, {
     get(_target, property: keyof GraphReader) {
       return async (...args: unknown[]) => {
-        await assertDraftOpen();
+        // One request, one handle: a concurrent stateful write may replace the
+        // remembered draft, but this read must validate and read the snapshot it
+        // started with rather than post-validating a different handle.
+        const requestDraftId = context.draftId;
+        await assertDraftOpen(requestDraftId);
         const reader = createAssistantReadHost({
           app,
-          ...(context.draftId === undefined
-            ? {}
-            : { draftId: context.draftId }),
+          ...(requestDraftId === undefined ? {} : { draftId: requestDraftId }),
         });
         const method = reader[property] as (...values: unknown[]) => unknown;
         const result = await method.apply(reader, args);
         // A person can publish or discard between the first check and the
         // overlay read. Refuse that result instead of returning canonical data
         // from a draft handle whose shadow disappeared mid-request.
-        await assertDraftOpen();
+        await assertDraftOpen(requestDraftId);
         return result;
       };
     },
@@ -263,23 +265,28 @@ function refLine(details: unknown): string | null {
     : `Ids: ${rendered}`;
 }
 
-function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
-  const inputSchema = isReadTool
-    ? {
-        ...tool.parameters,
-        properties: {
-          ...(tool.parameters as { properties: Record<string, TSchema> })
-            .properties,
-          draftId: Type.Optional(
-            Type.String({
-              description:
-                "Draft id from draft_batch. Pass it to read through that " +
-                "draft's overlay; omit to read canonical state.",
-            }),
-          ),
-        },
-      }
-    : tool.parameters;
+function toMcpTool(
+  tool: AssistantTool,
+  isReadTool: boolean,
+  mode: McpMode,
+): McpTool {
+  const inputSchema =
+    isReadTool && mode === "stateless"
+      ? {
+          ...tool.parameters,
+          properties: {
+            ...(tool.parameters as { properties: Record<string, TSchema> })
+              .properties,
+            draftId: Type.Optional(
+              Type.String({
+                description:
+                  "Draft id from draft_batch. Pass it to read through that " +
+                  "draft's overlay; omit to read canonical state.",
+              }),
+            ),
+          },
+        }
+      : tool.parameters;
   return {
     name: tool.name,
     description: tool.description,
@@ -287,6 +294,7 @@ function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
     async execute(args) {
       const isReadArgs =
         isReadTool &&
+        mode === "stateless" &&
         typeof args === "object" &&
         args !== null &&
         !Array.isArray(args);
@@ -329,24 +337,67 @@ function toMcpTool(tool: AssistantTool, isReadTool: boolean): McpTool {
 export function createMcpTools(
   app: WyStackApp,
   context: McpRequestContext,
+  mode: McpMode,
 ): McpTool[] {
+  let statefulAppendTail: Promise<void> = Promise.resolve();
+  async function serializeStatefulAppend<T>(run: () => Promise<T>): Promise<T> {
+    const current = statefulAppendTail.catch(() => {}).then(run);
+    statefulAppendTail = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    return current;
+  }
+  function retainStatefulDraft(error: unknown): void {
+    if (mode !== "stateful") return;
+    const retainedDraftId = draftIdFromBatchError(error);
+    if (retainedDraftId !== undefined) context.draftId = retainedDraftId;
+  }
+  async function recoverClosedStatefulDraft<T extends { draftId: string }>(
+    error: unknown,
+    rememberedDraftId: string | undefined,
+    append: (draftId: string | undefined) => Promise<T>,
+  ): Promise<T> {
+    retainStatefulDraft(error);
+    if (
+      mode !== "stateful" ||
+      rememberedDraftId === undefined ||
+      !(error instanceof Error) ||
+      error.message !== DRAFT_UNAVAILABLE
+    ) {
+      throw error;
+    }
+    context.draftId = undefined;
+    try {
+      const result = await append(undefined);
+      context.draftId = result.draftId;
+      return result;
+    } catch (retryError) {
+      retainStatefulDraft(retryError);
+      throw retryError;
+    }
+  }
   const readTools = Object.values(
     createReadTools(createDelegatingReader(app, context)),
   ) as AssistantTool[];
 
   const writeTool = defineToolHandler({
     name: DRAFT_BATCH_TOOL_NAME,
-    description: draftBatchDescription(),
+    description: draftBatchDescription(mode),
     label: "Draft batch",
     executionMode: "sequential",
     parameters: Type.Object({
-      draftId: Type.Optional(
-        Type.String({
-          description:
-            "Draft id returned by an earlier draft_batch call. Omit " +
-            "to open a new draft; a missing or stale id also opens a new draft.",
-        }),
-      ),
+      ...(mode === "stateless"
+        ? {
+            draftId: Type.Optional(
+              Type.String({
+                description:
+                  "Draft id returned by an earlier draft_batch call. Omit " +
+                  "to open a new draft.",
+              }),
+            ),
+          }
+        : {}),
       commands: Type.Array(
         Type.Object({
           type: Type.String({
@@ -382,16 +433,26 @@ export function createMcpTools(
         return response.result as { draftId: string; results: unknown[] };
       };
 
-      const draftId = (params as { draftId?: string }).draftId;
-      let result: { draftId: string; results: unknown[] };
-      try {
-        result = await append(draftId);
-      } catch (error) {
-        if (draftId === undefined || !isMissingDraftError(error)) {
-          throw error;
+      const performAppend = async () => {
+        const draftId =
+          mode === "stateless"
+            ? (params as { draftId?: string }).draftId
+            : context.draftId;
+        try {
+          const result = await append(draftId);
+          if (mode === "stateful") context.draftId = result.draftId;
+          return result;
+        } catch (error) {
+          // A remembered stateful handle is server-owned session state. Once a
+          // person closes it, the next write starts a new owned draft. Stateless
+          // caller-supplied handles never receive this fallback.
+          return recoverClosedStatefulDraft(error, draftId, append);
         }
-        result = await append(undefined);
-      }
+      };
+      const result =
+        mode === "stateful"
+          ? await serializeStatefulAppend(performAppend)
+          : await performAppend();
       return {
         content: [
           {
@@ -409,7 +470,7 @@ export function createMcpTools(
   });
 
   return [
-    ...readTools.map((tool) => toMcpTool(tool, true)),
-    toMcpTool(writeTool as AssistantTool, false),
+    ...readTools.map((tool) => toMcpTool(tool, true, mode)),
+    toMcpTool(writeTool as AssistantTool, false, mode),
   ];
 }

--- a/apps/server/src/mcp/tools.ts
+++ b/apps/server/src/mcp/tools.ts
@@ -167,45 +167,37 @@ function lowerCommands(commands: readonly DraftBatchCommandInput[]): Command[] {
  */
 function createDelegatingReader(
   app: WyStackApp,
-  context: McpRequestContext,
+  draftId: string | undefined,
 ): GraphReader {
-  const assertDraftOpen = async (
-    draftId: string | undefined,
-  ): Promise<void> => {
-    if (draftId === undefined) return;
-    const listed = await app.call(
-      "listDrafts",
-      {},
-      { principal: context.principal },
-    );
-    const drafts = listed.result as Array<{ draftId: string }>;
-    if (!drafts.some((draft) => draft.draftId === draftId)) {
-      throw new Error(DRAFT_UNAVAILABLE);
-    }
-  };
-
   return new Proxy({} as GraphReader, {
     get(_target, property: keyof GraphReader) {
       return async (...args: unknown[]) => {
-        // One request, one handle: a concurrent stateful write may replace the
-        // remembered draft, but this read must validate and read the snapshot it
-        // started with rather than post-validating a different handle.
-        const requestDraftId = context.draftId;
-        await assertDraftOpen(requestDraftId);
         const reader = createAssistantReadHost({
           app,
-          ...(requestDraftId === undefined ? {} : { draftId: requestDraftId }),
+          ...(draftId === undefined ? {} : { draftId }),
         });
         const method = reader[property] as (...values: unknown[]) => unknown;
-        const result = await method.apply(reader, args);
-        // A person can publish or discard between the first check and the
-        // overlay read. Refuse that result instead of returning canonical data
-        // from a draft handle whose shadow disappeared mid-request.
-        await assertDraftOpen(requestDraftId);
-        return result;
+        return method.apply(reader, args);
       };
     },
   });
+}
+
+async function assertDraftOpen(
+  app: WyStackApp,
+  context: McpRequestContext,
+  draftId: string | undefined,
+): Promise<void> {
+  if (draftId === undefined) return;
+  const listed = await app.call(
+    "listDrafts",
+    {},
+    { principal: context.principal },
+  );
+  const drafts = listed.result as Array<{ draftId: string }>;
+  if (!drafts.some((draft) => draft.draftId === draftId)) {
+    throw new Error(DRAFT_UNAVAILABLE);
+  }
 }
 
 /** Cap on the id line; a whole-graph `find_nodes` can return a lot. */
@@ -269,6 +261,8 @@ function toMcpTool(
   tool: AssistantTool,
   isReadTool: boolean,
   mode: McpMode,
+  app: WyStackApp,
+  context: McpRequestContext,
 ): McpTool {
   const inputSchema =
     isReadTool && mode === "stateless"
@@ -292,6 +286,7 @@ function toMcpTool(
     description: tool.description,
     inputSchema,
     async execute(args) {
+      const requestDraftId = isReadTool ? context.draftId : undefined;
       const isReadArgs =
         isReadTool &&
         mode === "stateless" &&
@@ -316,10 +311,19 @@ function toMcpTool(
         : args;
       const checked = validateToolArgs(tool.parameters, toolArgs);
       if (!checked.ok) throw new Error(checked.error.message);
-      const result = await tool.execute(
+      if (isReadTool) await assertDraftOpen(app, context, requestDraftId);
+      const executionTool = isReadTool
+        ? (Object.values(
+            createReadTools(createDelegatingReader(app, requestDraftId)),
+          ).find((candidate) => candidate.name === tool.name) as AssistantTool)
+        : tool;
+      const result = await executionTool.execute(
         crypto.randomUUID(),
         checked.value as never,
       );
+      // A person can close the exact captured handle during the read. Refuse
+      // that result instead of falling through to canonical or a replacement.
+      if (isReadTool) await assertDraftOpen(app, context, requestDraftId);
       const ids = isReadTool ? refLine(result.details) : null;
       return {
         content:
@@ -378,7 +382,7 @@ export function createMcpTools(
     }
   }
   const readTools = Object.values(
-    createReadTools(createDelegatingReader(app, context)),
+    createReadTools(createDelegatingReader(app, undefined)),
   ) as AssistantTool[];
 
   const writeTool = defineToolHandler({
@@ -470,7 +474,7 @@ export function createMcpTools(
   });
 
   return [
-    ...readTools.map((tool) => toMcpTool(tool, true, mode)),
-    toMcpTool(writeTool as AssistantTool, false, mode),
+    ...readTools.map((tool) => toMcpTool(tool, true, mode, app, context)),
+    toMcpTool(writeTool as AssistantTool, false, mode, app, context),
   ];
 }

--- a/packages/server-core/src/schema.test.ts
+++ b/packages/server-core/src/schema.test.ts
@@ -247,6 +247,7 @@ describe("draft_metadata table", () => {
   test("draft_metadata has the expected columns", async () => {
     const cols = await liveColumns("draft_metadata");
     expect(cols.has("draft_id")).toBe(true);
+    expect(cols.has("owner_principal_key")).toBe(true);
     expect(cols.has("base_version")).toBe(true);
     expect(cols.has("log_revision")).toBe(true);
     expect(cols.has("base_inventory")).toBe(true);

--- a/packages/server-core/src/schema.ts
+++ b/packages/server-core/src/schema.ts
@@ -508,6 +508,9 @@ export const draftCommandLog = pgTable(
 
 export const draftMetadata = pgTable("draft_metadata", {
   draftId: text("draft_id").primaryKey(),
+  // Durable owner for remote draft handles. Nullable preserves legacy and
+  // trusted in-process drafts; service principals may never claim null rows.
+  ownerPrincipalKey: text("owner_principal_key"),
   baseVersion: timestamp("base_version", { withTimezone: true }).notNull(),
   // Monotonic CAS token for every durable command-log replacement. Nullable so
   // syncSchema can add it safely to existing projects; NULL is the legacy zero.


### PR DESCRIPTION
## Summary

- serve MCP exclusively as sessionless Streamable HTTP; remove the session map, session ownership, stateful transport lifecycle, and mode flag
- preserve draft continuity explicitly: `draft_batch` returns a `draftId`, later writes append with it, and read tools accept it to read the draft overlay
- reject malformed JSON, JSON-RPC batches, stale/interrupted draft reads, and unsupported GET/DELETE requests instead of silently returning canonical or short-lived stream results
- preserve assistant argument coercion and the existing service-principal authorization boundary

## Stack

Merge order:

1. TASK-753 — `codex/task-753-server-dataframe-storage` (parent)
2. TASK-745 — this PR, `task-745/stateless-mcp`

This PR targets the TASK-753 branch and contains only its incremental MCP diff. Do not merge it before the parent. Hosted checks and reviews remain provisional until the parent merges and this branch is rebased/retargeted onto the final parent result.

## Validation

Final published head: `842a4095a148ad2739efdbc096708098449a8238`

- `bun run check` — PASS, 85/85 tasks on the final head
  - `@dashframe/server`: 32 files, 672/672 tests
- `bun run format:check` — PASS
- MCP route suite — 11/11 tests, including authenticated SDK discovery/calls, explicit draft continuity, canonical isolation, stale/interrupted draft rejection, stateless bare calls, and GET/DELETE refusal
- local incremental diff review — no findings
- independent Grok 4.5 review of `git diff codex/task-753-server-dataframe-storage...HEAD` — no findings
- hosted CI — PASS: Format; Lint, Type Check & Format; E2E Tests (19/19 on rerun)

Behavioral compatibility:

- the real MCP SDK completes initialization, tool discovery, read calls, draft writes, and explicit cross-request draft reuse against the live route
- Codex CLI 0.147.0 completed handshake and tool discovery against the live stateless endpoint; its noninteractive tool invocation was auto-cancelled by the known `codex exec` MCP approval issue, so successful tool execution is evidenced by the SDK integration test rather than overclaimed for Codex

## Broad-suite failure classification

- Reproduced sandbox-only server failures: 61 tests failed with `listen EPERM 127.0.0.1`; rerunning outside the network sandbox passed the full server suite. This is a loopback restriction, not an application failure.
- Reproduced one desktop bundle timeout under concurrent suite pressure; the isolated suite passed 37/37 and subsequent complete gates passed. The final exact-head gate also passed, though contention extended it to 7m06s. This is resource pressure, not a deterministic failure.
- The first hosted E2E attempt failed only `visualize-intent.spec.ts`: the visualization was created, selected, titled, and saved, but the chart SVG missed its readiness timeout. It reproduced once locally, while the unchanged test passed on the TASK-753 parent and passed all 19 E2Es unchanged on rerun. Classified as an existing chart-render readiness flake, not resource pressure and not an MCP regression.
