### PR TITLE
[codex] Fix the server insecure bind opt-out

### DIFF
--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -494,6 +494,24 @@ describe("dashframe serve CLI", () => {
       expect(options.authToken).toBe("plaintext-token");
     });
 
+    it("forwards --insecure to the server factory options", () => {
+      const project = {
+        db: {},
+        dir: "/unused-project",
+        touchSnapshot: vi.fn(),
+        flushSnapshot: vi.fn(),
+      } as unknown as ProjectHandle;
+
+      const options = createStandaloneServerOptions(
+        { hostname: "0.0.0.0", insecure: true },
+        project,
+        {},
+        { queryArrow: vi.fn(), registerArrowTable: vi.fn() },
+      );
+
+      expect(options.insecure).toBe(true);
+    });
+
     // End-to-end through the real ApiAccessCredentials + SecretVault +
     // encrypted-file backend. The unit suites prove each layer in isolation;
     // this proves the composed stack actually issues a usable credential and

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -470,6 +470,7 @@ export function createStandaloneServerOptions(
     mcpMode: opts.mcpMode,
     corsOrigin: opts.corsOrigin,
     authToken: opts.token,
+    insecure: opts.insecure,
     arrowEngine,
     ...secretServices,
     // Drive the debounced snapshot scheduler on the headless serve path too, so
@@ -582,12 +583,6 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
   }
 
   assertBindIsSafe(opts);
-
-  if (opts.insecure && !opts.token && !isLoopbackHost(opts.hostname)) {
-    console.warn(
-      "[dashframe] warning: --insecure non-loopback bind without --token exposes this project to the network",
-    );
-  }
 
   const projectDir = resolveProjectDirectory(opts);
   const dataDir = resolveDataDir(opts);


### PR DESCRIPTION
`dashframe serve --insecure` passed the CLI bind gate but lost the opt-out before the reusable server factory, so non-loopback startup still failed. Forward the option into `createDashframeServer` and leave warning ownership at the factory so operators see it exactly once.

Verification:
- focused `apps/server/src/index.test.ts`: 33 passed
- real CLI: insecure non-loopback bind started with one warning; default path exited 1; token path started
- `bun run check`: passed after permitted rerun for loopback socket tests
- `bun run format:check`: passed
- adaptive review: 2/2 independent source-depth seats passed, no findings

Review plan:
- runtime/spec: gpt-5.6-terra, low
- security/trust: gpt-5.5, low

Exclusions: no bind-classification or authentication-policy changes.

Closes #244