### PR TITLE
Fix oversized data source icons

### DIFF
--- a/packages/app/src/components/data-sources/DataSourceList.tsx
+++ b/packages/app/src/components/data-sources/DataSourceList.tsx
@@ -3,7 +3,7 @@ import {
   useRegistryVersion,
 } from "@/lib/connectors/registry";
 import { ItemCard } from "@wystack/ui-react";
-import { ConnectorIcon } from "./renderers/ConnectorIcon";
+import { DatabaseIcon, FileIcon } from "@wystack/ui-react/icons";
 
 export interface DataSourceInfo {
   id: string;
@@ -58,10 +58,12 @@ export function DataSourceList({
     <>
       {sources.map((source) => {
         const connector = getConnectorById(source.type);
-        const icon = connector ? (
-          <ConnectorIcon svg={connector.icon} className="h-4 w-4" />
-        ) : undefined;
         const isFileSource = connector?.sourceType === "file";
+        const icon = isFileSource ? (
+          <FileIcon className="h-4 w-4" />
+        ) : (
+          <DatabaseIcon className="h-4 w-4" />
+        );
         const itemLabel = isFileSource ? "file" : "table";
         const itemLabelPlural = isFileSource ? "files" : "tables";
         const subtitle = `${source.tableCount} ${source.tableCount === 1 ? itemLabel : itemLabelPlural}`;


### PR DESCRIPTION
Existing data-source rows rendered arbitrary connector SVG artwork in a compact slot, allowing some logos to expand beyond the intended icon size.

This replaces those row icons with standard bounded glyphs: a file glyph for local sources and a database glyph for remote or unresolved sources. Branded connector icons remain available in contexts that explicitly control their bounds.

## Changes

- Render a standard 16×16 file glyph for file-backed sources.
- Render a standard 16×16 database glyph for remote and unresolved sources.
- Preserve existing file/table subtitles, selection, and click behavior.

## Screenshots

### Light

<img width="1280" height="577" alt="Local Files picker using a bounded file icon in light theme" src="https://github.com/user-attachments/assets/8745181a-79b6-4cfc-9185-65c4933e7d71" />

### Dark

<img width="1280" height="577" alt="Local Files picker using a bounded file icon in dark theme" src="https://github.com/user-attachments/assets/1a4510d1-269a-41ed-b08f-ccb227d552f3" />

## Verification

- Exact PR head: `d39cefbbd3e0ee8e8ae859b7f4c12b4f2d8f8037`
- `bun run check` — passed, 85/85 tasks.
- `bun run format:check` — passed.
- Production build — passed, 22/22 tasks.
- Real CSV import and picker exercise — passed.
- Local Files rendered the standard `file-text` glyph at computed `16×16px`.
- Light and dark states were visually inspected.
- Two independent exact-diff reviews found no issues; adaptive review validation passed.
- The post-QA force-push rebased the commit, but the changed `DataSourceList.tsx` blob is byte-identical to the QA-tested revision.

## Excluded

- Untracked onboarding-selector prototypes; no onboarding redesign is included.
