### PR TITLE
feat: deploy MCP server on Railway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.env
+.env.*
+.data
+node_modules
+**/node_modules
+**/.turbo
+**/dist
+**/build
+**/coverage
+**/*.tsbuildinfo
+.vercel
+.wystack
+.codex-cockpit
+docs/screenshots
+e2e/web/test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.5
+
+WORKDIR /app
+
+COPY . .
+
+RUN HUSKY=0 bun install --frozen-lockfile
+RUN bun run build:wystack
+
+ENV NODE_ENV=production
+EXPOSE 8080
+
+CMD ["sh", "scripts/start-railway.sh"]

--- a/apps/server/src/index.test.ts
+++ b/apps/server/src/index.test.ts
@@ -18,6 +18,7 @@ import {
   createStandaloneServerOptions,
   parseArgs,
   printHelp,
+  resolveAuthToken,
   resolveDataDir,
   resolveProjectDirectory,
   shutdownStandaloneResources,
@@ -226,6 +227,10 @@ describe("dashframe serve CLI", () => {
       const helpText = output.join("\n");
       expect(helpText).toContain("--bind <addr>");
       expect(helpText).toContain("--token <token>");
+      expect(helpText).toContain("DASHFRAME_AUTH_TOKEN");
+      expect(helpText).toContain(
+        "non-loopback bind requires --token or DASHFRAME_AUTH_TOKEN",
+      );
       expect(helpText).toContain("--data-dir <dir>");
       expect(helpText).toContain("--mcp-mode <mode>");
       expect(helpText).toContain("canonical padded base64");
@@ -267,7 +272,7 @@ describe("dashframe serve CLI", () => {
 
     it("should reject a non-loopback bind without a token", () => {
       expect(() => assertBindIsSafe({ hostname: "0.0.0.0" })).toThrow(
-        /Refusing to bind 0\.0\.0\.0 without --token/,
+        /Refusing to bind 0\.0\.0\.0 without an authentication token/,
       );
     });
 
@@ -288,7 +293,9 @@ describe("dashframe serve CLI", () => {
       // this one is over-strict by design, not a bypass.
       "127.1",
     ])("should reject the non-loopback host %s without a token", (hostname) => {
-      expect(() => assertBindIsSafe({ hostname })).toThrow(/without --token/);
+      expect(() => assertBindIsSafe({ hostname })).toThrow(
+        /without an authentication token/,
+      );
     });
 
     it("should still allow real 127.0.0.0/8 literals without a token", () => {
@@ -311,6 +318,26 @@ describe("dashframe serve CLI", () => {
       expect(() =>
         assertBindIsSafe({ hostname: "0.0.0.0", insecure: true }),
       ).not.toThrow();
+    });
+  });
+
+  describe("resolveAuthToken", () => {
+    it("prefers the CLI token over the hosted environment", () => {
+      expect(
+        resolveAuthToken(
+          { token: "cli-token" },
+          { DASHFRAME_AUTH_TOKEN: "environment-token" },
+        ),
+      ).toBe("cli-token");
+    });
+
+    it("reads hosted credentials without placing them in process arguments", () => {
+      expect(
+        resolveAuthToken({}, { DASHFRAME_AUTH_TOKEN: "environment-token" }),
+      ).toBe("environment-token");
+      expect(
+        resolveAuthToken({}, { DASHFRAME_AUTH_TOKEN: "" }),
+      ).toBeUndefined();
     });
   });
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -63,21 +63,22 @@ Options:
   --project <dir>         Project directory (default: DASHFRAME_PROJECT_DIR or ~/.DashFrame/web-project)
   --data-dir <dir>        Host-local data directory (default: DASHFRAME_DATA_DIR or ~/.DashFrame/data)
   --bind <addr>           Bind address as host[:port] (default: 127.0.0.1:0)
-  --token <token>         Require Bearer token auth for HTTP and WebSocket clients
+  --token <token>         Require Bearer token auth (or set DASHFRAME_AUTH_TOKEN)
   --host <host>           Bind host alias (default: 127.0.0.1)
   --port <port>           Bind port alias (default: 0, OS-assigned)
   --mcp-mode <mode>       MCP transport: stateful (default) or stateless
   --name <name>           Project display name when initializing
   --cors-origin <origin>  Allowed browser origin; repeat or comma-separate for multiple
-  --insecure              Allow a non-loopback bind without --token (opt out of the auth requirement)
+  --insecure              Allow a non-loopback bind without a token (opt out of the auth requirement)
   --help                  Show this help
 
 Security boundary:
   The server exposes the selected local DashFrame project over HTTP and WebSocket.
   The default bind is loopback-only and safe to run without a token. Binding to
   0.0.0.0 or another network interface makes the project reachable from that
-  network, so a non-loopback bind requires --token; pass --insecure to opt out
-  deliberately. A token is not TLS and not multi-user authorization.
+  network, so a non-loopback bind requires --token or DASHFRAME_AUTH_TOKEN;
+  pass --insecure to opt out deliberately. A token is not TLS and not
+  multi-user authorization.
 
 Secret encryption:
   Set DASHFRAME_SECRET_KEY_FILE to an owner-only key file (the group and world
@@ -257,7 +258,8 @@ function parseArgAt(opts: CliOptions, args: string[], index: number): number {
 /**
  * Fail-closed auth gate. Loopback binds are reachable only from this machine,
  * so a token is optional there. A non-loopback bind exposes the project to the
- * network and must carry `--token`; `--insecure` is the deliberate opt-out.
+ * network and must carry a CLI or environment token; `--insecure` is the
+ * deliberate opt-out.
  * Throws (rather than warns) so a forgotten token never silently exposes data.
  */
 export function assertBindIsSafe(opts: CliOptions): void {
@@ -265,9 +267,10 @@ export function assertBindIsSafe(opts: CliOptions): void {
     return;
   }
   throw new Error(
-    `Refusing to bind ${opts.hostname} without --token: a non-loopback bind ` +
-      `exposes this project to the network. Pass --token <token>, or ` +
-      `--insecure to opt out deliberately.`,
+    `Refusing to bind ${opts.hostname} without an authentication token: ` +
+      `a non-loopback bind exposes this project to the network. Pass ` +
+      `--token <token>, set DASHFRAME_AUTH_TOKEN, or use --insecure to opt ` +
+      `out deliberately.`,
   );
 }
 
@@ -335,6 +338,15 @@ export function resolveProjectDirectory(
   return (
     opts.project ?? environment.DASHFRAME_PROJECT_DIR ?? DEFAULT_WEB_PROJECT_DIR
   );
+}
+
+/** Prefer an explicit CLI token, with an environment fallback for hosted runtimes. */
+export function resolveAuthToken(
+  opts: CliOptions,
+  environment: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const token = opts.token ?? environment.DASHFRAME_AUTH_TOKEN;
+  return token === "" ? undefined : token;
 }
 
 /** Refuse any configuration that places host-local access data in the project. */
@@ -575,17 +587,21 @@ async function closeProjectAfterStartupFailure(
 }
 
 export async function main(args = process.argv.slice(2)): Promise<void> {
-  const opts = parseArgs(args);
-  if (opts.help) {
+  const parsedOptions = parseArgs(args);
+  if (parsedOptions.help) {
     printHelp();
     return;
   }
+  const opts = {
+    ...parsedOptions,
+    token: resolveAuthToken(parsedOptions),
+  };
 
   assertBindIsSafe(opts);
 
   if (opts.insecure && !opts.token && !isLoopbackHost(opts.hostname)) {
     console.warn(
-      "[dashframe] warning: --insecure non-loopback bind without --token exposes this project to the network",
+      "[dashframe] warning: --insecure non-loopback bind without authentication exposes this project to the network",
     );
   }
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "sh scripts/start-railway.sh"
+drainingSeconds = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/scripts/start-railway.sh
+++ b/scripts/start-railway.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+: "${PORT:?Railway must provide PORT}"
+: "${RAILWAY_VOLUME_MOUNT_PATH:?Attach a Railway volume before starting DashFrame}"
+: "${DASHFRAME_AUTH_TOKEN:?Set DASHFRAME_AUTH_TOKEN in Railway variables}"
+: "${DASHFRAME_SECRET_KEY:?Set DASHFRAME_SECRET_KEY in Railway variables}"
+
+volume_root="${RAILWAY_VOLUME_MOUNT_PATH}"
+export DASHFRAME_PROJECT_DIR="${volume_root}/project"
+export DASHFRAME_DATA_DIR="${volume_root}/host-data"
+
+exec bun run --cwd apps/server start -- \
+  --bind "0.0.0.0:${PORT}" \
+  --mcp-mode stateless


### PR DESCRIPTION
## Why

DashFrame's remote MCP App needs a persistent server and durable storage; a request-scoped Vercel function is the wrong runtime boundary for the current local-first project model.

## Solution

Add a Bun Docker/Railway adapter that runs the existing stateless Streamable HTTP MCP endpoint as one authenticated service, forces project and host data onto an attached volume, excludes sensitive local data from the image, and gives shutdown 30 seconds to finish its durable snapshot. The CLI now accepts the bearer token from `DASHFRAME_AUTH_TOKEN` so hosted secrets never need to appear in process arguments.

The Railway development project is configured with one replica, an attached volume, generated auth/encryption secrets, and serverless sleep-to-zero. The deployed endpoint is:

`https://dashframe-mcp-production.up.railway.app/mcp`

## Verification

- `bun run check` — all 85 tasks passed, including 839 server tests
- `bun run format:check`
- `git diff --check origin/main...HEAD`
- independent exact-head review — no findings
- Railway Docker build and startup — passed
- live HTTPS: unauthenticated initialize returns 401; authenticated MCP 2025-06-18 initialize passes
- live tool/resource discovery: `render_data_frame` and `ui://dashframe/report-v2.html` present; resource read passes
- attached-volume marker survived a replacement deployment, was removed, and authenticated MCP still passed afterward

This proves the standards-compliant remote MCP server and fallback. It does not claim ChatGPT/Codex inline rendering; that remains a separate real-host acceptance step.