### PR TITLE
[codex] Reconcile client-hook schema columns at startup

### DIFF
--- a/packages/server-core/src/db.test.ts
+++ b/packages/server-core/src/db.test.ts
@@ -119,6 +119,38 @@ describe("openArtifactDb", () => {
     ]);
   });
 
+  test("reconciles nullable data frame updatedAt despite its client-side onUpdate hook", async () => {
+    const dbPath = join(dir, "artifacts.db");
+    const first = await openTestArtifactDb(dbPath);
+
+    const frameId = crypto.randomUUID();
+    await first.insert(schema.dataFrames).values({
+      id: frameId,
+      storage: { kind: "file" },
+      fieldIds: [],
+      name: "legacy-frame",
+    });
+    await first.execute(sql`ALTER TABLE data_frames DROP COLUMN updated_at`);
+    await first.$client.close();
+    openDbs = openDbs.filter((db) => db !== first);
+
+    const second = await openTestArtifactDb(dbPath);
+    const rows = await second.select().from(schema.dataFrames);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(frameId);
+    expect(rows[0]?.updatedAt).toBeNull();
+
+    await second
+      .update(schema.dataFrames)
+      .set({ name: "updated-frame" })
+      .where(eq(schema.dataFrames.id, frameId));
+    const [updated] = await second
+      .select()
+      .from(schema.dataFrames)
+      .where(eq(schema.dataFrames.id, frameId));
+    expect(updated?.updatedAt).toBeInstanceOf(Date);
+  });
+
   test("should declare required artifact provenance fields and parent indexes", async () => {
     const db = await openTestArtifactDb();
 

--- a/packages/server-core/src/db.test.ts
+++ b/packages/server-core/src/db.test.ts
@@ -1,4 +1,5 @@
 import { eq, sql } from "drizzle-orm";
+import { integer, pgTable, text } from "drizzle-orm/pg-core";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,6 +20,7 @@ import {
   schema,
   visualizations,
 } from "./schema";
+import { renderAddNullableColumnsIfNotExists } from "./sync-schema";
 
 describe("openArtifactDb", () => {
   let dir: string;
@@ -119,6 +121,9 @@ describe("openArtifactDb", () => {
     ]);
   });
 
+  // Existing schema tests materialized the current shape from scratch; they did
+  // not reopen a populated PGlite database after this nullable hook-backed
+  // column had been absent from its original table.
   test("reconciles nullable data frame updatedAt despite its client-side onUpdate hook", async () => {
     const dbPath = join(dir, "artifacts.db");
     const first = await openTestArtifactDb(dbPath);
@@ -149,6 +154,20 @@ describe("openArtifactDb", () => {
       .from(schema.dataFrames)
       .where(eq(schema.dataFrames.id, frameId));
     expect(updated?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  test("keeps generated and unique hook-backed columns off the additive path", () => {
+    const synthetic = pgTable("synthetic_additive_columns", {
+      safeHook: text("safe_hook").$onUpdate(() => "updated"),
+      uniqueHook: text("unique_hook")
+        .$onUpdate(() => "updated")
+        .unique(),
+      generatedValue: integer("generated_value").generatedAlwaysAs(sql`1 + 1`),
+    });
+
+    expect(renderAddNullableColumnsIfNotExists(synthetic)).toEqual([
+      'ALTER TABLE "synthetic_additive_columns" ADD COLUMN IF NOT EXISTS "safe_hook" text;',
+    ]);
   });
 
   test("should declare required artifact provenance fields and parent indexes", async () => {

--- a/packages/server-core/src/sync-schema.ts
+++ b/packages/server-core/src/sync-schema.ts
@@ -178,8 +178,13 @@ export function renderAddNullableColumnsIfNotExists(table: PgTable): string[] {
     // `isArray` is a Drizzle-internal flag not on the public column type
     // (matching the cast in `renderColumn`).
     const col = rawCol as any;
-    // Skip columns that can't be added safely to a populated table.
-    if (col.notNull || col.primary || col.hasDefault) continue;
+    // Skip columns that can't be added safely to a populated table. Drizzle's
+    // `hasDefault` also becomes true for client-side `$onUpdate` / `$defaultFn`
+    // hooks even when the column has no SQL DEFAULT. Those hooks do not affect
+    // ALTER TABLE safety: an existing nullable column may be added as NULL and
+    // populated by later application writes. Only an actual SQL default needs
+    // to stay on the explicit migration path.
+    if (col.notNull || col.primary || col.default !== undefined) continue;
     let type = col.getSQLType();
     if (col.isArray) type += "[]";
     stmts.push(

--- a/packages/server-core/src/sync-schema.ts
+++ b/packages/server-core/src/sync-schema.ts
@@ -182,9 +182,18 @@ export function renderAddNullableColumnsIfNotExists(table: PgTable): string[] {
     // `hasDefault` also becomes true for client-side `$onUpdate` / `$defaultFn`
     // hooks even when the column has no SQL DEFAULT. Those hooks do not affect
     // ALTER TABLE safety: an existing nullable column may be added as NULL and
-    // populated by later application writes. Only an actual SQL default needs
-    // to stay on the explicit migration path.
-    if (col.notNull || col.primary || col.default !== undefined) continue;
+    // populated by later application writes. Actual SQL defaults, generated
+    // expressions, and column-level uniqueness all require richer DDL than
+    // this additive path emits, so they stay on the explicit migration path.
+    if (
+      col.notNull ||
+      col.primary ||
+      col.default !== undefined ||
+      col.generated !== undefined ||
+      col.isUnique
+    ) {
+      continue;
+    }
     let type = col.getSQLType();
     if (col.isArray) type += "[]";
     stmts.push(


### PR DESCRIPTION
## Summary
- distinguish actual SQL defaults from Drizzle client-side `$onUpdate` / `$defaultFn` metadata during additive schema sync
- restore nullable `data_frames.updated_at` on legacy projects before startup frame cleanup queries it
- add a populated-PGlite reopen regression proving row preservation and later `$onUpdate` behavior

## Verification
- real existing desktop project now opens successfully with keychain vault and native DuckDB
- `bun run check`: 85/85 tasks, server 825/825, app 712/712
- `bun run format:check`: pass
- server-core focused suite: 151 passed, 1 todo
- independent review: CLEAN, no MUST/SUGGEST
- diff checks: pass
