### PR TITLE
[codex] Add GA4 weekly acquisition report

### DIFF
--- a/apps/server/src/functions/app-artifacts.ts
+++ b/apps/server/src/functions/app-artifacts.ts
@@ -1,5 +1,6 @@
 import {
   makeGa4Connector,
+  type Ga4ReportVersion,
   type GoogleOAuthTokenBundle,
 } from "@dashframe/connector-ga4";
 import { makeNotionConnector } from "@dashframe/connector-notion";
@@ -1994,6 +1995,7 @@ const queryPostgresTable = wy.procedure
 export async function ga4ConnectorFor(
   ctx: DashframeFunctionContext,
   dataSourceId: UUID,
+  reportVersion?: Ga4ReportVersion,
 ): Promise<ReturnType<typeof makeGa4Connector>> {
   const vault = vaultFromCtx(ctx);
   const row = (await ctx.db
@@ -2007,6 +2009,8 @@ export async function ga4ConnectorFor(
     );
   }
   const config = (row.config ?? {}) as DataSourceConfig;
+  const persistedReportVersion =
+    config.sourceBindingVersion === "v2" ? "v2" : "v1";
   const auth = mintBoundResolver(
     vault,
     config.apiKey,
@@ -2017,6 +2021,7 @@ export async function ga4ConnectorFor(
   // of a re-write of every connected source's vault entry.
   const oauthClient = ctx.googleOAuth;
   return makeGa4Connector(auth, {
+    reportVersion: reportVersion ?? persistedReportVersion,
     ...(oauthClient
       ? {
           oauthClient: {

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -296,6 +296,38 @@ describe("command vocabulary", () => {
       expect(await vault.has(stored as never)).toBe(true);
     });
 
+    it("server-binds new GA4 sources to the acquisition contract", async () => {
+      const sourceId = id();
+      await expect(
+        commit(
+          cmd("CreateDataSource", {
+            id: sourceId,
+            type: "googleAnalytics",
+            name: "Acquisition",
+          }),
+        ),
+      ).resolves.toBeDefined();
+      const [stored] = await db
+        .select()
+        .from(schema.dataSources)
+        .where(eq(schema.dataSources.id, sourceId));
+      expect(stored?.config).toMatchObject({ sourceBindingVersion: "v2" });
+    });
+
+    it("does not attach the GA4 binding contract to other connector kinds", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("CreateDataSource", {
+          id: sourceId,
+          type: "notion",
+          name: "Notes",
+        }),
+      );
+
+      const [stored] = await sourcesById(sourceId);
+      expect(stored?.config).not.toHaveProperty("sourceBindingVersion");
+    });
+
     it("should replace only config (not name) for SetDataSourceConfig", async () => {
       const sourceId = id();
       // Create first, then read the original ref BEFORE the config update so the

--- a/apps/server/src/functions/commands.test.ts
+++ b/apps/server/src/functions/commands.test.ts
@@ -328,6 +328,32 @@ describe("command vocabulary", () => {
       expect(stored?.config).not.toHaveProperty("sourceBindingVersion");
     });
 
+    it("server-binds get-or-created GA4 sources and rejects version rewrites", async () => {
+      const sourceId = id();
+      await commit(
+        cmd("GetOrCreateDataSource", {
+          id: sourceId,
+          type: "googleAnalytics",
+          name: "Acquisition",
+        }),
+      );
+      expect((await sourcesById(sourceId))[0]?.config).toMatchObject({
+        sourceBindingVersion: "v2",
+      });
+
+      await expect(
+        commit(
+          cmd("SetDataSourceConfig", {
+            id: sourceId,
+            extra: { sourceBindingVersion: "v1" },
+          }),
+        ),
+      ).rejects.toThrow(/sourceBindingVersion.*server-owned/u);
+      expect((await sourcesById(sourceId))[0]?.config).toMatchObject({
+        sourceBindingVersion: "v2",
+      });
+    });
+
     it("should replace only config (not name) for SetDataSourceConfig", async () => {
       const sourceId = id();
       // Create first, then read the original ref BEFORE the config update so the

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -339,7 +339,7 @@ const getOrCreateDataSource = wy.procedure
       name,
       kind: type,
       storage: "live",
-      config: {},
+      config: type === "googleAnalytics" ? { sourceBindingVersion: "v2" } : {},
       createdBy: { kind: "user" },
     })) as DataSourceRow[];
     if (!row) throw new Error("insert returned no row");
@@ -508,10 +508,12 @@ const setDataSourceConfig = wy.procedure
       // (Prior-ref release is deferred to the publish transition, not run here.)
       if (
         isRecord(extra) &&
-        ("apiKey" in extra || "connectionString" in extra)
+        ("apiKey" in extra ||
+          "connectionString" in extra ||
+          "sourceBindingVersion" in extra)
       ) {
         throw new Error(
-          "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, not extra",
+          "SetDataSourceConfig: 'apiKey' and 'connectionString' must use the typed credential fields, and sourceBindingVersion is server-owned; none may be set through extra",
         );
       }
       // store non-empty (replaces any existing ref with a fresh one) / clear-on-empty

--- a/apps/server/src/functions/commands.ts
+++ b/apps/server/src/functions/commands.ts
@@ -395,7 +395,12 @@ const createDataSource = wy.procedure
       // lifecycle transition; on a direct canonical call, release is synchronous.
       // (A fresh create has no prior ref, so deferral only matters for symmetry.)
       const deferRelease = shouldDeferRelease(ctx);
-      const config: DataSourceConfig = {};
+      const config: DataSourceConfig = {
+        // Persisted pre-version sources remain v1. Every newly created Google
+        // source is server-bound to the acquisition contract; callers never
+        // choose a provider report shape.
+        ...(type === "googleAnalytics" ? { sourceBindingVersion: "v2" } : {}),
+      };
       // store non-empty / skip-on-empty (applyCredentialField). On a fresh config an
       // empty string is a no-op. A real store fails closed when no vault is injected.
       // In preview mode the vault write is skipped — the DB transaction rolls back

--- a/apps/server/src/functions/connector-setup.test.ts
+++ b/apps/server/src/functions/connector-setup.test.ts
@@ -181,7 +181,12 @@ describe("connector setup functions", () => {
 
     const [source] = await db.select().from(dataSources);
     expect(source?.kind).toBe("googleAnalytics");
-    const ref = (source?.config as { apiKey?: unknown }).apiKey;
+    const sourceConfig = source?.config as {
+      apiKey?: unknown;
+      sourceBindingVersion?: unknown;
+    };
+    expect(sourceConfig.sourceBindingVersion).toBe("v2");
+    const ref = sourceConfig.apiKey;
     expect(isSecretRef(ref)).toBe(true);
     await expect(
       vault.withSecret(ref as never, async (value) => value),

--- a/apps/server/src/functions/data-fetch/bindings.test.ts
+++ b/apps/server/src/functions/data-fetch/bindings.test.ts
@@ -90,7 +90,7 @@ describe("Source Binding registry", () => {
     });
   });
 
-  it("accepts explicit v1 and fail-closes malformed, unknown, wrong-kind, or missing rows", async () => {
+  it("accepts registered GA4 versions and fail-closes malformed, unknown, wrong-kind, or missing rows", async () => {
     await expect(
       resolveSourceBinding(
         context({
@@ -100,9 +100,18 @@ describe("Source Binding registry", () => {
         table.id,
       ),
     ).resolves.toBeTruthy();
+    await expect(
+      resolveSourceBinding(
+        context({
+          table,
+          source: { ...source, config: { sourceBindingVersion: "v2" } },
+        }),
+        table.id,
+      ),
+    ).resolves.toMatchObject({ sourceBindingVersion: "v2" });
     for (const bad of [
       { ...source, config: { sourceBindingVersion: 1 } },
-      { ...source, config: { sourceBindingVersion: "v2" } },
+      { ...source, config: { sourceBindingVersion: "v3" } },
       { ...source, kind: "missing" },
     ]) {
       await expect(
@@ -115,6 +124,34 @@ describe("Source Binding registry", () => {
     await expect(
       resolveSourceBinding(context({ table }), table.id),
     ).rejects.toThrow("TARGET_NOT_READY");
+  });
+
+  it("routes GA4 v2 through the acquisition connector profile", async () => {
+    ga4ConnectorFor.mockResolvedValue({
+      query: vi.fn().mockResolvedValue(page([1, 2])),
+    });
+    const v2Source = {
+      ...source,
+      config: { sourceBindingVersion: "v2" },
+    };
+    const binding = await resolveSourceBinding(
+      context({ table, source: v2Source }),
+      table.id,
+    );
+
+    await expect(
+      fetchSourceBinding(context({ table, source: v2Source }), binding),
+    ).resolves.toMatchObject({
+      provenance: {
+        connectorKind: "googleAnalytics",
+        sourceBindingVersion: "v2",
+      },
+    });
+    expect(ga4ConnectorFor).toHaveBeenCalledWith(
+      expect.anything(),
+      source.id,
+      "v2",
+    );
   });
 
   it("uses only the persisted table property and returns server provenance", async () => {

--- a/apps/server/src/functions/data-fetch/bindings.ts
+++ b/apps/server/src/functions/data-fetch/bindings.ts
@@ -12,6 +12,7 @@ import {
 } from "../app-artifacts";
 
 const SOURCE_BINDING_VERSION = "v1";
+const GA4_ACQUISITION_BINDING_VERSION = "v2";
 /** GA4 supports offset windows; other adapters own their provider pagination. */
 const GA4_PAGE_SIZE = 10_000;
 
@@ -21,7 +22,7 @@ type FrameRow = typeof schema.dataFrames.$inferSelect;
 
 export type SourceBinding = Readonly<{
   connectorKind: string;
-  sourceBindingVersion: typeof SOURCE_BINDING_VERSION;
+  sourceBindingVersion: string;
   dataSourceId: UUID;
   table: Pick<
     TableRow,
@@ -76,7 +77,7 @@ export async function resolveSourceBinding(
     throw new Error("TARGET_NOT_READY");
   return {
     connectorKind: source.kind,
-    sourceBindingVersion: SOURCE_BINDING_VERSION,
+    sourceBindingVersion: version,
     dataSourceId: source.id,
     table,
   };
@@ -107,10 +108,11 @@ async function fetchPagedRemoteBinding(
     ctx: DashframeFunctionContext,
     sourceId: UUID,
   ) => Promise<QueryConnector>,
+  expectedVersion = SOURCE_BINDING_VERSION,
 ): Promise<LiveSourceResult> {
   if (
     binding.connectorKind !== kind ||
-    binding.sourceBindingVersion !== SOURCE_BINDING_VERSION
+    binding.sourceBindingVersion !== expectedVersion
   )
     throw new Error("TARGET_NOT_READY");
   try {
@@ -210,6 +212,20 @@ export async function fetchGa4Binding(
     binding,
     "googleAnalytics",
     ga4ConnectorFor,
+  );
+}
+
+/** New acquisition sources opt into the expanded report without migrating v1. */
+export async function fetchGa4AcquisitionBinding(
+  ctx: DashframeFunctionContext,
+  binding: SourceBinding,
+): Promise<LiveSourceResult> {
+  return fetchPagedRemoteBinding(
+    ctx,
+    binding,
+    "googleAnalytics",
+    (innerCtx, sourceId) => ga4ConnectorFor(innerCtx, sourceId, "v2"),
+    GA4_ACQUISITION_BINDING_VERSION,
   );
 }
 
@@ -441,6 +457,10 @@ function combinePages(
 sourceBindingRegistry.set(
   bindingKey("googleAnalytics", SOURCE_BINDING_VERSION),
   fetchGa4Binding,
+);
+sourceBindingRegistry.set(
+  bindingKey("googleAnalytics", GA4_ACQUISITION_BINDING_VERSION),
+  fetchGa4AcquisitionBinding,
 );
 sourceBindingRegistry.set(
   bindingKey("notion", SOURCE_BINDING_VERSION),

--- a/apps/server/src/functions/utils.ts
+++ b/apps/server/src/functions/utils.ts
@@ -26,6 +26,8 @@ export type DataSourceConfig = {
   connectionString?: string;
   /** Optional non-credential config for Postgres: default schema to list (default: "public"). */
   defaultSchema?: string;
+  /** Versioned server-owned connector execution contract. */
+  sourceBindingVersion?: string;
 };
 
 /**

--- a/packages/connector-ga4/src/connector.test.ts
+++ b/packages/connector-ga4/src/connector.test.ts
@@ -79,17 +79,39 @@ describe("GA4 connector", () => {
     ).toBe("Bearer fresh-token");
   });
 
-  it("runs the bounded default report and returns aligned Arrow data", async () => {
+  it("runs the bounded acquisition report and returns aligned Arrow data", async () => {
     const fetchImpl = vi.fn(
       async () =>
         new Response(
           JSON.stringify({
-            dimensionHeaders: [{ name: "date" }],
-            metricHeaders: [{ name: "activeUsers", type: "TYPE_INTEGER" }],
+            dimensionHeaders: [
+              { name: "yearWeek" },
+              { name: "sessionDefaultChannelGroup" },
+            ],
+            metricHeaders: [
+              { name: "activeUsers", type: "TYPE_INTEGER" },
+              { name: "newUsers", type: "TYPE_INTEGER" },
+              { name: "sessions", type: "TYPE_INTEGER" },
+              { name: "engagedSessions", type: "TYPE_INTEGER" },
+              { name: "engagementRate", type: "TYPE_FLOAT" },
+              { name: "keyEvents", type: "TYPE_FLOAT" },
+              { name: "totalRevenue", type: "TYPE_CURRENCY" },
+            ],
             rows: [
               {
-                dimensionValues: [{ value: "20260804" }],
-                metricValues: [{ value: "42" }],
+                dimensionValues: [
+                  { value: "202631" },
+                  { value: "Organic Search" },
+                ],
+                metricValues: [
+                  { value: "42" },
+                  { value: "12" },
+                  { value: "56" },
+                  { value: "31" },
+                  { value: "0.5536" },
+                  { value: "3" },
+                  { value: "98.75" },
+                ],
               },
             ],
           }),
@@ -108,20 +130,50 @@ describe("GA4 connector", () => {
     const arrow = tableFromIPC(Buffer.from(result.arrowBuffer, "base64"));
     expect(result.rowCount).toBe(1);
     expect(result.fields.map((field) => field.name)).toEqual([
-      "date",
+      "yearWeek",
+      "sessionDefaultChannelGroup",
       "activeUsers",
+      "newUsers",
+      "sessions",
+      "engagedSessions",
+      "engagementRate",
+      "keyEvents",
+      "totalRevenue",
     ]);
     expect(result.fields.map((field) => field.type)).toEqual([
-      "date",
+      "string",
+      "string",
+      "number",
+      "number",
+      "number",
+      "number",
+      "number",
+      "number",
       "number",
     ]);
-    expect(String(arrow.schema.fields[0]?.type)).toContain("Timestamp");
+    expect(String(arrow.schema.fields[0]?.type)).toContain("Utf8");
     expect(arrow.numRows).toBe(1);
-    expect(
-      JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)),
-    ).toMatchObject({
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))).toEqual({
+      dateRanges: [{ startDate: "90daysAgo", endDate: "yesterday" }],
+      dimensions: [
+        { name: "yearWeek" },
+        { name: "sessionDefaultChannelGroup" },
+      ],
+      metrics: [
+        { name: "activeUsers" },
+        { name: "newUsers" },
+        { name: "sessions" },
+        { name: "engagedSessions" },
+        { name: "engagementRate" },
+        { name: "keyEvents" },
+        { name: "totalRevenue" },
+      ],
       offset: "0",
       limit: "25",
+      orderBys: [
+        { dimension: { dimensionName: "yearWeek" } },
+        { dimension: { dimensionName: "sessionDefaultChannelGroup" } },
+      ],
     });
   });
 

--- a/packages/connector-ga4/src/connector.test.ts
+++ b/packages/connector-ga4/src/connector.test.ts
@@ -121,6 +121,7 @@ describe("GA4 connector", () => {
     const connector = makeGa4Connector(resolver(bundle()), {
       fetch: fetchImpl as typeof fetch,
       now: () => Date.parse("2026-08-05T12:00:00Z"),
+      reportVersion: "v2",
     });
     const result = await connector.query(
       "properties/123",
@@ -174,6 +175,44 @@ describe("GA4 connector", () => {
         { dimension: { dimensionName: "yearWeek" } },
         { dimension: { dimensionName: "sessionDefaultChannelGroup" } },
       ],
+    });
+  });
+
+  it("preserves the legacy v1 report shape unless acquisition is explicit", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            dimensionHeaders: [{ name: "date" }],
+            metricHeaders: [{ name: "activeUsers", type: "TYPE_INTEGER" }],
+            rows: [
+              {
+                dimensionValues: [{ value: "20260805" }],
+                metricValues: [{ value: "42" }],
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    const connector = makeGa4Connector(resolver(bundle()), {
+      fetch: fetchImpl as typeof fetch,
+      now: () => Date.parse("2026-08-05T12:00:00Z"),
+    });
+
+    const result = await connector.query("properties/123", crypto.randomUUID());
+
+    expect(result.fields.map((field) => field.name)).toEqual([
+      "date",
+      "activeUsers",
+    ]);
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))).toEqual({
+      dateRanges: [{ startDate: "30daysAgo", endDate: "yesterday" }],
+      dimensions: [{ name: "date" }],
+      metrics: [{ name: "activeUsers" }],
+      offset: "0",
+      limit: "10000",
+      orderBys: [{ dimension: { dimensionName: "date" } }],
     });
   });
 

--- a/packages/connector-ga4/src/connector.ts
+++ b/packages/connector-ga4/src/connector.ts
@@ -96,6 +96,15 @@ const ACQUISITION_METRICS = [
   "totalRevenue",
 ] as const;
 
+const LEGACY_DATE_RANGE = {
+  startDate: "30daysAgo",
+  endDate: "yesterday",
+} as const;
+const LEGACY_DIMENSIONS = ["date"] as const;
+const LEGACY_METRICS = ["activeUsers"] as const;
+
+export type Ga4ReportVersion = "v1" | "v2";
+
 export interface Ga4ConnectorDependencies {
   fetch?: typeof fetch;
   now?: () => number;
@@ -112,6 +121,11 @@ export interface Ga4ConnectorDependencies {
    * refresh grant.
    */
   persistTokenBundle?: PersistTokenBundle;
+  /**
+   * Versioned server-owned report shape. Existing persisted sources default to
+   * v1; newly onboarded acquisition sources opt into v2 explicitly.
+   */
+  reportVersion?: Ga4ReportVersion;
 }
 
 function parseTokenBundle(raw: string): GoogleOAuthTokenBundle {
@@ -329,6 +343,7 @@ export class Ga4Connector extends RemoteApiConnector {
   readonly #now: () => number;
   readonly #oauthClient: GoogleOAuthClientCredentials | undefined;
   readonly #persistTokenBundle: PersistTokenBundle | undefined;
+  readonly #reportVersion: Ga4ReportVersion;
 
   constructor(
     auth: SecretResolver,
@@ -339,6 +354,7 @@ export class Ga4Connector extends RemoteApiConnector {
     this.#now = dependencies.now ?? Date.now;
     this.#oauthClient = dependencies.oauthClient;
     this.#persistTokenBundle = dependencies.persistTokenBundle;
+    this.#reportVersion = dependencies.reportVersion ?? "v1";
   }
 
   getFormFields(): FormField[] {
@@ -382,6 +398,14 @@ export class Ga4Connector extends RemoteApiConnector {
         this.#oauthClient,
         this.#persistTokenBundle,
       );
+      const acquisition = this.#reportVersion === "v2";
+      const dateRange = acquisition
+        ? ACQUISITION_DATE_RANGE
+        : LEGACY_DATE_RANGE;
+      const dimensions = acquisition
+        ? ACQUISITION_DIMENSIONS
+        : LEGACY_DIMENSIONS;
+      const metrics = acquisition ? ACQUISITION_METRICS : LEGACY_METRICS;
       const response = (await fetchJson(
         this.#fetch,
         `https://analyticsdata.googleapis.com/v1beta/${property}:runReport`,
@@ -389,14 +413,14 @@ export class Ga4Connector extends RemoteApiConnector {
         {
           method: "POST",
           body: JSON.stringify({
-            dateRanges: [ACQUISITION_DATE_RANGE],
-            dimensions: ACQUISITION_DIMENSIONS.map((name) => ({ name })),
-            metrics: ACQUISITION_METRICS.map((name) => ({ name })),
+            dateRanges: [dateRange],
+            dimensions: dimensions.map((name) => ({ name })),
+            metrics: metrics.map((name) => ({ name })),
             offset: String(offset),
             limit: String(limit),
-            // Both dimensions participate so offset pagination is stable when
-            // a week contains several channel rows.
-            orderBys: ACQUISITION_DIMENSIONS.map((dimensionName) => ({
+            // Every dimension participates so offset pagination is stable
+            // when the report contains repeated values in its leading key.
+            orderBys: dimensions.map((dimensionName) => ({
               dimension: { dimensionName },
             })),
           }),

--- a/packages/connector-ga4/src/connector.ts
+++ b/packages/connector-ga4/src/connector.ts
@@ -71,6 +71,31 @@ interface RunReportResponse {
   }>;
 }
 
+/**
+ * The v0.3 server-owned GA4 dataset used to build acquisition reviews.
+ *
+ * The connector, rather than the renderer or RPC caller, owns this provider
+ * query. GA4 owns the weekly aggregation because user metrics such as
+ * activeUsers are not additive across daily rows.
+ */
+const ACQUISITION_DATE_RANGE = {
+  startDate: "90daysAgo",
+  endDate: "yesterday",
+} as const;
+const ACQUISITION_DIMENSIONS = [
+  "yearWeek",
+  "sessionDefaultChannelGroup",
+] as const;
+const ACQUISITION_METRICS = [
+  "activeUsers",
+  "newUsers",
+  "sessions",
+  "engagedSessions",
+  "engagementRate",
+  "keyEvents",
+  "totalRevenue",
+] as const;
+
 export interface Ga4ConnectorDependencies {
   fetch?: typeof fetch;
   now?: () => number;
@@ -364,12 +389,16 @@ export class Ga4Connector extends RemoteApiConnector {
         {
           method: "POST",
           body: JSON.stringify({
-            dateRanges: [{ startDate: "30daysAgo", endDate: "yesterday" }],
-            dimensions: [{ name: "date" }],
-            metrics: [{ name: "activeUsers" }],
+            dateRanges: [ACQUISITION_DATE_RANGE],
+            dimensions: ACQUISITION_DIMENSIONS.map((name) => ({ name })),
+            metrics: ACQUISITION_METRICS.map((name) => ({ name })),
             offset: String(offset),
             limit: String(limit),
-            orderBys: [{ dimension: { dimensionName: "date" } }],
+            // Both dimensions participate so offset pagination is stable when
+            // a week contains several channel rows.
+            orderBys: ACQUISITION_DIMENSIONS.map((dimensionName) => ({
+              dimension: { dimensionName },
+            })),
           }),
         },
       )) as RunReportResponse;

--- a/packages/connector-ga4/src/index.ts
+++ b/packages/connector-ga4/src/index.ts
@@ -2,6 +2,7 @@ export {
   Ga4Connector,
   makeGa4Connector,
   type Ga4ConnectorDependencies,
+  type Ga4ReportVersion,
   type GoogleOAuthTokenBundle,
   type PersistTokenBundle,
 } from "./connector.js";

--- a/packages/visualization/src/renderers/vgplot-renderer.test.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.test.ts
@@ -296,6 +296,29 @@ describe("createVgplotRenderer color domain", () => {
     cleanup();
   });
 
+  it("does not split expression-bound line color into one-point series", () => {
+    const api = createMockApi();
+    const renderer = createVgplotRenderer(api as never);
+    const container = document.createElement("div");
+
+    const cleanup = renderer.render(container, "line", {
+      tableName: "sales",
+      encoding: { x: "date", y: "revenue", color: "sum(profit)" },
+    });
+
+    expect(api.lineY).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        x: "date",
+        y: "revenue",
+        stroke: expect.anything(),
+      }),
+    );
+    expect(api.lineY.mock.calls[0]?.[1]).not.toHaveProperty("z");
+
+    cleanup();
+  });
+
   it("includes the colorDomain directive in options passed to api.plot for a plain color column", async () => {
     const colorDomainDirective = {
       __directive: "colorDomain",

--- a/packages/visualization/src/renderers/vgplot-renderer.test.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.test.ts
@@ -273,6 +273,29 @@ describe("createVgplotRenderer color domain", () => {
     vi.restoreAllMocks();
   });
 
+  it("groups colored line charts by the color column", () => {
+    const api = createMockApi();
+    const renderer = createVgplotRenderer(api as never);
+    const container = document.createElement("div");
+
+    const cleanup = renderer.render(container, "line", {
+      tableName: "weekly_acquisition",
+      encoding: { x: "yearWeek", y: "activeUsers", color: "channel" },
+    });
+
+    expect(api.lineY).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        x: "yearWeek",
+        y: "activeUsers",
+        stroke: "channel",
+        z: "channel",
+      }),
+    );
+
+    cleanup();
+  });
+
   it("includes the colorDomain directive in options passed to api.plot for a plain color column", async () => {
     const colorDomainDirective = {
       __directive: "colorDomain",

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -284,7 +284,9 @@ function buildEncodingOptions(
     // Observable Plot groups connected marks by z, not by stroke. Without an
     // explicit series channel, differently colored rows at the same x value
     // are still joined into one path, producing vertical jumps between series.
-    if (isLineChart) options.z = color;
+    if (isLineChart && !isExpressionBoundColor(encoding.color)) {
+      options.z = color;
+    }
   } else {
     const defaultColor = getDefaultFillColor();
     if (defaultColor) options[colorProperty] = defaultColor;

--- a/packages/visualization/src/renderers/vgplot-renderer.ts
+++ b/packages/visualization/src/renderers/vgplot-renderer.ts
@@ -279,7 +279,12 @@ function buildEncodingOptions(
   const colorProperty = isLineChart ? "stroke" : "fill";
 
   if (encoding.color) {
-    options[colorProperty] = parseEncodingValue(api, encoding.color);
+    const color = parseEncodingValue(api, encoding.color);
+    options[colorProperty] = color;
+    // Observable Plot groups connected marks by z, not by stroke. Without an
+    // explicit series channel, differently colored rows at the same x value
+    // are still joined into one path, producing vertical jumps between series.
+    if (isLineChart) options.z = color;
   } else {
     const defaultColor = getDefaultFillColor();
     if (defaultColor) options[colorProperty] = defaultColor;


### PR DESCRIPTION
## Outcome

- makes the server-owned GA4 connector fetch a 90-day weekly acquisition report
- includes channel grouping plus active users, new users, sessions, engaged sessions, engagement rate, key events, and revenue
- orders by week and channel so offset pagination is deterministic
- fixes colored line charts so each color is a separate series instead of one cross-channel path

## Real-path QA

- real Google OAuth grant and GA4 property, with identifiers and metric values kept out of logs and this PR
- complete live fetch: 126 rows, 14 weeks, 13 acquisition channel groups, 9 fields
- MCP paged the immutable result frame to end-of-data in bounded 37-row reads with no loss
- agent-created draft was reviewed and human-published as an Insight, Visualization, and Dashboard
- two saved Insight refreshes returned distinct immutable frame generations; the prior handle remained readable and artifact identities remained stable
- exact candidate web build rendered the live dashboard; colored channel lines were verified as separate SVG paths with no vertical cross-channel joins

## Local gate

- `TURBO_FORCE=true TURBO_CONCURRENCY=2 bun run check`: 85/85 tasks, all 4 summaries PASS
- `bun run format:check`: PASS
- `git diff --check origin/main...HEAD`: PASS
- independent exact-branch Codex review: clean

No credentials, account/property identifiers, raw GA4 captures, or sensitive values are included.