### PR TITLE
[codex] Wait for valid chart suggestions

### DIFF
--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.delete.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.delete.test.tsx
@@ -14,6 +14,7 @@ import {
   buildChartSuggestionInsight,
   canAttemptVisualizeIntent,
   requestSavedVisualizationDeletion,
+  resolvePendingVisualModeTarget,
   resolveVisualModeTarget,
 } from "./InsightView";
 
@@ -95,6 +96,25 @@ describe("resolveVisualModeTarget", () => {
       kind: "visualization",
       visualizationId: "visualization-1",
     });
+  });
+
+  it("does not carry a queued Visualize request to another insight", () => {
+    expect(
+      resolvePendingVisualModeTarget({
+        requestedInsightId: "insight-a",
+        currentInsightId: "insight-b",
+        suggestionsReady: true,
+        firstSuggestedChartType: "line",
+      }),
+    ).toBeNull();
+    expect(
+      resolvePendingVisualModeTarget({
+        requestedInsightId: "insight-a",
+        currentInsightId: "insight-a",
+        suggestionsReady: true,
+        firstSuggestedChartType: "line",
+      }),
+    ).toEqual({ kind: "chart", chartType: "line" });
   });
 });
 

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.delete.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.delete.test.tsx
@@ -84,6 +84,11 @@ describe("resolveVisualModeTarget", () => {
         firstSuggestedChartType: "line",
       }),
     ).toEqual({ kind: "chart", chartType: "line" });
+    expect(
+      resolveVisualModeTarget({
+        suggestionsReady: true,
+      }),
+    ).toBeNull();
   });
 
   it("opens an existing saved visualization without waiting for suggestions", () => {

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.delete.test.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.delete.test.tsx
@@ -14,6 +14,7 @@ import {
   buildChartSuggestionInsight,
   canAttemptVisualizeIntent,
   requestSavedVisualizationDeletion,
+  resolveVisualModeTarget,
 } from "./InsightView";
 
 describe("buildChartSuggestionInsight", () => {
@@ -66,6 +67,34 @@ describe("canAttemptVisualizeIntent", () => {
     expect(canAttemptVisualizeIntent({ ...ready, hasDataFrame: false })).toBe(
       false,
     );
+  });
+});
+
+describe("resolveVisualModeTarget", () => {
+  it("waits for suggestions instead of permanently selecting an unsupported fallback", () => {
+    expect(
+      resolveVisualModeTarget({
+        suggestionsReady: false,
+      }),
+    ).toBeNull();
+    expect(
+      resolveVisualModeTarget({
+        suggestionsReady: true,
+        firstSuggestedChartType: "line",
+      }),
+    ).toEqual({ kind: "chart", chartType: "line" });
+  });
+
+  it("opens an existing saved visualization without waiting for suggestions", () => {
+    expect(
+      resolveVisualModeTarget({
+        firstPinnedVisualizationId: "visualization-1",
+        suggestionsReady: false,
+      }),
+    ).toEqual({
+      kind: "visualization",
+      visualizationId: "visualization-1",
+    });
   });
 });
 

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -135,7 +135,9 @@ export function resolveVisualModeTarget(input: {
     return visualizationView(input.firstPinnedVisualizationId);
   }
   if (!input.suggestionsReady) return null;
-  return chartView(input.firstSuggestedChartType ?? CANVAS_CHART_TYPES[0]!);
+  return input.firstSuggestedChartType
+    ? chartView(input.firstSuggestedChartType)
+    : null;
 }
 
 export function resolvePendingVisualModeTarget(input: {
@@ -1244,6 +1246,7 @@ export function InsightView({
 
   useEffect(() => {
     if (activeView.kind !== "table") return;
+    const requestedForCurrentInsight = visualModeRequestedFor === insightId;
     const target = resolvePendingVisualModeTarget({
       requestedInsightId: visualModeRequestedFor,
       currentInsightId: insightId,
@@ -1251,12 +1254,13 @@ export function InsightView({
       suggestionsReady: areChartSuggestionsReady,
       firstSuggestedChartType: firstChartSuggestion?.chartType,
     });
-    if (!target) return;
+    if (!target && !(requestedForCurrentInsight && areChartSuggestionsReady))
+      return;
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
       setVisualModeRequestedFor(null);
-      handleSetActiveView(target);
+      if (target) handleSetActiveView(target);
     });
     return () => {
       cancelled = true;

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -138,6 +138,17 @@ export function resolveVisualModeTarget(input: {
   return chartView(input.firstSuggestedChartType ?? CANVAS_CHART_TYPES[0]!);
 }
 
+export function resolvePendingVisualModeTarget(input: {
+  requestedInsightId: string | null;
+  currentInsightId: string;
+  firstPinnedVisualizationId?: string;
+  suggestionsReady: boolean;
+  firstSuggestedChartType?: VisualizationType;
+}): InsightCanvasView | null {
+  if (input.requestedInsightId !== input.currentInsightId) return null;
+  return resolveVisualModeTarget(input);
+}
+
 interface InsightViewProps {
   insight: Insight;
   visualizeIntent?: boolean;
@@ -640,7 +651,9 @@ export function InsightView({
   const saveTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   const [suggestionSeed, setSuggestionSeed] = useState(0);
-  const [visualModeRequested, setVisualModeRequested] = useState(false);
+  const [visualModeRequestedFor, setVisualModeRequestedFor] = useState<
+    string | null
+  >(null);
 
   // Mutations — artifact writes go through commitBatch (one batch per user edit).
   const { mutateAsync: commitBatch } = useMutation(api.commitBatch);
@@ -1219,18 +1232,21 @@ export function InsightView({
       firstSuggestedChartType: firstChartSuggestion?.chartType,
     });
     if (target) handleSetActiveView(target);
-    else setVisualModeRequested(true);
+    else setVisualModeRequestedFor(insightId);
   }, [
     activeView.kind,
     areChartSuggestionsReady,
     firstChartSuggestion,
     handleSetActiveView,
+    insightId,
     insightVisualizations,
   ]);
 
   useEffect(() => {
-    if (!visualModeRequested || activeView.kind !== "table") return;
-    const target = resolveVisualModeTarget({
+    if (activeView.kind !== "table") return;
+    const target = resolvePendingVisualModeTarget({
+      requestedInsightId: visualModeRequestedFor,
+      currentInsightId: insightId,
       firstPinnedVisualizationId: insightVisualizations[0]?.id,
       suggestionsReady: areChartSuggestionsReady,
       firstSuggestedChartType: firstChartSuggestion?.chartType,
@@ -1239,7 +1255,7 @@ export function InsightView({
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
-      setVisualModeRequested(false);
+      setVisualModeRequestedFor(null);
       handleSetActiveView(target);
     });
     return () => {
@@ -1250,8 +1266,9 @@ export function InsightView({
     areChartSuggestionsReady,
     firstChartSuggestion,
     handleSetActiveView,
+    insightId,
     insightVisualizations,
-    visualModeRequested,
+    visualModeRequestedFor,
   ]);
 
   let activeViewLabel = "Data result";
@@ -1304,7 +1321,7 @@ export function InsightView({
                   label="Data"
                   description="View the rows produced by the current data model."
                   onClick={() => {
-                    setVisualModeRequested(false);
+                    setVisualModeRequestedFor(null);
                     handleSetActiveView(TABLE_CANVAS_VIEW);
                   }}
                 />

--- a/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
+++ b/packages/app/src/app/insights/[insightId]/_components/InsightView.tsx
@@ -126,6 +126,18 @@ export function canAttemptVisualizeIntent(input: {
   );
 }
 
+export function resolveVisualModeTarget(input: {
+  firstPinnedVisualizationId?: string;
+  suggestionsReady: boolean;
+  firstSuggestedChartType?: VisualizationType;
+}): InsightCanvasView | null {
+  if (input.firstPinnedVisualizationId) {
+    return visualizationView(input.firstPinnedVisualizationId);
+  }
+  if (!input.suggestionsReady) return null;
+  return chartView(input.firstSuggestedChartType ?? CANVAS_CHART_TYPES[0]!);
+}
+
 interface InsightViewProps {
   insight: Insight;
   visualizeIntent?: boolean;
@@ -628,6 +640,7 @@ export function InsightView({
   const saveTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   const [suggestionSeed, setSuggestionSeed] = useState(0);
+  const [visualModeRequested, setVisualModeRequested] = useState(false);
 
   // Mutations — artifact writes go through commitBatch (one batch per user edit).
   const { mutateAsync: commitBatch } = useMutation(api.commitBatch);
@@ -1200,19 +1213,45 @@ export function InsightView({
 
   const handleSelectVisualMode = useCallback(() => {
     if (activeView.kind !== "table") return;
-    const firstPinned = insightVisualizations[0];
-    if (firstPinned) {
-      handleSetActiveView(visualizationView(firstPinned.id));
-      return;
-    }
-    handleSetActiveView(
-      chartView(firstChartSuggestion?.chartType ?? CANVAS_CHART_TYPES[0]!),
-    );
+    const target = resolveVisualModeTarget({
+      firstPinnedVisualizationId: insightVisualizations[0]?.id,
+      suggestionsReady: areChartSuggestionsReady,
+      firstSuggestedChartType: firstChartSuggestion?.chartType,
+    });
+    if (target) handleSetActiveView(target);
+    else setVisualModeRequested(true);
   }, [
     activeView.kind,
+    areChartSuggestionsReady,
     firstChartSuggestion,
     handleSetActiveView,
     insightVisualizations,
+  ]);
+
+  useEffect(() => {
+    if (!visualModeRequested || activeView.kind !== "table") return;
+    const target = resolveVisualModeTarget({
+      firstPinnedVisualizationId: insightVisualizations[0]?.id,
+      suggestionsReady: areChartSuggestionsReady,
+      firstSuggestedChartType: firstChartSuggestion?.chartType,
+    });
+    if (!target) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setVisualModeRequested(false);
+      handleSetActiveView(target);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeView.kind,
+    areChartSuggestionsReady,
+    firstChartSuggestion,
+    handleSetActiveView,
+    insightVisualizations,
+    visualModeRequested,
   ]);
 
   let activeViewLabel = "Data result";
@@ -1264,7 +1303,10 @@ export function InsightView({
                   icon={<TableIcon className="h-3.5 w-3.5" />}
                   label="Data"
                   description="View the rows produced by the current data model."
-                  onClick={() => handleSetActiveView(TABLE_CANVAS_VIEW)}
+                  onClick={() => {
+                    setVisualModeRequested(false);
+                    handleSetActiveView(TABLE_CANVAS_VIEW);
+                  }}
                 />
                 <CanvasViewButton
                   active={activeView.kind !== "table"}


### PR DESCRIPTION
## Outcome
Make an Insight's **Visualize** action wait for a valid chart suggestion instead of silently no-oping or choosing an unsupported fallback while frame analysis is still loading.

## Changes
- Queue the user's visualize intent until the current Insight has a ready frame/view and chart suggestions.
- Scope pending intent to the originating Insight and cancel it when the user returns to Data.
- Fail closed when analysis completes with no supported suggestions; do not create an invalid chart.
- Add regressions for dependency-driven retry, cross-Insight navigation, cancellation, and zero-suggestion completion.

## Evidence
- Final rebased head: `08c5a6fcc9ff2302b98285cddec35d0105720131`
- Base: merged PR #332 / `f79ee282e02be59dcb072c5edb22ff83e9f41668`
- `bun run check`: 85/85 tasks passed after rebase
- `bun run format:check`: passed
- `git diff --check origin/main...HEAD`: passed
- Fresh independent post-rebase exact-head review: CLEAN
- Behavioral QA: live GA4 Insight clicked **Visualize** during loading, then resolved to a supported Line chart with Save/Add-to-dashboard enabled

## Scope
This PR contains only chart-intent orchestration. Desktop/system-browser OAuth merged separately in PR #332.