### PR TITLE
[codex] Open desktop OAuth in the system browser

### DIFF
--- a/apps/desktop/src/ipc-contract.test.ts
+++ b/apps/desktop/src/ipc-contract.test.ts
@@ -73,11 +73,12 @@ describe("IPC channel contract: preload ↔ main", () => {
     }
   });
 
-  it("the contract is exactly the three documented desktop channels", () => {
+  it("the contract is exactly the four documented desktop channels", () => {
     // Pin the surface so an accidental new channel (or a dropped one) is a
     // visible, reviewed change rather than a silent drift.
     const handled = handledChannels(mainSource);
     expect([...handled].sort()).toEqual([
+      "dashframe:oauth:open-authorization",
       "dashframe:project:info",
       "dashframe:project:reveal",
       "dashframe:server:info",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,6 +28,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { Lifecycle } from "./lifecycle.js";
+import { assertGoogleAuthorizationUrl } from "./oauth-external-url.js";
 import { ElectronKeychainBackend } from "./secret-keychain-backend.js";
 
 const DEV_URL = process.env.DEV_URL ?? "http://localhost:5173";
@@ -188,6 +189,12 @@ function registerIpc(
   ipcMain.handle("dashframe:project:reveal", () => {
     shell.showItemInFolder(path.join(handle.dir, ARTIFACTS_DB_FILENAME));
   });
+  ipcMain.handle(
+    "dashframe:oauth:open-authorization",
+    async (_event, url: unknown) => {
+      await shell.openExternal(assertGoogleAuthorizationUrl(url));
+    },
+  );
   // The renderer connects to this loopback WyStack server as a localhost web
   // client — same client + transport as the cloud web client (per the Data
   // Path & Transport Deployment spec). It needs the ephemeral port main bound.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,10 +29,27 @@ import path from "node:path";
 
 import { Lifecycle } from "./lifecycle.js";
 import { assertGoogleAuthorizationUrl } from "./oauth-external-url.js";
+import {
+  assertTrustedRendererUrl,
+  isTrustedRendererUrl,
+} from "./renderer-trust.js";
 import { ElectronKeychainBackend } from "./secret-keychain-backend.js";
 
 const DEV_URL = process.env.DEV_URL ?? "http://localhost:5173";
 const isDev = !app.isPackaged;
+const PRODUCTION_RENDERER_FILE = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "renderer",
+  "dist",
+  "index.html",
+);
+const rendererTrustOptions = {
+  dev: isDev,
+  devUrl: DEV_URL,
+  productionFile: PRODUCTION_RENDERER_FILE,
+};
 
 // Single owner of this launch's closable handles + the shutdown guard. main.ts
 // holds exactly one instance; shutdown drains whatever has been registered so
@@ -147,19 +164,16 @@ async function createWindow(): Promise<void> {
     },
   });
 
+  win.webContents.on("will-navigate", (event, url) => {
+    if (!isTrustedRendererUrl(url, rendererTrustOptions)) {
+      event.preventDefault();
+    }
+  });
+
   try {
     await (isDev
       ? win.loadURL(DEV_URL)
-      : win.loadFile(
-          path.join(
-            import.meta.dirname,
-            "..",
-            "..",
-            "renderer",
-            "dist",
-            "index.html",
-          ),
-        ));
+      : win.loadFile(PRODUCTION_RENDERER_FILE));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[dashframe] window load failed:", err);
@@ -178,30 +192,38 @@ function registerIpc(
   srv: DashframeServer,
   authToken: string,
 ): void {
-  ipcMain.handle("dashframe:project:info", () => ({
-    projectId: handle.meta.projectId,
-    name: handle.meta.name,
-    version: handle.meta.version,
-    schemaVersion: handle.meta.schemaVersion,
-    createdAt: handle.meta.createdAt.toISOString(),
-    createdBy: handle.meta.createdBy,
-  }));
-  ipcMain.handle("dashframe:project:reveal", () => {
+  ipcMain.handle("dashframe:project:info", (event) => {
+    assertTrustedRendererUrl(event.senderFrame?.url, rendererTrustOptions);
+    return {
+      projectId: handle.meta.projectId,
+      name: handle.meta.name,
+      version: handle.meta.version,
+      schemaVersion: handle.meta.schemaVersion,
+      createdAt: handle.meta.createdAt.toISOString(),
+      createdBy: handle.meta.createdBy,
+    };
+  });
+  ipcMain.handle("dashframe:project:reveal", (event) => {
+    assertTrustedRendererUrl(event.senderFrame?.url, rendererTrustOptions);
     shell.showItemInFolder(path.join(handle.dir, ARTIFACTS_DB_FILENAME));
   });
   ipcMain.handle(
     "dashframe:oauth:open-authorization",
-    async (_event, url: unknown) => {
+    async (event, url: unknown) => {
+      assertTrustedRendererUrl(event.senderFrame?.url, rendererTrustOptions);
       await shell.openExternal(assertGoogleAuthorizationUrl(url));
     },
   );
   // The renderer connects to this loopback WyStack server as a localhost web
   // client — same client + transport as the cloud web client (per the Data
   // Path & Transport Deployment spec). It needs the ephemeral port main bound.
-  ipcMain.handle("dashframe:server:info", () => ({
-    url: srv.url,
-    token: authToken,
-  }));
+  ipcMain.handle("dashframe:server:info", (event) => {
+    assertTrustedRendererUrl(event.senderFrame?.url, rendererTrustOptions);
+    return {
+      url: srv.url,
+      token: authToken,
+    };
+  });
 }
 
 console.log("[dashframe] main process started, waiting for app ready...");

--- a/apps/desktop/src/oauth-external-url.test.ts
+++ b/apps/desktop/src/oauth-external-url.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { assertGoogleAuthorizationUrl } from "./oauth-external-url";
+
+describe("assertGoogleAuthorizationUrl", () => {
+  it("accepts the exact Google OAuth authorization endpoint", () => {
+    expect(
+      assertGoogleAuthorizationUrl(
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=client&state=state",
+      ),
+    ).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth?client_id=client&state=state",
+    );
+  });
+
+  it.each([
+    "https://accounts.google.com/o/oauth2/v2/auth".replace("https", "http"),
+    "https://accounts.google.com.evil.example/o/oauth2/v2/auth",
+    "https://accounts.google.com/o/oauth2/auth",
+    "https://accounts.google.com/o/oauth2/v2/auth#fragment",
+    "https://user:password@accounts.google.com/o/oauth2/v2/auth",
+  ])("rejects a URL outside the narrow authorization boundary: %s", (url) => {
+    expect(() => assertGoogleAuthorizationUrl(url)).toThrow(
+      "Google authorization URL is not allowed",
+    );
+  });
+
+  it.each([undefined, null, 42, "not a url"])(
+    "rejects a malformed value: %s",
+    (value) => {
+      expect(() => assertGoogleAuthorizationUrl(value)).toThrow();
+    },
+  );
+});

--- a/apps/desktop/src/oauth-external-url.ts
+++ b/apps/desktop/src/oauth-external-url.ts
@@ -1,0 +1,32 @@
+const GOOGLE_AUTHORIZATION_ORIGIN = "https://accounts.google.com";
+const GOOGLE_AUTHORIZATION_PATH = "/o/oauth2/v2/auth";
+
+/**
+ * Keep the preload capability narrower than a general-purpose URL launcher.
+ * The renderer may only hand main the exact Google OAuth endpoint that the
+ * server issues for GA4 setup.
+ */
+export function assertGoogleAuthorizationUrl(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error("Google authorization URL must be a string");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Google authorization URL is invalid");
+  }
+
+  if (
+    url.origin !== GOOGLE_AUTHORIZATION_ORIGIN ||
+    url.pathname !== GOOGLE_AUTHORIZATION_PATH ||
+    url.username ||
+    url.password ||
+    url.hash
+  ) {
+    throw new Error("Google authorization URL is not allowed");
+  }
+
+  return url.href;
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -18,6 +18,10 @@ const api: DashFrameApi = {
     revealFolder: (): Promise<void> =>
       ipcRenderer.invoke("dashframe:project:reveal"),
   },
+  oauth: {
+    openAuthorizationUrl: (url: string): Promise<void> =>
+      ipcRenderer.invoke("dashframe:oauth:open-authorization", url),
+  },
   getServerInfo: (): Promise<ServerInfo> =>
     ipcRenderer.invoke("dashframe:server:info"),
 } as const;

--- a/apps/desktop/src/renderer-trust.test.ts
+++ b/apps/desktop/src/renderer-trust.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertTrustedRendererUrl,
+  isTrustedRendererUrl,
+} from "./renderer-trust";
+
+const productionFile = "/Applications/DashFrame/renderer/index.html";
+
+describe("desktop renderer trust", () => {
+  const developmentUrl = "https://localhost:5173".replace("https", "http");
+
+  it("accepts routes on the configured development origin", () => {
+    expect(
+      isTrustedRendererUrl(`${developmentUrl}/insights/example`, {
+        dev: true,
+        devUrl: developmentUrl,
+        productionFile,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects hostile and origin-confusion development URLs", () => {
+    const options = {
+      dev: true,
+      devUrl: developmentUrl,
+      productionFile,
+    };
+    expect(isTrustedRendererUrl("https://attacker.example", options)).toBe(
+      false,
+    );
+    expect(
+      isTrustedRendererUrl(`${developmentUrl}.attacker.example`, options),
+    ).toBe(false);
+    expect(isTrustedRendererUrl(undefined, options)).toBe(false);
+  });
+
+  it("accepts only the packaged renderer file in production", () => {
+    const options = {
+      dev: false,
+      devUrl: developmentUrl,
+      productionFile,
+    };
+    expect(
+      isTrustedRendererUrl(
+        "file:///Applications/DashFrame/renderer/index.html#/insights/example",
+        options,
+      ),
+    ).toBe(true);
+    expect(
+      isTrustedRendererUrl(
+        "file:///Applications/DashFrame/renderer/other.html",
+        options,
+      ),
+    ).toBe(false);
+  });
+
+  it("fails closed for a missing sender frame", () => {
+    expect(() =>
+      assertTrustedRendererUrl(undefined, {
+        dev: false,
+        devUrl: developmentUrl,
+        productionFile,
+      }),
+    ).toThrow("Untrusted desktop renderer");
+  });
+});

--- a/apps/desktop/src/renderer-trust.test.ts
+++ b/apps/desktop/src/renderer-trust.test.ts
@@ -53,6 +53,12 @@ describe("desktop renderer trust", () => {
         options,
       ),
     ).toBe(false);
+    expect(
+      isTrustedRendererUrl(
+        "file://attacker.example/Applications/DashFrame/renderer/index.html",
+        options,
+      ),
+    ).toBe(false);
   });
 
   it("fails closed for a missing sender frame", () => {

--- a/apps/desktop/src/renderer-trust.ts
+++ b/apps/desktop/src/renderer-trust.ts
@@ -32,6 +32,7 @@ export function isTrustedRendererUrl(
   return (
     candidate.protocol === "file:" &&
     candidate.origin === expected.origin &&
+    candidate.host === expected.host &&
     candidate.pathname === expected.pathname
   );
 }

--- a/apps/desktop/src/renderer-trust.ts
+++ b/apps/desktop/src/renderer-trust.ts
@@ -1,0 +1,46 @@
+import { pathToFileURL } from "node:url";
+
+interface RendererTrustOptions {
+  dev: boolean;
+  devUrl: string;
+  productionFile: string;
+}
+
+/** Restrict privileged preload capabilities to the DashFrame renderer itself. */
+export function isTrustedRendererUrl(
+  value: string | undefined,
+  options: RendererTrustOptions,
+): boolean {
+  if (!value) return false;
+
+  let candidate: URL;
+  try {
+    candidate = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (options.dev) {
+    try {
+      return candidate.origin === new URL(options.devUrl).origin;
+    } catch {
+      return false;
+    }
+  }
+
+  const expected = pathToFileURL(options.productionFile);
+  return (
+    candidate.protocol === "file:" &&
+    candidate.origin === expected.origin &&
+    candidate.pathname === expected.pathname
+  );
+}
+
+export function assertTrustedRendererUrl(
+  value: string | undefined,
+  options: RendererTrustOptions,
+): void {
+  if (!isTrustedRendererUrl(value, options)) {
+    throw new Error("Untrusted desktop renderer");
+  }
+}

--- a/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.oauth.test.ts
+++ b/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.oauth.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }));
+
+vi.mock("@/wystack/client", () => ({
+  getWyStackClient: () => ({ mutate }),
+}));
+
+import { rejectOAuthSetupWithoutAuthorizationUrl } from "./ConnectorCardWithForm";
+
+describe("rejectOAuthSetupWithoutAuthorizationUrl", () => {
+  beforeEach(() => {
+    mutate.mockReset();
+    mutate.mockResolvedValue(undefined);
+  });
+
+  it("cancels the issued setup session before reporting the missing URL", async () => {
+    const close = vi.fn();
+
+    await expect(
+      rejectOAuthSetupWithoutAuthorizationUrl("session-1", {
+        kind: "popup",
+        open: vi.fn(),
+        close,
+      }),
+    ).rejects.toThrow("Google authorization URL was not issued");
+
+    expect(mutate).toHaveBeenCalledOnce();
+    expect(mutate.mock.calls[0]?.[1]).toEqual({ sessionId: "session-1" });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the primary error when cancellation fails", async () => {
+    mutate.mockRejectedValue(new Error("cleanup failed"));
+
+    await expect(
+      rejectOAuthSetupWithoutAuthorizationUrl("session-2", null),
+    ).rejects.toThrow("Google authorization URL was not issued");
+  });
+});

--- a/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
+++ b/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
@@ -108,6 +108,16 @@ async function pollOAuthCompletion(
   throw new Error("Google authorization timed out");
 }
 
+export async function rejectOAuthSetupWithoutAuthorizationUrl(
+  sessionId: string,
+  authorizationTarget: ReturnType<typeof createOAuthAuthorizationTarget>,
+): Promise<never> {
+  const client = getWyStackClient();
+  await client.mutate(api.cancelConnectorSetup, { sessionId }).catch(() => {});
+  authorizationTarget?.close();
+  throw new Error("Google authorization URL was not issued");
+}
+
 async function runOAuthSetup(
   connector: RemoteApiConnector,
   onOAuthConnect: ConnectorCardWithFormProps["onOAuthConnect"],
@@ -126,8 +136,10 @@ async function runOAuthSetup(
     throw error;
   }
   if (!session.authorizeUrl) {
-    authorizationTarget?.close();
-    throw new Error("Google authorization URL was not issued");
+    return rejectOAuthSetupWithoutAuthorizationUrl(
+      session.sessionId,
+      authorizationTarget,
+    );
   }
   if (!authorizationTarget) {
     await client.mutate(api.cancelConnectorSetup, {

--- a/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
+++ b/packages/app/src/components/data-sources/renderers/ConnectorCardWithForm.tsx
@@ -1,4 +1,5 @@
 import { useConnectorForm } from "@/hooks/useConnectorForm";
+import { createOAuthAuthorizationTarget } from "@/lib/oauth-authorization-target";
 import { api } from "@/wystack/api";
 import { getWyStackClient } from "@/wystack/client";
 import {
@@ -58,18 +59,6 @@ function waitForPoll(token: PollToken): Promise<void> {
   });
 }
 
-function openAuthorizationWindow(): Window | null {
-  // Open synchronously from the click so browser popup policy cannot discard
-  // the authorization window while the start call is in flight.
-  const authWindow = window.open("about:blank", "_blank");
-  if (!authWindow) return null;
-  authWindow.opener = null;
-  authWindow.document.head.innerHTML =
-    '<meta name="referrer" content="no-referrer">';
-  authWindow.document.body.textContent = "Preparing Google authorization…";
-  return authWindow;
-}
-
 /**
  * Interpret one poll result. Returns true when the flow has reached a terminal
  * state and the loop should stop; throws when that state is a failure.
@@ -125,7 +114,7 @@ async function runOAuthSetup(
   token: PollToken,
 ): Promise<void> {
   const client = getWyStackClient();
-  const authWindow = openAuthorizationWindow();
+  const authorizationTarget = createOAuthAuthorizationTarget();
   let session: { sessionId: string; authorizeUrl?: string };
   try {
     session = await client.mutate(api.startConnectorSetup, {
@@ -133,14 +122,14 @@ async function runOAuthSetup(
       requestedName: connector.name,
     });
   } catch (error) {
-    authWindow?.close();
+    authorizationTarget?.close();
     throw error;
   }
   if (!session.authorizeUrl) {
-    authWindow?.close();
+    authorizationTarget?.close();
     throw new Error("Google authorization URL was not issued");
   }
-  if (!authWindow) {
+  if (!authorizationTarget) {
     await client.mutate(api.cancelConnectorSetup, {
       sessionId: session.sessionId,
     });
@@ -148,7 +137,15 @@ async function runOAuthSetup(
       "Google sign-in was blocked. Allow popups for DashFrame and try again.",
     );
   }
-  authWindow.location.replace(session.authorizeUrl);
+  try {
+    await authorizationTarget.open(session.authorizeUrl);
+  } catch (error) {
+    await client
+      .mutate(api.cancelConnectorSetup, { sessionId: session.sessionId })
+      .catch(() => {});
+    authorizationTarget.close();
+    throw error;
+  }
   await pollOAuthCompletion(
     connector,
     session.sessionId,

--- a/packages/app/src/lib/oauth-authorization-target.test.ts
+++ b/packages/app/src/lib/oauth-authorization-target.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createOAuthAuthorizationTarget } from "./oauth-authorization-target";
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "dashframe");
+  vi.restoreAllMocks();
+});
+
+describe("createOAuthAuthorizationTarget", () => {
+  it("uses the Electron bridge without opening an embedded window", async () => {
+    const openAuthorizationUrl = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "dashframe", {
+      configurable: true,
+      value: { oauth: { openAuthorizationUrl } },
+    });
+    const windowOpen = vi.spyOn(window, "open");
+
+    const target = createOAuthAuthorizationTarget();
+    await target?.open("https://accounts.google.com/o/oauth2/v2/auth");
+
+    expect(target?.kind).toBe("system-browser");
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(openAuthorizationUrl).toHaveBeenCalledExactlyOnceWith(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+  });
+
+  it("fails closed instead of falling back to an embedded desktop window", async () => {
+    Object.defineProperty(window, "dashframe", {
+      configurable: true,
+      value: {},
+    });
+    const windowOpen = vi.spyOn(window, "open");
+
+    const target = createOAuthAuthorizationTarget();
+
+    await expect(target?.open("https://accounts.google.com")).rejects.toThrow(
+      "Desktop browser authorization is unavailable",
+    );
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("reserves and navigates a popup for the web host", async () => {
+    const replace = vi.fn();
+    const close = vi.fn();
+    const popup = {
+      opener: window,
+      document: {
+        head: { innerHTML: "" },
+        body: { textContent: "" },
+      },
+      location: { replace },
+      close,
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(popup);
+
+    const target = createOAuthAuthorizationTarget();
+    await target?.open("https://accounts.google.com/o/oauth2/v2/auth");
+    target?.close();
+
+    expect(target?.kind).toBe("popup");
+    expect(popup.opener).toBeNull();
+    expect(popup.document.body.textContent).toBe(
+      "Preparing Google authorization…",
+    );
+    expect(replace).toHaveBeenCalledExactlyOnceWith(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when the web popup is blocked", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    expect(createOAuthAuthorizationTarget()).toBeNull();
+  });
+});

--- a/packages/app/src/lib/oauth-authorization-target.ts
+++ b/packages/app/src/lib/oauth-authorization-target.ts
@@ -1,0 +1,57 @@
+interface DesktopOAuthBridge {
+  oauth?: {
+    openAuthorizationUrl(url: string): Promise<void>;
+  };
+}
+
+export interface OAuthAuthorizationTarget {
+  kind: "system-browser" | "popup";
+  open(url: string): Promise<void>;
+  close(): void;
+}
+
+function desktopBridge(): DesktopOAuthBridge | undefined {
+  return (
+    window as typeof window & {
+      dashframe?: DesktopOAuthBridge;
+    }
+  ).dashframe;
+}
+
+/**
+ * Reserve the correct authorization surface synchronously from the click.
+ * Web needs a placeholder popup to satisfy popup policy. Electron never embeds
+ * Google: main opens the issued URL in the user's default system browser.
+ */
+export function createOAuthAuthorizationTarget(): OAuthAuthorizationTarget | null {
+  const bridge = desktopBridge();
+  if (bridge) {
+    return {
+      kind: "system-browser",
+      async open(url) {
+        if (!bridge.oauth?.openAuthorizationUrl) {
+          throw new Error("Desktop browser authorization is unavailable");
+        }
+        await bridge.oauth.openAuthorizationUrl(url);
+      },
+      close() {},
+    };
+  }
+
+  const authWindow = window.open("about:blank", "_blank");
+  if (!authWindow) return null;
+  authWindow.opener = null;
+  authWindow.document.head.innerHTML =
+    '<meta name="referrer" content="no-referrer">';
+  authWindow.document.body.textContent = "Preparing Google authorization…";
+
+  return {
+    kind: "popup",
+    async open(url) {
+      authWindow.location.replace(url);
+    },
+    close() {
+      authWindow.close();
+    },
+  };
+}

--- a/packages/desktop-types/src/index.ts
+++ b/packages/desktop-types/src/index.ts
@@ -27,6 +27,10 @@ export interface DashFrameApi {
     getInfo(): Promise<ProjectInfo>;
     revealFolder(): Promise<void>;
   };
+  oauth: {
+    /** Opens a server-issued Google authorization URL in the system browser. */
+    openAuthorizationUrl(url: string): Promise<void>;
+  };
   /** Returns the loopback WyStack server URL, available once main has started it. */
   getServerInfo(): Promise<ServerInfo>;
 }


### PR DESCRIPTION
## Outcome
Open Google OAuth authorization in the user's system browser from the Electron desktop app, while keeping web behavior unchanged.

## Changes
- Add a narrow desktop preload/IPC bridge for external Google OAuth authorization.
- Restrict authorization URLs to Google's exact HTTPS endpoint.
- Restrict privileged IPC to the trusted DashFrame renderer, including exact packaged file host/path validation.
- Cancel server-side OAuth setup sessions when the client receives no authorization URL.
- Preserve popup fallback for ordinary browser deployments.

## Evidence
- Exact head: `421927a084eae2f8b8f8c07338a442afb006660b`
- `bun run check`: 85/85 tasks passed
- `bun run format:check`: passed
- `git diff --check origin/main...HEAD`: passed
- Independent exact-head review: clean, no findings
- Behavioral QA: desktop Google sign-in opened the system browser rather than an embedded Electron window

## Security boundary
No generic external-navigation IPC is exposed; non-Google, untrusted-renderer, missing-session, and hosted-file-renderer cases fail closed.