### PR TITLE
[codex] Preserve CSV dates and mixed values

### DIFF
--- a/packages/csv/src/index.test.ts
+++ b/packages/csv/src/index.test.ts
@@ -3,8 +3,55 @@ import {
   MAX_LOCAL_SOURCE_BYTES,
   type UUID,
 } from "@dashframe/engine";
-import { describe, expect, it } from "vite-plus/test";
+import { tableFromIPC } from "apache-arrow";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { csvToDataFrame } from "./index";
+
+const originalTz = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "Pacific/Auckland";
+});
+afterAll(() => {
+  if (originalTz === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTz;
+});
+
+const DATA_TABLE_ID = "10000000-0000-4000-8000-000000000001" as UUID;
+
+describe("CSV date ingestion", () => {
+  it("preserves zoneless date-times as UTC calendar values", async () => {
+    const result = await csvToDataFrame(
+      [
+        ["zoneless_t", "zoneless_space", "explicit_offset"],
+        [
+          "2024-07-18T00:30:00",
+          "2024-07-18 00:30:00",
+          "2024-07-18T00:30:00+12:00",
+        ],
+      ],
+      DATA_TABLE_ID,
+    );
+    const row = tableFromIPC(result.arrowBuffer).get(0)?.toJSON();
+
+    expect(row).toEqual({
+      zoneless_t: Date.UTC(2024, 6, 18, 0, 30),
+      zoneless_space: Date.UTC(2024, 6, 18, 0, 30),
+      explicit_offset: Date.UTC(2024, 6, 17, 12, 30),
+    });
+  });
+
+  it("preserves non-ISO date-like values as text", async () => {
+    const raw = "2024/07/18 00:30:00";
+    const result = await csvToDataFrame(
+      [["legacy_date"], [raw]],
+      DATA_TABLE_ID,
+    );
+    const row = tableFromIPC(result.arrowBuffer).get(0)?.toJSON();
+
+    expect(result.fields[0]?.type).toBe("string");
+    expect(row).toEqual({ legacy_date: raw });
+  });
+});
 
 describe("CSV Arrow ingestion budget", () => {
   it("keeps expansion-heavy source uploads below a conservative encoded budget", async () => {
@@ -21,10 +68,7 @@ describe("CSV Arrow ingestion budget", () => {
       data.map((row) => row.join(",")).join("\n"),
     ).byteLength;
 
-    const result = await csvToDataFrame(
-      data,
-      "10000000-0000-4000-8000-000000000001" as UUID,
-    );
+    const result = await csvToDataFrame(data, DATA_TABLE_ID);
 
     // Empty strings are cheap in CSV but Arrow still stores a four-byte
     // offset for each cell. This is the concrete expansion the former equal

--- a/packages/csv/src/index.test.ts
+++ b/packages/csv/src/index.test.ts
@@ -51,6 +51,28 @@ describe("CSV date ingestion", () => {
     expect(result.fields[0]?.type).toBe("string");
     expect(row).toEqual({ legacy_date: raw });
   });
+
+  it("preserves impossible ISO-shaped calendar values as text", async () => {
+    const result = await csvToDataFrame(
+      [
+        ["invalid_date", "invalid_day", "invalid_hour"],
+        ["2024-02-30", "2024-02-30T00:00:00", "2024-07-18T24:00:00"],
+      ],
+      DATA_TABLE_ID,
+    );
+    const row = tableFromIPC(result.arrowBuffer).get(0)?.toJSON();
+
+    expect(result.fields.map((field) => field.type)).toEqual([
+      "string",
+      "string",
+      "string",
+    ]);
+    expect(row).toEqual({
+      invalid_date: "2024-02-30",
+      invalid_day: "2024-02-30T00:00:00",
+      invalid_hour: "2024-07-18T24:00:00",
+    });
+  });
 });
 
 describe("CSV Arrow ingestion budget", () => {

--- a/packages/csv/src/index.test.ts
+++ b/packages/csv/src/index.test.ts
@@ -22,11 +22,12 @@ describe("CSV date ingestion", () => {
   it("preserves zoneless date-times as UTC calendar values", async () => {
     const result = await csvToDataFrame(
       [
-        ["zoneless_t", "zoneless_space", "explicit_offset"],
+        ["zoneless_t", "zoneless_space", "explicit_offset", "basic_offset"],
         [
           "2024-07-18T00:30:00",
           "2024-07-18 00:30:00",
           "2024-07-18T00:30:00+12:00",
+          "2024-07-18T00:30:00+1200",
         ],
       ],
       DATA_TABLE_ID,
@@ -37,6 +38,7 @@ describe("CSV date ingestion", () => {
       zoneless_t: Date.UTC(2024, 6, 18, 0, 30),
       zoneless_space: Date.UTC(2024, 6, 18, 0, 30),
       explicit_offset: Date.UTC(2024, 6, 17, 12, 30),
+      basic_offset: Date.UTC(2024, 6, 17, 12, 30),
     });
   });
 

--- a/packages/csv/src/index.test.ts
+++ b/packages/csv/src/index.test.ts
@@ -73,6 +73,62 @@ describe("CSV date ingestion", () => {
       invalid_hour: "2024-07-18T24:00:00",
     });
   });
+
+  it("preserves every value when a column contains mixed types", async () => {
+    const result = await csvToDataFrame(
+      [
+        ["date_or_sku", "number_or_label", "boolean_or_label"],
+        ["2024-07-18T00:30:00", "42", "true"],
+        ["SKU-A", "N/A", "pending"],
+      ],
+      DATA_TABLE_ID,
+    );
+    const rows = tableFromIPC(result.arrowBuffer)
+      .toArray()
+      .map((row) => row.toJSON());
+
+    expect(result.fields.map((field) => field.type)).toEqual([
+      "string",
+      "string",
+      "string",
+    ]);
+    expect(rows).toEqual([
+      {
+        date_or_sku: "2024-07-18T00:30:00",
+        number_or_label: "42",
+        boolean_or_label: "true",
+      },
+      {
+        date_or_sku: "SKU-A",
+        number_or_label: "N/A",
+        boolean_or_label: "pending",
+      },
+    ]);
+  });
+
+  it("does not normalize an impossible date after a valid date", async () => {
+    const result = await csvToDataFrame(
+      [["date"], ["2024-02-29"], ["2024-02-30"]],
+      DATA_TABLE_ID,
+    );
+    const values = tableFromIPC(result.arrowBuffer)
+      .toArray()
+      .map((row) => row.toJSON().date);
+
+    expect(result.fields[0]?.type).toBe("string");
+    expect(values).toEqual(["2024-02-29", "2024-02-30"]);
+  });
+
+  it("keeps fractional-second timestamps typed as dates", async () => {
+    const result = await csvToDataFrame(
+      [["date"], ["2024-07-18T00:30:00.123"]],
+      DATA_TABLE_ID,
+    );
+    const value = tableFromIPC(result.arrowBuffer).get(0)?.toJSON().date;
+
+    expect(result.fields[0]?.type).toBe("date");
+    expect(value).toBe(Date.UTC(2024, 6, 18, 0, 30, 0, 123));
+  });
 });
 
 describe("CSV Arrow ingestion budget", () => {

--- a/packages/csv/src/index.ts
+++ b/packages/csv/src/index.ts
@@ -37,6 +37,36 @@ export interface CSVConversionResult {
   columnCount: number;
 }
 
+const ZONELESS_ISO_DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_OFFSET = /[+-]\d{2}:\d{2}$/;
+
+function isIsoDateOrDateTime(raw: string): boolean {
+  if (ISO_DATE.test(raw) || ZONELESS_ISO_DATE_TIME.test(raw)) return true;
+  const zoneless = raw.endsWith("Z")
+    ? raw.slice(0, -1)
+    : raw.replace(ISO_OFFSET, "");
+  return zoneless !== raw && ZONELESS_ISO_DATE_TIME.test(zoneless);
+}
+
+function inferCsvStringColumnType(raw: string | undefined): Field["type"] {
+  const type = inferStringColumnType(raw);
+  if (type !== "date" || raw === undefined) return type;
+  return isIsoDateOrDateTime(raw) ? "date" : "string";
+}
+
+function parseCsvStringValue(
+  raw: string | undefined,
+  type: Field["type"],
+): unknown {
+  const normalized =
+    type === "date" && raw !== undefined && ZONELESS_ISO_DATE_TIME.test(raw)
+      ? `${raw.replace(" ", "T")}Z`
+      : raw;
+  return parseStringValueByType(normalized, type);
+}
+
 /**
  * Converts CSV data into Arrow IPC plus structural metadata.
  */
@@ -65,7 +95,7 @@ export async function csvToDataFrame(
       ] ?? "";
     return {
       name,
-      type: inferStringColumnType(sampleValue),
+      type: inferCsvStringColumnType(sampleValue),
     };
   });
 
@@ -75,7 +105,7 @@ export async function csvToDataFrame(
   const rows = rowsData.map((row) =>
     header.reduce<Record<string, unknown>>((acc, key, colIndex) => {
       const column = userColumns[colIndex];
-      if (column) acc[key] = parseStringValueByType(row[colIndex], column.type);
+      if (column) acc[key] = parseCsvStringValue(row[colIndex], column.type);
       return acc;
     }, {}),
   );

--- a/packages/csv/src/index.ts
+++ b/packages/csv/src/index.ts
@@ -86,6 +86,27 @@ function inferCsvStringColumnType(raw: string | undefined): Field["type"] {
   return isIsoDateOrDateTime(raw) ? "date" : "string";
 }
 
+function inferCsvColumnType(
+  rows: string[][],
+  columnIndex: number,
+): Field["type"] {
+  let inferredType: Field["type"] = "unknown";
+
+  for (const row of rows) {
+    const raw = row[columnIndex];
+    if (raw === undefined || raw === "") continue;
+
+    const valueType = inferCsvStringColumnType(raw);
+    if (inferredType === "unknown") {
+      inferredType = valueType;
+    } else if (valueType !== inferredType) {
+      return "string";
+    }
+  }
+
+  return inferredType;
+}
+
 function parseCsvStringValue(
   raw: string | undefined,
   type: Field["type"],
@@ -119,13 +140,9 @@ export async function csvToDataFrame(
 
   // Create columns from CSV headers and infer types
   const userColumns = header.map((name, index) => {
-    const sampleValue =
-      rowsData.find((row) => row[index] !== undefined && row[index] !== "")?.[
-        index
-      ] ?? "";
     return {
       name,
-      type: inferCsvStringColumnType(sampleValue),
+      type: inferCsvColumnType(rowsData, index),
     };
   });
 

--- a/packages/csv/src/index.ts
+++ b/packages/csv/src/index.ts
@@ -42,12 +42,42 @@ const ZONELESS_ISO_DATE_TIME =
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_OFFSET = /[+-]\d{2}:\d{2}$/;
 
+function isValidIsoDate(raw: string): boolean {
+  if (!ISO_DATE.test(raw)) return false;
+  const date = new Date(`${raw}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().startsWith(raw);
+}
+
+function isValidZonelessIsoDateTime(raw: string): boolean {
+  if (!ZONELESS_ISO_DATE_TIME.test(raw)) return false;
+  const separatorIndex = raw.search(/[T ]/);
+  const datePart = raw.slice(0, separatorIndex);
+  const timeParts = raw.slice(separatorIndex + 1).split(":");
+  const hour = Number(timeParts[0]);
+  const minute = Number(timeParts[1]);
+  const second = Number(timeParts[2] ?? "0");
+  return (
+    isValidIsoDate(datePart) &&
+    Number.isInteger(hour) &&
+    hour >= 0 &&
+    hour <= 23 &&
+    Number.isInteger(minute) &&
+    minute >= 0 &&
+    minute <= 59 &&
+    second >= 0 &&
+    second < 60
+  );
+}
+
 function isIsoDateOrDateTime(raw: string): boolean {
-  if (ISO_DATE.test(raw) || ZONELESS_ISO_DATE_TIME.test(raw)) return true;
+  if (ISO_DATE.test(raw)) return isValidIsoDate(raw);
+  if (ZONELESS_ISO_DATE_TIME.test(raw)) {
+    return isValidZonelessIsoDateTime(raw);
+  }
   const zoneless = raw.endsWith("Z")
     ? raw.slice(0, -1)
     : raw.replace(ISO_OFFSET, "");
-  return zoneless !== raw && ZONELESS_ISO_DATE_TIME.test(zoneless);
+  return zoneless !== raw && isValidZonelessIsoDateTime(zoneless);
 }
 
 function inferCsvStringColumnType(raw: string | undefined): Field["type"] {

--- a/packages/csv/src/index.ts
+++ b/packages/csv/src/index.ts
@@ -40,7 +40,7 @@ export interface CSVConversionResult {
 const ZONELESS_ISO_DATE_TIME =
   /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/;
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
-const ISO_OFFSET = /[+-]\d{2}:\d{2}$/;
+const ISO_OFFSET = /[+-]\d{2}:?\d{2}$/;
 
 function isValidIsoDate(raw: string): boolean {
   if (!ISO_DATE.test(raw)) return false;

--- a/packages/ui/src/lib/format-virtual-table-value.test.ts
+++ b/packages/ui/src/lib/format-virtual-table-value.test.ts
@@ -41,6 +41,12 @@ describe("defaultFormatValue", () => {
     expect(defaultFormatValue("2024-03-15", "date")).toBe("Mar 15, 2024");
   });
 
+  it("formats numeric epoch values in date columns as UTC calendar dates", () => {
+    expect(defaultFormatValue(Date.UTC(2024, 0, 18), "date")).toBe(
+      "Jan 18, 2024",
+    );
+  });
+
   it("leaves an impossible calendar date as text rather than rolling it over", () => {
     expect(defaultFormatValue("2024-02-30", "date")).toBe("2024-02-30");
   });

--- a/packages/ui/src/lib/format-virtual-table-value.ts
+++ b/packages/ui/src/lib/format-virtual-table-value.ts
@@ -31,7 +31,20 @@ function formatDate(value: unknown, type?: ColumnType): string | null {
     });
   }
 
-  if (type !== "date" || typeof value !== "string") return null;
+  if (type !== "date") return null;
+
+  if (typeof value === "number") {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+  }
+
+  if (typeof value !== "string") return null;
 
   const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   if (dateOnly) {


### PR DESCRIPTION
Numeric date values currently render as raw epoch timestamps, while zoneless CSV timestamps are interpreted in the browser's local timezone. CSV columns are also typed from only their first non-empty value, so a later incompatible value can be coerced to null or silently normalized.

This change formats schema-declared numeric dates as UTC calendar dates and makes CSV ingestion deterministic and lossless. Zoneless ISO timestamps are interpreted as UTC, explicit offsets retain their instant, ambiguous or impossible date-like values remain text, and mixed-type columns fall back to strings before Arrow encoding so every original value is preserved.

This is a current-main replacement for the obsolete approach in #320.

## Local verification

- `TURBO_CONCURRENCY=2 bun run check` — 85/85 tasks passed
- `bun run format:check`
- `bunx turbo build --filter='!@wystack/*'` — 22/22 tasks passed
- Runtime CSV-to-Arrow exercises under `Pacific/Auckland`
- Focused CSV package gate — 22/22 tests passed

## Independent review

The adaptive plan used two required low-effort seats: a Terra runtime review and a Sol source review. Both found the same blocker: impossible or incompatible values after a valid first value could still be corrupted. The fix now infers across every non-empty value. A focused runtime scenario recheck and strict source regression review both passed on `0e02be452df4167c2cfb1b9bf3f22f1118a95b9a`.

A fractional-seconds concern was dismissed with source evidence and a passing Arrow regression proving `2024-07-18T00:30:00.123` remains a UTC date.

## Exclusions

- The analogous first-value inference path in the REST connector is unchanged.
- The old #320 client-side schema-inference changes are not reused.
- The unrelated local `bun.lock` change is not included.
