### PR TITLE
Fix Windows Electron startup and window controls

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -42,6 +42,13 @@ const externalizeNpm = {
     // Bare specifiers only (not "./x" or "../x"). Inline workspace scopes;
     // externalize everything else (npm packages + node: builtins).
     build.onResolve({ filter: /^[^./]/ }, (args) => {
+      // Windows absolute paths begin with a drive letter, so they also match
+      // the bare-specifier filter. In particular, esbuild passes the absolute
+      // main.ts path through this hook as an entry point; externalizing it
+      // makes the Windows build fail before bundling starts.
+      if (args.kind === "entry-point" || path.isAbsolute(args.path)) {
+        return undefined;
+      }
       if (
         args.path.startsWith("@wystack/") ||
         args.path.startsWith("@dashframe/")

--- a/apps/desktop/scripts/dev-helpers.test.ts
+++ b/apps/desktop/scripts/dev-helpers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { createElectronEnvironment, parseViteUrl } from "./dev-helpers";
+
+describe("desktop development launcher", () => {
+  it("parses a colorized Vite URL", () => {
+    expect(
+      parseViteUrl(
+        "\u001b[32mâžœ\u001b[39m  \u001b[1mLocal\u001b[22m:   \u001b[36mhttp://localhost:\u001b[1m5173\u001b[22m/\u001b[39m",
+      ),
+    ).toBe("http://localhost:5173");
+  });
+
+  it("launches Electron outside inherited Node-only mode", () => {
+    expect(
+      createElectronEnvironment(
+        { ELECTRON_RUN_AS_NODE: "1", EXISTING_VALUE: "preserved" },
+        "http://localhost:5174",
+      ),
+    ).toEqual({
+      DEV_URL: "http://localhost:5174",
+      EXISTING_VALUE: "preserved",
+    });
+  });
+});

--- a/apps/desktop/scripts/dev-helpers.ts
+++ b/apps/desktop/scripts/dev-helpers.ts
@@ -1,0 +1,18 @@
+import { stripVTControlCharacters } from "node:util";
+
+/** Extract Vite's local origin from its optionally colorized startup banner. */
+export function parseViteUrl(output: string): string | undefined {
+  return stripVTControlCharacters(output).match(
+    /Local:\s+(https?:\/\/[^\s/]+)/,
+  )?.[1];
+}
+
+/** Build the Electron child environment without inheriting Node-only mode. */
+export function createElectronEnvironment(
+  environment: NodeJS.ProcessEnv,
+  viteUrl: string,
+): NodeJS.ProcessEnv {
+  const result = { ...environment, DEV_URL: viteUrl };
+  delete result.ELECTRON_RUN_AS_NODE;
+  return result;
+}

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -3,6 +3,8 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 
+import { createElectronEnvironment, parseViteUrl } from "./dev-helpers.ts";
+
 const desktopDir = path.resolve(import.meta.dirname, "..");
 const rendererDir = path.resolve(desktopDir, "..", "renderer");
 
@@ -103,11 +105,14 @@ const viteUrl = await new Promise((resolve, reject) => {
     if (settled) return;
     buffer += text;
     // Match Vite banner: "  ➜  Local:   http://localhost:5174/"
-    const match = buffer.match(/Local:\s+(https?:\/\/[^\s/]+)/);
-    if (match) {
+    // Vite colorizes its banner even when stdout is piped on Windows. Remove
+    // those control codes before matching so sequences inside "Local" and the
+    // port number do not make startup time out.
+    const parsedUrl = parseViteUrl(buffer);
+    if (parsedUrl) {
       settled = true;
       clearTimeout(timeout);
-      resolve(match[1]);
+      resolve(parsedUrl);
       buffer = "";
       return;
     }
@@ -126,9 +131,12 @@ console.log(
 console.log(`[dev] launching Electron...\n`);
 
 // 4. Launch Electron with DEV_URL env + CDP remote debugging
-electronProc = spawn("electron", [`--remote-debugging-port=${cdpPort}`, "."], {
+// Agent hosts and Electron-based terminals may set this for their own child
+// processes. DashFrame needs the normal Chromium runtime, not Node-only mode.
+const electronEnv = createElectronEnvironment(process.env, viteUrl);
+electronProc = spawn("electron", [".", `--remote-debugging-port=${cdpPort}`], {
   cwd: desktopDir,
-  env: { ...process.env, DEV_URL: viteUrl },
+  env: electronEnv,
   stdio: "inherit",
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -145,17 +145,29 @@ async function storeServeToken(
 }
 
 async function createWindow(): Promise<void> {
+  let windowChrome = {};
+  if (process.platform === "darwin") {
+    windowChrome = { titleBarStyle: "hiddenInset" as const };
+  } else if (process.platform === "win32") {
+    windowChrome = {
+      titleBarStyle: "hidden" as const,
+      titleBarOverlay: {
+        color: "#00000000",
+        symbolColor: "#8a8a8a",
+        height: 40,
+      },
+    };
+  }
+
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
+    autoHideMenuBar: true,
     // macOS only: hide the title bar but keep the traffic lights, inset over the
     // app's own top bar (the renderer reserves a spacer for them in AppTopBar).
-    // On Windows/Linux `hiddenInset` would hide the title bar *without* giving
-    // back window controls, so keep the standard frame there until the app
-    // draws its own controls.
-    ...(process.platform === "darwin"
-      ? { titleBarStyle: "hiddenInset" as const }
-      : {}),
+    // Windows: merge the native caption controls into DashFrame's draggable
+    // 40px top bar. The renderer reserves the corresponding right-side space.
+    ...windowChrome,
     webPreferences: {
       preload: path.join(import.meta.dirname, "preload.cjs"),
       contextIsolation: true,
@@ -163,6 +175,10 @@ async function createWindow(): Promise<void> {
       sandbox: true,
     },
   });
+
+  // `autoHideMenuBar` still reveals the native menu when Alt is pressed.
+  // DashFrame has its own complete application navigation, so remove it.
+  win.removeMenu();
 
   win.webContents.on("will-navigate", (event, url) => {
     if (!isTrustedRendererUrl(url, rendererTrustOptions)) {

--- a/apps/desktop/src/renderer-trust.test.ts
+++ b/apps/desktop/src/renderer-trust.test.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -6,6 +7,7 @@ import {
 } from "./renderer-trust";
 
 const productionFile = "/Applications/DashFrame/renderer/index.html";
+const productionUrl = pathToFileURL(productionFile).href;
 
 describe("desktop renderer trust", () => {
   const developmentUrl = "https://localhost:5173".replace("https", "http");
@@ -42,16 +44,10 @@ describe("desktop renderer trust", () => {
       productionFile,
     };
     expect(
-      isTrustedRendererUrl(
-        "file:///Applications/DashFrame/renderer/index.html#/insights/example",
-        options,
-      ),
+      isTrustedRendererUrl(`${productionUrl}#/insights/example`, options),
     ).toBe(true);
     expect(
-      isTrustedRendererUrl(
-        "file:///Applications/DashFrame/renderer/other.html",
-        options,
-      ),
+      isTrustedRendererUrl(new URL("other.html", productionUrl).href, options),
     ).toBe(false);
     expect(
       isTrustedRendererUrl(

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.ts"],
     testTimeout: 15_000,
     hookTimeout: 15_000,
   },

--- a/packages/app/src/components/AppTopBar.tsx
+++ b/packages/app/src/components/AppTopBar.tsx
@@ -11,6 +11,8 @@ import { AssistantToggle } from "./assistant/AssistantToggle";
 
 /** Width reserved for the macOS traffic lights when the title bar is hidden. */
 const TRAFFIC_LIGHT_SPACER_PX = 64;
+/** Width occupied by Windows' minimize, maximize, and close overlay buttons. */
+const WINDOWS_CAPTION_SPACER_PX = 138;
 
 /**
  * Full-width window top bar — the macOS title-bar replacement. Spans above both
@@ -23,8 +25,9 @@ const TRAFFIC_LIGHT_SPACER_PX = 64;
  * automatically via the `button { app-region: no-drag }` rule there.
  */
 export function AppTopBar() {
-  const { isElectron, isMacOS } = usePlatform();
+  const { isElectron, isMacOS, isWindows } = usePlatform();
   const macDesktop = isElectron && isMacOS;
+  const windowsDesktop = isElectron && isWindows;
 
   const leftNavOpen = useShellStore((s) => s.leftNavOpen);
   const toggleLeftNav = useShellStore((s) => s.toggleLeftNav);
@@ -76,6 +79,13 @@ export function AppTopBar() {
               !appearanceOpen && "text-neutral-fg-subtle hover:text-neutral-fg",
             )}
           />
+          {windowsDesktop && (
+            <div
+              className="shrink-0"
+              style={{ width: WINDOWS_CAPTION_SPACER_PX }}
+              aria-hidden
+            />
+          )}
         </div>
       }
     />

--- a/packages/app/src/lib/platform.tsx
+++ b/packages/app/src/lib/platform.tsx
@@ -12,13 +12,15 @@ export interface Platform {
   isElectron: boolean;
   /** macOS — where the traffic lights live top-left and need a spacer. */
   isMacOS: boolean;
+  /** Windows, where caption controls overlay the top-right of the app. */
+  isWindows: boolean;
 }
 
 const PlatformContext = createContext<Platform | null>(null);
 
 function detectPlatform(): Platform {
   if (typeof window === "undefined") {
-    return { isElectron: false, isMacOS: false };
+    return { isElectron: false, isMacOS: false, isWindows: false };
   }
   // The preload bridge exposes `window.dashframe`; its presence is the Electron
   // signal (web host never defines it).
@@ -30,7 +32,8 @@ function detectPlatform(): Platform {
     navigator.platform ??
     "";
   const isMacOS = /mac/i.test(platform);
-  return { isElectron, isMacOS };
+  const isWindows = /win/i.test(platform);
+  return { isElectron, isMacOS, isWindows };
 }
 
 /**
@@ -47,6 +50,8 @@ export function PlatformProvider({ children }: { children: React.ReactNode }) {
     else root.removeAttribute("data-electron");
     if (platform.isMacOS) root.setAttribute("data-macos", "");
     else root.removeAttribute("data-macos");
+    if (platform.isWindows) root.setAttribute("data-windows", "");
+    else root.removeAttribute("data-windows");
   }, [platform]);
 
   return <PlatformContext value={platform}>{children}</PlatformContext>;


### PR DESCRIPTION
Fixes Electron development startup on Windows and integrates native Windows caption controls into the app top bar.

## Changes

- Prevent Windows absolute paths from being externalized during the Electron main-process build.
- Remove inherited `ELECTRON_RUN_AS_NODE` mode when launching Electron.
- Parse colorized Vite startup output reliably on Windows.
- Add Windows title-bar overlays, caption spacing, and menu-bar removal.
- Simplify desktop and web development launchers by removing obsolete worktree runtime tracking.
- Add coverage for Vite URL parsing, Electron environment setup, and Windows-compatible renderer URL handling.

## Screenshots

- UI screenshots should be attached for the Windows desktop window controls in light and dark themes.

## Verification

- Added and updated Vitest coverage for the desktop development helpers and renderer trust logic.
- Verified the Electron launcher builds WyStack and the desktop bundle before starting Vite and Electron.
- Verified the Windows-specific title-bar configuration and renderer caption-control spacing are applied only in the Electron Windows runtime.

Base branch: main
Head branch: fix/windows-electron